### PR TITLE
Ability to exclude link to active tab

### DIFF
--- a/Website/admin/Skins/Links.ascx.cs
+++ b/Website/admin/Skins/Links.ascx.cs
@@ -46,6 +46,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         private string _alignment;
         private bool _forceLinks = true;
+        private bool _includeActiveTab = true;
         private string _level;
 
 		#endregion
@@ -91,6 +92,18 @@ namespace DotNetNuke.UI.Skins.Controls
             set
             {
                 _forceLinks = value;
+            }
+        }
+
+        public bool IncludeActiveTab
+        {
+            get
+            {
+                return _includeActiveTab;
+            }
+            set
+            {
+                _includeActiveTab = value;
             }
         }
 		
@@ -172,7 +185,10 @@ namespace DotNetNuke.UI.Skins.Controls
                     case "":
                         if (objTab.ParentId == PortalSettings.ActiveTab.ParentId)
                         {
-                            return AddLink(objTab.TabName, objTab.FullUrl, strCssClass);
+                            if (IncludeActiveTab || objTab.TabID != PortalSettings.ActiveTab.TabID)
+                            {
+                                return AddLink(objTab.TabName, objTab.FullUrl, strCssClass);
+                            }
                         }
                         break;
                     case "child": //Render the current tabs child tabs

--- a/Website/admin/Skins/Links.xml
+++ b/Website/admin/Skins/Links.xml
@@ -35,4 +35,10 @@
 		<Help>Sets if the links will rendered with Level "Same", if not links are returned</Help>
 		<Value>True, False</Value>
 	</Setting>
+	<Setting>
+		<Name>IncludeActiveTab</Name>
+		<Type>Boolean</Type>
+		<Help>Sets whether link to active tab will be displayed, defaults to True</Help>
+		<Value>True, False</Value>
+	</Setting>
 </Settings>


### PR DESCRIPTION
It can be useful in some skins to exclude link to active tab in a LINKS skinobject. 

I've added IncludeActiveTab property to LINKS skinobject with default value of "True" -  to make this change backward-compatible. So, if no IncludeActiveTab is specified for control instance, then link to active tab included in a list.
