### PR TITLE
DNN-6609 HTTPS 301 redirect

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -532,7 +532,7 @@ namespace DotNetNuke.Entities.Urls
                                                 ShowDebugData(context, fullUrl, result, null);
                                             }
                                             response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
-                                            response.Redirect(result.FinalUrl, false);
+                                            response.RedirectPermanent(result.FinalUrl);
                                             finished = true;
                                         }
                                         else
@@ -564,7 +564,7 @@ namespace DotNetNuke.Entities.Urls
                                             else
                                             {
                                                 response.AppendHeader("X-Redirect-Reason", result.Reason.ToString().Replace("_", " ") + " Requested");
-                                                response.Redirect(result.FinalUrl, false);
+                                                response.RedirectPermanent(result.FinalUrl);
                                                 finished = true;
                                             }
                                         }


### PR DESCRIPTION
When SSL-enforced is enabled, and the page is secure, it will now do a http 301 redirect when using advanced url's (basic already does a 301 redirect)