### PR TITLE
DNN-6093 Changes for streamlining "Use Email Address as Username" 

### DIFF
--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -2273,6 +2273,16 @@ namespace DotNetNuke.Data
 								 superUsersOnly);
 		}
 
+        public virtual int GetDuplicateEmailCount(int portalId)
+        {
+            return ExecuteScalar<int>("GetDuplicateEmailCount", portalId);
+        }
+
+        public virtual int GetSingleUserByEmail(int portalId, string emailToMatch)
+        {
+            return ExecuteScalar<int>("GetSingleUserByEmail", portalId, emailToMatch);
+        }
+
         public virtual void RemoveUser(int userId, int portalId)
         {
             ExecuteNonQuery("RemoveUser", userId, GetNull(portalId));

--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -583,6 +583,16 @@ namespace DotNetNuke.Entities.Users
             }
         }
 
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// Gets the number count for all duplicate e-mail adresses in the database
+        /// </summary>
+        /// -----------------------------------------------------------------------------
+        public static int GetDuplicateEmailCount()
+        {
+            return DataProvider.Instance().GetDuplicateEmailCount(PortalSettings.Current.PortalId);
+        }
+
         #endregion
 
         #region Public Helper Methods
@@ -1355,6 +1365,30 @@ namespace DotNetNuke.Entities.Users
         public static ArrayList GetUsersByEmail(int portalId, string emailToMatch, int pageIndex, int pageSize, ref int totalRecords)
         {
             return GetUsersByEmail(portalId, emailToMatch, pageIndex, pageSize, ref totalRecords, false, false);
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// GetUsersByEmail gets all the users of the portal whose email matches a provided
+        /// filter expression
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <param name="portalId">The Id of the Portal</param>
+        /// <param name="emailToMatch">The email address to use to find a match.</param>
+        /// <param name="pageIndex">The page of records to return.</param>
+        /// <param name="pageSize">The size of the page</param>
+        /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
+        /// <returns>An ArrayList of UserInfo objects.</returns>
+        /// -----------------------------------------------------------------------------
+        public static UserInfo GetUserByEmail(int portalId, string emailToMatch)
+        {
+            int uid = DataProvider.Instance().GetSingleUserByEmail(portalId, emailToMatch);
+            if (uid > -1)
+            {
+                return GetUserById(portalId, uid);
+            }
+            return null;
         }
 
         /// -----------------------------------------------------------------------------

--- a/Website/App_GlobalResources/GlobalResources.resx
+++ b/Website/App_GlobalResources/GlobalResources.resx
@@ -1573,4 +1573,7 @@ Sincerely,
   <data name="EMAIL_SOCIAL_FOLLOWREQUESTACTIONS.Text" xml:space="preserve">
     <value>&lt;p&gt;&lt;a href="{0}"&gt;Follow back&lt;/a&gt; | &lt;a href="{1}"&gt;View Profile&lt;/a&gt;&lt;/p&gt;</value>
   </data>
+  <data name="MESSAGE_USERNAME_CHANGED_INSTRUCTIONS.Text" xml:space="preserve">
+    <value>Please verify your e-mail address change by re-entering your password.</value>
+  </data>
 </root>

--- a/Website/DesktopModules/Admin/Portals/App_LocalResources/SiteSettings.ascx.resx
+++ b/Website/DesktopModules/Admin/Portals/App_LocalResources/SiteSettings.ascx.resx
@@ -1251,4 +1251,10 @@ The host-level settings are currently set as follows:
   <data name="pl500TabId.Text" xml:space="preserve">
     <value>500 Error Page</value>
   </data>
+  <data name="ContainsDuplicateAddresses.Text" xml:space="preserve">
+    <value>The user base of this portal contains duplicate e-mail addresses. If you would like to use e-mail addresses as usernames you must fix those entries first.</value>
+  </data>
+  <data name="MustEnableUniqueEmail.Text" xml:space="preserve">
+    <value>You must enable unique e-mail addresses in the membership provider for this instance.</value>
+  </data>
 </root>

--- a/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
@@ -1474,6 +1474,22 @@ namespace DesktopModules.Admin.Portals
 
                     foreach (DnnFormItemBase item in standardRegistrationSettings.Items)
                     {
+                        //Make sure that enabling Registration_UseEmailAsUserName doesn't cause issues with duplicate e-mail addresses
+                        if (item.DataField.ToLower() == "registration_useemailasusername" && Boolean.Parse(item.Value.ToString()) == true)
+                        {
+                            if (UserController.GetDuplicateEmailCount() > 0)
+                            {
+                                string message = Localization.GetString("ContainsDuplicateAddresses", LocalResourceFile);
+                                DotNetNuke.UI.Skins.Skin.AddModuleMessage(this, message, ModuleMessage.ModuleMessageType.RedError);
+                                return;
+                            }
+                            if (MembershipProvider.Instance().RequiresUniqueEmail == false)
+                            {
+                                string message = Localization.GetString("MustEnableUniqueEmail", LocalResourceFile);
+                                DotNetNuke.UI.Skins.Skin.AddModuleMessage(this, message, ModuleMessage.ModuleMessageType.RedError);
+                                return;
+                            }
+                        }
                         PortalController.UpdatePortalSetting(_portalId, item.DataField, item.Value.ToString());
                     }
 

--- a/Website/DesktopModules/Admin/Security/EditUser.ascx.cs
+++ b/Website/DesktopModules/Admin/Security/EditUser.ascx.cs
@@ -234,6 +234,13 @@ namespace DotNetNuke.Modules.Admin.Users
                 }
                 userForm.DataSource = User;
 
