### PR TITLE
DNN-6324 Don't HTML decode the Razor engine's output

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Razor/RazorModuleBase.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorModuleBase.cs
@@ -67,7 +67,7 @@ namespace DotNetNuke.Web.Razor
                     var writer = new StringWriter();
                     razorEngine.Render(writer);
 
-                    Controls.Add(new LiteralControl(Server.HtmlDecode(writer.ToString())));
+                    Controls.Add(new LiteralControl(writer.ToString()));
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
The `RazorModuleBase` class (used by the Razor Host module) calls `Server.HtmlDecode` on the output from the `RazorEngine`. This is probably to combat Razor's default HTML encoding, but also means that anyone using the Razor Host module will not get the normal behavior of Razor, and will not be able to easily output HTML encoded content.

I think it is important for the behavior of the Razor Host module to match Razor itself, however this will be a breaking change for existing Razor Host scripts that need the extra HTML decoding.

See [DNN-6324](https://dnntracker.atlassian.net/browse/DNN-6324)