### PR TITLE
DNN-6677 Label: Setting "ControlName" does not work

### DIFF
--- a/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
@@ -622,24 +622,29 @@ namespace DesktopModules.Admin.Portals
 
                 basicRegistrationSettings.DataSource = settings;
                 basicRegistrationSettings.DataBind();
+                chkRegistrationUseAuthProviders.Checked = PortalController.GetPortalSettingAsBoolean("Registration_UseAuthProviders", portal.PortalID, false);
+                chkRegistrationUseProfanityFilter.Checked = PortalController.GetPortalSettingAsBoolean("Registration_UseProfanityFilter", portal.PortalID, false);
+				
+                registrationFormType.Select(PortalSettings.Registration.RegistrationFormType.ToString(CultureInfo.InvariantCulture));
 
-				registrationFormType.Select(PortalSettings.Registration.RegistrationFormType.ToString(CultureInfo.InvariantCulture));
-
-                standardRegistrationSettings.DataSource = settings;
-                standardRegistrationSettings.DataBind();
+                //standard registration settings
+                chkRegistrationUseEmailAsUserName.Checked = PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", portal.PortalID, false);
 
                 validationRegistrationSettings.DataSource = settings;
                 validationRegistrationSettings.DataBind();
+                chkRegistrationRequireUniqueDisplayName.Checked = PortalController.GetPortalSettingAsBoolean("Registration_RequireUniqueDisplayName", portal.PortalID, false);
 
 				var customRegistrationFields = PortalSettings.Registration.RegistrationFields;
 
                 CustomRegistrationFields = BuildCustomRegistrationFields(customRegistrationFields);
 
-                passwordRegistrationSettings.DataSource = settings;
-                passwordRegistrationSettings.DataBind();
+                //password registration settings
+                chkRegistrationRandomPassword.Checked = PortalController.GetPortalSettingAsBoolean("Registration_RandomPassword", portal.PortalID, false);
+                chkRegistrationRequireConfirmPassword.Checked = PortalController.GetPortalSettingAsBoolean("Registration_RequireConfirmPassword", portal.PortalID, true);
 
-                otherRegistrationSettings.DataSource = settings;
-                otherRegistrationSettings.DataBind();
+                //other registration settings
+                chkSecurityRequireValidProfile.Checked = PortalController.GetPortalSettingAsBoolean("Security_RequireValidProfile", portal.PortalID, false);
+                chkSecurityCaptchaRegister.Checked = PortalController.GetPortalSettingAsBoolean("Security_CaptchaRegister", portal.PortalID, false);
 
                 //Set up special page lists
                 List<TabInfo> listTabs = TabController.GetPortalTabs(TabController.GetTabsBySortOrder(portal.PortalID, activeLanguage, true),
@@ -672,9 +677,11 @@ namespace DesktopModules.Admin.Portals
                 PasswordStrengthRegularExpressionLabel.Text = MembershipProviderConfig.PasswordStrengthRegularExpression;
                 MaxInvalidPasswordAttemptsLabel.Text = MembershipProviderConfig.MaxInvalidPasswordAttempts.ToString(CultureInfo.InvariantCulture);
                 PasswordAttemptWindowLabel.Text = MembershipProviderConfig.PasswordAttemptWindow.ToString(CultureInfo.InvariantCulture);
-
-                loginSettings.DataSource = settings;
-                loginSettings.DataBind();
+                //login settings
+                chkSecurityCaptchaLogin.Checked = PortalController.GetPortalSettingAsBoolean("Security_CaptchaLogin", portal.PortalID, false);
+                chkSecurityRequireValidProfileAtLogin.Checked = PortalController.GetPortalSettingAsBoolean("Security_RequireValidProfileAtLogin", portal.PortalID, true);
+                chkSecurityCaptchaRetrivePassword.Checked = PortalController.GetPortalSettingAsBoolean("Security_CaptchaRetrivePassword", portal.PortalID, false);
+                chkSecurityCaptchaChangePassword.Checked = PortalController.GetPortalSettingAsBoolean("Security_CaptchaChangePassword", portal.PortalID, false);
 
                 //using values from current portal
                 redirectTab = PortalSettings.Registration.RedirectAfterLogin;
@@ -703,7 +710,7 @@ namespace DesktopModules.Admin.Portals
                 userVisiblity.EnumType = "DotNetNuke.Entities.Users.UserVisibilityMode, DotNetNuke";
                 profileSettings.DataSource = settings;
                 profileSettings.DataBind();
-
+                chkProfileDisplayVisibility.Checked = PortalController.GetPortalSettingAsBoolean("Profile_DisplayVisibility", portal.PortalID, true);
                 //Bind auth providers
                 var authSystems = AuthenticationController.GetEnabledAuthenticationServices();
                 var authProviders = (from authProvider in authSystems let authLoginControl = (AuthenticationLoginBase)LoadControl("~/" + authProvider.LoginControlSrc) let oAuthLoginControl = authLoginControl as OAuthLoginBase where oAuthLoginControl ==null && authLoginControl.Enabled select authProvider.AuthenticationType).ToList();
@@ -1468,7 +1475,7 @@ namespace DesktopModules.Admin.Portals
                             return;
                         }
 
