### PR TITLE
Dnn 6096: Member Directory SortBy error

### DIFF
--- a/DNN Platform/Library/Security/PortalSecurity.cs
+++ b/DNN Platform/Library/Security/PortalSecurity.cs
@@ -367,7 +367,8 @@ namespace DotNetNuke.Security
         ///-----------------------------------------------------------------------------
         private string FormatRemoveSQL(string strSQL)
         {
-            const string BadStatementExpression = ";|--|create|drop|select|insert|delete|update|union|sp_|xp_|exec|/\\*.*\\*/|declare|waitfor|%|&";
+            // Check for forbidden T-SQL commands. Use word boundaries to filter only real statements.
+            const string BadStatementExpression = ";|--|\bcreate\b|\bdrop\b|\bselect\b|\binsert\b|\bdelete\b|\bupdate\b|\bunion\b|sp_|xp_|\bexec\b|\bexecute\b|/\\*.*\\*/|\bdeclare\b|\bwaitfor\b|%|&";
             return Regex.Replace(strSQL, BadStatementExpression, " ", RegexOptions.IgnoreCase | RegexOptions.Compiled).Replace("'", "''");
         }
 

--- a/DNN Platform/Modules/MemberDirectory/Services/MemberDirectoryController.cs
+++ b/DNN Platform/Modules/MemberDirectory/Services/MemberDirectoryController.cs
@@ -105,6 +105,16 @@ namespace DotNetNuke.Modules.MemberDirectory.Services
             }
 
             var sortField = GetSetting(ActiveModule.TabModuleSettings, "SortField", "DisplayName");
+
+            // QuickFix DNN-6096. See: https://dnntracker.atlassian.net/browse/DNN-6096
+            // Instead of changing the available SortFields, we'll use "UserId" as SortField if the TabModuleSetting SortField was CreatedOnDate.
+            // This is because the GetUsersBasicSearch and GetUsersAdvancedSearch do not allow sorting on CreatedOnDate. Sorting on UserId however
+            // has the same effect as sorting on CreatedOnDate.
+            if (sortField.Equals("CreatedOnDate", StringComparison.InvariantCultureIgnoreCase))
+            {
+                sortField = "UserId";
+            }
+
             var sortOrder = GetSetting(ActiveModule.TabModuleSettings, "SortOrder", "ASC");
 
             var excludeHostUsers = Boolean.Parse(GetSetting(ActiveModule.TabModuleSettings, "ExcludeHostUsers", "false"));


### PR DESCRIPTION
See: https://dnntracker.atlassian.net/browse/DNN-6096
- Instead of changing the available SortFields, we'll use "UserId" as SortField if the TabModuleSetting SortField was CreatedOnDate. This is because the GetUsersBasicSearch and GetUsersAdvancedSearch do not allow sorting on CreatedOnDate. Sorting on UserId however has the same effect as sorting on CreatedOnDate.
- Also invalid T-SQL statements are filtered from the inputstring.