### PR TITLE
[DNN-6037] Drag/Drop of Images in HTML Module from FireFox/Chrome/Opera

### DIFF
--- a/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
+++ b/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
@@ -504,6 +504,12 @@ namespace DotNetNuke.Modules.Html
                         strURL = strHTML.Substring(S).ToLower();
                     }
 
+                    if (strHTML.Substring(P + tLen, 10).Equals("data:image", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        P = strHTML.IndexOf(strToken + "=\"", S + strURL.Length + 2, StringComparison.InvariantCultureIgnoreCase);
+                        continue;
+                    }
+
                     // if we are linking internally
                     if (strURL.Contains("://") == false)
                     {


### PR DESCRIPTION
Updated HtmlTextController.cs, ManageRelativePaths() to skip tags with
"data:image" in the src property.  As the calling method
(FormatHtmlText) also hard codes the search for "src" and "background",
and the Data URI Scheme has been integrated in HTML since version 4.01,
it seems safe to allow the hard coding.  A potential improvement could
be to also allow "data:text/csv". This fix only applies to most non-IE
browsers.  IE doesn't send the base64 data when drag/drop is utilized,
so this fix also doesn't positively or negatively affect IE users.
Solution is simpler and cleaner than that suggested in DNN-6037.
