### PR TITLE
DNN-6849: Fixed IFileLinkClickController.GetFileIdFromLinkClick if fileticket parameter has wrong format

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FileLinkClickController.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileLinkClickController.cs
@@ -76,7 +76,8 @@ namespace DotNetNuke.Services.FileSystem
         {
             var linkClickPortalSettings = GetPortalSettingsForLinkClick(GetPortalIdFromLinkClick(queryParams));
             var strFileId = UrlUtils.DecryptParameter(queryParams["fileticket"], linkClickPortalSettings.PortalGUID);
-            return Convert.ToInt32(strFileId);
+            int fileId;
+            return int.TryParse(strFileId, out fileId) ? fileId : -1;
         }
 
         protected override Func<IFileLinkClickController> GetFactory()

--- a/DNN Platform/Library/Services/FileSystem/IFileLincClickController.cs
+++ b/DNN Platform/Library/Services/FileSystem/IFileLincClickController.cs
@@ -36,7 +36,7 @@ namespace DotNetNuke.Services.FileSystem
         /// Get the File Id value contained in a Link Click Url
         /// </summary>
         /// <param name="queryParams">Query string parameters collection from a Link Click url</param>
-        /// <returns>A File Id</returns>
+        /// <returns>A File Id (or -1 if no File Id could be extracted from the query string parameters)</returns>
         int GetFileIdFromLinkClick(NameValueCollection queryParams);
     }
 }


### PR DESCRIPTION
See https://dnntracker.atlassian.net/browse/DNN-6849 for more details.

Please note: I'm not sure whether to use -1 as return value for an invalid fileticket  parameter is best practice in DNN. IMHO using int? and returning null is a better option, but this would be a breaking change.