### PR TITLE
DNN-4928 Fix error when editing JavaScript Library extension

### DIFF
--- a/Website/DesktopModules/Admin/Extensions/Editors/JavaScriptLibraryEditor.ascx
+++ b/Website/DesktopModules/Admin/Extensions/Editors/JavaScriptLibraryEditor.ascx
@@ -44,7 +44,7 @@
                 <asp:TemplateColumn HeaderText="Version">
                     <HeaderStyle HorizontalAlign="Left" Wrap="False" Width="150px"/>
                     <ItemStyle HorizontalAlign="Left" />
-                    <ItemTemplate><asp:Label ID="lblVersion" runat="server" Text='<%# FormatVersion(Container.DataItem) %>' /></ItemTemplate>
+                    <ItemTemplate><asp:Label ID="lblVersion" runat="server" Text='<%# FormatVersion(Eval("Version")) %>' /></ItemTemplate>
                 </asp:TemplateColumn>
             </Columns>
         </asp:DataGrid>
@@ -61,7 +61,7 @@
                 <asp:TemplateColumn HeaderText="Version">
                     <HeaderStyle HorizontalAlign="Left" Wrap="False" Width="150px"/>
                     <ItemStyle HorizontalAlign="Left" />
-                    <ItemTemplate><asp:Label ID="lblVersion" runat="server" Text='<%# FormatVersion(Container.DataItem) %>' /></ItemTemplate>
+                    <ItemTemplate><asp:Label ID="lblVersion" runat="server" Text='<%# FormatVersion(Eval("Version")) %>' /></ItemTemplate>
                 </asp:TemplateColumn>
             </Columns>
         </asp:DataGrid>

--- a/Website/DesktopModules/Admin/Extensions/Editors/JavaScriptLibraryEditor.ascx.cs
+++ b/Website/DesktopModules/Admin/Extensions/Editors/JavaScriptLibraryEditor.ascx.cs
@@ -42,24 +42,16 @@ namespace DotNetNuke.Modules.Admin.Extensions
             }
         }
 
-        protected string FormatVersion(object version)
+        protected string FormatVersion(object v)
         {
-            var retValue = Null.NullString;
-            var package = version as PackageInfo;
-            if (package != null)
+            var version = v as System.Version;
+            if (version == null)
             {
-                retValue = package.Version.ToString(3);
+                return Null.NullString;
             }
-            else
-            {
-                var dependency = version as PackageDependencyInfo;
-                if (dependency != null)
-                {
-                    retValue = dependency.Version.ToString(3);
-                }
-            }
-
-            return retValue;
+            
+            var fieldCount = version.Build > -1 ? 3 : 2;
+            return version.ToString(fieldCount);
         }
 
 


### PR DESCRIPTION
When a JavaScript Library extension has a dependency on a library, and the
version of that dependency only has two digits (e.g. 1.7), then there is an
exception that is thrown when trying to format the version

This commit checks the version before formatting it, so that the exception
won't be thrown.
