### PR TITLE
DNN-6024 Don't default link manager to https:// when SSL is enabled

### DIFF
--- a/DNN Platform/Library/Common/Utilities/HtmlUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/HtmlUtils.cs
@@ -760,10 +760,10 @@ namespace DotNetNuke.Common.Utilities
                 {
                     searchAlias = string.Format("{0}/", portalAlias);
                 }
-            	string protocol = PortalSettings.Current.SSLEnabled ? "https://" : "http://";
-                Regex exp = new Regex(string.Format("((?:href|src)=&quot;){0}{1}(.*?&quot;)", protocol, searchAlias), RegexOptions.IgnoreCase);
 
-                if(portalAlias.Contains("/"))
+                Regex exp = new Regex(string.Format("((?:href|src)=&quot;)https?://{0}(.*?&quot;)", searchAlias), RegexOptions.IgnoreCase);
+
+                if (portalAlias.Contains("/"))
                 {
                     html = exp.Replace(html, "$1" + portalAlias.Substring(portalAlias.IndexOf("/", StringComparison.InvariantCultureIgnoreCase)) + "/$2");
                 }

--- a/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/Components/EditorProvider.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/Components/EditorProvider.cs
@@ -1033,7 +1033,6 @@ namespace DotNetNuke.Providers.RadEditorProvider
                 ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "editorModuleId", moduleid.ToString(), true);
                 ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "editorTabId", tabId.ToString(), true);
                 ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "editorPortalId", portalId.ToString(), true);
-                ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "sslEnabled", PortalSettings.SSLEnabled.ToString().ToLowerInvariant(), true);
                 ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "editorHomeDirectory", PortalSettings.HomeDirectory, true);
                 ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "editorPortalGuid", PortalSettings.GUID.ToString(), true);
                 ClientAPI.RegisterClientVariable(HtmlEditorControl.Page, "editorEnableUrlLanguage", PortalSettings.EnableUrlLanguage.ToString(), true);

--- a/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/Dialogs/LinkManager.ascx
+++ b/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/Dialogs/LinkManager.ascx
@@ -59,7 +59,7 @@
 	    var trackClicksCheckbox = $get("TrackLink");
 	    var trackUserCheckbox = $get("TrackUser");
 
-		if (linkClickURL != "http:///" && linkClickURL != "https://") {
+		if (linkClickURL != "http:///" && linkClickURL != "http://") {
 			
 			$.ajax({
 				type: 'POST',
@@ -188,7 +188,7 @@
 	            return;
 	        }
 
-	        var href = (_sslEnabled == "true") ? "https://" : "http://"; //"link"
+	        var href = "http://"; //"link"
 
 	        if (currentLink.href) {
 	            href = GetLinkClickURL(currentHref);
@@ -605,7 +605,6 @@
 	var _homeDirectory = parent.dnn.getVar('editorHomeDirectory');
 	var _portalGuid = parent.dnn.getVar('editorPortalGuid');
 	var _enableUrlLanguage = parent.dnn.getVar('editorEnableUrlLanguage');
-	var _sslEnabled = parent.dnn.getVar('sslEnabled');
 </script>
 
 <table cellpadding="0" cellspacing="0" class="reDialog LinkManager NoMarginDialog" style="width: 392px;">


### PR DESCRIPTION
[DNN-6024](https://dnntracker.atlassian.net/browse/DNN-6024) Don't default link manager to https:// when SSL is enabled. Instead, update the `AbsoluteToRelativeUrls` method to ignore the protocol.

Reverts some of 9703902883c289717e9ea926fd7e5f6610e2a8e2
