### PR TITLE
DNN-3742 Update binding redirect for WebFormsMvp

### DIFF
--- a/DNN Platform/Website/Install/Config/07.01.03.config
+++ b/DNN Platform/Website/Install/Config/07.01.03.config
@@ -1,0 +1,13 @@
+<configuration>
+  <nodes configfile="Web.config">
+    <!-- add assembly redirect for WebFormsMVP-->
+    <node path="/configuration/runtime/ab:assemblyBinding" action="update" 
+          targetpath="/configuration/runtime/ab:assemblyBinding[ab:dependentAssembly/ab:assemblyIdentity/@name='WebFormsMvp']" 
+          collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
+      <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
+        <assemblyIdentity name="WebFormsMvp" publicKeyToken="537f18701145dff0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.999.999" newVersion="1.4.1.0" />
+      </dependentAssembly>
+    </node>
+  </nodes>
+</configuration>


### PR DESCRIPTION
WebFormsMvp was updated from version 1.2.0 to 1.4.1 by bcfe795.
Since it is strong-named, there needs to be a binding redirect in the
web.config to allow assemblies compiled against other versions to continue
working without recompiling.

This commit adds a new install config XML Merge script, to run for version
7.1.3, which, when run (automatically during an upgrade to 7.1.3 or later)
updates the assembly binding to use version 1.4.1.0.

I also changed the range of version which it redirects.  It previously only
redirected starting at version 1.0.0.0, but there were older versions which
DNN shipped, which should get redirected as well.
