### PR TITLE
(DNN-4471) Check for null ModuleControl within ActionButton control

### DIFF
--- a/DNN Platform/Library/UI/Containers/ActionBase.cs
+++ b/DNN Platform/Library/UI/Containers/ActionBase.cs
@@ -311,6 +311,11 @@ namespace DotNetNuke.UI.Containers
         {
             try
             {
+                if (this.ModuleControl == null)
+                {
+                    return;
+                }
+
                 ActionRoot.Actions.AddRange(Actions);
             }
             catch (Exception exc)

--- a/DNN Platform/Library/UI/Containers/ActionButtonList.cs
+++ b/DNN Platform/Library/UI/Containers/ActionButtonList.cs
@@ -246,6 +246,10 @@ namespace DotNetNuke.UI.Containers
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
+            if (this.ModuleControl == null)
+            {
+                return;
+            }
 
             foreach (ModuleAction action in ModuleActions)
             {


### PR DESCRIPTION
When a container, such as the default Pop-Up Container, uses `ActionButton` controls, errors that occur early in the module's lifetime will cause the `ActionButton` to not get setup completely, and throw errors.

This means that when errors occur in the module, the users sees an error message that doesn't have anything to do with the real error. In the same way, when they look in the Event Viewer, they need to know to ignore the most recent error, and look at the first error that occurred in the group of errors.

To address the issue, I had the control short-circuit its operation if it detect that it isn't setup correctly, instead of getting to the null reference. This fixes the extraneous null reference errors. The real error still gets logged three different times, which may be a separate issue to look at; however, wherever you look, you see a meaningful error, so I think it's a clear improvement.
