### PR TITLE
DNN-26810: Save / Restore Module with Settings + Content

### DIFF
--- a/Website/admin/Modules/App_LocalResources/Import.ascx.resx
+++ b/Website/admin/Modules/App_LocalResources/Import.ascx.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="plFolder.Text" xml:space="preserve">
     <value>Folder</value>
@@ -158,5 +158,11 @@
   </data>
   <data name="ModuleContent.Text" xml:space="preserve">
     <value>Module Content</value>
+  </data>
+  <data name="plIncludeSettings.Help" xml:space="preserve">
+    <value>Check if settings should also be imported</value>
+  </data>
+  <data name="plIncludeSettings.Text" xml:space="preserve">
+    <value>Include Settings</value>
   </data>
 </root>

--- a/Website/admin/Modules/Export.ascx.cs
+++ b/Website/admin/Modules/Export.ascx.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.UI.WebControls;
-
+using System.Xml;
 using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
@@ -97,14 +97,30 @@ namespace DotNetNuke.Modules.Admin.Modules
 						//Double-check
 						if (objObject is IPortable)
                         {
-                            var content = Convert.ToString(((IPortable)objObject).ExportModule(moduleID));
+                            XmlDocument moduleXml = new XmlDocument();
+                            XmlNode moduleNode = ModuleController.SerializeModule(moduleXml, Module, true);
+
+                            //add attributes to XML document
+                            XmlAttribute typeAttribute = moduleXml.CreateAttribute("type");
+                            typeAttribute.Value = CleanName(Module.DesktopModule.ModuleName);
+                            moduleNode.Attributes.Append(typeAttribute);
+
+                            XmlAttribute versionAttribute = moduleXml.CreateAttribute("version");
+                            versionAttribute.Value = Module.DesktopModule.Version;
+                            moduleNode.Attributes.Append(versionAttribute);
+
+                            // Create content from XmlNode
+                            StringWriter sw = new StringWriter();
+                            XmlTextWriter xw = new XmlTextWriter(sw);
+                            moduleNode.WriteTo(xw);
+                            var content = sw.ToString();
                             if (!String.IsNullOrEmpty(content))
                             {
-								//remove invalid chars in content
-	                            content = Regex.Replace(content, _invalidCharsRegex, string.Empty);
+								//remove invalid chars in content -> DNN 26810: Handled by ModuleController.SerializeModule
+	                            //content = Regex.Replace(content, _invalidCharsRegex, string.Empty);
 								//add attributes to XML document
-                                content = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" + "<content type=\"" + CleanName(Module.DesktopModule.ModuleName) + "\" version=\"" +
-                                          Module.DesktopModule.Version + "\">" + content + "</content>";
+                                //content = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" + "<content type=\"" + CleanName(Module.DesktopModule.ModuleName) + "\" version=\"" +
+                                //          Module.DesktopModule.Version + "\">" + content + "</content>";
 
                                 //First check the Portal limits will not be exceeded (this is approximate)
                                 var objPortalController = new PortalController();

--- a/Website/admin/Modules/import.ascx
+++ b/Website/admin/Modules/import.ascx
@@ -16,6 +16,10 @@
             <dnn:Label ID="plFile" runat="server" ControlName="cboFiles" Suffix=":" />
               <dnn:DnnComboBox runat="server" ID="cboFiles"  AutoPostBack="true"/>
         </div>
+        <div class="dnnFormItem">
+            <dnn:Label ID="plIncludeSettings"  runat="server" ControlName="chkIncludeSettings" Suffix=":" />
+            <dnn:DnnCheckbox runat="server" ID="chkIncludeSettings" />
+        </div>
     </fieldset>
     <h2 id="dnnPanel-ModuleContent" class="dnnFormSectionHead">
         <a href="#" class="">


### PR DESCRIPTION
Problem: Often modules have more content in the "settings" than in "content". I have for example an HTML module with a lot of javascript in the head section of the settings and only one simple canvas element in the content. Exporting content only exports the canvas and nothing else.
Solution: DNN has internal methods for saving a complete page or even a complete website as a template, with all settings. But when exporting and importing module content, these methods are not used. Instead there is a special solution for this which only fetches the content and nothing else.

In this pull request I implemented this + added an additional checkbox in the import dialog for restoring the not only the modulecontent but also the settings. 
