### PR TITLE
DNN-6398: Fixed broken links for entry into the online help system. 

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -2994,7 +2994,7 @@ namespace DotNetNuke.Services.Upgrade
             DataProvider.Instance().RegisterAssembly(Null.NullInteger, "WebMatrix.WebData.dll", "2.0.20126");
 
             //update help url
-            HostController.Instance.Update("HelpURL", "http://help.dotnetnuke.com/070300/default.htm?showToc=true", false);
+            HostController.Instance.Update("HelpURL", "http://www.dnnsoftware.com/help", false);
         }
 
         private static void UpgradeToVersion733()

--- a/DNN Platform/Modules/CoreMessaging/CoreMessaging.dnn
+++ b/DNN Platform/Modules/CoreMessaging/CoreMessaging.dnn
@@ -36,7 +36,7 @@
                     <controlTitle>Core Messaging View</controlTitle>
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Message Centre/About the Messaging Module.htm</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <viewOrder>0</viewOrder>
                   </moduleControl>
                 </moduleControls>

--- a/DNN Platform/Modules/DigitalAssets/dnn_DigitalAssets.dnn
+++ b/DNN Platform/Modules/DigitalAssets/dnn_DigitalAssets.dnn
@@ -37,7 +37,7 @@
                     <controlTitle />
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Using the Control Panel/Admin Console/File Management/01AboutDAM.htm</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <viewOrder>0</viewOrder>
                   </moduleControl>                  
                   <moduleControl>

--- a/DNN Platform/Modules/Groups/SocialGroups.dnn
+++ b/DNN Platform/Modules/Groups/SocialGroups.dnn
@@ -35,7 +35,7 @@
                     <controlTitle />
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Social Groups/Adding a Social Group.html</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <supportsPopUps>False</supportsPopUps>
                     <viewOrder>0</viewOrder>
                   </moduleControl>
@@ -46,7 +46,7 @@
                     <controlTitle>Create A Group</controlTitle>
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Social Groups/Adding a Social Group.html</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <supportsPopUps>True</supportsPopUps>
                     <viewOrder>0</viewOrder>
                   </moduleControl>

--- a/DNN Platform/Modules/HTML/dnn_HTML.dnn
+++ b/DNN Platform/Modules/HTML/dnn_HTML.dnn
@@ -122,7 +122,7 @@
                     <controlTitle />
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/HTML/About the Text HTML Module.htm</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <viewOrder>0</viewOrder>
                   </moduleControl>
                   <moduleControl>

--- a/DNN Platform/Modules/HtmlEditorManager/dnn_HtmlEditorManager.dnn
+++ b/DNN Platform/Modules/HtmlEditorManager/dnn_HtmlEditorManager.dnn
@@ -36,7 +36,7 @@
                     <controlTitle>Html Editor Management</controlTitle>
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Using the Control Panel/Host Console/HTML Editor Manager/About the HTML Editor Manager.html</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <viewOrder>0</viewOrder>
                   </moduleControl>
                 </moduleControls>

--- a/DNN Platform/Modules/Journal/Journal.dnn
+++ b/DNN Platform/Modules/Journal/Journal.dnn
@@ -36,7 +36,7 @@
                                         <controlTitle />
                                         <controlType>View</controlType>
                                         <iconFile />
-                                        <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Journal/About the Journal Module.html</helpUrl>
+                                        <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                                         <viewOrder>0</viewOrder>
                                     </moduleControl>
                                     <moduleControl>

--- a/DNN Platform/Modules/MemberDirectory/MemberDirectory.dnn
+++ b/DNN Platform/Modules/MemberDirectory/MemberDirectory.dnn
@@ -36,7 +36,7 @@
                     <controlTitle>Social Messaging View</controlTitle>
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Member Directory/About the Member Directory Module.html</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <viewOrder>0</viewOrder>
                   </moduleControl>
                   <moduleControl>

--- a/DNN Platform/Modules/MobileManagement/dnn_MobileManagement.dnn
+++ b/DNN Platform/Modules/MobileManagement/dnn_MobileManagement.dnn
@@ -36,7 +36,7 @@
 										<controlTitle>Site Redirection Management</controlTitle>
 										<controlType>View</controlType>
 										<iconFile />
-										<helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Using the Control Panel/Admin Console/Site Redirection Management/About the Site Redirection Management Module.html</helpUrl>
+										<helpUrl>http://www.dnnsoftware.com/help</helpUrl>
 										<viewOrder>0</viewOrder>
 									</moduleControl>
 									<moduleControl>

