### PR TITLE
DNN-6660 ClientDependancy breaks dataUris in css

### DIFF
--- a/DNN Platform/Components/ClientDependency/Source/CssFileUrlFormatter.cs
+++ b/DNN Platform/Components/ClientDependency/Source/CssFileUrlFormatter.cs
@@ -19,7 +19,8 @@ namespace ClientDependency.Core
 		{
 			string str = Regex.Replace(
 				fileContent,
-				@"url\(((?!data:).+?)\)",
+        // DNN-6660 Fix for CDF breaking dateUris
+        @"url\(((?![""']?data:).+?)\)",
 				new MatchEvaluator(
 					delegate(Match m)
 					{


### PR DESCRIPTION
Fix for the CDF striping out the data: attribute from CSS embed images. Images can actually render now.