### PR TITLE
DNN-6554 PortalSettings not getting parsed correctly

### DIFF
--- a/DNN Platform/Library/Collections/CollectionExtensions.cs
+++ b/DNN Platform/Library/Collections/CollectionExtensions.cs
@@ -755,8 +755,16 @@ namespace DotNetNuke.Collections
         {
             Requires.NotNull("dictionary", dictionary);
             Requires.NotNull("converter", converter);
-
-            return dictionary.Contains(key) ? converter(dictionary[key]) : defaultValue;
+            var value = defaultValue;
+            try
+            {
+                value = dictionary.Contains(key) ? converter(dictionary[key]) : defaultValue;
+            }
+            catch (Exception ex)
+            {
+                // ignored
+            }
+            return value;
         }
 
         #endregion

--- a/DNN Platform/Library/Collections/CollectionExtensions.cs
+++ b/DNN Platform/Library/Collections/CollectionExtensions.cs
@@ -29,11 +29,14 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 
 using DotNetNuke.Common;
+using DotNetNuke.Common.Internal;
+using DotNetNuke.Instrumentation;
 
 namespace DotNetNuke.Collections
 {
     public static class CollectionExtensions
     {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(CollectionExtensions));
         /// <summary>
         /// This method is extracted from the FriendlyUrlSettings class
         /// </summary>
@@ -762,7 +765,7 @@ namespace DotNetNuke.Collections
             }
             catch (Exception ex)
             {
-                // ignored
+                Logger.ErrorFormat("Error loading portal setting: {0} Default value {1} was used instead", key + ":" + dictionary[key], defaultValue.ToString());
             }
             return value;
         }


### PR DESCRIPTION
Added defensive code in the `GetValueOrDefault` to catch exception when string value is invalid and can't be converted