### PR TITLE
DNN-6730 use parameters names in generated SQL when calling stored procedure

### DIFF
--- a/DNN Platform/Library/Data/DataUtil.cs
+++ b/DNN Platform/Library/Data/DataUtil.cs
@@ -22,6 +22,8 @@
 #endregion
 
 using System;
+using System.Data;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -114,14 +116,25 @@ namespace DotNetNuke.Data
         {
             var sb = new StringBuilder(";Exec ");
             sb.Append(procedureName);
-            for (int i = 0; i < args.Count(); i++)
+            for (int i = 0; i < args.Length; i++)
             {
-                sb.Append(String.Format(" @{0}", i));
-                if (i < args.Count() - 1)
+                var parameterFormat = " @{0}";
+                string parameterName = null;
+                var param = args[i] as IDataParameter;
+                if (param != null)
+                {
+                    // intentionally adding an extra @ before parameter name, so PetaPoco won't try to match it to a passed-in arg
+                    parameterFormat = " @{1}=@{0}";
+                    parameterName = param.ParameterName;
+                }
+
+                sb.AppendFormat(CultureInfo.InvariantCulture, parameterFormat, i, parameterName);
+                if (i < args.Length - 1)
                 {
                     sb.Append(",");
                 }
             }
+
             return sb.ToString();
         }
 


### PR DESCRIPTION
See [DNN-6730](https://dnntracker.atlassian.net/browse/DNN-6730)

>When calling `DataProvider.Instance().ExecuteReader` (or any other `Execute*` method), you should be able to pass `SqlParameter` objects to include the parameter name with the value. This makes the calling code not have to be dependent on the order of parameters in the stored procedure.
>
>I'm fairly certain that this worked before PetaPoco was introduced, but it now ignores the parameter names.
