### PR TITLE
Support virtual relative path "~" symbol in URL link type for tabs.

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabInfo.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabInfo.cs
@@ -543,8 +543,8 @@ namespace DotNetNuke.Entities.Tabs
         {
             get
             {
-                var key = string.Format("{0}_{1}", TestableGlobals.Instance.AddHTTP(PortalSettings.Current.PortalAlias.HTTPAlias),
-                                            Thread.CurrentThread.CurrentCulture);
+                string urlAlias = TestableGlobals.Instance.AddHTTP(PortalSettings.Current.PortalAlias.HTTPAlias);
+                var key = string.Format("{0}_{1}", urlAlias, Thread.CurrentThread.CurrentCulture);
 
                 string fullUrl;
                 using (_fullUrlDictionary.GetReadLock())
@@ -572,7 +572,7 @@ namespace DotNetNuke.Entities.Tabs
                                 break;
                             case TabType.Url:
                                 //external url
-                                fullUrl = Url;
+                                fullUrl = (Url.StartsWith("~") ? urlAlias + Url.Substring(1) : Url);
                                 break;
                         }
 


### PR DESCRIPTION
Very often, administrators use the External URL Link type when creating internal links where they need to specify querystring parameters to an internal page or need to link to a child portal alias.  Supporting the virtual symbol "~" in the URL means that the full path and "http/https" designation does not need to be hardcoded in the URL and can therefore make it much easier to manage links between stage and production environments where the portal alias and SSL strategy is different.