### PR TITLE
DNN-6690 EVOQCONTENT: Parent site cannot be created with an error

### DIFF
--- a/Website/DesktopModules/Admin/Portals/Signup.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/Signup.ascx.cs
@@ -388,7 +388,16 @@ namespace DotNetNuke.Modules.Admin.Portals
                     //Validate Portal Alias
                     if (!string.IsNullOrEmpty(strPortalAlias))
                     {
-                        PortalAliasInfo portalAlias = PortalAliasController.Instance.GetPortalAlias(strPortalAlias.ToLower());
+                        PortalAliasInfo portalAlias = null;
+                        foreach (PortalAliasInfo alias in PortalAliasController.Instance.GetPortalAliases().Values)
+                        {
+                            if (String.Equals(alias.HTTPAlias, strPortalAlias, StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                portalAlias = alias;
+                                break;
+                            }
+                        }
+
                         if (portalAlias != null)
                         {
                             message = Localization.GetString("DuplicatePortalAlias", LocalResourceFile);


### PR DESCRIPTION
This commit modifies how the Create New Site logic checks for the existence of the chosen portal alias.  This allows subdomains "p1.domain.com" to be created when "www.domain.com" already exists.  The original logic did not allow this.