### PR TITLE
Updated AdvancedFriendlyUrlProvider and BasicFriendlyUrlProvider to consider SSL URL setting when creating https://-links to secure pages

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
@@ -462,13 +462,20 @@ namespace DotNetNuke.Entities.Urls
             //set it to lower case if so allowed by settings
             friendlyPath = ForceLowerCaseIfAllowed(tab, friendlyPath, localSettings);
 
-            // Replace http:// by https:// if SSL is enabled an site is marked as secure 
+            // Replace http:// by https:// if SSL is enabled and site is marked as secure 
             // (i.e. requests to http://... will be redirected to https://...)
             if (tab != null && portalSettings.SSLEnabled && tab.IsSecure &&
                 friendlyPath.StartsWith("http://", StringComparison.InvariantCultureIgnoreCase))
             {
                 var regex = new Regex(@"^http://", RegexOptions.IgnoreCase);
                 friendlyPath = regex.Replace(friendlyPath, "https://");
+
+                // If portal's "SSL URL" setting is defined: Use "SSL URL" instaed of current portal alias
+                var sslUrl = portalSettings.SSLURL;
+                if (!string.IsNullOrEmpty(sslUrl))
+                {
+                    friendlyPath = friendlyPath.Replace("https://" + portalAlias, "https://" + sslUrl);
+                }
             }
 
             return friendlyPath;

--- a/DNN Platform/Library/Entities/Urls/BasicFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/BasicFriendlyUrlProvider.cs
@@ -409,7 +409,7 @@ namespace DotNetNuke.Entities.Urls
 
             friendlyPath = CheckPathLength(Globals.ResolveUrl(friendlyPath), path);
 
-            // Replace http:// by https:// if SSL is enabled an site is marked as secure
+            // Replace http:// by https:// if SSL is enabled and site is marked as secure
             // (i.e. requests to http://... will be redirected to https://...)
             var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
             if (tab != null && portalSettings.SSLEnabled && tab.IsSecure &&
@@ -417,6 +417,13 @@ namespace DotNetNuke.Entities.Urls
             {
                 var regex = new Regex(@"^http://", RegexOptions.IgnoreCase);
                 friendlyPath = regex.Replace(friendlyPath, "https://");
+
+                // If portal's "SSL URL" setting is defined: Use "SSL URL" instaed of current portal alias
+                var sslUrl = portalSettings.SSLURL;
+                if (!string.IsNullOrEmpty(sslUrl))
+                {
+                    friendlyPath = friendlyPath.Replace("https://" + portalAlias, "https://" + sslUrl);
+                }
             }
 
             return friendlyPath;


### PR DESCRIPTION
This is a follow up pull request for tickets https://dnntracker.atlassian.net/browse/DNN-6364 and https://dnntracker.atlassian.net/browse/DNN-6366.

This pull request should fix the problems mentioned by Ben Zhong in the Jira comments https://dnntracker.atlassian.net/browse/DNN-6364?focusedCommentId=74812&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-74812 and https://dnntracker.atlassian.net/browse/DNN-6366?focusedCommentId=74813&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-74813