### PR TITLE
tweak default skin to follow the DisplayCopyright configuration setting

### DIFF
--- a/Website/Portals/_default/Skins/Gravity/2-Col.ascx
+++ b/Website/Portals/_default/Skins/Gravity/2-Col.ascx
@@ -94,11 +94,13 @@
 				    </div>
 				    <dnn:COPYRIGHT ID="dnnCopyright" runat="server" CssClass="pull-left" />
                 </div>
+                <% If DotNetNuke.Entities.Host.Host.DisplayCopyright Then %>
                 <div class="row-fluid copyright-container">
 					<span class="split"></span>
 					<a href="http://www.dnnsoftware.com/?utm_source=dnn-install&utm_medium=web-link&utm_term=cms-by-dnn&utm_content=gravity-skin-link&utm_campaign=dnn-install" target="_blank">CMS By DNN</a>
 					<span class="split"></span>
 				</div>
+                <% End If %>
             </div>
         </div>
 	</div>


### PR DESCRIPTION
the 2-col variation of the gravity skin includes an additional copyright line. this isn't in every variation of the skin, and it didn't check if the install was configured to display copyright info. this pull request at least adjusts the skin to check if copyright display is enabled before adding it to the 2-col variation. 
