### PR TITLE
(doc) Clarify use of portalId param

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -1279,7 +1279,7 @@ namespace DotNetNuke.Entities.Tabs
         /// Gets the tab.
         /// </summary>
         /// <param name="tabId">The tab id.</param>
-        /// <param name="portalId">The portal id.</param>
+        /// <param name="portalId">The portal id or <see cref="P:DotNetNuke.Common.Utilities.Null.NullInteger" />.</param>
         /// <returns>tab info.</returns>
         public TabInfo GetTab(int tabId, int portalId)
         {
@@ -1290,7 +1290,7 @@ namespace DotNetNuke.Entities.Tabs
         /// Gets the tab.
         /// </summary>
         /// <param name="tabId">The tab id.</param>
-        /// <param name="portalId">The portal id.</param>
+        /// <param name="portalId">The portal id or <see cref="P:DotNetNuke.Common.Utilities.Null.NullInteger" />.</param>
         /// <param name="ignoreCache">if set to <c>true</c> will get tab info directly from database.</param>
         /// <returns>tab info.</returns>
         public TabInfo GetTab(int tabId, int portalId, bool ignoreCache)


### PR DESCRIPTION
It's not obvious how to use GetTab() method in the case we don't know portalId, but only tabId (may happen in some cross-portal scenario), without looking on GetPortalId() source.