+                // hide username field in UseEmailAsUserName mode
+                bool disableUsername = PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false);
+                if(disableUsername)
+                {
+                    userForm.Items[0].Visible = false;
+                }
+
                 if (!Page.IsPostBack)
                 {
                     userForm.DataBind();
@@ -491,6 +498,20 @@ namespace DotNetNuke.Modules.Admin.Users
                     UpdateDisplayName();
 
                     UserController.UpdateUser(UserPortalID, User);
+
+                    // make sure username matches possibly changed email address
+                    bool disableUsername = PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false);
+                    if (disableUsername)
+                    {
+                        if (User.Username.ToLower() != User.Email.ToLower())
+                        {
+                            UserController.ChangeUsername(User.UserID, User.Email);
+
+                            //note that this effectively will cause a signout due to the cookie not matching anymore.
+                            HttpContext.Current.Session.Add("USERNAME_CHANGED", User.Email);
+                        }
+                    }
+
 
                     Response.Redirect(Request.RawUrl);
                 }

--- a/Website/DesktopModules/Admin/Security/User.ascx
+++ b/Website/DesktopModules/Admin/Security/User.ascx
@@ -3,6 +3,7 @@
 <%@ Register TagPrefix="dnn" Assembly="DotNetNuke" Namespace="DotNetNuke.UI.WebControls"%>
 <%@ Register TagPrefix="dnn" Assembly="DotNetNuke.Web" Namespace="DotNetNuke.Web.UI.WebControls" %>
 
+
 <dnn:DnnFormEditor id="userForm" runat="Server" FormMode="Short">
     <Items>
         <dnn:DnnFormLiteralItem ID="userNameReadOnly" runat="server"  DataField="Username" />

--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.00.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.00.SqlDataProvider
@@ -692,6 +692,29 @@ AS
 	WHERE  [MessageID] = @MessageID
 GO
 
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}GetDuplicateEmailCount]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}GetDuplicateEmailCount]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetDuplicateEmailCount]
+    @PortalId INT
+AS 
+	SELECT ISNULL((SELECT COUNT(*) TotalCount FROM {databaseOwner}[{objectQualifier}Users] U Inner Join {databaseOwner}[{objectQualifier}UserPortals] UP on UP.[UserId] = U.[UserId] WHERE UP.PortalId = @PortalId  GROUP BY U.[Email] HAVING COUNT(*) > 1), 0)
+GO
+
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}GetSingleUserByEmail]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}GetSingleUserByEmail]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetSingleUserByEmail]
+    @PortalId INT,
+	@Email nvarchar(255)
+AS 
+	SELECT ISNULL((SELECT TOP 1 U.UserId from {databaseOwner}[{objectQualifier}Users] U Inner Join {databaseOwner}[{objectQualifier}UserPortals] UP on UP.[UserId] = U.[UserId] Where U.Email = @Email and UP.[PortalId] = @PortalId), -1)
+GO
+
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/

--- a/Website/admin/Security/App_LocalResources/PasswordReset.ascx.resx
+++ b/Website/admin/Security/App_LocalResources/PasswordReset.ascx.resx
@@ -156,4 +156,13 @@
   <data name="ControlTitle_passwordreset.Text" xml:space="preserve">
     <value>Password Reset</value>
   </data>
