### PR TITLE
DNN-5829 SEO Sitemap provider needs defensive coding

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -84,7 +84,7 @@ namespace DotNetNuke.Services.Sitemap
                 catch (Exception ex)
                 {
                     Services.Exceptions.Exceptions.LogException(new Exception(Localization.Localization.GetExceptionMessage("SitemapUrlGenerationError",
-                                "URL sitemap generation for page {0}-{1} caused an exception: {2}",
+                                "URL sitemap generation for page '{0} - {1}' caused an exception: {2}",
                                 tab.TabID, tab.TabName, ex.Message)));
                 }
             }

--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -69,14 +69,23 @@ namespace DotNetNuke.Services.Sitemap
 
             foreach (TabInfo tab in TabController.Instance.GetTabsByPortal(portalId).Values.Where(t => !t.IsSystem))
             {
-                if (!tab.IsDeleted && !tab.DisableLink && tab.TabType == TabType.Normal && (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
-                    (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && IsTabPublic(tab.TabPermissions))
+                try
                 {
-                    if ((includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished)
+                    if (!tab.IsDeleted && !tab.DisableLink && tab.TabType == TabType.Normal && (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
+                        (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && IsTabPublic(tab.TabPermissions))
                     {
-                        pageUrl = GetPageUrl(tab, (ps.ContentLocalizationEnabled) ? tab.CultureCode : null);
-                        urls.Add(pageUrl);
+                        if ((includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished)
+                        {
+                            pageUrl = GetPageUrl(tab, (ps.ContentLocalizationEnabled) ? tab.CultureCode : null);
+                            urls.Add(pageUrl);
+                        }
                     }
+                }
+                catch (Exception ex)
+                {
+                    Services.Exceptions.Exceptions.LogException(new Exception(Localization.Localization.GetExceptionMessage("SitemapUrlGenerationError",
+                                "URL sitemap generation for page {0}-{1} caused an exception: {2}",
+                                tab.TabID, tab.TabName, ex.Message)));
                 }
             }
 
@@ -124,10 +133,10 @@ namespace DotNetNuke.Services.Sitemap
                         (includeHiddenPages || localized.IsVisible) && localized.HasBeenPublished)
                     {
                         string alternateUrl = TestableGlobals.Instance.NavigateURL(localized.TabID, localized.IsSuperTab, ps, "", localized.CultureCode);
-                        alternates.Add(new AlternateUrl() 
-                        { 
-                            Url = alternateUrl, 
-                            Language = localized.CultureCode 
+                        alternates.Add(new AlternateUrl()
+                        {
+                            Url = alternateUrl,
+                            Language = localized.CultureCode
                         });
                     }
                 }
@@ -141,7 +150,7 @@ namespace DotNetNuke.Services.Sitemap
                         Url = alternateUrl,
                         Language = currentTab.CultureCode
                     });
-                    
+
                     pageUrl.AlternateUrls = alternates;
                 }
             }

--- a/DNN Platform/Library/Services/Sitemap/SitemapBuilder.cs
+++ b/DNN Platform/Library/Services/Sitemap/SitemapBuilder.cs
@@ -101,7 +101,18 @@ namespace DotNetNuke.Services.Sitemap
                     providerPriorityValue = float.Parse(PortalController.GetPortalSetting(_provider.Name + "Value", PortalSettings.PortalId, "50")) / 100;
 
                     // Get all urls from provider
-                    List<SitemapUrl> urls = _provider.GetUrls(PortalSettings.PortalId, PortalSettings, SITEMAP_VERSION);
+                    List<SitemapUrl> urls = new List<SitemapUrl>();
+                    try
+                    {
+                        urls = _provider.GetUrls(PortalSettings.PortalId, PortalSettings, SITEMAP_VERSION);
+                    }
+                    catch (Exception ex)
+                    {
+                        Services.Exceptions.Exceptions.LogException(new Exception(Localization.Localization.GetExceptionMessage("SitemapProviderError",
+                            "URL sitemap provider '{0}' failed with error: {1}",
+                            _provider.Name, ex.Message)));
+                    }
+
                     foreach (SitemapUrl url in urls)
                     {
                         if (isProviderPriorityOverrided)
@@ -200,7 +211,7 @@ namespace DotNetNuke.Services.Sitemap
                 {
                     Directory.CreateDirectory(PortalSettings.HomeSystemDirectoryMapPath + "Sitemap");
                 }
-                var cachedFile = (index > 0) ? "sitemap_" + index + ".xml": "sitemap.xml";                
+                var cachedFile = (index > 0) ? "sitemap_" + index + ".xml" : "sitemap.xml";
                 sitemapOutput = new StreamWriter(PortalSettings.HomeSystemDirectoryMapPath + "Sitemap\\" + cachedFile, false, Encoding.UTF8);
             }
 

--- a/Website/App_GlobalResources/Exceptions.resx
+++ b/Website/App_GlobalResources/Exceptions.resx
@@ -441,4 +441,7 @@
   <data name="UserHasNoPermissionToBrowseFolder.Text" xml:space="preserve">
     <value>The user has no permission to browse this folder</value>
   </data>
+  <data name="SitemapUrlGenerationError.Text" xml:space="preserve">
+    <value>URL sitemap generation for page {0}-{1} caused an exception: {2}</value>
+  </data>
 </root>

--- a/Website/App_GlobalResources/Exceptions.resx
+++ b/Website/App_GlobalResources/Exceptions.resx
@@ -441,7 +441,10 @@
   <data name="UserHasNoPermissionToBrowseFolder.Text" xml:space="preserve">
     <value>The user has no permission to browse this folder</value>
   </data>
+  <data name="SitemapProviderError.Text" xml:space="preserve">
+    <value>URL sitemap provider '{0}' failed with error: {1}</value>
+  </data>
   <data name="SitemapUrlGenerationError.Text" xml:space="preserve">
-    <value>URL sitemap generation for page {0}-{1} caused an exception: {2}</value>
+    <value>URL sitemap generation for page '{0} - {1}' caused an exception: {2}</value>
   </data>
 </root>


### PR DESCRIPTION
Added defensive coding and exception logging to url generation to prevent the sitemap to fail in case some providers fail with url generation