### PR TITLE
DNN-6703 PortalController and PortalSettingsController Unit tests are br...

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2266,7 +2266,7 @@ namespace DotNetNuke.Entities.Portals
                 else
                 {
                     //DNN-6544 portal creation requires valid culture, if template has no culture defined, then use current 
-                    list.Add(new PortalTemplateInfo(templateFilePath, GetCurrentPortalSettingsInternal().CultureCode ?? Thread.CurrentThread.CurrentCulture.Name));
+                    list.Add(new PortalTemplateInfo(templateFilePath, (GetCurrentPortalSettingsInternal() != null) ? GetCurrentPortalSettingsInternal().CultureCode : Thread.CurrentThread.CurrentCulture.Name));
                 }
             }
 
@@ -3461,7 +3461,7 @@ namespace DotNetNuke.Entities.Portals
                 else
                 {
                     //DNN-6544 portal creation requires valid culture, if template has no culture defined, then use current
-                    CultureCode = GetCurrentPortalSettingsInternal().CultureCode ?? Thread.CurrentThread.CurrentCulture.Name;
+                    CultureCode = (GetCurrentPortalSettingsInternal() != null) ? GetCurrentPortalSettingsInternal().CultureCode : Thread.CurrentThread.CurrentCulture.Name;
                 }
             }
 

--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -316,14 +316,16 @@ namespace DotNetNuke.Entities.Portals
             if (Globals.IsAdminSkin())
             {
                 //DNN-6170 ensure skin value is culture specific
-                activeTab.SkinSrc = PortalController.GetPortalSetting("DefaultAdminSkin", portalSettings.PortalId,
-                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode) ?? portalSettings.DefaultAdminSkin;
+                activeTab.SkinSrc = String.IsNullOrEmpty(PortalController.GetPortalSetting("DefaultAdminSkin", portalSettings.PortalId,
+                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode)) ? portalSettings.DefaultAdminSkin : PortalController.GetPortalSetting("DefaultAdminSkin", portalSettings.PortalId,
+                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode);
             }
             else if (String.IsNullOrEmpty(activeTab.SkinSrc))
             {
                 //DNN-6170 ensure skin value is culture specific
-                activeTab.SkinSrc = PortalController.GetPortalSetting("DefaultPortalSkin", portalSettings.PortalId,
-                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode) ?? portalSettings.DefaultPortalSkin;
+                activeTab.SkinSrc = String.IsNullOrEmpty(PortalController.GetPortalSetting("DefaultPortalSkin", portalSettings.PortalId,
+                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode)) ? portalSettings.DefaultPortalSkin : PortalController.GetPortalSetting("DefaultPortalSkin", portalSettings.PortalId,
+                    Host.Host.DefaultPortalSkin, portalSettings.CultureCode);
             }
             activeTab.SkinSrc = SkinController.FormatSkinSrc(activeTab.SkinSrc, portalSettings);
             activeTab.SkinPath = SkinController.FormatSkinPath(activeTab.SkinSrc);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Portal/PortalControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Portal/PortalControllerTests.cs
@@ -21,7 +21,7 @@
 
 using System.Collections.Generic;
 using System.IO;
-
+using System.Threading;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Portals.Internal;
 
@@ -61,13 +61,15 @@ namespace DotNetNuke.Tests.Core.Controllers.Portal
                                                                                     };
 
         private const string StaticName = "Static";
+        readonly static string CultureCode = Thread.CurrentThread.CurrentCulture.Name;
         private static readonly string StaticPath = MakePath(StaticName);
         const string StaticDescription = "An description from a template file";
         private static readonly Dictionary<string, string> StaticExpectations = new Dictionary<string, string>
                                                                                     {
                                                                                         {"Name", StaticName},
                                                                                         {"TemplateFilePath", StaticPath},
-                                                                                        {"Description", StaticDescription}
+                                                                                        {"Description", StaticDescription},
+                                                                                        {"CultureCode", CultureCode}
                                                                                     };
 
         private const string AlternateName = "Alternate";
