### PR TITLE
DNN-4893 Fix broken jQuery UI dialog style

### DIFF
--- a/Website/Portals/_default/default.css
+++ b/Website/Portals/_default/default.css
@@ -2247,7 +2247,11 @@ ul.dnnButtonGroup {
     width: 100%;
     height: 100%;
     background: rgba(0,0,0,0.65);
-	z-index: 9999;
+    z-index: 9999;
+}
+
+.ui-dialog {
+    z-index: 100000;
 }
 
 .dnnFormPopup {
@@ -2256,8 +2260,8 @@ ul.dnnButtonGroup {
     background: #fff;
     -webkit-box-shadow: 0 0 25px 0 rgba(0, 0, 0, 0.75);
     box-shadow: 0 0 25px 0 rgba(0, 0, 0, 0.75);
-	z-index: 100000;
 }
+
     /* Popup header */
     .dnnFormPopup .ui-dialog-titlebar {
         position: relative;


### PR DESCRIPTION
When using the jQuery UI dialog, the "background" overlay appears over the dialog. This happens because the default.css gives the overlay a z-index, but does not give the dialog a z-index (instead, it gives .dnnFormPopup the z-index). So, using the dialog directly, outside of the dnnModal function, has a broken display.

This commit moves the "z-index: 100000" style from .dnnFormPopup to .ui-dialog