-                        if (!setting.Contains("DisplayName") && Convert.ToBoolean(requireUniqueDisplayName.Value))
+                        if (!setting.Contains("DisplayName") && chkRegistrationRequireUniqueDisplayName.Checked)
                         {
                             PortalController.UpdatePortalSetting(_portalId, "Registration_RegistrationFormType", "0", false);
                             Skin.AddModuleMessage(this, Localization.GetString("NoDisplayName", LocalResourceFile), ModuleMessage.ModuleMessageType.RedError);
@@ -1484,33 +1491,33 @@ namespace DesktopModules.Admin.Portals
                     {
                         PortalController.UpdatePortalSetting(_portalId, item.DataField, item.Value.ToString());
                     }
+                    PortalController.UpdatePortalSetting(_portalId, "Registration_UseProfanityFilter", chkRegistrationUseProfanityFilter.Checked.ToString(), false);
+                    PortalController.UpdatePortalSetting(_portalId, "Registration_UseAuthProviders", chkRegistrationUseAuthProviders.Checked.ToString(), false);
 
-                    //DNN-6093
-                    foreach (DnnFormItemBase item in standardRegistrationSettings.Items)
+
+                    if (chkRegistrationUseEmailAsUserName.Checked && UserController.GetDuplicateEmailCount() > 0)
                     {
-                        //Make sure that enabling Registration_UseEmailAsUserName doesn't cause issues with duplicate e-mail addresses
-                        if (item.DataField.ToLower() == "registration_useemailasusername" && Boolean.Parse(item.Value.ToString()) == true)
-                        {
-                            if (UserController.GetDuplicateEmailCount() > 0)
-                            {
-                                string message = Localization.GetString("ContainsDuplicateAddresses", LocalResourceFile);
-                                DotNetNuke.UI.Skins.Skin.AddModuleMessage(this, message, ModuleMessage.ModuleMessageType.RedError);
-                                return;
-                            }
-                            
-                            // can't actualy use this as web.config settings are system wide.
-
-                            //if (MembershipProvider.Instance().RequiresUniqueEmail == false)
-                            //{
-                            //    string message = Localization.GetString("MustEnableUniqueEmail", LocalResourceFile);
-                            //    DotNetNuke.UI.Skins.Skin.AddModuleMessage(this, message, ModuleMessage.ModuleMessageType.RedError);
-                            //    return;
-                            //}
-
-                        }
-                        PortalController.UpdatePortalSetting(_portalId, item.DataField, item.Value.ToString());
+                        string message = Localization.GetString("ContainsDuplicateAddresses", LocalResourceFile);
+                        DotNetNuke.UI.Skins.Skin.AddModuleMessage(this, message, ModuleMessage.ModuleMessageType.RedError);
+                        return;
                     }
+                    else
+                    {
+                        PortalController.UpdatePortalSetting(_portalId, "Registration_UseEmailAsUserName", chkRegistrationUseEmailAsUserName.Checked.ToString(), false);
+                    }
+                            
+                    // can't actualy use this as web.config settings are system wide.
 
+                    //if (MembershipProvider.Instance().RequiresUniqueEmail == false)
+                    //{
+                    //    string message = Localization.GetString("MustEnableUniqueEmail", LocalResourceFile);
+                    //    DotNetNuke.UI.Skins.Skin.AddModuleMessage(this, message, ModuleMessage.ModuleMessageType.RedError);
+                    //    return;
+                    //}
+
+                    
+                    PortalController.UpdatePortalSetting(_portalId, "Registration_RequireUniqueDisplayName", chkRegistrationRequireUniqueDisplayName.Checked.ToString(), false);
+                    
                     foreach (DnnFormItemBase item in validationRegistrationSettings.Items)
                     {
                         try
@@ -1528,24 +1535,22 @@ namespace DesktopModules.Admin.Portals
                         }
                     }
 
