### PR TITLE
Dnn-3522: If-tokens in DDRmenu templates fail

### DIFF
--- a/DNN Platform/Modules/DDRMenu/MenuBase.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuBase.cs
@@ -9,6 +9,7 @@ using System.Web.UI;
 using System.Xml;
 using System.Xml.Serialization;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Host;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Entities.Users;
@@ -97,7 +98,10 @@ namespace DotNetNuke.Web.DDRMenu
 
 		internal void Render(HtmlTextWriter htmlWriter)
 		{
-			htmlWriter.Write("<!-- DDRmenu v02.00.01 - {0} template -->", menuSettings.MenuStyle);
+		    if (Host.DebugMode)
+		    {
+                htmlWriter.Write("<!-- DDRmenu v07.04.01 - {0} template -->", menuSettings.MenuStyle);
+		    }
 
 			UserInfo user = null;
 			if (menuSettings.IncludeContext)

--- a/DNN Platform/Modules/DDRMenu/TemplateEngine/TokenTemplateProcessor.cs
+++ b/DNN Platform/Modules/DDRMenu/TemplateEngine/TokenTemplateProcessor.cs
@@ -115,7 +115,7 @@ namespace DotNetNuke.Web.DDRMenu.TemplateEngine
 					if (nodeName != "else")
 					{
 						elt = xml.CreateElement("when", xmlNs);
-						var test = String.Format("{0} or (@{0}=1)", nodeName);
+                        var test = String.Format("{0} or (@{0}=1) or (@{0}!=0 and @{0}!=1 and @{0}!='')", nodeName);
 						if (directive == "?!")
 						{
 							test = String.Format("not({0})", test);


### PR DESCRIPTION
The token template processor would only check for true/false values (0, 1). Added a super ugly check if they're not 0 or 1 and also not an empty string. It seems to solve the issue with checking for icons or any other string node via the ddr token text template. 