### PR TITLE
DNN-6564 - Fixed wrong module order after using "down" and "up" actions

### DIFF
--- a/Website/admin/Menus/ModuleActions/ModuleActions.js
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.js
@@ -195,7 +195,7 @@
                     .fadeIn("slow", function () {
 
                         //update server
-                        completeMove(targetPane, ( 2 * moduleIndex + 2));
+                        completeMove(targetPane, ( 2 * moduleIndex + 4));
                     });
             });
         }
@@ -238,7 +238,7 @@
                     .insertBefore($("#dnn_" + targetPane).children()[moduleIndex - 1])
                     .fadeIn("slow", function () {
                         //update server
-                        completeMove(targetPane, (2 * moduleIndex - 4));
+                        completeMove(targetPane, (2 * moduleIndex - 2));
                     });
             });
         }


### PR DESCRIPTION
The module order was calculated wrong. The `up` action moved the module two positions up. The `down` action did not move the module at all.
Applying this fix worked for me, although I do not understand why the index is multiplied with 2.