-                    foreach (DnnFormItemBase item in passwordRegistrationSettings.Items)
-                    {
-                        PortalController.UpdatePortalSetting(_portalId, item.DataField, item.Value.ToString());
-                    }
+                    PortalController.UpdatePortalSetting(_portalId, "Registration_RandomPassword", chkRegistrationRandomPassword.Checked.ToString(), false);
+                    PortalController.UpdatePortalSetting(_portalId, "Registration_RequireConfirmPassword", chkRegistrationRequireConfirmPassword.Checked.ToString(), true);
 
-                    foreach (DnnFormItemBase item in otherRegistrationSettings.Items)
-                    {
-                        PortalController.UpdatePortalSetting(_portalId, item.DataField, item.Value.ToString());
-                    }
+                    PortalController.UpdatePortalSetting(_portalId, "Security_RequireValidProfile", chkSecurityRequireValidProfile.Checked.ToString(), false);
+                    PortalController.UpdatePortalSetting(_portalId, "Security_CaptchaRegister", chkSecurityCaptchaRegister.Checked.ToString(), false);
+
                     var redirectTabId = !String.IsNullOrEmpty(RedirectAfterRegistration.SelectedItem.Value) ?
                                         RedirectAfterRegistration.SelectedItem.Value
                                         : "-1";
                     PortalController.UpdatePortalSetting(_portalId, "Redirect_AfterRegistration", redirectTabId, SelectedCultureCode);
 
-                    foreach (DnnFormItemBase item in loginSettings.Items)
-                    {
-                        PortalController.UpdatePortalSetting(_portalId, item.DataField, item.Value.ToString());
-                    }
+                    PortalController.UpdatePortalSetting(_portalId, "Security_CaptchaLogin", chkSecurityCaptchaLogin.Checked.ToString(), false);
+                    PortalController.UpdatePortalSetting(_portalId, "Security_RequireValidProfileAtLogin", chkSecurityRequireValidProfileAtLogin.Checked.ToString(), true);
+                    PortalController.UpdatePortalSetting(_portalId, "Security_CaptchaRetrivePassword", chkSecurityCaptchaRetrivePassword.Checked.ToString(), false);
+                    PortalController.UpdatePortalSetting(_portalId, "Security_CaptchaChangePassword", chkSecurityCaptchaChangePassword.Checked.ToString(), false);
+
                     redirectTabId = !String.IsNullOrEmpty(RedirectAfterLogin.SelectedItem.Value) ?
                                         RedirectAfterLogin.SelectedItem.Value
                                         : "-1";
@@ -1569,6 +1574,7 @@ namespace DesktopModules.Admin.Portals
                                                                     : item.Value.ToString()
                                                                 );
                     }
+                    PortalController.UpdatePortalSetting(_portalId, "Profile_DisplayVisibility", chkProfileDisplayVisibility.Checked.ToString(), true);
 
                     PortalController.UpdatePortalSetting(_portalId, "PageHeadText", string.IsNullOrEmpty(txtPageHeadText.Text) ? "false" : txtPageHeadText.Text); // Hack to store empty string portalsetting with non empty default value
                     PortalController.UpdatePortalSetting(_portalId, "InjectModuleHyperLink", chkInjectModuleHyperLink.Checked.ToString());

--- a/Website/DesktopModules/Admin/Portals/sitesettings.ascx
+++ b/Website/DesktopModules/Admin/Portals/sitesettings.ascx
@@ -200,7 +200,7 @@
                         <dnn:DnnComboBox ID="cboAdministratorId" runat="server" DataTextField="FullName" DataValueField="UserId" />
                     </div>
 				    <div class="dnnFormItem">
-                        <dnn:label id="plHideLoginControl" runat="server" controlname="enablePopUpsCheckBox" />
+                        <dnn:label id="plHideLoginControl" runat="server" controlname="chkHideLoginControl" />
                         <asp:CheckBox ID="chkHideLoginControl" runat="server" />
                     </div>
                 </fieldset>
