### PR TITLE
DNN-4941 ssl-offload issue with platform update image

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -5427,10 +5427,8 @@ namespace DotNetNuke.Services.Upgrade
             if (Host.CheckUpgrade && version != new Version(0, 0, 0))
             {
                 url = DotNetNukeContext.Current.Application.UpgradeUrl + "/update.aspx";
-                if (UrlUtils.IsSecureConnectionOrSslOffload(HttpContext.Current.Request))
-                {
-                    url = url.Replace("http://", "https://");
-                }
+                //use network path reference so it works in ssl-offload scenarios
+                url = url.Replace("http://", "//");
                 url += "?core=" + Globals.FormatVersion(Assembly.GetExecutingAssembly().GetName().Version, "00", 3, "");
                 url += "&version=" + Globals.FormatVersion(version, "00", 3, "");
                 url += "&type=" + packageType;


### PR DESCRIPTION
use network path reference (AKA protocol less url - http://tools.ietf.org/html/rfc3986#section-4.2) in image indicator to ensure that this works in ssl-offload scenarios.