### PR TITLE
DNN-6659 Allow long JS library version numbers

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
@@ -162,14 +162,14 @@ BEGIN
 END
 GO
 
-IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}JavaScriptLibraries]') AND name = 'Version' AND max_length = 64)
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}JavaScriptLibraries]') AND name = 'Version' AND max_length = 100)
 	BEGIN
 		ALTER TABLE {databaseOwner}[{objectQualifier}JavaScriptLibraries]
-			ALTER COLUMN [Version] [nvarchar](32) NOT NULL;
+			ALTER COLUMN [Version] [nvarchar](50) NOT NULL;
 	END
 GO
 
-IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]') AND type in (N'P', N'PC'))
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]') AND type in (N'P', N'PC'))
 	DROP PROCEDURE {databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]
 GO
 
@@ -177,7 +177,7 @@ CREATE PROCEDURE {databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]
 	@JavaScriptLibraryID INT,
 	@PackageID INT,
 	@LibraryName NVARCHAR(200),
-	@Version NVARCHAR(32),
+	@Version NVARCHAR(50),
 	@FileName NVARCHAR(100),
 	@ObjectName NVARCHAR(100),
 	@PreferredScriptLocation int,

--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
@@ -162,6 +162,65 @@ BEGIN
 END
 GO
 
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}JavaScriptLibraries]') AND name = 'Version' AND max_length = 64)
+	BEGIN
+		ALTER TABLE {databaseOwner}[{objectQualifier}JavaScriptLibraries]
+			ALTER COLUMN [Version] [nvarchar](32) NOT NULL;
+	END
+GO
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}SaveJavaScriptLibrary]
+	@JavaScriptLibraryID INT,
+	@PackageID INT,
+	@LibraryName NVARCHAR(200),
+	@Version NVARCHAR(32),
+	@FileName NVARCHAR(100),
+	@ObjectName NVARCHAR(100),
+	@PreferredScriptLocation int,
+	@CDNPath NVARCHAR(250)
+AS
+
+	IF EXISTS (SELECT JavaScriptLibraryID FROM {objectQualifier}JavaScriptLibraries WHERE JavaScriptLibraryID = @JavaScriptLibraryID)
+		BEGIN
+			UPDATE {databaseOwner}[{objectQualifier}JavaScriptLibraries]
+			   SET [PackageID] = @PackageID,
+					[LibraryName] = @LibraryName,
+					[Version] = @Version,
+					[FileName] = @FileName,
+					[ObjectName] = @ObjectName,
+					[PreferredScriptLocation] = @PreferredScriptLocation,
+					[CDNPath] = @CDNPath
+			 WHERE JavaScriptLibraryID = @JavaScriptLibraryID
+	 	END
+	ELSE
+		BEGIN
+			INSERT INTO {databaseOwner}[{objectQualifier}JavaScriptLibraries] (
+				[PackageID],
+				[LibraryName],
+				[Version],
+				[FileName],
+				[ObjectName],
+				[PreferredScriptLocation],
+				[CDNPath]
+			)
+			VALUES (
+				@PackageID,
+				@LibraryName,
+				@Version,
+				@FileName,
+				@ObjectName,
+				@PreferredScriptLocation,
+				@CDNPath
+			)
+			SET @JavaScriptLibraryID = (SELECT @@IDENTITY)
+		END
+		
+	SELECT @JavaScriptLibraryID
+GO
 
 /************************************************************/
 /*****              SqlDataProvider                     *****/

--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
@@ -222,6 +222,42 @@ AS
 	SELECT @JavaScriptLibraryID
 GO
 
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}SavePackageDependency]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}SavePackageDependency]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}SavePackageDependency]
+	@PackageDependencyID INT,
+	@PackageID INT,
+	@PackageName NVARCHAR(128),
+	@Version NVARCHAR(50)
+AS
+	IF EXISTS (SELECT PackageDependencyID FROM {objectQualifier}PackageDependencies WHERE PackageID = @PackageID AND PackageName = @PackageName AND Version = @Version)
+		BEGIN
+			UPDATE {databaseOwner}[{objectQualifier}PackageDependencies]
+			   SET [PackageID] = @PackageID,
+					[PackageName] = @PackageName,
+					[Version] = @Version
+			 WHERE PackageDependencyID = @PackageDependencyID
+		END
+	ELSE
+		BEGIN
+			INSERT INTO {databaseOwner}[{objectQualifier}PackageDependencies] (
+				[PackageID],
+				[PackageName],
+				[Version]
+			)
+			VALUES (
+				@PackageID,
+				@PackageName,
+				@Version
+			)
+			SET @PackageDependencyID = (SELECT @@IDENTITY)
+		END
+
+	SELECT @PackageDependencyID
+GO
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/


### PR DESCRIPTION
[DNN-6659](https://dnntracker.atlassian.net/browse/DNN-6659)

>The JavaScript Library table's `Version` column can only hold 10 characters, but versions can be longer than that. Installing [JS libraries for Kendo UI](https://github.com/EngageSoftware/DNN-JavaScript-Libraries/releases/tag/kendo-ui-core_2014.3.1424) demonstrates the problem. The version number 2014.3.1424 is 11 characters, so a link is generated to `/Resources/libraries/kendo.core/2014_03_142/kendo.core.min.js` (notice the missing `4` at the end of the version part of the URL).