### PR TITLE
DNN-6509 investigate and fix instances of hardcoded en-us/localzation.sy...

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2329,7 +2329,7 @@ namespace DotNetNuke.Entities.Portals
                     //Get Fallback language
                     string fallbackLanguage = string.Empty;
 
-                    if (string.IsNullOrEmpty(cultureCode)) cultureCode = GetPortalDefaultLanguage(portalId) ?? Localization.SystemLocale;
+                    if (string.IsNullOrEmpty(cultureCode)) cultureCode = GetPortalDefaultLanguage(portalId);
 
                     Locale userLocale = LocaleController.Instance.GetLocale(cultureCode);
                     if (userLocale != null && !string.IsNullOrEmpty(userLocale.Fallback))

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1035,8 +1035,7 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 var setting = Null.NullString;
-                //DNN-6509 - using empty string will ensure active portal language is used
-                GetPortalSettingsDictionary(portalId, Null.NullString).TryGetValue("EnableBrowserLanguage", out setting);
+                GetPortalSettingsDictionary(portalId, Localization.SystemLocale).TryGetValue("EnableBrowserLanguage", out setting);
                 if (string.IsNullOrEmpty(setting))
                 {
                     retValue = Host.Host.EnableBrowserLanguage;

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2329,7 +2329,7 @@ namespace DotNetNuke.Entities.Portals
                     //Get Fallback language
                     string fallbackLanguage = string.Empty;
 
-                    if (string.IsNullOrEmpty(cultureCode)) cultureCode = GetPortalDefaultLanguage(portalId); //Localization.SystemLocale;
+                    if (string.IsNullOrEmpty(cultureCode)) cultureCode = GetPortalDefaultLanguage(portalId) ?? Localization.SystemLocale;
 
                     Locale userLocale = LocaleController.Instance.GetLocale(cultureCode);
                     if (userLocale != null && !string.IsNullOrEmpty(userLocale.Fallback))
@@ -2338,7 +2338,7 @@ namespace DotNetNuke.Entities.Portals
                     }
                     if (String.IsNullOrEmpty(fallbackLanguage))
                     {
-                        fallbackLanguage = LocaleController.Instance.GetDefaultLocale(portalId).Fallback; //Localization.SystemLocale);
+                        fallbackLanguage = Localization.SystemLocale; 
                     }
                     portal = GetPortalInternal(portalId, fallbackLanguage);
                     //if we cannot find any fallback, it mean's it's a non portal default langauge

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1035,7 +1035,8 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 var setting = Null.NullString;
-                GetPortalSettingsDictionary(portalId, Localization.SystemLocale).TryGetValue("EnableBrowserLanguage", out setting);
+                //DNN-6509 - using empty string will ensure active portal language is used
+                GetPortalSettingsDictionary(portalId, Null.NullString).TryGetValue("EnableBrowserLanguage", out setting);
                 if (string.IsNullOrEmpty(setting))
                 {
                     retValue = Host.Host.EnableBrowserLanguage;
@@ -2329,7 +2330,7 @@ namespace DotNetNuke.Entities.Portals
                     //Get Fallback language
                     string fallbackLanguage = string.Empty;
 
-                    if (string.IsNullOrEmpty(cultureCode)) cultureCode = Localization.SystemLocale;
+                    if (string.IsNullOrEmpty(cultureCode)) cultureCode = GetPortalDefaultLanguage(portalId); //Localization.SystemLocale;
 
                     Locale userLocale = LocaleController.Instance.GetLocale(cultureCode);
                     if (userLocale != null && !string.IsNullOrEmpty(userLocale.Fallback))
@@ -2338,7 +2339,7 @@ namespace DotNetNuke.Entities.Portals
                     }
                     if (String.IsNullOrEmpty(fallbackLanguage))
                     {
-                        fallbackLanguage = Localization.SystemLocale;
+                        fallbackLanguage = LocaleController.Instance.GetDefaultLocale(portalId).Fallback; //Localization.SystemLocale);
                     }
                     portal = GetPortalInternal(portalId, fallbackLanguage);
                     //if we cannot find any fallback, it mean's it's a non portal default langauge


