### PR TITLE
DNN-4785 Do not lowercase registered URLs

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeï¿½ - http://www.dotnetnuke.com
 // Copyright (c) 2002-2014
 // by DotNetNuke Corporation
 // 
@@ -286,7 +286,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
         public static void RegisterScript(Page page, string filePath, int priority, string provider)
         {
-            var include = new DnnJsInclude { ForceProvider = provider, Priority = priority, FilePath = filePath.ToLowerInvariant(), AddTag = false };
+            var include = new DnnJsInclude { ForceProvider = provider, Priority = priority, FilePath = filePath, AddTag = false };
             var loader = page.FindControl("ClientResourceIncludes");
             if (loader != null)
             {
@@ -351,7 +351,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
 
             if (fileExists || FileExists(page, filePath))
             {
-                var include = new DnnCssInclude {ForceProvider = provider, Priority = priority, FilePath = filePath.ToLowerInvariant(), AddTag = false};
+                var include = new DnnCssInclude {ForceProvider = provider, Priority = priority, FilePath = filePath, AddTag = false};
                 var loader = page.FindControl("ClientResourceIncludes");
 
                 if (loader != null)


### PR DESCRIPTION
The client resource manager's RegisterScript (and RegisterStyleSheet) methods call ToLowerInvariant on the file paths, but some URLs are case sensitive (e.g. the Google Maps API requires passing a case-sensitive API key on the query-string, and WebResource.axd URLs have a case-sensitive hash).

This change removes the lower-casing.

I'm assuming that the lower-casing was done to aid de-duplication, but given that more requested scripts are using the DnnJsInclude and DnnCssInclude controls, I'd have to hope that the de-duplication mechanism is able to do case-insensitive comparisons...
