### PR TITLE
DNN-5814 Avoid errors on redirect

### DIFF
--- a/Website/DesktopModules/Admin/Security/Register.ascx.cs
+++ b/Website/DesktopModules/Admin/Security/Register.ascx.cs
@@ -753,7 +753,8 @@ namespace DotNetNuke.Modules.Admin.Users
             //Verify that the current user has access to this page
             if (PortalSettings.UserRegistration == (int)Globals.PortalRegistrationType.NoRegistration && Request.IsAuthenticated == false)
             {
-                Response.Redirect(Globals.NavigateURL("Access Denied"), true);
+                Response.Redirect(Globals.NavigateURL("Access Denied"), false);
+                Context.ApplicationInstance.CompleteRequest();
             }
 
             cancelButton.Click += cancelButton_Click;


### PR DESCRIPTION
Instead of terminating the response, run Context.ApplicationInstance.CompleteRequest(); to avoid logging threadabort errors.

https://dnntracker.atlassian.net/browse/DNN-5814