+  <data name="Email.Help" xml:space="preserve">
+    <value>Please enter your e-mail address</value>
+  </data>
+  <data name="Email.Required" xml:space="preserve">
+    <value>You must provide your email address</value>
+  </data>
+  <data name="Email.Text" xml:space="preserve">
+    <value>Confirm E-Mail Address:</value>
+  </data>
 </root>

--- a/Website/admin/Security/App_LocalResources/SendPassword.ascx.resx
+++ b/Website/admin/Security/App_LocalResources/SendPassword.ascx.resx
@@ -136,7 +136,7 @@
     <value>This account has been locked out after too many unsuccessful login attempts. Please wait 10 minutes before trying to login again. If you have forgotten your password, please try the Password Reminder option before contacting an Administrator.</value>
   </data>
   <data name="PasswordSent.Text" xml:space="preserve">
-    <value>If the username entered was correct, you should receive a new email shortly with a link to reset your password.</value>
+    <value>If the details entered were correct, you should receive a new email shortly with a link to reset your password.</value>
   </data>
   <data name="EnterUsername.Text" xml:space="preserve">
     <value>Please Enter Your User Name</value>
@@ -177,9 +177,6 @@
   <data name="plEmail.Text" xml:space="preserve">
     <value>Email Address:</value>
   </data>
-  <data name="SendPasswordHelp.Text" xml:space="preserve">
-    <value>You can request your password by providing your User Name and the Password will be sent to the email address you provided during registration.</value>
-  </data>
   <data name="EnterUsernameEmail.Text" xml:space="preserve">
     <value>Please Enter Your User Name or the Email Address you used during Registration</value>
   </data>
@@ -193,7 +190,7 @@
     <value>&lt;br/&gt;&lt;br/&gt; You also must provide the answer to the question you provided on registration.</value>
   </data>
   <data name="RequiresUniqueEmail.Text" xml:space="preserve">
-    <value>&lt;br/&gt;&lt;br/&gt;You can optionally request your password by providing this email address.  In this case you do not need to provide the username.</value>
+    <value>&lt;br/&gt;&lt;br/&gt;You can request the email by providing your email address or your username.</value>
   </data>
   <data name="ResetPassword.Text" xml:space="preserve">
     <value>Reset Password</value>
@@ -214,9 +211,12 @@
     <value>Cancel</value>
   </data>
   <data name="ResetTokenHelp.Text" xml:space="preserve">
-    <value>If you forgot your password, you can create a new one by providing your User Name. An email with a password reset link will be sent to your registered address. Click on the link and you will be taken to a page where you can then create a new password.</value>
+    <value>If you forgot your password an email with a password reset link will be sent to your registered address. Click on the link in that email and you will be taken to a page where you can then create a new password.</value>
   </data>
   <data name="ResetToken.Text" xml:space="preserve">
     <value>Send Reset Link</value>
+  </data>
+  <data name="EmailNotFound.Text" xml:space="preserve">
+    <value>We could not find an account with that e-mail address. Please try again.</value>
   </data>
 </root>

--- a/Website/admin/Security/PasswordReset.ascx
+++ b/Website/admin/Security/PasswordReset.ascx
@@ -5,9 +5,9 @@
     <div class="dnnFormMessage dnnFormInfo" runat="server" Visible="False" id="resetMessages"><asp:Label ID="lblHelp" runat="Server" /></div>
 	<div id="divPassword" runat="server" class="dnnPasswordResetContent">
         <div class="dnnFormItem">
-                            <dnn:Label ID="lblUsername" runat="server" ControlName="txtUsername" ResourceKey="Username" CssClass="dnnFormRequired"/>
+                            <dnn:Label ID="lblUsername" runat="server" ControlName="txtUsername" CssClass="dnnFormRequired"/>
                             <asp:TextBox ID="txtUsername" runat="server" TextMode="SingleLine"/>
-                            <asp:RequiredFieldValidator ID="valUsername" CssClass="dnnFormMessage dnnFormError dnnRequired" runat="server" resourcekey="Username.Required" Display="Dynamic" ControlToValidate="txtPassword" />
+                            <asp:RequiredFieldValidator ID="valUsername" CssClass="dnnFormMessage dnnFormError dnnRequired" runat="server" Display="Dynamic" ControlToValidate="txtPassword" />
                         </div>
 		<div class="dnnFormItem">
                             <dnn:Label ID="lblPassword" runat="server" ControlName="txtPassword" ResourceKey="Password" CssClass="dnnFormRequired"/>

