### PR TITLE
DNN-6876 SI: Scheduled Task Update vs Run Now

### DIFF
--- a/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
@@ -268,6 +268,24 @@ namespace DotNetNuke.Services.Scheduling
             }
         }
 
+        public override void UpdateScheduleWithoutExecution(ScheduleItem scheduleItem)
+        {
+            SchedulingController.UpdateSchedule(scheduleItem.ScheduleID,
+                                    scheduleItem.TypeFullName,
+                                    scheduleItem.TimeLapse,
+                                    scheduleItem.TimeLapseMeasurement,
+                                    scheduleItem.RetryTimeLapse,
+                                    scheduleItem.RetryTimeLapseMeasurement,
+                                    scheduleItem.RetainHistoryNum,
+                                    scheduleItem.AttachToEvent,
+                                    scheduleItem.CatchUpEnabled,
+                                    scheduleItem.Enabled,
+                                    scheduleItem.ObjectDependencies,
+                                    scheduleItem.Servers,
+                                    scheduleItem.FriendlyName,
+                                    scheduleItem.ScheduleStartDate);
+        }
+
         public override void UpdateSchedule(ScheduleItem scheduleItem)
         {
             //Remove item from queue
@@ -285,7 +303,8 @@ namespace DotNetNuke.Services.Scheduling
                                                 scheduleItem.Enabled,
                                                 scheduleItem.ObjectDependencies,
                                                 scheduleItem.Servers,
-                                                scheduleItem.FriendlyName);
+                                                scheduleItem.FriendlyName,
+                                                scheduleItem.ScheduleStartDate);
             //Update items that are already scheduled
             var futureHistory = GetScheduleHistory(scheduleItem.ScheduleID).Cast<ScheduleHistoryItem>().Where(h => h.NextStart > DateTime.Now);
 

--- a/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
+++ b/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
@@ -247,6 +247,8 @@ namespace DotNetNuke.Services.Scheduling
 
         public abstract void UpdateSchedule(ScheduleItem scheduleItem);
 
+        public abstract void UpdateScheduleWithoutExecution (ScheduleItem scheduleItem);
+
         public abstract void DeleteSchedule(ScheduleItem scheduleItem);
 
         public virtual void RunScheduleItemNow(ScheduleItem scheduleItem)

--- a/Website/DesktopModules/Admin/Scheduler/EditSchedule.ascx.cs
+++ b/Website/DesktopModules/Admin/Scheduler/EditSchedule.ascx.cs
@@ -267,6 +267,7 @@ namespace DotNetNuke.Modules.Admin.Scheduler
             }
         }
 
+
         /// <summary>
         /// cmdUpdate_Click runs when the Update Button is clicked
         /// </summary>
@@ -285,7 +286,21 @@ namespace DotNetNuke.Modules.Admin.Scheduler
             if (ViewState["ScheduleID"] != null)
             {
                 objScheduleItem.ScheduleID = Convert.ToInt32(ViewState["ScheduleID"]);
-                SchedulingProvider.Instance().UpdateSchedule(objScheduleItem);
+                var scheduleItem = SchedulingProvider.Instance().GetSchedule(Convert.ToInt32(Request.QueryString["ScheduleID"]));
+                if ((startScheduleDatePicker.SelectedDate != scheduleItem.ScheduleStartDate) || (chkEnabled.Checked) ||
+                    (txtTimeLapse.Text != Convert.ToString(scheduleItem.TimeLapse)) ||
+                    (txtRetryTimeLapse.Text != Convert.ToString(scheduleItem.RetryTimeLapse)) ||
+                    (ddlRetryTimeLapseMeasurement.SelectedValue != scheduleItem.RetryTimeLapseMeasurement) ||
+                    (ddlTimeLapseMeasurement.SelectedValue != scheduleItem.TimeLapseMeasurement))
+                {
+                    SchedulingProvider.Instance().UpdateSchedule(objScheduleItem);     
+                }
+                else
+                {
+                    SchedulingProvider.Instance().UpdateScheduleWithoutExecution(objScheduleItem);
+                                 
+                }
+
             }
             else
             {


### PR DESCRIPTION
Task would be executed on Update if:
it was enabled
start time was changed
frequency or retry time lapse was changed

if other settings were changes - task would be updated without execution.

I also made a change in the public override void UpdateSchedule(ScheduleItem scheduleItem) to use SchedulingController.UpdateSchedule(...) that takes scheduleItem.ScheduleStartDate as a last param.
This was necessary as Schedule Start Date/Time was set always to Now.