### PR TITLE
DNN-5815 - DDRMenu filter by taxonomy #tags

### DIFF
--- a/DNN Platform/Modules/DDRMenu/MenuNode.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuNode.cs
@@ -131,6 +131,28 @@ namespace DotNetNuke.Web.DDRMenu
             return null;
         }
 
+        public List<MenuNode> FlattenChildren(MenuNode root)
+        {
+
+            var flattened = new List<MenuNode>();
+            if (root.TabId != 0)
+            {
+                flattened.Add(root);
+            }
+
+            var children = root.Children;
+
+            if (children != null)
+            {
+                foreach (var child in children)
+                {
+                    flattened.AddRange(FlattenChildren(child));
+                }
+            }
+
+            return flattened;
+        }
+
         public MenuNode FindByNameOrId(string tabNameOrId)
         {
             if (tabNameOrId.Equals(Text, StringComparison.InvariantCultureIgnoreCase))

--- a/Website/development.config
+++ b/Website/development.config
@@ -31,17 +31,12 @@
   <connectionStrings>
     <!-- Connection String for SQL Server 2008/2012 Express -->
     <add name="SiteSqlServer" connectionString="Data Source=.\SQLExpress;Integrated Security=True;User Instance=True;AttachDBFilename=|DataDirectory|Database.mdf;" providerName="System.Data.SqlClient"/>
-    <!-- Connection String for SQL Server 2008/2012
-    <add name="SiteSqlServer" connectionString="Server=(local);Database=DotNetNuke;uid=;pwd=;" providerName="System.Data.SqlClient" /> 
-    -->
+    <!-- Connection String for SQL Server 2008/2012-->
+    <add name="SiteSqlServer" connectionString="Server=(local);Database=Dnn732Source;Integrated Security=True" providerName="System.Data.SqlClient" /> 
   </connectionStrings>
   
   <appSettings>
-    <!-- Connection String for SQL Server 2008/2012 Express - kept for backwards compatability - legacy modules   -->
-    <add key="SiteSqlServer" value="Data Source=.\SQLExpress;Integrated Security=True;User Instance=True;AttachDBFilename=|DataDirectory|Database.mdf;"/>
-    <!-- Connection String for SQL Server 2008/2012 - kept for backwards compatability - legacy modules
-    <add key="SiteSqlServer" value="Server=(local);Database=DotNetNuke;uid=;pwd=;"/>
-    -->
+    <add key="SiteSqlServer" value="Server=(local);Database=Dnn732Source;Integrated Security=True"/>
     <add key="InstallTemplate" value="DotNetNuke.install.config"/>
     <add key="AutoUpgrade" value="true"/>
     <add key="UseInstallWizard" value="true"/>

--- a/Website/release.config
+++ b/Website/release.config
@@ -31,17 +31,12 @@
   <connectionStrings>
     <!-- Connection String for SQL Server 2008/2012 Express -->
     <add name="SiteSqlServer" connectionString="Data Source=.\SQLExpress;Integrated Security=True;User Instance=True;AttachDBFilename=|DataDirectory|Database.mdf;" providerName="System.Data.SqlClient"/>
-    <!-- Connection String for SQL Server 2008/2012
-    <add name="SiteSqlServer" connectionString="Server=(local);Database=DotNetNuke;uid=;pwd=;" providerName="System.Data.SqlClient" /> 
-    -->
+    <!-- Connection String for SQL Server 2008/2012-->
+    <add name="SiteSqlServer" connectionString="Server=(local);Database=Dnn732Source;Integrated Security=True" providerName="System.Data.SqlClient" /> 
   </connectionStrings>
   
   <appSettings>
-    <!-- Connection String for SQL Server 2008/2012 Express - kept for backwards compatability - legacy modules   -->
-    <add key="SiteSqlServer" value="Data Source=.\SQLExpress;Integrated Security=True;User Instance=True;AttachDBFilename=|DataDirectory|Database.mdf;"/>
-    <!-- Connection String for SQL Server 2008/2012 - kept for backwards compatability - legacy modules
-    <add key="SiteSqlServer" value="Server=(local);Database=DotNetNuke;uid=;pwd=;"/>
-    -->
+    <add key="SiteSqlServer" value="Server=(local);Database=Dnn732Source;Integrated Security=True"/>
     <add key="InstallTemplate" value="DotNetNuke.install.config"/>
     <add key="AutoUpgrade" value="true"/>
     <add key="UseInstallWizard" value="true"/>


### PR DESCRIPTION
Easily create a "related content" style menu using DDR menu tags.
Similar to what you might find on a news sites

![screen shot 2014-08-26 at 3 40 42 pm](https://cloud.githubusercontent.com/assets/279802/4042975/18a6ee8e-2d0b-11e4-8823-10ced025bb8b.png)
![screen shot 2014-08-26 at 3 41 47 pm](https://cloud.githubusercontent.com/assets/279802/4042977/1aed080e-2d0b-11e4-9143-e8283b150142.png)
1. setup a custom simple taxonomy (if you haven't already) 
2. in your page settings, apply a tag
3. in your ddr menu configuration, specify a IncludeNodes attribute with the tag(s) "#tagname"

viola, now you have filtered the current nodeselector to pages matching
the tags, in a flat non-hierarchy list.

ignore the web.config changes!
