### PR TITLE
DNN-5361 Config manager upload button always active

### DIFF
--- a/Website/DesktopModules/Admin/XmlMerge/XmlMerge.ascx
+++ b/Website/DesktopModules/Admin/XmlMerge/XmlMerge.ascx
@@ -67,6 +67,16 @@
 	    var $fileUpload = $('#dnnConfigMerge input[type="file"]');
 	    $fileUpload.data("text", '<%=LocalizeSafeJsString("ChooseFile.Text")%>');
 
+        //DNN-5361 Fix xml merge upload button issue
+	    var $cmdUpload = $('a[id$="cmdUpload"]');
+	    $cmdUpload.attr('disabled', true).addClass('dnnDisabled');
+
+	    $fileUpload.change(function () {
+	        if ($(this).val()) {
+	            $cmdUpload.attr('disabled', false).removeClass('dnnDisabled');
+	        }
+	    });
+
 	    var configeditor = CodeMirror.fromTextArea($("textarea[id$='txtConfiguration']")[0], {
 	        lineNumbers: true,
 	        matchBrackets: true,


### PR DESCRIPTION
This is a simple fix that disables the button until a file has been selected.
