### PR TITLE
DNN-5271 Reverting ExecuteSQLInternal from Petapoco to SqlHelper

### DIFF
--- a/DNN Platform/Library/Data/SqlDataProvider.cs
+++ b/DNN Platform/Library/Data/SqlDataProvider.cs
@@ -161,7 +161,7 @@ namespace DotNetNuke.Data
             {
                 sql = DataUtil.ReplaceTokens(sql);
                 errorMessage = "";
-                return PetaPocoHelper.ExecuteReader(connectionString, CommandType.Text, sql);
+                return SqlHelper.ExecuteReader(connectionString, CommandType.Text, sql);
             }
             catch (SqlException sqlException)
             {


### PR DESCRIPTION
The method ExecuteSQLInternal(string connectionString, string sql, out string errorMessage) uses PetaPoco but doesn't need to. As far as I can see this method is only reached through the SQL module and that is what caused the issue. So reverting this to SqlHelper would solve the issue.
