### PR TITLE
DNN-6170 Switching Language does not clear portalsettings cache

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2265,7 +2265,8 @@ namespace DotNetNuke.Entities.Portals
                 }
                 else
                 {
-                    list.Add(new PortalTemplateInfo(templateFilePath, ""));
+                    //DNN-6544 portal creation requires valid culture, if template has no culture defined, then use current 
+                    list.Add(new PortalTemplateInfo(templateFilePath, GetCurrentPortalSettingsInternal().CultureCode ?? Thread.CurrentThread.CurrentCulture.Name));
                 }
             }
 
@@ -3459,7 +3460,8 @@ namespace DotNetNuke.Entities.Portals
                 }
                 else
                 {
-                    CultureCode = "";
+                    //DNN-6544 portal creation requires valid culture, if template has no culture defined, then use current
+                    CultureCode = GetCurrentPortalSettingsInternal().CultureCode ?? Thread.CurrentThread.CurrentCulture.Name;
                 }
             }
 

--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -316,11 +316,15 @@ namespace DotNetNuke.Entities.Portals
         {
             if (Globals.IsAdminSkin())
             {
-                activeTab.SkinSrc = portalSettings.DefaultAdminSkin;
+                //DNN-6170 ensure skin value is culture specific
+                activeTab.SkinSrc = PortalController.GetPortalSetting("DefaultAdminSkin", portalSettings.PortalId,
+                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode) ?? portalSettings.DefaultAdminSkin;
             }
             else if (String.IsNullOrEmpty(activeTab.SkinSrc))
             {
-                activeTab.SkinSrc = portalSettings.DefaultPortalSkin;
+                //DNN-6170 ensure skin value is culture specific
+                activeTab.SkinSrc = PortalController.GetPortalSetting("DefaultPortalSkin", portalSettings.PortalId,
+                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode) ?? portalSettings.DefaultPortalSkin;
             }
             activeTab.SkinSrc = SkinController.FormatSkinSrc(activeTab.SkinSrc, portalSettings);
             activeTab.SkinPath = SkinController.FormatSkinPath(activeTab.SkinSrc);

--- a/DNN Platform/Library/Services/Cache/CachingProvider.cs
+++ b/DNN Platform/Library/Services/Cache/CachingProvider.cs
@@ -223,7 +223,7 @@ namespace DotNetNuke.Services.Cache
         private void ClearPortalCacheInternal(int portalId, bool cascade, bool clearRuntime)
         {
             //DNN-6170 PortalSettingsCacheKey has culture param
-            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId);
+            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, );
 
             Dictionary<string, Locale> locales = LocaleController.Instance.GetLocales(portalId);
             if (locales == null || locales.Count == 0)
@@ -242,7 +242,6 @@ namespace DotNetNuke.Services.Cache
                     RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, portalLocale.Code);
                 }
                 RemoveCacheKey(String.Format(DataCache.PortalCacheKey, portalId, Null.NullString), clearRuntime);
-                RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, Null.NullString);
             }
             if (cascade)
             {

--- a/DNN Platform/Library/Services/Cache/CachingProvider.cs
+++ b/DNN Platform/Library/Services/Cache/CachingProvider.cs
@@ -223,7 +223,7 @@ namespace DotNetNuke.Services.Cache
         private void ClearPortalCacheInternal(int portalId, bool cascade, bool clearRuntime)
         {
             //DNN-6170 PortalSettingsCacheKey has culture param
-            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, );
+            //RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId);
 
             Dictionary<string, Locale> locales = LocaleController.Instance.GetLocales(portalId);
             if (locales == null || locales.Count == 0)
@@ -242,6 +242,7 @@ namespace DotNetNuke.Services.Cache
                     RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, portalLocale.Code);
                 }
                 RemoveCacheKey(String.Format(DataCache.PortalCacheKey, portalId, Null.NullString), clearRuntime);
+                RemoveFormattedCacheKey(DataCache.PortalSettingsCacheKey, clearRuntime, portalId, Null.NullString);
             }
             if (cascade)
             {

--- a/DNN Platform/Library/UI/Skins/Skin.cs
+++ b/DNN Platform/Library/UI/Skins/Skin.cs
@@ -997,7 +997,10 @@ namespace DotNetNuke.UI.Skins
             //load assigned skin
             if (skin == null)
             {
-                skinSource = Globals.IsAdminSkin() ? SkinController.FormatSkinSrc(page.PortalSettings.DefaultAdminSkin, page.PortalSettings) : page.PortalSettings.ActiveTab.SkinSrc;
+                //DNN-6170 ensure skin value is culture specific
+                //skinSource = Globals.IsAdminSkin() ? SkinController.FormatSkinSrc(page.PortalSettings.DefaultAdminSkin, page.PortalSettings) : page.PortalSettings.ActiveTab.SkinSrc;
+                skinSource = Globals.IsAdminSkin() ? PortalController.GetPortalSetting("DefaultAdminSkin", page.PortalSettings.PortalId,
+                    Host.DefaultPortalSkin, page.PortalSettings.CultureCode) : page.PortalSettings.ActiveTab.SkinSrc;
                 if (!String.IsNullOrEmpty(skinSource))
                 {
                     skinSource = SkinController.FormatSkinSrc(skinSource, page.PortalSettings);

--- a/Website/admin/Skins/Language.ascx.cs
+++ b/Website/admin/Skins/Language.ascx.cs
@@ -25,7 +25,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Web.UI.WebControls;
-
+using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Framework;
@@ -386,6 +386,8 @@ namespace DotNetNuke.UI.Skins.Controls
         {
 			//Redirect to same page to update all controls for newly selected culture
             LocalTokenReplace.Language = selectCulture.SelectedItem.Value;
+            //DNN-6170 ensure skin value is culture specific in case of  static localization
+            DataCache.RemoveCache(string.Format(DataCache.PortalSettingsCacheKey, PortalSettings.PortalId, Null.NullString));
             Response.Redirect(LocalTokenReplace.ReplaceEnvironmentTokens("[URL]"));
         }
 


### PR DESCRIPTION
Since PortalCacheKey now has a culture variation, each culture, including neutral one would have its own portalsettings dictionary. 
When site settings are loaded both dictionaries would be used, depending on the current culture and setting type (culture dependent or not). When setting gets update we need to ensure both cachekeys are cleared (when clear cache is set to true) because we don't know if setting is culture specific or not.
