### PR TITLE
DNN-6636 Sitemap : Shows 404 Page in the Sitemap

### DIFF
--- a/DNN Platform/Website/Templates/Blank Website.template
+++ b/DNN Platform/Website/Templates/Blank Website.template
@@ -4762,7 +4762,7 @@
       <pageheadtext />
       <permanentredirect>false</permanentredirect>
       <refreshinterval>-1</refreshinterval>
-      <sitemappriority>0.5</sitemappriority>
+      <sitemappriority>0</sitemappriority>
       <startdate>0001-01-01T00:00:00</startdate>
       <name>404 Error Page</name>
       <title>[Tab.404ErrorPage.Title.Text]</title>

--- a/DNN Platform/Website/Templates/Default Website.template
+++ b/DNN Platform/Website/Templates/Default Website.template
@@ -4788,7 +4788,7 @@
       <pageheadtext />
       <permanentredirect>false</permanentredirect>
       <refreshinterval>-1</refreshinterval>
-      <sitemappriority>0.5</sitemappriority>
+      <sitemappriority>0</sitemappriority>
       <startdate>0001-01-01T00:00:00</startdate>
       <name>404 Error Page</name>
       <title>[Tab.404ErrorPage.Title.Text]</title>

--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.01.SqlDataProvider
@@ -414,6 +414,17 @@ END
 GO
 
 
+
+-- Fix for DNN-6636 Sitemap : Shows 404 Page in the Sitemap
+
+UPDATE {databaseOwner}[{objectQualifier}Tabs]
+SET SiteMapPriority = 0
+WHERE TabId IN (SELECT Custom404TabId FROM {databaseOwner}[{objectQualifier}PortalLocalization]) OR
+      TabId IN (SELECT Custom500TabId FROM {databaseOwner}[{objectQualifier}PortalLocalization])
+GO
+
+
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/


### PR DESCRIPTION
Sets the default priority for 404 pages to 0 so they are not included in the sitemaps.
Also fixes current 404 and 500 to priority 0.