--- a/Website/admin/Security/SendPassword.ascx
+++ b/Website/admin/Security/SendPassword.ascx
@@ -2,35 +2,42 @@
 <%@ Register TagPrefix="dnn" Assembly="DotNetNuke" Namespace="DotNetNuke.UI.WebControls"%>
 <%@ Control Language="C#" Inherits="DotNetNuke.Modules.Admin.Security.SendPassword" AutoEventWireup="false" CodeFile="SendPassword.ascx.cs" %>
 <div class="dnnForm dnnSendPassword dnnClear">
+
 	<asp:panel id="pnlRecover" runat="server" >
-    <div class="dnnFormMessage dnnFormInfo"><asp:Label ID="lblHelp" runat="Server" /></div>
-	<div id="divPassword" runat="server" class="dnnSendPasswordContent">
-		<div class="dnnFormItem">
-			<dnn:label id="plUsername" controlname="txtUsername" runat="server" />
-			<asp:textbox id="txtUsername" CssClass="dnnFormRequired" runat="server" />
-		</div>
-		<div class="dnnFormItem" id="divEmail" runat="server">
-			<dnn:label id="plEmail" controlname="txtEmail" runat="server" />
-			<asp:textbox id="txtEmail" runat="server" />
-		</div>
-		<div id="divCaptcha" runat="server" class="dnnFormItem">
-			<dnn:label id="plCaptcha" controlname="ctlCaptcha" runat="server" />
-			<dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" runat="server" errorstyle-cssclass="dnnFormMessage dnnFormError" />
-		</div>
-		<div id="divQA" runat="server" visible="false">
-			<div class="dnnFormItem">
-				<dnn:label id="plQuestion" runat="server" controlname="lblQuestion" />
-				<asp:label id = "lblQuestion" runat="server" />
-			</div>
-			<div class="dnnFormItem">
-				<dnn:label id="plAnswer" runat="server" controlname="txtAnswer" />
-				<asp:textbox id="txtAnswer" runat="server" size="25" maxlength="20" />
-			</div>
-		</div>
-		<ul class="dnnActions dnnClear">
-			<li><asp:LinkButton id="cmdSendPassword" cssclass="dnnPrimaryAction" runat="server" /></li>
-			<li id="liLogin" runat="server"><asp:LinkButton id="cancelButton" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" /></li>
-		</ul>
-	</div>
-        </asp:panel>
+        
+        <div class="dnnFormMessage dnnFormInfo"><asp:Label ID="lblHelp" runat="Server" /></div>
+	    
+        <div id="divPassword" runat="server" class="dnnSendPasswordContent">
+		    <div class="dnnFormItem" id="divUsername" runat="server">
+			    <dnn:label id="plUsername" controlname="txtUsername" runat="server" />
+			    <asp:textbox id="txtUsername" CssClass="dnnFormRequired" runat="server" />
+		    </div>
+		    <div class="dnnFormItem" id="divEmail" runat="server">
+			    <dnn:label id="plEmail" controlname="txtEmail" runat="server" />
+			    <asp:textbox id="txtEmail" runat="server" />
+		    </div>
+		    <div id="divCaptcha" runat="server" class="dnnFormItem">
+			    <dnn:label id="plCaptcha" controlname="ctlCaptcha" runat="server" />
+			    <dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" runat="server" errorstyle-cssclass="dnnFormMessage dnnFormError" />
+		    </div>
+		    <div id="divQA" runat="server" visible="false">
+			    <div class="dnnFormItem">
+				    <dnn:label id="plQuestion" runat="server" controlname="lblQuestion" />
+				    <asp:label id = "lblQuestion" runat="server" />
+			    </div>
+			    <div class="dnnFormItem">
+				    <dnn:label id="plAnswer" runat="server" controlname="txtAnswer" />
+				    <asp:textbox id="txtAnswer" runat="server" size="25" maxlength="20" />
+			    </div>
+		    </div>
+
+	    </div>
+
+    </asp:panel>
+
+	<ul class="dnnActions dnnClear">
+	    <li id="liSend" runat="server"><asp:LinkButton id="cmdSendPassword" cssclass="dnnPrimaryAction" runat="server" /></li>
+	    <li id="liCancel" runat="server"><asp:LinkButton id="cancelButton" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" /></li>
+	</ul>
+
 </div>

