### PR TITLE
DNN-5471 SI: Logoff.aspx 404

### DIFF
--- a/DNN Platform/Library/Entities/Urls/TabIndexController.cs
+++ b/DNN Platform/Library/Entities/Urls/TabIndexController.cs
@@ -421,6 +421,16 @@ namespace DotNetNuke.Entities.Urls
                             false,
                             false);
             AddToTabDict(tabIndex,
+                dupCheck,
+                httpAlias,
+                "logoff",
+                portalRewritePath + "&ctl=Logoff" + cultureRewritePath,
+                -1,
+                UrlEnums.TabKeyPreference.TabDeleted,
+                ref tabDepth,
+                false,
+                false);
+            AddToTabDict(tabIndex,
                             dupCheck,
                             httpAlias,
                             "terms",


### PR DESCRIPTION
Added logoff to the TabDictionary.
Logoff and Login would redirect correctly when appended to the alias root.
For example:
evoq.dnndev.me/en-us/Login
evoq.dnndev.me/en-us/Logoff

If Logoff or Login is appended to the existing page:
evoq.dnndev.me/en-us/MyTest/Login
evoq.dnndev.me/en-us//MyTest/Logoff
it won't work as we can't be adding all possible combinations to the TabDictionary.

In this situations ctl=Login or ctl=Logoff would work:
evoq.dnndev.me/en-us/MyTest?ctl=Login
evoq.dnndev.me/en-us//MyTest?ctl=Logoff
or
evoq.dnndev.me/en-us/MyTest/ctl/Login
evoq.dnndev.me/en-us//MyTest/ctl/Logoff
