### PR TITLE
DNN-5904 Exporting a site with content doesn't save URL information

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -387,6 +388,17 @@ namespace DotNetNuke.Entities.Tabs
             }
         }
 
+        private static void DeserializeTabUrls(XmlNode nodeTabUrl, TabUrlInfo objTabUrl)
+        {
+            objTabUrl.SeqNum = XmlUtils.GetAttributeValueAsInteger(nodeTabUrl.CreateNavigator(), "seqNum", 0);
+            objTabUrl.Url = String.IsNullOrEmpty(XmlUtils.GetAttributeValue(nodeTabUrl.CreateNavigator(), "Url")) ? "/" : XmlUtils.GetAttributeValue(nodeTabUrl.CreateNavigator(), "Url") ;
+            objTabUrl.CultureCode = XmlUtils.GetAttributeValue(nodeTabUrl.CreateNavigator(), "CultureCode");
+            objTabUrl.HttpStatus = String.IsNullOrEmpty(XmlUtils.GetAttributeValue(nodeTabUrl.CreateNavigator(), "HttpStatus")) ? "200" : XmlUtils.GetAttributeValue(nodeTabUrl.CreateNavigator(), "HttpStatus");
+            objTabUrl.IsSystem = XmlUtils.GetAttributeValueAsBoolean(nodeTabUrl.CreateNavigator(), "IsSystem", true);
+            objTabUrl.PortalAliasId = Null.NullInteger;
+            objTabUrl.PortalAliasUsage = PortalAliasUsageType.Default;
+        }
+        
         private Dictionary<int, List<TabAliasSkinInfo>> GetAliasSkins(int portalId)
         {
             string cacheKey = string.Format(DataCache.TabAliasSkinCacheKey, portalId);
@@ -2376,9 +2388,17 @@ namespace DotNetNuke.Entities.Tabs
                 }
                 else
                 {
-                    Instance.UpdateTab(tab);
+                    Instance.UpdateTab(tab);                   
                 }
 
+                //UpdateTabUrls
+                foreach (XmlNode oTabUrlNode in tabNode.SelectNodes("tabUrls/tabUrl"))
+                {
+                    var tabUrl = new TabUrlInfo();
+                    DeserializeTabUrls(oTabUrlNode, tabUrl);
+                    DataProvider.Instance().SaveTabUrl(tab.TabID, tabUrl.SeqNum, tabUrl.PortalAliasId, (int)tabUrl.PortalAliasUsage, tabUrl.Url, tabUrl.QueryString, tabUrl.CultureCode, tabUrl.HttpStatus, tabUrl.IsSystem, UserController.Instance.GetCurrentUserInfo().UserID);
+                }
+                
                 //extra check for duplicate tabs in same level
                 if (tabs[tabName] == null)
                 {
@@ -2854,6 +2874,21 @@ namespace DotNetNuke.Entities.Tabs
                     modulesNode = panesNode.SelectSingleNode("descendant::pane[name='" + module.PaneName + "']/modules");
                     modulesNode.AppendChild(tabXml.ImportNode(moduleNode, true));
                 }
+            }
+
+            //Serialize TabUrls
+            var tabUrlsNode = tabNode.AppendChild(tabXml.CreateElement("tabUrls"));
+            foreach (var tabUrl in TabController.Instance.GetTabUrls(tab.TabID, portal.PortalID))
+            {
+                var tabUrlXml = new XmlDocument();
+                XmlNode tabUrlNode = tabUrlXml.CreateElement("tabUrl");
+                tabUrlNode.AddAttribute("SeqNum", tabUrl.SeqNum.ToString(CultureInfo.InvariantCulture));
+                tabUrlNode.AddAttribute("Url", tabUrl.Url);
+                tabUrlNode.AddAttribute("QueryString", tabUrl.QueryString);
+                tabUrlNode.AddAttribute("HttpStatus", tabUrl.HttpStatus);
+                tabUrlNode.AddAttribute("CultureCode", tabUrl.CultureCode);
+                tabUrlNode.AddAttribute("IsSystem", tabUrl.IsSystem.ToString());
+                tabUrlsNode.AppendChild(tabXml.ImportNode(tabUrlNode, true));
             }
 
             if (TabSerialize != null)

--- a/Website/DesktopModules/Admin/Portals/portal.template.xsd
+++ b/Website/DesktopModules/Admin/Portals/portal.template.xsd
@@ -282,6 +282,22 @@
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="tabUrls" maxOccurs="1" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="tabUrl" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="SeqNum" type="xs:string"/>
+                              <xs:attribute name="Url" type="xs:string"/>
+                              <xs:attribute name="QueryString" type="xs:string"/>
+                              <xs:attribute name="HttpStatus" type="xs:string"/>
+                              <xs:attribute name="CultureCode" type="xs:string"/>
+                              <xs:attribute name="IsSystem" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
                     <xs:element name="refreshinterval" type="xs:string" minOccurs="0" maxOccurs="1" />
                     <xs:element name="pageheadtext" type="xs:string" minOccurs="0" maxOccurs="1" />
                     <xs:element name="permanentredirect" type="xs:boolean" minOccurs="0" maxOccurs="1" />


### PR DESCRIPTION
Added taburls to the portal template (export /import).
PortalAlias usage and Id are not exported, but set to default (tab serialization used for both templates and pages export/import so I set default values to avoid issues with portalid reference during portal creation):
            objTabUrl.PortalAliasId = Null.NullInteger;
            objTabUrl.PortalAliasUsage = PortalAliasUsageType.Default;
Other values are exported/imported as is.

Tested using DNN Platform site with localized content and tabUrls set on multiple pages.