### PR TITLE
DNN-5601 Allow specifying null type to GetValue and GetValueOrDefault

### DIFF
--- a/DNN Platform/Library/Collections/CollectionExtensions.cs
+++ b/DNN Platform/Library/Collections/CollectionExtensions.cs
@@ -853,6 +853,11 @@ namespace DotNetNuke.Collections
             {
                 if (typeof(T).IsValueType)
                 {
+                    if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        return (T)value;
+                    }
+
                     // TODO: this should probably return the default value if called from GetOrDefault...
                     throw new InvalidCastException();
                 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/CollectionExtensionTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/CollectionExtensionTests.cs
@@ -181,6 +181,36 @@ namespace DotNetNuke.Tests.Core.Collections
         }
 
         [Test]
+        public void get_null_string_without_default()
+        {
+            var collection = new Dictionary<string, string> { { "app id", null } };
+
+            var value = collection.GetValue<string>("app id");
+
+            Expect(value, Is.Null);
+        }
+
+        [Test]
+        public void get_null_string_with_default()
+        {
+            var collection = new Dictionary<string, string> { { "app id", null } };
+
+            var value = collection.GetValueOrDefault("app id", "a default value");
+
+            Expect(value, Is.Null);
+        }
+
+        [Test]
+        public void get_nullable_datetime()
+        {
+            var collection = new Dictionary<string, DateTime?> { { "startDate", null } };
+
+            var value = collection.GetValue<DateTime?>("startDate");
+
+            Expect(value, Is.Null);
+        }
+
+        [Test]
         [SetCulture("nl-NL")]
         public void get_datetime_from_other_culture()
         {


### PR DESCRIPTION
The `GetValue` and `GetValueOrDefault` methods in `DotNetNuke.Collection.CollectionExtensions` try to automatically convert a value into a given type. However, if that type is nullable and the value is `null`, then an `InvalidCastException` is thrown. The code should allow returning `null` for a nullable type.
