### PR TITLE
DNN-6672: Do not include GhostDoc solution files in commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.user
 *.sln.docstates
 *.local.sln
+*.local.sln.GhostDoc.xml
 
 ## Ignore VS2015/Roslyn artifacts
 *.sln.ide/


### PR DESCRIPTION
Needed for people working with Ghostdoc for auto code documentation