### PR TITLE
DNN-3908 Extension URL Provider does not validate settings

### DIFF
--- a/DNN Platform/Modules/UrlManagement/UrlProviderSettings.ascx.cs
+++ b/DNN Platform/Modules/UrlManagement/UrlProviderSettings.ascx.cs
@@ -65,6 +65,11 @@ namespace DotNetNuke.Modules.UrlManagement
 
         void cmdUpdate_Click(object sender, EventArgs e)
         {
+            if (!this.Page.IsValid)
+            {
+                return;
+            }
+
             if (_providerSettingsControl != null)
             {
                 var settings = _providerSettingsControl.SaveSettings();


### PR DESCRIPTION
The settings for the Extension URL Providers is not validated on the server before submitting, so a CustomValidator which doesn't do client-side validation won't be considered before trying to save settings.

This fix checks the page validation state before submitting.
