### PR TITLE
DNN-6845: Multiple uses of non-standard target="_new"

### DIFF
--- a/DNN Platform/Library/Services/Vendors/BannerController.cs
+++ b/DNN Platform/Library/Services/Vendors/BannerController.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2014
 // by DotNetNuke Corporation
 // 
@@ -177,7 +177,7 @@ namespace DotNetNuke.Services.Vendors
                                    string HomeDirectory, string BannerClickthroughUrl)
         {
             string strBanner = "";
-            string strWindow = "_new";
+            string strWindow = "_blank";
             if (Globals.GetURLType(URL) == TabType.Tab)
             {
                 strWindow = "_self";

--- a/DNN Platform/Library/UI/Navigation.cs
+++ b/DNN Platform/Library/UI/Navigation.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2014
 // by DotNetNuke Corporation
 // 
@@ -214,7 +214,7 @@ namespace DotNetNuke.UI
                 bool newWindow = false;
                 if (objTab.TabSettings["LinkNewWindow"] != null && Boolean.TryParse((string)objTab.TabSettings["LinkNewWindow"], out newWindow) && newWindow)
                 {
-                    objNode.Target = "_new";
+                    objNode.Target = "_blank";
                 }
 
                 objNodes.Add(objNode);

--- a/DNN Platform/Library/UI/Skins/SkinThumbNailControl.cs
+++ b/DNN Platform/Library/UI/Skins/SkinThumbNailControl.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2014
 // by DotNetNuke Corporation
 // 
@@ -198,7 +198,7 @@ namespace DotNetNuke.UI.Skins
             var strImage = "";
             if (File.Exists(strFile.Replace(".ascx", ".jpg")))
             {
-                strImage += "<a href=\"" + CreateThumbnail(strFile.Replace(".ascx", ".jpg")).Replace("thumbnail_", "") + "\" target=\"_new\"><img src=\"" +
+                strImage += "<a href=\"" + CreateThumbnail(strFile.Replace(".ascx", ".jpg")).Replace("thumbnail_", "") + "\" target=\"_blank\"><img src=\"" +
                             CreateThumbnail(strFile.Replace(".ascx", ".jpg")).Replace("\\", "/") + "\" border=\"1\"></a>";
             }
             else

--- a/Website/DesktopModules/Admin/Extensions/InstalledExtensions.ascx.cs
+++ b/Website/DesktopModules/Admin/Extensions/InstalledExtensions.ascx.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2014
 // by DotNetNuke Corporation
 // 
@@ -376,13 +376,13 @@ namespace DotNetNuke.Modules.Admin.Extensions
         {
             var strUpgradeService = "";
             strUpgradeService += "<a title=\"" + Localization.GetString("UpgradeMessage", LocalResourceFile) + "\" href=\"" + UpgradeRedirect(version, packageType, packageName, "") +
-                                 "\" target=\"_new\"><img title=\"" + Localization.GetString("UpgradeMessage", LocalResourceFile) + "\" src=\"" +
+                                 "\" target=\"_blank\"><img title=\"" + Localization.GetString("UpgradeMessage", LocalResourceFile) + "\" src=\"" +
                                  UpgradeIndicator(version, packageType, packageName, "") + "\" border=\"0\" /></a>";
             if (!string.IsNullOrEmpty(cboLocales.SelectedValue))
             {
                 strUpgradeService += "<br />";
                 strUpgradeService += "<a title=\"" + Localization.GetString("LanguageMessage", LocalResourceFile) + "\" href=\"" +
-                                     UpgradeRedirect(version, packageType, packageName, cboLocales.SelectedItem.Value) + "\" target=\"_new\"><img title=\"" +
+                                     UpgradeRedirect(version, packageType, packageName, cboLocales.SelectedItem.Value) + "\" target=\"_blank\"><img title=\"" +
                                      Localization.GetString("LanguageMessage", LocalResourceFile) + "\" src=\"" + UpgradeIndicator(version, packageType, packageName, cboLocales.SelectedItem.Value) +
                                      "\" border=\"0\" /></a>";
             }

--- a/Website/DesktopModules/Admin/Extensions/MoreExtensions.ascx
+++ b/Website/DesktopModules/Admin/Extensions/MoreExtensions.ascx
@@ -88,9 +88,9 @@
                                 </a>
                             {{/if}}
                             {{if DetailURL}}
-                                <a class="galleryLink inline" href="${DetailURL}" target="_new"><img class='deploy galleryLink' alt='Browse ${Catalog.CatalogName}' Title='Browse ${Catalog.CatalogName}' src='${_gallery.resolveImage(Catalog.CatalogIcon)}' /></a>
+                                <a class="galleryLink inline" href="${DetailURL}" target="_blank"><img class='deploy galleryLink' alt='Browse ${Catalog.CatalogName}' Title='Browse ${Catalog.CatalogName}' src='${_gallery.resolveImage(Catalog.CatalogIcon)}' /></a>
                             {{else Catalog.CatalogUrl}}                                            
-                                <a class="galleryLink inline" href="${Catalog.CatalogUrl}" target="_new"><img class='deploy galleryLink' alt='Browse ${Catalog.CatalogName}' Title='Browse ${Catalog.CatalogName}' src='${_gallery.resolveImage(Catalog.CatalogIcon)}' /></a>
+                                <a class="galleryLink inline" href="${Catalog.CatalogUrl}" target="_blank"><img class='deploy galleryLink' alt='Browse ${Catalog.CatalogName}' Title='Browse ${Catalog.CatalogName}' src='${_gallery.resolveImage(Catalog.CatalogIcon)}' /></a>
                             {{/if}}                
                         </div>
                     </div>

--- a/Website/DesktopModules/Admin/HostSettings/hostsettings.ascx
+++ b/Website/DesktopModules/Admin/HostSettings/hostsettings.ascx
@@ -43,7 +43,7 @@
                 </div>
                 <div class="dnnFormItem">
                     <dnn:label id="plAvailable" controlname="hypUpgrade" runat="server" />
-                    <asp:HyperLink ID="hypUpgrade" Target="_new" runat="server" />
+                    <asp:HyperLink ID="hypUpgrade" Target="_blank" runat="server" />
                 </div>
                 <div class="dnnFormItem">
                     <dnn:label id="plDataProvider" controlname="lblDataProvider" runat="server" />

--- a/Website/DesktopModules/Admin/Skins/EditSkins.ascx.cs
+++ b/Website/DesktopModules/Admin/Skins/EditSkins.ascx.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2014
 // by DotNetNuke Corporation
 // 
@@ -415,7 +415,7 @@ namespace DotNetNuke.Modules.Admin.Skins
 					}
 
 				    previewLink.CssClass = "dnnSecondaryAction";
-					previewLink.Target = "_new";
+					previewLink.Target = "_blank";
 					previewLink.Text = Localization.GetString("cmdPreview", LocalResourceFile);
 					cell.Controls.Add(previewLink);
 
@@ -458,7 +458,7 @@ namespace DotNetNuke.Modules.Admin.Skins
 											{
 												NavigateUrl = ResolveUrl("~" + strURL),
 												CssClass = "dnnSecondaryAction",
-												Target = "_new",
+												Target = "_blank",
 												Text = string.Format(Localization.GetString("About", LocalResourceFile), strFolder)
 											};
 					cell.Controls.Add(copyrightLink);
@@ -479,7 +479,7 @@ namespace DotNetNuke.Modules.Admin.Skins
 	        var imgLink = new HyperLink();
 	        var strURL = file.Substring(file.LastIndexOf("\\portals\\", StringComparison.OrdinalIgnoreCase));
 	        imgLink.NavigateUrl = this.ResolveUrl("~" + strURL.Replace(".ascx", extension));
-	        imgLink.Target = "_new";
+	        imgLink.Target = "_blank";
 
 	        var img = new System.Web.UI.WebControls.Image { ImageUrl = CreateThumbnail(file.Replace(".ascx", extension)), BorderWidth = new Unit(1) };
 

--- a/Website/Resources/FeedBrowser/scripts/feedbrowser.js
+++ b/Website/Resources/FeedBrowser/scripts/feedbrowser.js
@@ -185,7 +185,7 @@ DotNetNuke.UI.WebControls.FeedBrowser.Browser.prototype =
                 this._templates["default"] = 
                 '<table>' +
                     '<tr>' +
-                     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding-bottom:10px\"><a href=\"[[link]]\" target=\"_new\" class=\"Head\">[[title]]</a></td>' +
+                     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding-bottom:10px\"><a href=\"[[link]]\" target=\"_blank\" class=\"Head\">[[title]]</a></td>' +
                     '</tr>' + 
                     '<tr>' + 
                       '<td align=\"left\" valign=\"top\" class=\"Normal\">' + 

--- a/Website/Resources/FeedBrowser/scripts/templates.js
+++ b/Website/Resources/FeedBrowser/scripts/templates.js
@@ -23,7 +23,7 @@ htmlTemplates['default'] =
 
 '<table width=\"100%\">' +
 '<tr>' +
-     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding-bottom:10px\"><a href=\"[[link]]\" target=\"_new\" class=\"Head\">[[title]]</a></td>' +
+     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding-bottom:10px\"><a href=\"[[link]]\" target=\"_blank\" class=\"Head\">[[title]]</a></td>' +
 '</tr>' + 
 '<tr>' + 
       '<td align=\"left\" valign=\"top\" class=\"Normal\">' + 
@@ -44,7 +44,7 @@ htmlTemplates['dotnetnuke'] =
 
 '<table width=\"100%\">' +
 '<tr>' +
-     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"background-color:#cc0000;padding:5px\"><a href=\"[[link]]\" target=\"_new\" class=\"Head\" style=\"color:white\">[[title]]</a></td>' +
+     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"background-color:#cc0000;padding:5px\"><a href=\"[[link]]\" target=\"_blank\" class=\"Head\" style=\"color:white\">[[title]]</a></td>' +
 '</tr>' + 
 '<tr>' + 
       '<td align=\"left\" valign=\"top\" class=\"Normal\" style=\"padding-top:5px\">' + 
@@ -58,7 +58,7 @@ htmlTemplates['hosting'] =
 
 '<table width=\"100%\">' +
 '<tr>' +
-     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding-bottom:10px\"><a href=\"[[link]]\" target=\"_new\" class=\"Head\">[[title]]</a></td>' +
+     '<td class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding-bottom:10px\"><a href=\"[[link]]\" target=\"_blank\" class=\"Head\">[[title]]</a></td>' +
 '</tr>' + 
 '<tr>' + 
       '<td align=\"left\" valign=\"top\" class=\"Normal\">' + 
@@ -68,8 +68,8 @@ htmlTemplates['hosting'] =
 '</table><br /><br />';
 
 
-htmlHeaders['dotnetnuke'] = '<div style=\"padding-bottom:5px;position:relative;top:-15px\"><a href=\"http://www.dotnetnuke.com\" target=\"_new\"><img src=\"http://www.dotnetnuke.com/portals/25/SolutionsExplorer/images/DNN-small.gif\" border=\"0\"></a></div>';
-htmlHeaders['marketplace'] = '<div style=\"padding-bottom:5px;position:relative;top:-25px\"><a href=\"http://marketplace.dotnetnuke.com\" target=\"_new\"><img src=\"http://www.dotnetnuke.com/portals/25/SolutionsExplorer/images/DNNMarketplace-small.gif\" border=\"0\"></a></div>';
+htmlHeaders['dotnetnuke'] = '<div style=\"padding-bottom:5px;position:relative;top:-15px\"><a href=\"http://www.dotnetnuke.com\" target=\"_blank\"><img src=\"http://www.dotnetnuke.com/portals/25/SolutionsExplorer/images/DNN-small.gif\" border=\"0\"></a></div>';
+htmlHeaders['marketplace'] = '<div style=\"padding-bottom:5px;position:relative;top:-25px\"><a href=\"http://marketplace.dotnetnuke.com\" target=\"_blank\"><img src=\"http://www.dotnetnuke.com/portals/25/SolutionsExplorer/images/DNNMarketplace-small.gif\" border=\"0\"></a></div>';
 
 // Used by Marketplace template
 function marketplacePreviewHandler(url)
@@ -92,7 +92,7 @@ function marketplaceItemRenderer(title, url, description, imageUrl, isReviewed, 
         '<!-- 0: Reviewed Product -->' + // Add a comment to force reviewed products to be grouped first
         '<table width=\"100%\" style=\"margin-bottom:15px\">' +
         '<tr>' +
-             '<td colspan=\"2\" class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding:5px;background-color:#ededed\"><img src=\"http://marketplace.dotnetnuke.com/reviewprogram/logos/reviewed-tiny.gif\" align="right"><a href=\"' + url + '\" target=\"_new\" class=\"Head\">' + title + '</a> <span class=\"Normal\"><br /><small> by <a href=\"' + vendorUrl + '\" target=\"_new\" class=\"Normal\">' + vendor + '</a></small></span></td>' +
+             '<td colspan=\"2\" class=\"Head\" align=\"left\" valign=\"middle\" style=\"padding:5px;background-color:#ededed\"><img src=\"http://marketplace.dotnetnuke.com/reviewprogram/logos/reviewed-tiny.gif\" align="right"><a href=\"' + url + '\" target=\"_blank\" class=\"Head\">' + title + '</a> <span class=\"Normal\"><br /><small> by <a href=\"' + vendorUrl + '\" target=\"_blank\" class=\"Normal\">' + vendor + '</a></small></span></td>' +
         '</tr>' +
         '<tr>' + 
               '<td align=\"center\" valign=\"top\" class=\"Normal\" style=\"width:100px;padding-top:10px\">' +
@@ -100,7 +100,7 @@ function marketplaceItemRenderer(title, url, description, imageUrl, isReviewed, 
                  '<br /><p>from $' + price + '</p>' +
                  '<p class=\"Head\">' + 
                  '<a href=\"javascript:void(0)\" onClick=\"marketplacePreviewHandler(\'' + overviewUrl + '\')\">Info</a> | ' +
-                 '<a href=\"' + url + '\" target=\"_new\">BUY</a> <br />' +
+                 '<a href=\"' + url + '\" target=\"_blank\">BUY</a> <br />' +
                  '</p>'+ 
               '</td>' +
               '<td align=\"left\" valign=\"top\" class=\"Normal\" style=\"padding-left:10px;padding-top:10px\">' + 
@@ -115,8 +115,8 @@ function marketplaceItemRenderer(title, url, description, imageUrl, isReviewed, 
         '<!-- 1: Non-Reviewed Product -->' + // Add a comment to force non-reviewed products to be grouped first
         '<table width=\"100%\" cellspacing=\"0\" style=\"margin-bottom:15px\">' +
         '<tr>' +
-             '<td class=\"Head\" width=\"80%\"align=\"left\" valign=\"middle\" style=\"padding:5px;background-color:#f3f3f3\"><a href=\"' + url + '\" target=\"_new\" class=\"SubHead\">' + title + '</a> <span class=\"Normal\"><br/><small> by <a href=\"' + vendorUrl + '\" target=\"_new\" class=\"Normal\">' + vendor + '</a></small></td>' + 
-             '<td class=\"Normal\" width=\"20%\" valign=\"middle\" style=\"padding:5px;background-color:#f3f3f3\">from $' + price + ' <a class=\"SubHead\" href=\"' + url + '\" target=\"_new\">BUY</a></span></td>' +
+             '<td class=\"Head\" width=\"80%\"align=\"left\" valign=\"middle\" style=\"padding:5px;background-color:#f3f3f3\"><a href=\"' + url + '\" target=\"_blank\" class=\"SubHead\">' + title + '</a> <span class=\"Normal\"><br/><small> by <a href=\"' + vendorUrl + '\" target=\"_blank\" class=\"Normal\">' + vendor + '</a></small></td>' + 
+             '<td class=\"Normal\" width=\"20%\" valign=\"middle\" style=\"padding:5px;background-color:#f3f3f3\">from $' + price + ' <a class=\"SubHead\" href=\"' + url + '\" target=\"_blank\">BUY</a></span></td>' +
          '</tr>';
          
          var firstSentence = description.indexOf(". ");

--- a/Website/admin/ControlPanel/RibbonBar.ascx
+++ b/Website/admin/ControlPanel/RibbonBar.ascx
@@ -24,7 +24,7 @@
                 </Items>
             </dnn:DnnComboBox>
         </div>
-        <asp:HyperLink ID="hypMessage" runat="server" Target="_new" CssClass="dnnCPHMessage" />
+        <asp:HyperLink ID="hypMessage" runat="server" Target="_blank" CssClass="dnnCPHMessage" />
     </div>
     <div id="BodyPanel" runat="server" class="dnnCPContent" style="display: none">
         <asp:Panel ID="CommonTasksPanel" runat="server" CssClass="cpcbCommonTasks dnnClear">

--- a/Website/controls/help.ascx
+++ b/Website/controls/help.ascx
@@ -7,7 +7,7 @@
         </div>
         <ul class="dnnActions dnnClear">
             <li>
-                <asp:HyperLink ID="cmdHelp" runat="server" CssClass="dnnPrimaryAction" resourcekey="cmdHelp" Target="_new" EnableViewState="False" /></li>
+                <asp:HyperLink ID="cmdHelp" runat="server" CssClass="dnnPrimaryAction" resourcekey="cmdHelp" Target="_blank" EnableViewState="False" /></li>
             <li>
                 <asp:LinkButton ID="cmdCancel" runat="server" class="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="False" EnableViewState="False" /></li>
         </ul>


### PR DESCRIPTION
This will replace all occurrences of target="_new" with target="_blank" to get better standards compatibility.

http://www.w3.org/html/wg/drafts/html/master/single-page.html#browsing-context-names describes browsing context names. According to it, "_new" isn't valid browsing context name nor keyword.

In case when we need to open links in a specific window, target="new" or any other valid browsing context name (window name) should be used.