@@ -542,13 +542,19 @@
                 </div>
                 <div class="dnnFormItem">
                     <fieldset>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Registration_UseAuthProviders" runat="server" controlname="chkRegistrationUseAuthProviders" />
+                            <asp:CheckBox ID="chkRegistrationUseAuthProviders" runat="server" />
+                        </div>
                         <dnn:dnnformeditor id="basicRegistrationSettings" runat="Server" formmode="Short">
                             <Items>
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem1" runat="server" DataField="Registration_UseAuthProviders" />
                                 <dnn:DnnFormTextBoxItem ID="DnnFormTextBoxItem1" runat="server" DataField="Registration_ExcludeTerms" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem2" runat="server" DataField="Registration_UseProfanityFilter" />
                             </Items>
                         </dnn:dnnformeditor>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Registration_UseProfanityFilter" runat="server" controlname="chkRegistrationUseProfanityFilter" />
+                            <asp:CheckBox ID="chkRegistrationUseProfanityFilter" runat="server" />
+                        </div>
                     </fieldset>
                 </div>
                 <div class="dnnFormItem">
@@ -563,11 +569,10 @@
                         </div>
                     </fieldset>
                     <div id="standardRegistration">
-                        <dnn:dnnformeditor id="standardRegistrationSettings" runat="Server" formmode="Short">
-                            <Items>
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem3" runat="server" DataField="Registration_UseEmailAsUserName" />
-                            </Items>
-                        </dnn:dnnformeditor>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Registration_UseEmailAsUserName" runat="server" controlname="chkRegistrationUseEmailAsUserName" />
+                            <asp:CheckBox ID="chkRegistrationUseEmailAsUserName" runat="server" />
+                        </div>
                     </div>
                     <fieldset id="customRegistrationFieldSet">
                         <div class="dnnFormItem">
@@ -575,29 +580,36 @@
                             <asp:TextBox ID="registrationFields" runat="server" />
                         </div>
                     </fieldset>
+                    <div class="dnnFormItem">
+                         <dnn:label id="Registration_RequireUniqueDisplayName" runat="server" controlname="chkRegistrationRequireUniqueDisplayName" />
+                         <asp:CheckBox ID="chkRegistrationRequireUniqueDisplayName" runat="server" />
+                    </div>
                     <dnn:dnnformeditor id="validationRegistrationSettings" runat="Server" formmode="Short">
                         <Items>
-                            <dnn:DnnFormToggleButtonItem ID="requireUniqueDisplayName" runat="server" DataField="Registration_RequireUniqueDisplayName" />
                             <dnn:DnnFormTextBoxItem ID="DnnFormTextBoxItem2" runat="server" DataField="Security_DisplayNameFormat" />
                             <dnn:DnnFormTextBoxItem ID="DnnFormTextBoxItem3" runat="server" DataField="Security_UserNameValidation" />
                             <dnn:DnnFormTextBoxItem ID="DnnFormTextBoxItem4" runat="server" DataField="Security_EmailValidation" />
                         </Items>
                     </dnn:dnnformeditor>
                     <fieldset id="passwordRegistrationFieldSet">
-                        <dnn:dnnformeditor id="passwordRegistrationSettings" runat="Server" formmode="Short">
-                            <Items>
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem4" runat="server" DataField="Registration_RandomPassword" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem5" runat="server" DataField="Registration_RequireConfirmPassword" />
-                            </Items>
-                        </dnn:dnnformeditor>
+                        <div class="dnnFormItem">
+                             <dnn:label id="Registration_RandomPassword" runat="server" controlname="chkRegistrationRandomPassword" />
+                             <asp:CheckBox ID="chkRegistrationRandomPassword" runat="server" />
+                        </div>
+                        <div class="dnnFormItem">
+                             <dnn:label id="Registration_RequireConfirmPassword" runat="server" controlname="chkRegistrationRequireConfirmPassword" />
+                             <asp:CheckBox ID="chkRegistrationRequireConfirmPassword" runat="server" />
+                        </div>
                     </fieldset>
                     <fieldset>
