### PR TITLE
Fixed DNN-5955: AUM 301 redirects should be done with HttpRequest.RedirectPermanent

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -298,11 +298,9 @@ namespace DotNetNuke.Entities.Urls
                     {
                         //not correct alias for portal : will be redirected
                         //perform a 301 redirect if one has already been found
-                        response.Status = "301 Moved Permanently";
                         response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
-                        response.AddHeader("Location", result.FinalUrl);
+                        response.RedirectPermanent(result.FinalUrl);
                         finished = true;
-                        response.End();
                     }
                     if (!finished)
                     {
@@ -417,10 +415,8 @@ namespace DotNetNuke.Entities.Urls
                             {
                                 finished = true;
                                 //perform a 301 redirect if one has already been found
-                                response.Status = "301 Moved Permanently";
                                 response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
-                                response.AddHeader("Location", result.FinalUrl);
-                                response.End();
+                                response.RedirectPermanent(result.FinalUrl);
                             }
                         }
                     }
@@ -450,10 +446,8 @@ namespace DotNetNuke.Entities.Urls
                             switch (result.Action)
                             {
                                 case ActionType.Redirect301:
-                                    response.Status = "301 Moved Permanently";
                                     response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
-                                    response.AddHeader("Location", result.FinalUrl);
-                                    response.End();
+                                    response.RedirectPermanent(result.FinalUrl);
                                     break;
                                 case ActionType.Redirect302:
                                     response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
@@ -586,11 +580,9 @@ namespace DotNetNuke.Entities.Urls
                                     {
                                         if (result.Action == ActionType.Redirect301)
                                         {
-                                            response.Status = "301 Moved Permanently";
                                             response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
-                                            response.AddHeader("Location", result.FinalUrl);
+                                            response.RedirectPermanent(result.FinalUrl);
                                             finished = true;
-                                            response.End();
                                         }
                                         else if (result.Action == ActionType.Redirect302)
                                         {
@@ -1428,11 +1420,9 @@ namespace DotNetNuke.Entities.Urls
                                 if (response != null)
                                 {
                                     //perform a 301 redirect to the external url of the tab
-                                    response.Status = "301 Moved Permanently";
                                     response.AppendHeader("X-Redirect-Reason",
                                                           result.Reason.ToString().Replace("_", " ") + " Requested");
-                                    response.AddHeader("Location", result.FinalUrl);
-                                    response.End();
+                                    response.RedirectPermanent(result.FinalUrl);
                                 }
                             }
                             else


### PR DESCRIPTION
Changed all 301 redirects AUM performs from manual `.AddHeader("Location", ...)` to `.RedirectPermanent()`

This fixes issue https://dnntracker.atlassian.net/browse/DNN-5955
