### PR TITLE
DNN-6178 Fix en-US culture constructor

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
@@ -1330,7 +1330,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         [TestCase("2/16/2012 12:15:12 PM", "2/16/2012 12:14:12 PM", 10, 540)]
         public void WaitTimeForNextMessage_Returns_The_Number_Of_Seconds_Since_Last_Message_Sent(string actualDateString, string lastMessageDateString, int throttlingInterval, int expected)
         {
-            var culture = CultureInfo.CreateSpecificCulture("en-US");
+            var culture = CultureInfo.GetCultureInfo("en-US");
             var actualDate = DateTime.Parse(actualDateString, culture);
             var lastMessageDate = DateTime.Parse(lastMessageDateString, culture);
             _user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;


### PR DESCRIPTION
WaitTimeForNextMessage_Returns_The_Number_Of_Seconds_Since_Last_Message_Sent could not parse the date correctly on my non en-US machine as it expected a European style date (d/m/yyyy).
