### PR TITLE
DNN-6655 HTML Module Conventions

### DIFF
--- a/DNN Platform/Library/UI/Modules/Html5/Html5HostControl.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/Html5HostControl.cs
@@ -23,6 +23,8 @@ using System;
 using System.IO;
 using System.Web;
 using System.Web.UI;
+using DotNetNuke.Web.Client;
+using DotNetNuke.Web.Client.ClientResourceManagement;
 using Lucene.Net.Index;
 
 namespace DotNetNuke.UI.Modules.Html5
@@ -39,6 +41,28 @@ namespace DotNetNuke.UI.Modules.Html5
         protected virtual string Html5File
         {
             get { return _html5File; }
+        }
+
+        protected override void OnInit(EventArgs e)
+        {
+            base.OnInit(e);
+
+            if (!(string.IsNullOrEmpty(Html5File)))
+            {
+                //Check if css file exists
+                var cssFile = Path.ChangeExtension(Html5File, ".css");
+                if (File.Exists(Page.Server.MapPath(cssFile)))
+                {
+                    ClientResourceManager.RegisterStyleSheet(Page, cssFile, FileOrder.Css.DefaultPriority);
+                }
+
+                //Check if js file exists
+                var jsFile = Path.ChangeExtension(Html5File, ".js");
+                if (File.Exists(Page.Server.MapPath(cssFile)))
+                {
+                    ClientResourceManager.RegisterScript(Page, jsFile, FileOrder.Js.DefaultPriority);
+                }
+            }
         }
 
         protected override void OnPreRender(EventArgs e)

--- a/Website/DesktopModules/Admin/Extensions/Editors/EditModuleControl.ascx.cs
+++ b/Website/DesktopModules/Admin/Extensions/Editors/EditModuleControl.ascx.cs
@@ -142,6 +142,7 @@ namespace DotNetNuke.Modules.Admin.ModuleDefinitions
                 AddFiles(root, "*.ascx");
                 AddFiles(root, "*.cshtml");
                 AddFiles(root, "*.vbhtml");
+                AddFiles(root, "*.html");
             }
         }
 
@@ -154,7 +155,7 @@ namespace DotNetNuke.Modules.Admin.ModuleDefinitions
 
             foreach (var folder in controlfolders)
             {
-                  var moduleControls = Directory.EnumerateFiles(folder, "*.*", SearchOption.TopDirectoryOnly).Count(s => s.EndsWith(".ascx") || s.EndsWith(".cshtml")|| s.EndsWith(".vbhtml"));
+                var moduleControls = Directory.EnumerateFiles(folder, "*.*", SearchOption.TopDirectoryOnly).Count(s => s.EndsWith(".ascx") || s.EndsWith(".cshtml") || s.EndsWith(".vbhtml") || s.EndsWith(".html") || s.EndsWith(".htm"));
                     if (moduleControls > 0)
                     {
                         var shortFolder =folder.Substring(Request.MapPath(Globals.ApplicationPath).Length + 1).Replace('\\', '/');


### PR DESCRIPTION
This pull request adds support for javascript files and css files in HTML5 (SPA) modules that are named following a standard convention.  e.g. if the html file is test.html, the js file should be called test.js and the css file should be called test.css.