### PR TITLE
DNN-5018 Default LocalResourceFile in RazorEngine

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Razor/RazorEngine.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorEngine.cs
@@ -28,6 +28,7 @@ using System.Web;
 using System.Web.Compilation;
 using System.Web.WebPages;
 using DotNetNuke.Services.Exceptions;
+using DotNetNuke.Services.Localization;
 using DotNetNuke.UI.Modules;
 using DotNetNuke.Web.Razor.Helpers;
 
@@ -41,7 +42,7 @@ namespace DotNetNuke.Web.Razor
         {
             RazorScriptFile = razorScriptFile;
             ModuleContext = moduleContext;
-            LocalResourceFile = localResourceFile;
+            LocalResourceFile = localResourceFile ?? Path.Combine(Path.GetDirectoryName(razorScriptFile), Localization.LocalResourceDirectory, Path.GetFileName(razorScriptFile) + ".resx");
 
             try
             {


### PR DESCRIPTION
When null is passed to the localResourceFile argument of the RazorEngine (e.g.
by DDR Menu), the path to the resource file should be derived from the razor
file's path
