### PR TITLE
DNN-5206: DotNetNuke.Services.FileSystemFileManager.WriteFileToHttpContext(): Do not send negative "Content-Length" header

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileManager.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -1735,7 +1736,8 @@ namespace DotNetNuke.Services.FileSystem
                     throw new ArgumentOutOfRangeException("contentDisposition");
             }
 
-            objResponse.AppendHeader("Content-Length", file.Size.ToString());
+            // Do not send negative Content-Length (file.Size could be negative due to integer overflow for files > 2GB)
+            if (file.Size >= 0) objResponse.AppendHeader("Content-Length", file.Size.ToString(CultureInfo.InvariantCulture));
             objResponse.ContentType = GetContentType(file.Extension.Replace(".", ""));
 
             try


### PR DESCRIPTION
This pull request fixes the problem, that files > 2GB are not downloadable using the with LinkClick.aspx. 

Please note: The problem, that the file size are negative for large files (due too integer overflow) is not fixed in the pull request. This requires changing the API (see @cathalconnolly comments here https://dnntracker.atlassian.net/browse/DNN-5206)