### PR TITLE
DNN-6239: Fixed DotNetNuke.Services.Upgrade.Internals.InstallControllerImpl.IsAbleToPerformDatabaseActions(string connectionString)

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Internals/InstallControllerImpl.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/InstallControllerImpl.cs
@@ -513,7 +513,7 @@ namespace DotNetNuke.Services.Upgrade.Internals
         {
             var fakeName = "FakeTable_" + DateTime.Now.Ticks.ToString("x16");
             var databaseActions = string.Format(
-@"CREATE TABLE {{databaseOwner}}.[{0}]([fakeColumn] [int] NULL);select * from [{0}];drop table {{databaseOwner}}.[{0}];", fakeName);
+@"CREATE TABLE {{databaseOwner}}[{{objectQualifier}}{0}]([fakeColumn] [int] NULL);select * from {{databaseOwner}}[{{objectQualifier}}{0}];drop table {{databaseOwner}}[{{objectQualifier}}{0}];", fakeName);
             //TODO: this is an obsolete member, need a better solution to support querystring from install.config (i think)
             var strExceptions = DataProvider.Instance().ExecuteScript(connectionString, databaseActions);
             //if no exceptions we have necessary drop etc permissions


### PR DESCRIPTION
This pull requests fixes Fixed DotNetNuke.Services.Upgrade.Internals.InstallControllerImpl.IsAbleToPerformDatabaseActions(string connectionString): There is one "." too much (after {{databaseOwner}}). 
IMHO adding the {{objectQualifier}} is also a good idea.
