### PR TITLE
DNN-6967 Hovering over Password Strength Meter does not activate Tooltip

### DIFF
--- a/Website/Install/InstallWizard.aspx
+++ b/Website/Install/InstallWizard.aspx
@@ -21,6 +21,7 @@
     <script type="text/javascript" src="../Resources/Shared/Scripts/jquery/jquery.hoverIntent.min.js"></script>
     <script type="text/javascript" src="../Resources/Shared/scripts/dnn.PasswordStrength.js"></script>
     <script type="text/javascript" src="../DesktopModules/Admin/Security/Scripts/dnn.PasswordComparer.js"></script>
+    <script type="text/javascript" src="../Resources/Shared/scripts/dnn.jquery.extensions.js"></script>
     <script type="text/javascript" src="../Resources/Shared/scripts/dnn.jquery.tooltip.js"></script>
     <asp:placeholder id="SCRIPTS" runat="server"></asp:placeholder>
 </head>  


### PR DESCRIPTION
added dnn.jquery.extensions.js to the InstallWizard as the error occurs because .removeCssProperties() is defined in that script and it was not loaded on the page.

Tested one the DNN_Platform_7.4.2.63 + changes in InstallWizard.aspx
in IE11, Chrome and FF