### PR TITLE
DNN-4914 Error reading manifest with comment in JavaScriptLibrary component

### DIFF
--- a/DNN Platform/Library/Framework/JavaScriptLibraries/JavaScriptLibrary.cs
+++ b/DNN Platform/Library/Framework/JavaScriptLibraries/JavaScriptLibrary.cs
@@ -121,9 +121,6 @@ namespace DotNetNuke.Framework.JavaScriptLibraries
                         case "CDNPath":
                             CDNPath = reader.ReadElementContentAsString();
                             break;
-                        default:
-                            var content = reader.ReadElementContentAsString();
-                            break;
                     }
                 }
             }


### PR DESCRIPTION
When reading a JavaScript Library from a manifest, there's an exception when it includes a comment.  All nodes are read, even if they can't be read (e.g. they're a comment).
