### PR TITLE
Fixed DotNetNuke.UI.Skins.ControlsLanguageTokenReplace.NewUrl() to not remove query string parameters

### DIFF
--- a/DNN Platform/Library/UI/Skins/Controls/LanguageTokenReplace.cs
+++ b/DNN Platform/Library/UI/Skins/Controls/LanguageTokenReplace.cs
@@ -31,6 +31,7 @@ using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Entities.Urls;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Security;
 using DotNetNuke.Services.Localization;
@@ -233,24 +234,24 @@ namespace DotNetNuke.UI.Skins.Controls
         private string NewUrl(string newLanguage)
         {
             var objSecurity = new PortalSecurity();
-            Locale newLocale = LocaleController.Instance.GetLocale(newLanguage);
+            var newLocale = LocaleController.Instance.GetLocale(newLanguage);
 
             //Ensure that the current ActiveTab is the culture of the new language
-            int tabId = objPortal.ActiveTab.TabID;
-            bool islocalized = false;
+            var tabId = objPortal.ActiveTab.TabID;
+            var islocalized = false;
 
-            TabInfo localizedTab = TabController.Instance.GetTabByCulture(tabId, objPortal.PortalId, newLocale);
+            var localizedTab = TabController.Instance.GetTabByCulture(tabId, objPortal.PortalId, newLocale);
             if (localizedTab != null)
             {
                 islocalized = true;
                 if (localizedTab.IsDeleted || !TabPermissionController.CanViewPage(localizedTab))
                 {
-                    PortalInfo localizedPortal = PortalController.Instance.GetPortal(objPortal.PortalId, newLocale.Code);
+                    var localizedPortal = PortalController.Instance.GetPortal(objPortal.PortalId, newLocale.Code);
                     tabId = localizedPortal.HomeTabId;
                 }
                 else
                 {
-                    string fullurl = "";
+                    var fullurl = string.Empty;
                     switch (localizedTab.TabType)
                     {
                         case TabType.Normal:
@@ -277,14 +278,7 @@ namespace DotNetNuke.UI.Skins.Controls
                 }
             }
 
-            // on localised pages most of the querystring parameters have no sense and generate duplicate urls for the same content
-            // because we are on a other tab with other modules (example : ?returntab=/en-US/about)
-            string rawQueryString = "";
-            if (DotNetNuke.Entities.Host.Host.UseFriendlyUrls && !islocalized )
-            {
-                rawQueryString = new Uri(HttpContext.Current.Request.Url.Scheme + "://" + HttpContext.Current.Request.Url.Authority + HttpContext.Current.Request.RawUrl).Query;
-            }
-
+            var rawQueryString = new Uri(string.Concat(HttpContext.Current.Request.Url.GetLeftPart(UriPartial.Authority), HttpContext.Current.Request.RawUrl)).Query;
             return
                 objSecurity.InputFilter(
                     TestableGlobals.Instance.NavigateURL(tabId, objPortal.ActiveTab.IsSuperTab, objPortal, HttpContext.Current.Request.QueryString["ctl"], newLanguage, GetQsParams(newLocale.Code, islocalized)) +


### PR DESCRIPTION
Please see https://dnntracker.atlassian.net/browse/DNN-6310 for more information.

This pull request removes a logic that was introduced with this pull request https://github.com/sachatrauwaen/Dnn.Platform/commit/f98b4a3e5e05bc67200d1a6572c43f0c5bfd00dd created by @sachatrauwaen 

if (DotNetNuke.Entities.Host.Host.UseFriendlyUrls && !islocalized ) {
  [...]
}

I do not see a reason for not adding the query string when creating the "change language"-links, because query parameters that are "encoded" in the path (like the "Id" parameter in http://.../Home/Id/1?category=2) are not removed when creating links to the same page in other languages.

In other words: I would either remove all parameters (from query string and paths) or none of them when creating "change language links". IMHO, the current logic is confusing, because only query string parameters are removed.