### PR TITLE
DNN-6139 Folder Provider deletion fix

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -2062,7 +2062,7 @@ namespace DotNetNuke.Services.FileSystem
                     {
                         if (!folderProvider.FileExists(folder, file.FileName))
                         {
-                            FileManager.Instance.DeleteFile(file);
+                            FileDeletionController.Instance.DeleteFileData(file);
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
When detecting a deleted file in the folder provider it should delete the file data in DNN directly and not attempt to delete the source which is already deleted.
