### PR TITLE
DNN-5015 Mark ExtensionUrlProviderInfo as Serializable

### DIFF
--- a/DNN Platform/Library/Entities/Urls/ExtensionUrlProviderInfo.cs
+++ b/DNN Platform/Library/Entities/Urls/ExtensionUrlProviderInfo.cs
@@ -21,6 +21,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 
@@ -29,6 +30,7 @@ using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.Entities.Urls
 {
+    [Serializable]
     public class ExtensionUrlProviderInfo : IHydratable
     {
         public ExtensionUrlProviderInfo()


### PR DESCRIPTION
Types which inherit from ExtensionUrlProvider cannot be serialized, since the
base type has a property of type ExtensionUrlProviderInfo, which is not marked
with the Serializable attribute
