### PR TITLE
DNN-6450 Change default trust level to Full Trust

### DIFF
--- a/Website/development.config
+++ b/Website/development.config
@@ -119,7 +119,7 @@
   <system.web>
     <machineKey validationKey="F9D1A2D3E1D3E2F7B3D9F90FF3965ABDAC304902" decryptionKey="F9D1A2D3E1D3E2F7B3D9F90FF3965ABDAC304902F8D923AC" decryption="3DES" validation="SHA1"/>
     <!-- set code access security trust level - this is generally set in the machine.config -->
-    <trust level="Medium" originUrl=".*" />
+    <trust level="Full" originUrl=".*" />
     <!-- set debugmode to false for running application -->
     <compilation debug="true" strict="false" targetFramework="4.0">
       <buildProviders>

--- a/Website/release.config
+++ b/Website/release.config
@@ -119,7 +119,7 @@
   <system.web>
     <machineKey validationKey="F9D1A2D3E1D3E2F7B3D9F90FF3965ABDAC304902" decryptionKey="F9D1A2D3E1D3E2F7B3D9F90FF3965ABDAC304902F8D923AC" decryption="3DES" validation="SHA1"/>
     <!-- set code access security trust level - this is generally set in the machine.config
-    <trust level="Medium" originUrl=".*" />
+    <trust level="Full" originUrl=".*" />
     -->
     <!-- set debugmode to false for running application -->
     <compilation debug="false" strict="false" targetFramework="4.0">


### PR DESCRIPTION
Microsoft no longer recommends using trust levels to enforce security boundaries since it has been shown to not be effective.