### PR DESCRIPTION
                 
1. Here usage of SystemLocale is fine as we define new language in case if it doesn't exist.
ParseEnabledLocales
// if language does not exist in the installation, create it
locale = new Locale { Code = cultureCode, Fallback = Localization.SystemLocale, Text = CultureInfo.GetCultureInfo(cultureCode).NativeName };

2. Here usage of SystemLocale is fine as we define new language in case if it doesn't exist.
ParseTemplateInternal
defaultLocale = new Locale { Code = portalInfo.DefaultLanguage, Fallback = Localization.SystemLocale, Text = CultureInfo.GetCultureInfo(portalInfo.DefaultLanguage).NativeName };

3.GetPortal
if (string.IsNullOrEmpty(cultureCode)) cultureCode = GetPortalDefaultLanguage(portalId); //Localization.SystemLocale;
fallbackLanguage = LocaleController.Instance.GetDefaultLocale(portalId).Fallback; //Localization.SystemLocale);


4.GetActivePortalLanguage
This is avalid use case:
            // get Language
            string Language = Localization.SystemLocale;

5. LoadPortal
This is a valid use case
portalSettings.DefaultLanguage = Null.IsNull(portal.DefaultLanguage) ? Localization.SystemLocale : portal.DefaultLanguage;


6. Dashboard module uses following datareader:
        public static IDataReader GetPortals()
        {
            string cultureCode = Localization.SystemLocale;
            return provider.GetPortals(cultureCode);
        }

This will return portals with default language culture only  - this needs further investigation (new JIRA issue).


7. ProcessLegacyLanguages
                        //Save Language
                        Localization.Localization.SaveLanguage(language);
                        if (language.Code != Localization.Localization.SystemLocale)
This is a valid case


8. LanguagePackWriter
            _Language.Fallback = Localization.Localization.SystemLocale;
This is a valid use case


9. BestCultureCodeBasedOnBrowserLanguages
            return BestCultureCodeBasedOnBrowserLanguages(cultureCodes, Localization.SystemLocale);
This is a valid use case as second param is a fallback language value


10. GetCurrentLocale
        public Locale GetCurrentLocale(int PortalId)
        {
            Locale locale = null;

            if (HttpContext.Current != null && !string.IsNullOrEmpty(HttpContext.Current.Request.QueryString["language"]))
            {
                locale = GetLocale(HttpContext.Current.Request.QueryString["language"]);
            }
            return locale ?? ((PortalId == Null.NullInteger)
                                ? GetLocale(Localization.SystemLocale)
                                : GetDefaultLocale(PortalId));
        }
This is a valid use case as we'll use hardcoded value only of PortalId=-1 and there is no way to get active portal language

11.  GetPageLocale
           // 6. system default
            if (pageCulture == null)
                pageCulture = new CultureInfo(SystemLocale);
This is a valid use case 


12. TryGetStringInternal
string fallbackLanguage = Localization.SystemLocale;
This is a valid use case as value is redefined within the method.

13. GetInstallConfig
installConfig.InstallCulture = XmlUtils.GetNodeValue(rootNode.CreateNavigator(), "installCulture") ?? Localization.Localization.SystemLocale;
Valid use case


14.         internal static PortalController.PortalTemplateInfo FindBestTemplate(string templateFileName)
            if (String.IsNullOrEmpty(currentCulture))
            {
                currentCulture = Localization.Localization.SystemLocale;
            }
This is a valid use case


15. GetNavigationNodes
var hostTabs = TabController.GetTabsBySortOrder(Null.NullInteger, Localization.SystemLocale, true);
Even though here passed System.Locale last param (includeNeutral) is set to true so that way host pages are returned anyways 


16. GetLinkUrl
string cultureCode = Localization.SystemLocale;
Valid use case as value is redefined later on in the method
