### PR TITLE
DNN-5455 Extension method for binding PetaPoco dynamic result set 

### DIFF
--- a/DNN Platform/Library/Collections/EnumerableExtensions.cs
+++ b/DNN Platform/Library/Collections/EnumerableExtensions.cs
@@ -1,0 +1,66 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2014
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+using DotNetNuke.Common;
+
+namespace DotNetNuke.Collections
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Extension method to convert dynamic data to a DataTable. Useful for databinding.
+        /// </summary>
+        /// <param name="items"></param>
+        /// <returns>A DataTable with the copied dynamic data.</returns>
+        public static DataTable ToDataTable(this IEnumerable<dynamic> items)
+        {
+            var data = items.ToArray();
+
+            if (!data.Any()) 
+                return null;
+
+            var dt = new DataTable();
+            
+            //Create the columns
+            foreach (var key in ((IDictionary<string, object>)data[0]).Keys)
+            {
+                dt.Columns.Add(key);
+            }
+
+            // Add data rows to the datatable
+            foreach (var d in data)
+            {
+                dt.Rows.Add(((IDictionary<string, object>)d).Values.ToArray());
+            }
+            return dt;
+        }
+    }
+}


### PR DESCRIPTION
PetaPoco is mostly used together with strong typed Info-classes. Thats nice and working well but sometimes we need a more flexible way to retrieve data. Think of a simple module where the user enters an arbitrary select statement to any table of the database (yes, I wont do that! Its just for explanation!). With PetaPoco this could be done with ExecuteQuery<dynamic> and the result is of type IEnumerable<dynamic>. This is nice and working "out of the box". But you can not databind this IEnumerable<dynamic> to a datagrid : even if the data is retrieved correctly, nothing is shown in the grid. So I implemented an extension method for IEnumerable<dynamic> named "ToDataTable"