### PR TITLE
DNN-5201 When reading XML with XmlReader, skip unknown elements safely

### DIFF
--- a/DNN Platform/Library/Entities/Modules/Definitions/ModuleDefinitionInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/Definitions/ModuleDefinitionInfo.cs
@@ -260,6 +260,12 @@ namespace DotNetNuke.Entities.Modules.Definitions
                         case "definitionName":
                             DefinitionName = reader.ReadElementContentAsString();
                             break;
+                        default:
+                            if(reader.NodeType == XmlNodeType.Element && !String.IsNullOrEmpty(reader.Name))
+                            {
+                                reader.ReadElementContentAsString();
+                            }
+                            break;
                     }
                 }
             }

--- a/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
@@ -470,9 +470,11 @@ namespace DotNetNuke.Entities.Modules
                             IsPremium = isPremium;
                             break;
                         default:
-                            var content = reader.ReadElementContentAsString();
+                            if(reader.NodeType == XmlNodeType.Element && !String.IsNullOrEmpty(reader.Name))
+                            {
+                                reader.ReadElementContentAsString();
+                            }
                             break;
-
                     }
                 }
             }

--- a/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
@@ -135,6 +135,12 @@ namespace DotNetNuke.Entities.Portals
                     case "primary":
                         IsPrimary = reader.ReadElementContentAsBoolean();
                         break;
+                    default:
+                        if(reader.NodeType == XmlNodeType.Element && !String.IsNullOrEmpty(reader.Name))
+                        {
+                            reader.ReadElementContentAsString();
+                        }
+                        break;
                 }
             }
         }

--- a/DNN Platform/Library/Framework/JavaScriptLibraries/JavaScriptLibrary.cs
+++ b/DNN Platform/Library/Framework/JavaScriptLibraries/JavaScriptLibrary.cs
@@ -121,6 +121,12 @@ namespace DotNetNuke.Framework.JavaScriptLibraries
                         case "CDNPath":
                             CDNPath = reader.ReadElementContentAsString();
                             break;
+                        default:
+                            if(reader.NodeType == XmlNodeType.Element && !String.IsNullOrEmpty(reader.Name))
+                            {
+                                reader.ReadElementContentAsString();
+                            }
+                            break;
                     }
                 }
             }

--- a/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
+++ b/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
@@ -273,6 +273,12 @@ namespace DotNetNuke.Security.Roles
                         case "description":
                             Description = reader.ReadElementContentAsString();
                             break;
+                        default:
+                            if(reader.NodeType == XmlNodeType.Element && !String.IsNullOrEmpty(reader.Name))
+                            {
+                                reader.ReadElementContentAsString();
+                            }
+                            break;
                     }
                 }
             }

--- a/DNN Platform/Library/Security/Roles/RoleInfo.cs
+++ b/DNN Platform/Library/Security/Roles/RoleInfo.cs
@@ -657,6 +657,12 @@ namespace DotNetNuke.Security.Roles
                                     break;
                             }
                             break;
+                        default:
+                            if(reader.NodeType == XmlNodeType.Element && !String.IsNullOrEmpty(reader.Name))
+                            {
+                                reader.ReadElementContentAsString();
+                            }
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
When using an `XmlReader`, trying to read content from a comment (such as
`DesktopModuleInfo` could do) will cause an exception.  On the other hand, if
there is an unexpected element, it needs to be read in order for the reader to
move to the next element.
