### PR TITLE
DNN-5337 - Select an icon set

### DIFF
--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnUrlControl.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnUrlControl.cs
@@ -581,7 +581,7 @@ namespace DotNetNuke.Web.UI.WebControls
                 string TrackingUrl = _Url;
 
                 _Urltype = Globals.GetURLType(_Url).ToString("g").Substring(0, 1);
-                if (_Urltype == "U" && (_Url.StartsWith("~/" + IconController.DefaultIconLocation, StringComparison.InvariantCultureIgnoreCase)))
+                if (_Urltype == "U" && (_Url.StartsWith("~/" + PortalSettings.DefaultIconLocation, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     _Urltype = "I";
                 }
@@ -846,11 +846,11 @@ namespace DotNetNuke.Web.UI.WebControls
 
                         cboImages.Items.Clear();
 
-                        string strImagesFolder = Path.Combine(Globals.ApplicationMapPath, IconController.DefaultIconLocation.Replace('/', '\\'));
+                        string strImagesFolder = Path.Combine(Globals.ApplicationMapPath, PortalSettings.DefaultIconLocation.Replace('/', '\\'));
                         foreach (string strImage in Directory.GetFiles(strImagesFolder))
                         {
                             string img = strImage.Replace(strImagesFolder, "").Trim('/').Trim('\\');
-                            cboImages.Items.Add(new ListItem(img, string.Format("~/{0}/{1}", IconController.DefaultIconLocation, img).ToLower()));
+                            cboImages.Items.Add(new ListItem(img, string.Format("~/{0}/{1}", PortalSettings.DefaultIconLocation, img).ToLower()));
                         }
 
                         ListItem selecteItem = cboImages.Items.FindByValue(_Url.ToLower());

--- a/DNN Platform/Library/Entities/Icons/IconController.cs
+++ b/DNN Platform/Library/Entities/Icons/IconController.cs
@@ -68,7 +68,6 @@ namespace DotNetNuke.Entities.Icons
         public const string DefaultIconSize = "16X16";
         public const string DefaultLargeIconSize = "32X32";
         public const string DefaultIconStyle = "Standard";
-        public const string DefaultIconLocation = "icons/sigma";
         public const string IconKeyName = "IconKey";
         public const string IconSizeName = "IconSize";
         public const string IconStyleName = "IconStyle";
@@ -115,7 +114,7 @@ namespace DotNetNuke.Entities.Icons
             if (string.IsNullOrEmpty(style))
                 style = DefaultIconStyle;
 
-            string fileName = string.Format("{0}/{1}_{2}_{3}.png", DefaultIconLocation, key, size, style);
+            string fileName = string.Format("{0}/{1}_{2}_{3}.png", PortalSettings.Current.DefaultIconLocation, key, size, style);
 
             //In debug mode, we want to warn (onluy once) if icon is not present on disk
 #if DEBUG
@@ -152,6 +151,20 @@ namespace DotNetNuke.Entities.Icons
 						Logger.WarnFormat(string.Format("Icon Not Present on Disk {0}", iconPhysicalPath));
                 }
             }            