-                        <dnn:dnnformeditor id="otherRegistrationSettings" runat="Server" formmode="Short">
-                            <Items>
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem6" runat="server" DataField="Security_RequireValidProfile" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem7" runat="server" DataField="Security_CaptchaRegister" />
-                            </Items>
-                        </dnn:dnnformeditor>
+                        <div class="dnnFormItem">
+                             <dnn:label id="Security_RequireValidProfile" runat="server" controlname="chkSecurityRequireValidProfile" />
+                             <asp:CheckBox ID="chkSecurityRequireValidProfile" runat="server" />
+                        </div>
+                        <div class="dnnFormItem">
+                             <dnn:label id="Security_CaptchaRegister" runat="server" controlname="chkSecurityCaptchaRegister" />
+                             <asp:CheckBox ID="chkSecurityCaptchaRegister" runat="server" />
+                        </div>
                     </fieldset>
                     <div class="dnnFormItem">
                         <dnn:label id="RedirectAfterRegistrationLabel" runat="server" controlname="cboHomeTabId" ResourceKey="Redirect_AfterRegistration"/>
@@ -651,14 +663,22 @@
             <fieldset>
                 <div class="dnnFormItem">
                     <fieldset>
-                        <dnn:dnnformeditor id="loginSettings" runat="Server" formmode="Short">
-                            <Items>
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem8" runat="server" DataField="Security_CaptchaLogin" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem9" runat="server" DataField="Security_RequireValidProfileAtLogin" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem10" runat="server" DataField="Security_CaptchaRetrivePassword" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem12" runat="server" DataField="Security_CaptchaChangePassword" />
-                            </Items>
-                        </dnn:dnnformeditor>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Security_CaptchaLogin" runat="server" controlname="chkSecurityCaptchaLogin" />
+                            <asp:CheckBox ID="chkSecurityCaptchaLogin" runat="server" />
+                        </div>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Security_RequireValidProfileAtLogin" runat="server" controlname="chkSecurityRequireValidProfileAtLogin" />
+                            <asp:CheckBox ID="chkSecurityRequireValidProfileAtLogin" runat="server" />
+                        </div>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Security_CaptchaRetrivePassword" runat="server" controlname="chkSecurityCaptchaRetrivePassword" />
+                            <asp:CheckBox ID="chkSecurityCaptchaRetrivePassword" runat="server" />
+                        </div>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Security_CaptchaChangePassword" runat="server" controlname="chkSecurityCaptchaChangePassword" />
+                            <asp:CheckBox ID="chkSecurityCaptchaChangePassword" runat="server" />
+                        </div>
                     </fieldset>
                     <div class="dnnFormItem">
                         <dnn:label id="DefaultAuthProviderLabel" runat="server" controlname="authProviderCombo" ResourceKey="DefaultAuthProvider"/>
@@ -694,13 +714,16 @@
                     </div>
                 </div>
                 <div class="dnnFormItem">
-                    <fieldset>
+                    <fieldset>                      
                         <dnn:dnnformeditor id="profileSettings" runat="Server" formmode="Short">
                             <Items>
                                 <dnn:DnnFormEnumItem id="userVisiblity" runat="server" DataField="Profile_DefaultVisibility" />
-                                <dnn:DnnFormToggleButtonItem ID="DnnFormToggleButtonItem11" runat="server" DataField="Profile_DisplayVisibility" />
                             </Items>
                         </dnn:dnnformeditor>
+                        <div class="dnnFormItem">
+                            <dnn:label id="Profile_DisplayVisibility" runat="server" controlname="chkProfileDisplayVisibility" />
+                            <asp:CheckBox ID="chkProfileDisplayVisibility" runat="server" />
+                        </div>
                     </fieldset>
                     <dnn:profiledefinitions id="profileDefinitions" runat="server" />
                 </div>


### PR DESCRIPTION
Following properties were updated and use dnn:label control:
Registration Settings
Registration_UseProfanityFilter
Registration_UseAuthProviders
Registration_UseEmailAsUserName
Registration_RequireUniqueDisplayName
Registration_RandomPassword
Registration_RequireConfirmPassword
Security Settings
Security_RequireValidProfile
Security_CaptchaRegister
Login Settings
Security_CaptchaLogin
Security_RequireValidProfileAtLogin
Security_CaptchaRetrivePassword
Security_CaptchaChangePassword
Profile Settings
Profile_DisplayVisibility