### PR TITLE
performance updates in purge schedule history

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.00.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.00.SqlDataProvider
@@ -2675,6 +2675,23 @@ AS
 	WHERE wu.WorkflowID = @WorkflowId
 GO
 
+IF OBJECT_ID(N'{databaseOwner}[{objectQualifier}PurgeScheduleHistory]', N'P') IS NOT NULL
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}PurgeScheduleHistory]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}PurgeScheduleHistory]
+AS
+delete from {databaseOwner}{objectQualifier}schedulehistory where schedulehistoryid in (
+	select top 50000 ScheduleHistoryID from {databaseOwner}{objectQualifier}ScheduleHistory sh 
+		inner join {databaseOwner}{objectQualifier}schedule s on s.ScheduleID = sh.ScheduleID and s.Enabled = 1
+	where 
+		(select count(*) from {databaseOwner}{objectQualifier}ScheduleHistory sh where sh.ScheduleID = s.ScheduleID) > s.RetainHistoryNum
+		AND s.RetainHistoryNum <> -1
+		AND s.ScheduleID = sh.ScheduleID
+	order by ScheduleHistoryID
+)
+GO
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/


### PR DESCRIPTION
It seems the old script doesn't work too well. This change reduces the time to clear the history table with 465k rows by 97%. However, because it limited to 50k rows per execution, it will take multiple days to fully clean up the scheduled history table. 

Total Rows: 465k
Default Query: 3992 seconds (1hr 6m 32s)
Optimized (all at once): 96 seconds
100k batches: 143 seconds total, 5 runs (14, 34, 35, 31, 29)
50k batches: 94 seconds total, 10 runs (6, 6, 11, 7, 8, 8, 10, 14, 20, 5)
