### PR TITLE
DNN-6163 - see ticket for more info on implementation

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalAliasExtensions.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasExtensions.cs
@@ -52,7 +52,27 @@ namespace DotNetNuke.Entities.Portals
                 HttpResponse response = HttpContext.Current.Response;
                 browserType = FriendlyUrlController.GetBrowserType(request, response, settings);
             }
+            return GetAliasByPortalIdAndSettings(aliases, portalId, result, cultureCode, browserType);
+        }
 
+        public static PortalAliasInfo GetAliasByPortalIdAndSettings(this IEnumerable<PortalAliasInfo> aliases, int portalId, string requestedAlias, string cultureCode, FriendlyUrlSettings settings)
+        {
+            var browserType = BrowserTypes.Normal;
+            UrlAction result = null;
+            //if required, and possible, detect browser type
+            if (HttpContext.Current != null && settings != null)
+            {
+                HttpRequest request = HttpContext.Current.Request;
+                HttpResponse response = HttpContext.Current.Response;
+                browserType = FriendlyUrlController.GetBrowserType(request, response, settings);
+
+                result = new UrlAction(HttpContext.Current.Request)
+                {
+                    IsSecureConnection = request.IsSecureConnection,
+                    RawUrl = request.RawUrl,
+                    HttpAlias = requestedAlias,
+                };
+            }
             return GetAliasByPortalIdAndSettings(aliases, portalId, result, cultureCode, browserType);
         }
 
@@ -79,34 +99,56 @@ namespace DotNetNuke.Entities.Portals
                                         .OrderByDescending(a => a.IsPrimary)
                                         .FirstOrDefault();
 
+            //First check if our current alias is already a perfect match.
+            PortalAliasInfo foundAlias = null;
+            if (result != null && !string.IsNullOrEmpty(result.HttpAlias))
+            {
+                //try to find exact match
+                foundAlias = aliasList.FirstOrDefault(a => a.BrowserType == browserType &&
+                                                         (String.Compare(a.CultureCode, cultureCode,
+                                                             StringComparison.OrdinalIgnoreCase) == 0)
+                                                         && a.PortalID == portalId
+                                                         && a.HTTPAlias == result.HttpAlias);
+                if (foundAlias == null) //let us try again using Startswith()
+                {
+                    foundAlias = aliasList.FirstOrDefault(a => a.BrowserType == browserType &&
+                                                         (String.Compare(a.CultureCode, cultureCode,
+                                                             StringComparison.OrdinalIgnoreCase) == 0)
+                                                         && a.PortalID == portalId
+                                                         && a.HTTPAlias.StartsWith(result.HttpAlias + "/"));
+                }
+            }
             //27138 : Redirect loop caused by duplicate primary aliases.  Changed to only check by browserType/Culture code which makes a primary alias
-            var foundAlias = aliasList.Where(a => a.BrowserType == browserType
+            if (foundAlias == null)
+            {
+                foundAlias = aliasList.Where(a => a.BrowserType == browserType 
                                             && (String.Compare(a.CultureCode, cultureCode, StringComparison.OrdinalIgnoreCase) == 0 || String.IsNullOrEmpty(a.CultureCode))
                                             && a.PortalID == portalId)
-                        .OrderByDescending(a => a.IsPrimary)
-                        .ThenByDescending(a => a.CultureCode)
-                        .FirstOrDefault();
+                    .OrderByDescending(a => a.IsPrimary)
+                    .ThenByDescending(a => a.CultureCode)
+                    .FirstOrDefault();
+            }
 
-			//JIRA DNN-4882 : DevPCI fix bug with url Mobile -> Search alias with culture code
-			// START DNN-4882
+            //JIRA DNN-4882 : DevPCI fix bug with url Mobile -> Search alias with culture code
+            // START DNN-4882
             if (foundAlias == null)
             {
                 foundAlias = aliasList.Where(a => (String.Compare(a.CultureCode, cultureCode, StringComparison.OrdinalIgnoreCase) == 0 || String.IsNullOrEmpty(a.CultureCode))
                                            && a.PortalID == portalId)
-					   .OrderByDescending(a => a.IsPrimary)
-					   .ThenByDescending(a => a.CultureCode)
-					   .FirstOrDefault();
+                       .OrderByDescending(a => a.IsPrimary)
+                       .ThenByDescending(a => a.CultureCode)
+                       .FirstOrDefault();
             }
             // END DNN-4882
-		
+
             if (foundAlias != null)
             {
-                if(result !=null && result.PortalAlias != null)
+                if (result != null && result.PortalAlias != null)
                 {
                     if (foundAlias.BrowserType != result.PortalAlias.BrowserType)
                     {
-                        result.Reason = foundAlias.CultureCode != result.PortalAlias.CultureCode 
-                            ? RedirectReason.Wrong_Portal_Alias_For_Culture_And_Browser 
+                        result.Reason = foundAlias.CultureCode != result.PortalAlias.CultureCode
+                            ? RedirectReason.Wrong_Portal_Alias_For_Culture_And_Browser
                             : RedirectReason.Wrong_Portal_Alias_For_Browser_Type;
                     }
                     else
@@ -139,8 +181,8 @@ namespace DotNetNuke.Entities.Portals
 
         public static string GetCultureByPortalIdAndAlias(this IEnumerable<PortalAliasInfo> aliases, int portalId, string alias)
         {
-            return (from cpa in aliases 
-                    where cpa.PortalID == portalId && String.Compare(alias, cpa.HTTPAlias, StringComparison.OrdinalIgnoreCase) == 0 
+            return (from cpa in aliases
+                    where cpa.PortalID == portalId && String.Compare(alias, cpa.HTTPAlias, StringComparison.OrdinalIgnoreCase) == 0
                     select cpa.CultureCode)
                     .FirstOrDefault();
         }

--- a/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
@@ -554,7 +554,7 @@ namespace DotNetNuke.Entities.Urls
                         cultureCode = GetCultureOfSettings(portalSettings);
                         //lookup the culture code of the portal settings object
                     }
-                    var primaryAlias = primaryAliases.GetAliasByPortalIdAndSettings(portalId, null, cultureCode, settings);
+                    var primaryAlias = primaryAliases.GetAliasByPortalIdAndSettings(portalId, httpAlias, cultureCode, settings);
 
                     if (primaryAlias != null)
                     {


### PR DESCRIPTION
Consider you enter the website via http://domain2.com. 
You will be redirected to http://domain1.com/fr-be if those both aliasses are identical with regard to language, browsertype and IsPrimary.
But GetAliasByPortalIdAndSettings() will force a redirect because of the OrderBy().FirstOrDefault() it uses.
 This code fixes that. It will first try to find an alias with the correct language that resembels the requested (http://domain2.com/fr-be) alias before just giving the FirstOrDefault()
