### PR TITLE
DNN-6544 Platform - Cannot Create Child Site or Parent Site. Error parsi...

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2265,7 +2265,8 @@ namespace DotNetNuke.Entities.Portals
                 }
                 else
                 {
-                    list.Add(new PortalTemplateInfo(templateFilePath, ""));
+                    //DNN-6544 portal creation requires valid culture, if template has no culture defined, then use current 
+                    list.Add(new PortalTemplateInfo(templateFilePath, GetCurrentPortalSettingsInternal().CultureCode ?? Thread.CurrentThread.CurrentCulture.Name));
                 }
             }
 
@@ -3459,7 +3460,8 @@ namespace DotNetNuke.Entities.Portals
                 }
                 else
                 {
-                    CultureCode = "";
+                    //DNN-6544 portal creation requires valid culture, if template has no culture defined, then use current
+                    CultureCode = GetCurrentPortalSettingsInternal().CultureCode ?? Thread.CurrentThread.CurrentCulture.Name;
                 }
             }
 

--- a/DNN Platform/Library/Services/Cache/CachingProvider.cs
+++ b/DNN Platform/Library/Services/Cache/CachingProvider.cs
@@ -223,7 +223,7 @@ namespace DotNetNuke.Services.Cache
         private void ClearPortalCacheInternal(int portalId, bool cascade, bool clearRuntime)
         {
             //DNN-6170 PortalSettingsCacheKey has culture param
-            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId);
+            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, );
 
             Dictionary<string, Locale> locales = LocaleController.Instance.GetLocales(portalId);
             if (locales == null || locales.Count == 0)
@@ -242,7 +242,6 @@ namespace DotNetNuke.Services.Cache
                     RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, portalLocale.Code);
                 }
                 RemoveCacheKey(String.Format(DataCache.PortalCacheKey, portalId, Null.NullString), clearRuntime);
-                RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, Null.NullString);
             }
             if (cascade)
             {

--- a/DNN Platform/Library/Services/Cache/CachingProvider.cs
+++ b/DNN Platform/Library/Services/Cache/CachingProvider.cs
@@ -223,7 +223,7 @@ namespace DotNetNuke.Services.Cache
         private void ClearPortalCacheInternal(int portalId, bool cascade, bool clearRuntime)
         {
             //DNN-6170 PortalSettingsCacheKey has culture param
-            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, );
+            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId);
 
             Dictionary<string, Locale> locales = LocaleController.Instance.GetLocales(portalId);
             if (locales == null || locales.Count == 0)
@@ -242,6 +242,7 @@ namespace DotNetNuke.Services.Cache
                     RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, portalLocale.Code);
                 }
                 RemoveCacheKey(String.Format(DataCache.PortalCacheKey, portalId, Null.NullString), clearRuntime);
+                RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, Null.NullString);
             }
             if (cascade)
             {


### PR DESCRIPTION
This issue is caused by the absence of culture code in templates that are created using "Export Site" option: var portalInfo inside ParseTemplateInternal returns null because portal was created with null CultureCode value.
Changes that were introduced in DNN-6530 now use culture code during portal creation, but methods inside PortalTemplateInfo class define culture based on the language resource file, that are absent in case when template is created from existing portal.
