### PR TITLE
DNN-5946 Allow robots meta-tag to be overridden by page settings 

### DIFF
--- a/Website/Default.aspx.cs
+++ b/Website/Default.aspx.cs
@@ -385,8 +385,8 @@ namespace DotNetNuke.Framework
                 Generator = "";
             }
 
-            //META Robots
-            if (!UrlUtils.InPopUp())
+            //META Robots - hide it inside popups and if PageHeadText of current tab already contains a robots meta tag
+            if (!UrlUtils.InPopUp() && !Regex.IsMatch(PortalSettings.ActiveTab.PageHeadText, "<meta([^>])+name=('|\")robots('|\")", RegexOptions.IgnoreCase | RegexOptions.Multiline))
             {
                 MetaRobots.Visible = true;
                 var allowIndex = true;


### PR DESCRIPTION
This is the code proposal for the improvement https://dnntracker.atlassian.net/browse/DNN-5946. Goal is to hide the MetaRobots tag if PageHeadText of the current page already contains a robots meta tag.
