### PR TITLE
Bug/dnn 6135

### DIFF
--- a/DNN Platform/Library/Entities/Urls/TabIndexController.cs
+++ b/DNN Platform/Library/Entities/Urls/TabIndexController.cs
@@ -421,6 +421,16 @@ namespace DotNetNuke.Entities.Urls
                             false,
                             false);
             AddToTabDict(tabIndex,
+                dupCheck,
+                httpAlias,
+                "logoff",
+                portalRewritePath + "&ctl=Logoff" + cultureRewritePath,
+                -1,
+                UrlEnums.TabKeyPreference.TabDeleted,
+                ref tabDepth,
+                false,
+                false);
+            AddToTabDict(tabIndex,
                             dupCheck,
                             httpAlias,
                             "terms",

--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -32,6 +32,7 @@ using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Instrumentation;
 using DotNetNuke.Security.Permissions;
 
 #endregion
@@ -42,6 +43,7 @@ namespace DotNetNuke.Services.Sitemap
     {
         private bool includeHiddenPages;
         private float minPagePriority;
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(CoreSitemapProvider));
 
         private PortalSettings ps;
         private bool useLevelBasedPagePriority;
@@ -74,8 +76,16 @@ namespace DotNetNuke.Services.Sitemap
                 {
                     if ((includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished)
                     {
-                        pageUrl = GetPageUrl(tab, (ps.ContentLocalizationEnabled) ? tab.CultureCode : null);
-                        urls.Add(pageUrl);
+                        try
+                        {
+                            pageUrl = GetPageUrl(tab, (ps.ContentLocalizationEnabled) ? tab.CultureCode : null);
+                            urls.Add(pageUrl);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.ErrorFormat("Error has occurred getting PageUrl for {0}", tab.TabName);
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION
I've tested sitemap on localized site without fix that is provided in DNN-4122, but couldn't replicate the exception.
I think issue could be related to the tab settings or modules on the localized pages.
To prevent failure of the SiteMap creation I've added try catch around the
GetPageUrl call:
                        try
                        {
                            pageUrl = GetPageUrl(tab, (ps.ContentLocalizationEnabled) ? tab.CultureCode : null);
                            urls.Add(pageUrl);
                        }
                        catch (Exception ex)
                        {
                            Logger.ErrorFormat("Error has occurred getting PageUrl for {0}", tab.TabName);
                        }
This way even if one page has failed process will continue and problematic tab would be reported in the log file.