+        }
+
+        public static string[] GetIconSets()
+        {
+            string iconPhysicalPath = Path.Combine(Globals.ApplicationMapPath, "icons");
+            var iconRootDir = new DirectoryInfo(iconPhysicalPath);
+            string result = "";
+            foreach (var iconDir in iconRootDir.EnumerateDirectories())
+            {
+                string testFile = Path.Combine(iconDir.FullName,"About_16x16_Standard.png");
+                if (File.Exists(testFile))
+                    result += iconDir.Name + ",";
+            }
+            return result.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -329,6 +329,14 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
+        public string DefaultIconLocation
+        {
+            get
+            {
+                return PortalController.GetPortalSetting("DefaultIconLocation", PortalId, "icons/sigma");
+            }
+        }
+        
         /// -----------------------------------------------------------------------------
         /// <summary>
         /// Gets the Default Module Id

--- a/DNN Platform/Library/UI/UserControls/URLControl.cs
+++ b/DNN Platform/Library/UI/UserControls/URLControl.cs
@@ -717,7 +717,7 @@ namespace DotNetNuke.UI.UserControls
                 string TrackingUrl = _Url;
 
                 _Urltype = Globals.GetURLType(_Url).ToString("g").Substring(0, 1);
-                if (_Urltype == "U" && (_Url.StartsWith("~/" + IconController.DefaultIconLocation, StringComparison.InvariantCultureIgnoreCase)))
+                if (_Urltype == "U" && (_Url.StartsWith("~/" + PortalSettings.DefaultIconLocation, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     _Urltype = "I";
                 }
@@ -982,11 +982,11 @@ namespace DotNetNuke.UI.UserControls
 
                         cboImages.Items.Clear();
 
-                        string strImagesFolder = Path.Combine(Globals.ApplicationMapPath, IconController.DefaultIconLocation.Replace('/', '\\'));
+                        string strImagesFolder = Path.Combine(Globals.ApplicationMapPath, PortalSettings.DefaultIconLocation.Replace('/', '\\'));
                         foreach (string strImage in Directory.GetFiles(strImagesFolder))
                         {
                             string img = strImage.Replace(strImagesFolder, "").Trim('/').Trim('\\');
-                            cboImages.Items.Add(new ListItem(img, string.Format("~/{0}/{1}", IconController.DefaultIconLocation, img).ToLower()));
+                            cboImages.Items.Add(new ListItem(img, string.Format("~/{0}/{1}", PortalSettings.DefaultIconLocation, img).ToLower()));
                         }
 
                         ListItem selecteItem = cboImages.Items.FindByValue(_Url.ToLower());

--- a/Website/DesktopModules/Admin/Portals/App_LocalResources/SiteSettings.ascx.resx
+++ b/Website/DesktopModules/Admin/Portals/App_LocalResources/SiteSettings.ascx.resx
@@ -219,6 +219,12 @@
   <data name="plAdminContainer.Help" xml:space="preserve">
     <value>The selected container will be applied to all edit mode (ctl=) modules on the site.</value>
   </data>
+  <data name="plIconSet.Text" xml:space="preserve">
+    <value>Icon Set:</value>
+  </data>
+  <data name="plIconSet.Help" xml:space="preserve">
+    <value>The selected iconset will be applied to all icons on the site.</value>
+  </data>
   <data name="plBackground.Text" xml:space="preserve">
     <value>Body Background:</value>
   </data>

--- a/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
@@ -37,6 +37,7 @@ using DotNetNuke.Common.Utilities;
 using DotNetNuke.Data;
 using DotNetNuke.Entities.Controllers;
 using DotNetNuke.Entities.Host;
+using DotNetNuke.Entities.Icons;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
@@ -556,6 +557,10 @@ namespace DesktopModules.Admin.Portals
             editContainerCombo.RootPath = SkinController.RootContainer;
             editContainerCombo.Scope = SkinScope.All;
             editContainerCombo.SelectedValue = PortalController.GetPortalSetting("DefaultAdminContainer", portal.PortalID, Host.DefaultAdminContainer);
+
+            iconSetCombo.DataSource = IconController.GetIconSets();
+            iconSetCombo.DataBind();
+            iconSetCombo.SelectedValue = PortalController.GetPortalSetting("DefaultIconLocation", portal.PortalID, "Sigma").Replace("icons/","");
 
             if (ModuleContext.PortalSettings.UserInfo.IsSuperUser)
             {
@@ -1377,6 +1382,7 @@ namespace DesktopModules.Admin.Portals
                     PortalController.UpdatePortalSetting(_portalId, "DefaultPortalSkin", portalSkinCombo.SelectedValue, false);
                     PortalController.UpdatePortalSetting(_portalId, "DefaultAdminContainer", editContainerCombo.SelectedValue, false);
                     PortalController.UpdatePortalSetting(_portalId, "DefaultPortalContainer", portalContainerCombo.SelectedValue, false);
+                    PortalController.UpdatePortalSetting(_portalId, "DefaultIconLocation", "icons/" + iconSetCombo.SelectedValue, false);
                     PortalController.UpdatePortalSetting(_portalId, "EnablePopups", enablePopUpsCheckBox.Checked.ToString(), false);
                     PortalController.UpdatePortalSetting(_portalId, "EnableModuleEffect", enableModuleEffectCheckBox.Checked.ToString(), false);
                     PortalController.UpdatePortalSetting(_portalId, "InlineEditorEnabled", chkInlineEditor.Checked.ToString(), false);

--- a/Website/DesktopModules/Admin/Portals/sitesettings.ascx
+++ b/Website/DesktopModules/Admin/Portals/sitesettings.ascx
@@ -140,6 +140,12 @@
                             <a href="#" class="dnnSecondaryAction"><%=LocalizeString("EditSkinPreview")%></a>
                         </div>
                     </div>
+                    <div id="iconSetSettings">
+                        <div class="dnnFormItem">
+                            <dnn:label id="plIconSet" controlname="iconSetCombo" runat="server" />
+                            <asp:DropDownList ID="iconSetCombo" runat="server" Width="300px" CssClass="dnnFixedSizeComboBox" />
+                        </div>
+                    </div>
                 </fieldset>
             </div>
         </div>


### PR DESCRIPTION
DNN 6 introduced the iconcontroller. I think the original intention with this was to have a flexible solution for using the icons but in the actual source code you only have the possibility to choose an icon from the actual "Sigma" collection. It would be nice to have a setting on portal level to select an Icon set. This could be another subfolder located in the icon folder beneath the Sigma folder containing all the needed icons. This could be even a great opportunity for third Party vendors to provide icon sets in the store. A github pull will follow.
