### PR TITLE
Fix issue DNN-5988 that was introduced in 7.3.3.

### DIFF
--- a/Website/DesktopModules/Admin/Lists/ListEntries.ascx.cs
+++ b/Website/DesktopModules/Admin/Lists/ListEntries.ascx.cs
@@ -659,7 +659,7 @@ namespace DotNetNuke.Common.Lists
 			{
 				entry.DefinitionID = Null.NullInteger;
 				entry.PortalID = ListPortalID;
-				entry.ListName = ListName;
+				entry.ListName = (string.IsNullOrEmpty(ListName)) ? txtEntryName.Text : ListName;
                 entry.Value = entryValue;
                 entry.Text = entryText;
 			}


### PR DESCRIPTION
The change that caused the error was introduced in 7.3.3 because the ListName was needed to save localized values to the correct lists (hence the ListName) resx files. This has now been changed to check if the ListName is empty first. The ListName should be empty when we create a new list. So then the old behavior kicks in and the txtEntryName value is used.
