### PR TITLE
DNN-4663 Sub-sub-menu items not accessible by mouse

### DIFF
--- a/Website/Portals/_default/Skins/Gravity/skin.css
+++ b/Website/Portals/_default/Skins/Gravity/skin.css
@@ -1,4 +1,4 @@
-﻿@charset "UTF-8";
+@charset "UTF-8";
 @import url('./bootstrap/css/bootstrap.min.css');
 body {
     font-family: Arial, Helvetica, sans-serif;
@@ -824,7 +824,6 @@ a.altButton:hover {
     }
     .nav-collapse:not(.in) .nav .dropdown-menu{
         border-radius:0!important;
-        top:37px!important;
     }
     .nav > li > ul li:hover {
 		color:#D00;


### PR DESCRIPTION
In the DDRmenu, this line makes the sub-sub-menu items too far from the
sub-menu items in such a way that it is impossible to access it without
loosing focus on the parent, so the sub-sub-item disappears before
reaching it.