--- a/Website/admin/Security/SendPassword.ascx.cs
+++ b/Website/admin/Security/SendPassword.ascx.cs
@@ -30,6 +30,7 @@ using DotNetNuke.Entities.Host;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Entities.Users.Membership;
+using DotNetNuke.Entities.Portals;
 using DotNetNuke.Instrumentation;
 using DotNetNuke.Security;
 using DotNetNuke.Security.Membership;
@@ -148,7 +149,7 @@ namespace DotNetNuke.Modules.Admin.Security
         private void GetUser()
         {
             ArrayList arrUsers;
-            if (MembershipProviderConfig.RequiresUniqueEmail && !String.IsNullOrEmpty(txtEmail.Text.Trim()) && String.IsNullOrEmpty(txtUsername.Text.Trim()))
+            if (MembershipProviderConfig.RequiresUniqueEmail && !String.IsNullOrEmpty(txtEmail.Text.Trim()) && (String.IsNullOrEmpty(txtUsername.Text.Trim()) || divUsername.Visible == false))
             {
                 arrUsers = UserController.GetUsersByEmail(PortalSettings.PortalId, txtEmail.Text, 0, Int32.MaxValue, ref _userCount);
                 if (arrUsers != null && arrUsers.Count == 1)
@@ -192,8 +193,7 @@ namespace DotNetNuke.Modules.Admin.Security
                 divPassword.Visible = false;
             }
 
-			
-            if (MembershipProviderConfig.RequiresUniqueEmail && isEnabled)
+            if (MembershipProviderConfig.RequiresUniqueEmail && isEnabled && !PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false))
             {
                 lblHelp.Text += Localization.GetString("RequiresUniqueEmail", LocalResourceFile);
             }
@@ -202,6 +202,8 @@ namespace DotNetNuke.Modules.Admin.Security
             {
                 lblHelp.Text += Localization.GetString("RequiresQuestionAndAnswer", LocalResourceFile);
             }
+
+
         }
 
         /// <summary>
@@ -223,7 +225,10 @@ namespace DotNetNuke.Modules.Admin.Security
             {
                 _ipAddress = Request.UserHostAddress;
             }
-            divEmail.Visible = MembershipProviderConfig.RequiresUniqueEmail;
+
+            bool usernameDisabled = PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false);
+            divEmail.Visible = MembershipProviderConfig.RequiresUniqueEmail || usernameDisabled;
+            divUsername.Visible = !usernameDisabled;
             divCaptcha.Visible = UseCaptcha;
 
             if (UseCaptcha)
@@ -368,8 +373,18 @@ namespace DotNetNuke.Modules.Admin.Security
 					//always hide panel so as to not reveal if username exists.
                     pnlRecover.Visible = false;
                     UI.Skins.Skin.AddModuleMessage(this, message, moduleMessageType);
+                    liSend.Visible = false;
+                    liCancel.Visible = true;
 
-                    liLogin.Visible = true;
+                    // don't hide panel when e-mail only in use and error occured. We must provide negative feedback to the user, in case he doesn't rember what e-mail address he has used
+                    if (!canSend && _user == null && MembershipProviderConfig.RequiresUniqueEmail && PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false))
+                    {
+                        message = Localization.GetString("EmailNotFound", LocalResourceFile);
+                        pnlRecover.Visible = true;
+                        UI.Skins.Skin.AddModuleMessage(this, message, moduleMessageType);
+                        liSend.Visible = true;
+                        liCancel.Visible = true;
+                    }
                 }
                 else
                 {
@@ -415,8 +430,7 @@ namespace DotNetNuke.Modules.Admin.Security
             LogController.Instance.AddLog(log);
 
         }
-		
-		
+			
         private void cancelButton_Click(object sender, EventArgs e)
         {
             Response.Redirect(RedirectURL, true);


### PR DESCRIPTION
This is certainly nothing that can be merged right away. It does improve a lot on the end user experience though.

The main issue IMHO before this can be merged are upgrade scenarios. With the changes made here the site setting "Use Email Address as Username" is depending on "RequireUniqueEmail" in web.config set to true and also require that no duplicate emails exist in the database.

In installations where the setting is turned off there shouldn't be any issues in upgrade scenarios since the code behind in site settings is now validating those requirements before turning on the feature.

The question is what to do in upgrades where Use "Email Address as Username" is turned on already. Obviosly we cannot swipe out duplicate email addresses automatically. This work needs to be done by the site admin manually.

The document attached in https://dnntracker.atlassian.net/browse/DNN-6093 does outline the changes made in more detail btw. 
