### PR TITLE
DNN-5776 SI: Security Role Names - Invalid Characters

### DIFF
--- a/Website/DesktopModules/Admin/Security/App_LocalResources/EditRoles.ascx.resx
+++ b/Website/DesktopModules/Admin/Security/App_LocalResources/EditRoles.ascx.resx
@@ -247,7 +247,7 @@
     <value>You must select a billing frequency if you wish to enter a fee for this role</value>
   </data>
   <data name="valRoleName2.Text" xml:space="preserve">
-    <value>&lt;br&gt;The Name is invalid - roles can not contain the following characters: &amp; $ + , / ? ~ # &lt; &gt; ( ) ¿ ¡ « » !  . :  * ' [ ]</value>
+    <value>&lt;br&gt;The Name is invalid - roles can not contain the following characters: &amp; $ + , / ? ~ # &lt; &gt; ¿ ¡ « » !  . :  * ' [ ]</value>
   </data>
   <data name="securityModeListLabel.Help" xml:space="preserve">
     <value>Choose the security mode for this role/group.</value>

--- a/Website/DesktopModules/Admin/Security/editroles.ascx
+++ b/Website/DesktopModules/Admin/Security/editroles.ascx
@@ -17,7 +17,7 @@
                     <asp:TextBox ID="txtRoleName" runat="server" MaxLength="50" />
                     <asp:Label ID="lblRoleName" Visible="False" runat="server" />
                     <asp:RequiredFieldValidator ID="valRoleName" CssClass="dnnFormMessage dnnFormError" runat="server" resourcekey="valRoleName" ControlToValidate="txtRoleName" Display="Dynamic" />
-                    <asp:RegularExpressionValidator ID="valRoleName2" CssClass="dnnFormMessage dnnFormError" runat="server" resourcekey="valRoleName2" ControlToValidate="txtRoleName" Display="Dynamic" ValidationExpression="[^&\$\+,/?~#<>\(\)¿¡«»!\.:\*'\[\]]*" />
+                    <asp:RegularExpressionValidator ID="valRoleName2" CssClass="dnnFormMessage dnnFormError" runat="server" resourcekey="valRoleName2" ControlToValidate="txtRoleName" Display="Dynamic" ValidationExpression="[^&\$\+,/?~#<>¿¡«»!\.:\*'\[\]]*" />
                 </div>
                 <div class="dnnFormItem">
                     <dnn:Label ID="plDescription" runat="server" ResourceKey="Description" ControlName="txtDescription" />


### PR DESCRIPTION
Amended code to allow support for brackets (parenthesis) i.e. "(" and ")" in role names -this was already supported at the API level and brackets are used in the translator role names generated by content localization, so this just allows support at the UI level for brackets.