@@ -89,7 +91,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Portal
                                                                                     {
                                                                                         {"Name", ResourceName},
                                                                                         {"TemplateFilePath", ResourcePath},
-                                                                                        {"ResourceFilePath", ResourceFilePath}
+                                                                                        {"ResourceFilePath", ResourceFilePath},
+                                                                                        {"CultureCode", CultureCode}
                                                                                     };
 
         [SetUp]
@@ -262,7 +265,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Portal
             _mockPortalTemplateIO.Setup(x => x.OpenTextReader(StaticPath)).Returns(CreateTemplateFileReader(StaticDescription));
 
             //Act
-            var template = PortalController.Instance.GetPortalTemplate(StaticPath, null);
+            var template = PortalController.Instance.GetPortalTemplate(StaticPath, CultureCode);
 
             //Assert
             AssertTemplateInfo(StaticExpectations, template);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
 using DotNetNuke.Common;
+using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Controllers;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
@@ -78,7 +79,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
             var isHostDefault = Boolean.Parse(testFields["IsHostDefault"]);
             var defaultValue = testFields["DefaultValue"];
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings() { PortalId = ValidPortalId};
+            var settings = new PortalSettings() { PortalId = ValidPortalId, CultureCode = Null.NullString};
             var hostSettings = PortalSettingsControllerTestFactory.GetHostSettings();
 
             var mockPortalController = new Mock<IPortalController>();
@@ -130,7 +131,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
             var settingValue = testFields["SettingValue"];
             var propertyValue = (testFields.ContainsKey("PropertyValue")) ? testFields["PropertyValue"] : settingValue;
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings() { PortalId = ValidPortalId };
+            var settings = new PortalSettings() { PortalId = ValidPortalId, CultureCode = Null.NullString };
             var hostSettings = PortalSettingsControllerTestFactory.GetHostSettings();
 
             var mockPortalController = new Mock<IPortalController>();
@@ -171,7 +172,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings() { PortalId = ValidPortalId };
+            var settings = new PortalSettings() { PortalId = ValidPortalId, CultureCode = Null.NullString };
             var hostSettings = PortalSettingsControllerTestFactory.GetHostSettings();
 
             var mockPortalController = new Mock<IPortalController>();
@@ -210,7 +211,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
                 DefaultLanguage = Localization.SystemLocale,
                 HomeDirectory = "Portals/0"
             };
-            var settings = new PortalSettings() { PortalId = ValidPortalId };
+            var settings = new PortalSettings() { PortalId = ValidPortalId, CultureCode = Null.NullString };
 
             //Act
             controller.LoadPortal(portal,settings);
@@ -263,7 +264,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId };
+            var settings = new PortalSettings { PortalId = ValidPortalId, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId };
 
             var mockLocaleController = new Mock<ILocaleController>();
@@ -287,7 +288,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId };
+            var settings = new PortalSettings { PortalId = ValidPortalId, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = HostTabId, PortalID = HostPortalId };
 
             var mockLocaleController = new Mock<ILocaleController>();
@@ -311,7 +312,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, SplashTabId = SplashTabId};
+            var settings = new PortalSettings { PortalId = ValidPortalId, SplashTabId = SplashTabId, CultureCode = Null.NullString};
             var splashTabId = new TabInfo {TabID = SplashTabId, PortalID = ValidPortalId};
 
             var mockLocaleController = new Mock<ILocaleController> ();
@@ -334,7 +335,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, HomeTabId = HomeTabId };
+            var settings = new PortalSettings { PortalId = ValidPortalId, HomeTabId = HomeTabId, CultureCode = Null.NullString };
             var homeTabId = new TabInfo { TabID = HomeTabId, PortalID = ValidPortalId };
 
             var mockLocaleController = new Mock<ILocaleController>();
@@ -357,7 +358,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, SplashTabId = SplashTabId, HomeTabId = HomeTabId};
+            var settings = new PortalSettings { PortalId = ValidPortalId, SplashTabId = SplashTabId, HomeTabId = HomeTabId, CultureCode = Null.NullString};
             var splashTabId = new TabInfo { TabID = SplashTabId, PortalID = ValidPortalId };
             var homeTabId = new TabInfo { TabID = HomeTabId, PortalID = ValidPortalId };
 
