### PR TITLE
DNN-6649 Now the ModuleRemoved in IModuleEventHandler is raised when a m...

### DIFF
--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -815,7 +815,8 @@ namespace DotNetNuke.Entities.Modules
                 if (!uncopy)
                 {
                     UpdateTabModuleOrder(moduleInfo.TabID);
-                    if (ModuleRemoved != null)
+                    //ModuleRemove is only raised when doing a soft delete of the module
+                    if (softDelete && ModuleRemoved != null)
                     { 
                         ModuleRemoved(null, new ModuleEventArgs { Module = moduleInfo });
                     }
@@ -1193,7 +1194,8 @@ namespace DotNetNuke.Entities.Modules
             {
                 ClearCache(tabId);
 
-                if (ModuleRemoved != null)
+                //ModuleRemove is only raised when doing a soft delete of the module
+                if (softDelete && ModuleRemoved != null)
                     ModuleRemoved(null, new ModuleEventArgs { Module = moduleInfo });
             }
         }

--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -814,7 +814,11 @@ namespace DotNetNuke.Entities.Modules
                 //reorder all modules on tab
                 if (!uncopy)
                 {
-                    UpdateTabModuleOrder(moduleInfo.TabID);                    
+                    UpdateTabModuleOrder(moduleInfo.TabID);
+                    if (ModuleRemoved != null)
+                    { 
+                        ModuleRemoved(null, new ModuleEventArgs { Module = moduleInfo });
+                    }
                 }
 
                 //check if all modules instances have been deleted
@@ -1169,6 +1173,8 @@ namespace DotNetNuke.Entities.Modules
         ///	<param name="deleteBaseModule">A flag to indicate whether to delete the Module itself</param>
         public void DeleteAllModules(int moduleId, int tabId, List<TabInfo> fromTabs, bool softDelete, bool includeCurrent, bool deleteBaseModule)
         {
+            var moduleInfo = GetModule(moduleId, tabId, false); 
+
             //Iterate through collection deleting the module from each Tab (except the current)
             foreach (TabInfo objTab in fromTabs)
             {
@@ -1188,7 +1194,7 @@ namespace DotNetNuke.Entities.Modules
                 ClearCache(tabId);
 
                 if (ModuleRemoved != null)
-                    ModuleRemoved(null, new ModuleEventArgs { Module = new ModuleInfo { ModuleID = moduleId } });
+                    ModuleRemoved(null, new ModuleEventArgs { Module = moduleInfo });
             }
         }
 


### PR DESCRIPTION
Now the ModuleRemoved in IModuleEventHandler is raised when a module is removed from a page.
Also a complete ModuleInfo object is used when raising the event of removing a module from all pages instead of one with only the ModuleId.
Could you please review the code and merge it?