### PR TITLE
DNN-5981 SendEmail from address cannot be empty.

### DIFF
--- a/Website/DesktopModules/Admin/Portals/App_LocalResources/Signup.ascx.resx
+++ b/Website/DesktopModules/Admin/Portals/App_LocalResources/Signup.ascx.resx
@@ -294,6 +294,9 @@
   <data name="UnknownSendMail.Error" xml:space="preserve">
     <value>There was an error sending confirmation emails.  However, the website was created. &lt;a href='{0}' {1}&gt;Click Here To Access the new site&lt;/a&gt;</value>
   </data>
+  <data name="UnknownEmailAddress.Error" xml:space="preserve">
+    <value>There is no email address set on Site and/or Host level.</value>
+  </data>
   <data name="ValidationResults.Text" xml:space="preserve">
     <value>Validation Results</value>
   </data>

--- a/Website/DesktopModules/Admin/Portals/Signup.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/Signup.ascx.cs
@@ -490,9 +490,12 @@ namespace DotNetNuke.Modules.Admin.Portals
                             {
                                 if (!Globals.IsHostTab(PortalSettings.ActiveTab.TabID))
                                 {
-                                    message = Mail.SendMail(PortalSettings.Email,
+                                    message = (String.IsNullOrEmpty(PortalSettings.Email) &&
+                                        String.IsNullOrEmpty(Host.HostEmail)) ?
+                                        string.Format(Localization.GetString("UnknownEmailAddress.Error", LocalResourceFile), message, webUrl, closePopUpStr):
+                                        Mail.SendMail(PortalSettings.Email,
                                                                txtEmail.Text,
-                                                               PortalSettings.Email + ";" + Host.HostEmail,
+                                                               string.IsNullOrEmpty(PortalSettings.Email)? Host.HostEmail : string.IsNullOrEmpty(Host.HostEmail)? PortalSettings.Email : PortalSettings.Email  + ";" + Host.HostEmail,
                                                                Localization.GetSystemMessage(newSettings, "EMAIL_PORTAL_SIGNUP_SUBJECT", adminUser),
                                                                Localization.GetSystemMessage(newSettings, "EMAIL_PORTAL_SIGNUP_BODY", adminUser),
                                                                "",
@@ -501,10 +504,13 @@ namespace DotNetNuke.Modules.Admin.Portals
                                                                "",
                                                                "",
                                                                "");
+                                    
                                 }
                                 else
                                 {
-                                    message = Mail.SendMail(Host.HostEmail,
+                                    message = String.IsNullOrEmpty(Host.HostEmail)?
+                                        string.Format(Localization.GetString("UnknownEmailAddress.Error", LocalResourceFile), message, webUrl, closePopUpStr) :
+                                        Mail.SendMail(Host.HostEmail,
                                                                txtEmail.Text,
                                                                Host.HostEmail,
                                                                Localization.GetSystemMessage(newSettings, "EMAIL_PORTAL_SIGNUP_SUBJECT", adminUser),


### PR DESCRIPTION
To prevent exception I added verification of host email address - if it is empty email won't be sent with empty address and following message would be displayed:
There was an error sending confirmation emails - There is no email address set on Site and/or Host level. However, the website was created. Click Here To Access the new site