### PR TITLE
Add Base Robots.TXT to root

### DIFF
--- a/Website/robots.txt
+++ b/Website/robots.txt
@@ -1,0 +1,168 @@
+# Begin robots.txt file
+#/-----------------------------------------------\
+#| In single portal/domain situations, uncomment the sitmap line and enter domain name
+#\-----------------------------------------------/
+#Sitemap: http://www.DomainNamehere.com/sitemap.aspx
+
+
+User-agent: *
+Disallow: /admin/
+Disallow: /App_Browsers/
+Disallow: /App_Code/
+Disallow: /App_Data/
+Disallow: /App_GlobalResources/
+Disallow: /bin/
+Disallow: /Components/
+Disallow: /Config/
+Disallow: /contest/
+Disallow: /controls/
+Disallow: /DesktopModules/
+Disallow: /Documentation/
+Disallow: /HttpModules/
+Disallow: /images/
+Disallow: /Install/
+Disallow: /js/
+Disallow: /Portals/
+Disallow: /Providers/
+Disallow: /Resources/ContentRotator/
+Disallow: /Resources/ControlPanel/
+Disallow: /Resources/Dashboard/
+Disallow: /Resources/FeedBrowser/
+Disallow: /Resources/OpenForceAd/
+Disallow: /Resources/Search/
+Disallow: /Resources/Shared/
+Disallow: /Resources/SkinWidgets/
+Disallow: /Resources/TabStrip/
+Disallow: /Resources/Widgets/
+Disallow: /Activity-Feed/userId/	# Do not index user profiles
+
+User-agent: msnbot
+Disallow: /admin/
+Disallow: /App_Browsers/
+Disallow: /App_Code/
+Disallow: /App_Data/
+Disallow: /App_GlobalResources/
+Disallow: /bin/
+Disallow: /Components/
+Disallow: /Config/
+Disallow: /contest/
+Disallow: /controls/
+Disallow: /DesktopModules/
+Disallow: /Documentation/
+Disallow: /HttpModules/
+Disallow: /images/
+Disallow: /Install/
+Disallow: /js/
+Disallow: /Portals/
+Disallow: /Providers/
+Disallow: /Resources/ContentRotator/
+Disallow: /Resources/ControlPanel/
+Disallow: /Resources/Dashboard/
+Disallow: /Resources/FeedBrowser/
+Disallow: /Resources/OpenForceAd/
+Disallow: /Resources/Search/
+Disallow: /Resources/Shared/
+Disallow: /Resources/SkinWidgets/
+Disallow: /Resources/TabStrip/
+Disallow: /Resources/Widgets/
+Disallow: /Activity-Feed/userId/	# Do not index user profiles
+Crawl-delay: 5
+
+User-agent: Slurp
+Disallow: /*/ctl/		# Slurp permits *
+Disallow: /admin/
+Disallow: /App_Browsers/
+Disallow: /App_Code/
+Disallow: /App_Data/
+Disallow: /App_GlobalResources/
+Disallow: /bin/
+Disallow: /Components/
+Disallow: /Config/
+Disallow: /contest/
+Disallow: /controls/
+Disallow: /DesktopModules/
+Disallow: /Documentation/
+Disallow: /HttpModules/
+Disallow: /images/
+Disallow: /Install/
+Disallow: /js/
+Disallow: /Portals/
+Disallow: /Providers/
+Disallow: /Resources/ContentRotator/
+Disallow: /Resources/ControlPanel/
+Disallow: /Resources/Dashboard/
+Disallow: /Resources/FeedBrowser/
+Disallow: /Resources/OpenForceAd/
+Disallow: /Resources/Search/
+Disallow: /Resources/Shared/
+Disallow: /Resources/SkinWidgets/
+Disallow: /Resources/TabStrip/
+Disallow: /Resources/Widgets/
+Disallow: /Activity-Feed/userId/	# Do not index user profiles
+Crawl-delay: 5
+
+User-agent: Googlebot
+Disallow: /*/ctl/		# Googlebot permits *
+Disallow: /admin/
+Disallow: /App_Browsers/
+Disallow: /App_Code/
+Disallow: /App_Data/
+Disallow: /App_GlobalResources/
+Disallow: /bin/
+Disallow: /Components/
+Disallow: /Config/
+Disallow: /contest/
+Disallow: /controls/
+Disallow: /DesktopModules/
+Disallow: /Documentation/
+Disallow: /HttpModules/
+Disallow: /images/
+Disallow: /Install/
+Disallow: /js/
+Disallow: /Portals/
+Disallow: /Providers/
+Disallow: /Resources/ContentRotator/
+Disallow: /Resources/ControlPanel/
+Disallow: /Resources/Dashboard/
+Disallow: /Resources/FeedBrowser/
+Disallow: /Resources/OpenForceAd/
+Disallow: /Resources/Search/
+Disallow: /Resources/Shared/
+Disallow: /Resources/SkinWidgets/
+Disallow: /Resources/TabStrip/
+Disallow: /Resources/Widgets/
+Disallow: /Activity-Feed/userId/	# Do not index user profiles
+
+User-agent: Yahoo Pipes 1.0
+Disallow: /admin/
+Disallow: /App_Browsers/
+Disallow: /App_Code/
+Disallow: /App_Data/
+Disallow: /App_GlobalResources/
+Disallow: /bin/
+Disallow: /Components/
+Disallow: /Config/
+Disallow: /contest/
+Disallow: /controls/
+Disallow: /DesktopModules/
+Disallow: /Documentation/
+Disallow: /HttpModules/
+Disallow: /images/
+Disallow: /Install/
+Disallow: /js/
+Disallow: /Portals/
+Disallow: /Providers/
+Disallow: /Resources/ContentRotator/
+Disallow: /Resources/ControlPanel/
+Disallow: /Resources/Dashboard/
+Disallow: /Resources/FeedBrowser/
+Disallow: /Resources/OpenForceAd/
+Disallow: /Resources/Search/
+Disallow: /Resources/Shared/
+Disallow: /Resources/SkinWidgets/
+Disallow: /Resources/TabStrip/
+Disallow: /Resources/Widgets/
+Disallow: /Activity-Feed/userId/	# Do not index user profiles
+
+
+# End of robots.txt file


### PR DESCRIPTION
(DNN-3909) Consider Basic Robots.txt in root

Not a "bug fix" specifically or something broken, however, how about
considering adding a basic robots.txt to the root? This is an old item
that has been discussed, and if generic, could be a good addition of
basics. This one is basically the setup from the dnnsoftware.com site.

I know that the sitemap.aspx and sitemap provider are preferred, however
in every project, we add a basic starter robots.txt file, especially if
it is a single domain/portal site where we can reference the
sitemap.aspx
