### PR TITLE
(DNN-5578) Fix "Divide by zero" error in InstallExtensionsStep if no packages need to be installed

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Internals/Steps/InstallExtensionsStep.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/Steps/InstallExtensionsStep.cs
@@ -45,10 +45,17 @@ namespace DotNetNuke.Services.Upgrade.InternalController.Steps
         /// </summary>        
         public override void Execute()
         {
+            var packages = Upgrade.GetInstallPackages();
+            if (packages.Count == 0)
+            {
+                Percentage = 100;
+                Status = StepStatus.Done;
+                return;
+            }
+
             Percentage = 0;
             Status = StepStatus.Running;
 
-            var packages = Upgrade.GetInstallPackages();
             var percentForEachStep = 100 / packages.Count;
             var counter = 0;
             foreach (var package in packages)


### PR DESCRIPTION
See https://dnntracker.atlassian.net/browse/DNN-5578 for more information
