### PR TITLE
DNN-6415 Added support for Http-Equiv on Meta skin object

### DIFF
--- a/Website/admin/Skins/Meta.ascx.cs
+++ b/Website/admin/Skins/Meta.ascx.cs
@@ -36,24 +36,27 @@ namespace DotNetNuke.UI.Skins.Controls
     /// </history>
     /// -----------------------------------------------------------------------------
     public partial class Meta : SkinObjectBase
-	{
-		#region "Public Properties"
+    {
+        ///<summary>Backing field for <see cref="Http" /></summary>
+        private readonly HttpPlaceholder http = new HttpPlaceholder();
 
-		public string Name { get; set; }
+        public string Name { get; set; }
 
-		public string Content { get; set; }
+        public string Content { get; set; }
+    
+        public HttpPlaceholder Http { get { return this.http; } }
 
-        public string HttpEquiv { get; set; }
+        public string HttpEquiv 
+        {
+            get { return this.Http.Equiv; } 
+            set { this.Http.Equiv = value; } 
+        }
 
         public bool InsertFirst { get; set; }
 
-		#endregion
-
-		#region "Event Handlers"
-
-		protected override void OnPreRender(EventArgs e)
-		{
-			base.OnPreRender(e);
+        protected override void OnPreRender(EventArgs e)
+        {
+            base.OnPreRender(e);
 
             //if(!string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(Content))
             //{
@@ -79,8 +82,11 @@ namespace DotNetNuke.UI.Skins.Controls
                 else
                     Page.Header.Controls.Add(metaTag);
             }
-		}
+        }
 
-		#endregion
-	}
+        public class HttpPlaceholder 
+        {
+            public string Equiv { get; set; }
+        }
+    }
 }

--- a/Website/admin/Skins/Meta.ascx.cs
+++ b/Website/admin/Skins/Meta.ascx.cs
@@ -28,8 +28,7 @@ using System.Web.UI.HtmlControls;
 namespace DotNetNuke.UI.Skins.Controls
 {
     /// -----------------------------------------------------------------------------
-    /// <summary></summary>
-    /// <remarks></remarks>
+    /// <summary>A skin object which enables adding a <c>meta</c> element to the <c>head</c></summary>
     /// <history>
     /// 	[cniknet]	10/15/2004	Replaced public members with properties and removed
     ///                             brackets from property names
@@ -37,21 +36,43 @@ namespace DotNetNuke.UI.Skins.Controls
     /// -----------------------------------------------------------------------------
     public partial class Meta : SkinObjectBase
     {
-        ///<summary>Backing field for <see cref="Http" /></summary>
+        /// <summary>Backing field for <see cref="Http" /></summary>
         private readonly HttpPlaceholder http = new HttpPlaceholder();
 
+        /// <summary>
+        /// Gets or sets the name of the <c>meta</c> element
+        /// Either the name or the <see cref="HttpEquiv" /> must be set.
+        /// The <c>name</c> attribute is not rendered if it is not set.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>Gets or sets the content of the <c>meta</c> element</summary>
         public string Content { get; set; }
-    
-        public HttpPlaceholder Http { get { return this.http; } }
 
+        /// <summary>Gets an object to set the <see cref="HttpEquiv" /> property</summary>
+        public HttpPlaceholder Http
+        {
+            get { return this.http; }
+        }
+
+        /// <summary>
+        /// Gets or sets the <c>http-equiv</c> attribute of the <c>meta</c> element.
+        /// If specified, this is the name of the HTTP header that the 
+        /// <c>meta</c>
+        /// The attribute is not rendered if it is not set.
+        /// Either this or the <see cref="Name" /> must be set.
+        /// </summary>
         public string HttpEquiv 
         {
             get { return this.Http.Equiv; } 
             set { this.Http.Equiv = value; } 
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to insert this <c>meta</c> 
+        /// element at the beginning of the <c>head</c> element, rather than the
+        /// end.
+        /// </summary>
         public bool InsertFirst { get; set; }
 
         protected override void OnPreRender(EventArgs e)
@@ -84,8 +105,17 @@ namespace DotNetNuke.UI.Skins.Controls
             }
         }
 
+        /// <summary>
+        /// A class used by the <see cref="Http" /> property to enable setting
+        /// the <see cref="HttpEquiv" /> property via <c>Http-Equiv</c> syntax
+        /// in Web Forms markup.
+        /// </summary>
         public class HttpPlaceholder 
         {
+            /// <summary>
+            /// Gets or sets the <see cref="Meta.HttpEquiv"/> of the parent 
+            /// <c>meta</c> element
+            /// </summary>
             public string Equiv { get; set; }
         }
     }


### PR DESCRIPTION
The Meta skin object has an `HttpEquiv` property, but it should also support `Http-Equiv`, since may skinners will see it work for `Name` and `Content` and assume that it works with `http-equiv`.

In a skin file, with the `meta` tag registered:

    <%@ Register TagPrefix="dnn" TagName="META" Src="~/admin/Skins/Meta.ascx" %>

the following skin object reference should work:

    <dnn:Meta http-equiv="X-UA-Compatible" content="IE=edge" InsertFirst="true" runat="server"/>

See [DNN-6415](https://dnntracker.atlassian.net/browse/DNN-6415)