@@ -381,7 +382,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId };
+            var settings = new PortalSettings { PortalId = ValidPortalId, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId };
 
             var mockLocaleController = new Mock<ILocaleController>();
@@ -406,9 +407,13 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalSkin = DefaultSkin };
+            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalSkin = DefaultSkin, DefaultPortalContainer = DefaultContainer, CultureCode = Null.NullString};
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId };
             settings.ActiveTab = validTab;
+
+            var mockHostController = new Mock<IHostController>();
+            mockHostController.Setup(c => c.GetString("DefaultPortalSkin")).Returns(DefaultSkin);
+            HostController.RegisterInstance(mockHostController.Object);
 
             var mockLocaleController = new Mock<ILocaleController>();
             mockLocaleController.Setup(c => c.GetLocales(It.IsAny<int>())).Returns(new Dictionary<string, Locale>());
@@ -431,7 +436,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalSkin = DefaultSkin };
+            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalSkin = DefaultSkin, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId, SkinSrc = TabSkin};
             settings.ActiveTab = validTab;
 
@@ -456,7 +461,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalSkin = DefaultSkin };
+            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalSkin = DefaultSkin, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId, SkinSrc = GlobalTabSkin };
             settings.ActiveTab = validTab;
 
@@ -481,9 +486,10 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalContainer = DefaultContainer };
+            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalContainer = DefaultContainer, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId };
             settings.ActiveTab = validTab;
+            settings.ActiveTab.SkinSrc = TabSkin;
 
             var mockLocaleController = new Mock<ILocaleController>();
             mockLocaleController.Setup(c => c.GetLocales(It.IsAny<int>())).Returns(new Dictionary<string, Locale>());
@@ -506,9 +512,10 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalContainer = DefaultContainer };
+            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalContainer = DefaultContainer, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId, ContainerSrc = TabContainer };
             settings.ActiveTab = validTab;
+            settings.ActiveTab.SkinSrc = TabSkin;
 
             var mockLocaleController = new Mock<ILocaleController>();
             mockLocaleController.Setup(c => c.GetLocales(It.IsAny<int>())).Returns(new Dictionary<string, Locale>());
@@ -531,9 +538,10 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalContainer = DefaultContainer };
+            var settings = new PortalSettings { PortalId = ValidPortalId, DefaultPortalContainer = DefaultContainer, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId, ContainerSrc = GlobalTabContainer };
             settings.ActiveTab = validTab;
+            settings.ActiveTab.SkinSrc = TabSkin;
 
             var mockLocaleController = new Mock<ILocaleController>();
             mockLocaleController.Setup(c => c.GetLocales(It.IsAny<int>())).Returns(new Dictionary<string, Locale>());
@@ -556,8 +564,8 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId };
-            var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId };
+            var settings = new PortalSettings { PortalId = ValidPortalId, CultureCode = Null.NullString};
+            var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId, SkinSrc = GlobalTabSkin };
             settings.ActiveTab = validTab;
 
             var mockLocaleController = new Mock<ILocaleController>();
@@ -582,10 +590,11 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             //Arrange
             var controller = new PortalSettingsController();
-            var settings = new PortalSettings { PortalId = ValidPortalId };
+            var settings = new PortalSettings { PortalId = ValidPortalId, CultureCode = Null.NullString };
             var validTab = new TabInfo { TabID = ValidTabId, PortalID = ValidPortalId, ParentId = ParentTabId};
             var parentTab = new TabInfo { TabID = ParentTabId, PortalID = ValidPortalId };
             settings.ActiveTab = validTab;
+            settings.ActiveTab.SkinSrc = TabSkin;
 
             var mockLocaleController = new Mock<ILocaleController>();
             mockLocaleController.Setup(c => c.GetLocales(It.IsAny<int>())).Returns(new Dictionary<string, Locale>());


### PR DESCRIPTION
This changes will fix 10 broken unit tests in PortalController and PortalSettingsController.
Changes not only in unit tests, but also in controllers - this was required to better deal with possible null value of the PortalSettings. Changes in controllers won't affect existing behavior and intended for unit tests only.
