### PR TITLE
Committed Changes for DNN-5909 - GetFoldersByPermission Performance Improvement

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/07.03.04.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.03.04.SqlDataProvider
@@ -1,0 +1,77 @@
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}GetFoldersByPermission]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}GetFoldersByPermission]
+GO
+
+--DNN-5909 - Removed un-needed joins from query
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetFoldersByPermissions] 
+	@PortalID int,
+	@Permissions nvarchar(300),
+	@UserID int,
+	@FolderID int,
+	@FolderPath nvarchar(300)
+
+AS
+	DECLARE @IsSuperUser BIT
+	DECLARE @Admin BIT
+	DECLARE @Read INT
+	DECLARE @Write INT
+	DECLARE @Browse INT
+	DECLARE @Add INT
+
+	--Determine Admin or SuperUser
+	IF @UserId IN (SELECT UserId FROM {databaseOwner}[{objectQualifier}UserRoles] WHERE RoleId IN (SELECT RoleId FROM {databaseOwner}[{objectQualifier}Roles] WHERE PortalId = @PortalId AND RoleName = 'Administrators')) BEGIN SET @Admin = 1 END;
+	SELECT @IsSuperUser = IsSuperUser FROM {databaseOwner}[{objectQualifier}Users] WHERE UserId = @UserId;
+
+	--Retrieve Permission Ids
+	IF @Permissions LIKE '%READ%' BEGIN SELECT TOP 1 @Read = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'READ' END;
+	IF @Permissions LIKE '%WRITE%' BEGIN SELECT TOP 1 @Write = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'WRITE' END;
+	IF @Permissions LIKE '%BROWSE%' BEGIN SELECT TOP 1 @Browse = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'BROWSE' END;
+	IF @Permissions LIKE '%ADD%' BEGIN SELECT TOP 1 @Add = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'ADD' END;
+
+	IF @PortalID IS NULL
+		BEGIN
+			SELECT DISTINCT F.*
+			FROM {databaseOwner}[{objectQualifier}Folders] F
+			WHERE F.PortalID IS NULL
+				AND (F.FolderID = @FolderID OR @FolderID = -1)
+				AND (F.FolderPath = @FolderPath OR @FolderPath = '')
+		  
+			 ORDER BY F.FolderPath
+		END
+	ELSE
+		BEGIN
+			CREATE TABLE #Skip_Folders(folderid INT PRIMARY KEY(folderid))
+			INSERT INTO #Skip_Folders
+				 SELECT DISTINCT folderid FROM {databaseOwner}[{objectQualifier}FolderPermission] FP
+									JOIN {databaseOwner}[{objectQualifier}Permission] P ON FP.PermissionID = P.PermissionID
+									WHERE
+										((P.PermissionKey = 'WRITE' OR @IsSuperUser=1 OR @Admin=1) OR
+										FP.PermissionID = CASE WHEN @Read > 0 THEN @Read END OR
+										FP.PermissionID = CASE WHEN @Write > 0 THEN @Write END OR
+										FP.PermissionID = CASE WHEN @Browse > 0 THEN @Browse END OR
+										FP.PermissionID = CASE WHEN @Add > 0 THEN @Add END)
+										AND FP.FolderID NOT IN (SELECT DISTINCT folderid FROM {databaseOwner}[{objectQualifier}FolderPermission] WHERE allowaccess=0 AND (userid=@UserId OR roleid=-1 OR roleid IN (SELECT roleid FROM {databaseOwner}[{objectQualifier}UserRoles] WHERE UserID=@UserId)))		
+
+			SELECT DISTINCT F.*
+			FROM {databaseOwner}[{objectQualifier}Folders] F
+				JOIN {databaseOwner}[{objectQualifier}FolderPermission] FP ON F.FolderId = FP.FolderID
+				JOIN {databaseOwner}[{objectQualifier}Permission] P ON FP.PermissionID = P.PermissionID
+				JOIN #Skip_Folders sf ON sf.folderid=f.folderid 
+			WHERE ((F.PortalID = @PortalID) OR (F.PortalID IS NULL AND @PortalID IS NULL))
+				AND (F.FolderID = @FolderID OR @FolderID = -1)
+				AND (F.FolderPath = @FolderPath OR @FolderPath = '')
+				AND 
+					((P.PermissionKey = 'WRITE' OR @IsSuperUser=1 OR @Admin=1) OR
+						FP.PermissionID = CASE WHEN @Read > 0 THEN @Read END OR
+						FP.PermissionID = CASE WHEN @Write > 0 THEN @Write END OR
+						FP.PermissionID = CASE WHEN @Browse > 0 THEN @Browse END OR
+						FP.PermissionID = CASE WHEN @Add > 0 THEN @Add END)
+				AND FP.AllowAccess = 1
+			 ORDER BY F.FolderPath
+
+			 DROP TABLE #Skip_Folders
+		END
+GO
+
+


### PR DESCRIPTION
Changes to the GetFoldersbyPermission procedure to improve performance.  Change was removing "Users" and "UserRoles" from the last query in the procedure.  These tables are un-used, not returned, and not filtering any data.  Removing these reduce the CPU cost greatly.  Full details on DNN JIRA ticket 5909!