--- a/DNN Platform/Modules/PreviewProfileManagement/dnn_PreviewProfileManagement.dnn
+++ b/DNN Platform/Modules/PreviewProfileManagement/dnn_PreviewProfileManagement.dnn
@@ -36,7 +36,7 @@
 										<controlTitle>Device Preview Management</controlTitle>
 										<controlType>View</controlType>
 										<iconFile />
-										<helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Using the Control Panel/Admin Console/Device Preview Management/About the Device Preview Management Module.html</helpUrl>
+										<helpUrl>http://www.dnnsoftware.com/help</helpUrl>
 										<viewOrder>0</viewOrder>
 									</moduleControl>
 								</moduleControls>

--- a/DNN Platform/Modules/Taxonomy/Taxonomy.dnn
+++ b/DNN Platform/Modules/Taxonomy/Taxonomy.dnn
@@ -35,7 +35,7 @@
 										<controlTitle />
 										<controlType>View</controlType>
 										<iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Using the Control Panel/Admin Console/Taxonomy/About the Taxonomy Manager Module.html</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
 										<viewOrder>0</viewOrder>
 									</moduleControl>
 									<moduleControl>

--- a/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/DotNetNuke.RadEditorProvider.dnn
+++ b/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/DotNetNuke.RadEditorProvider.dnn
@@ -36,7 +36,7 @@
                     <controlTitle />
                     <controlType>View</controlType>
                     <iconFile />
-                    <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Using the Control Panel/Host Console/HTML Editor Manager/About the HTML Editor Manager.html</helpUrl>
+                    <helpUrl>http://www.dnnsoftware.com/help</helpUrl>
                     <viewOrder>0</viewOrder>
                   </moduleControl>
                 </moduleControls>

--- a/Documentation/Using the Control Panel/Host Console/Host Settings/Other Settings/Enabling-Disabling Online Module Help.html
+++ b/Documentation/Using the Control Panel/Host Console/Host Settings/Other Settings/Enabling-Disabling Online Module Help.html
@@ -14,7 +14,7 @@
                 <li>Unmark <img src="../../../../Resources/Images/Icons/uncheck.png" style="vertical-align: bottom;" />&#160;the check box to disable.</li>
             </ul>
             <li value="4">In <b>Help URL</b> text box, choose one of these options:
-    <ol><li><b>To restore Online Help URL to the default DotNetNuke Online Help</b>: Enter http://help.dotnetnuke.com/070100/default.htm?showToc=true</li><li><b>To set a custom URL</b>: Enter the URL to your help resource.</li><li><b>To disable Online Help</b>: Leave this field blank.</li></ol></li>
+    <ol><li><b>To restore Online Help URL to the default DotNetNuke Online Help</b>: Enter http://www.dnnsoftware.com/help</li><li><b>To set a custom URL</b>: Enter the URL to your help resource.</li><li><b>To disable Online Help</b>: Leave this field blank.</li></ol></li>
         </ol>
         <p>
             <img alt="" src="../../../../Resources/Images/Host/HostSettings/HostSettings_OtherSettings_Help.png" />

--- a/Website/Install/DotNetNuke.install.config.resources
+++ b/Website/Install/DotNetNuke.install.config.resources
@@ -40,7 +40,7 @@
     <EncryptionKey Secure="True"></EncryptionKey>
     <EventLogBuffer>N</EventLogBuffer>
     <FileExtensions>swf,jpg,jpeg,jpe,gif,bmp,png,svg,ttf,eot,woff,doc,docx,xls,xlsx,ppt,pptx,pdf,txt,xml,xsl,xsd,css,zip,rar,template,htmtemplate,ico,avi,mpg,mpeg,mp3,wmv,mov,wav</FileExtensions>
-    <HelpURL>http://help.dotnetnuke.com/070300/default.htm?showToc=true</HelpURL>
+    <HelpURL>http://www.dnnsoftware.com/help</HelpURL>
     <HostCurrency>USD</HostCurrency>
     <HostEmail></HostEmail>
     <HostFee></HostFee>

--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
@@ -8,6 +8,8 @@
 /*****                                                  *****/
 /************************************************************/
 
+UPDATE {databaseOwner}{objectQualifier}HostSettings Set SettingValue ='http://www.dnnsoftware.com/help' Where SettingName='HelpURL'
+GO
 
 
 /************************************************************/


### PR DESCRIPTION
Due to limitations of the online help (help.dnnsoftware.com aka www.dnnsoftware.com/help), the fixed URL is always pointing to the top level of the online help, since fully qualified direct links do not work.