### PR TITLE
Fix assembly binding for WebFormsMvp to install correctly

### DIFF
--- a/DNN Platform/Website/Install/Config/07.02.00.config
+++ b/DNN Platform/Website/Install/Config/07.02.00.config
@@ -2,7 +2,7 @@
   <nodes configfile="Web.config">
     <!-- add assembly redirect for WebFormsMVP-->
     <node path="/configuration/runtime/ab:assemblyBinding" action="update"
-          targetpath="/configuration/runtime/ab:assemblyBinding[ab:dependentAssembly/ab:assemblyIdentity/@name='WebFormsMvp']"
+          targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='WebFormsMvp']"
           collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
       <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="WebFormsMvp" publicKeyToken="537f18701145dff0" />


### PR DESCRIPTION
The old target path failed when trying to remove the existing node (`collision="overwrite"`). Note that there _isn't_ an existing node by default for fresh DNN 7 installs (which seems like it's as separate problem).  

The target path needs to be a child of the path to allow replacing.
