### PR TITLE
DNN-6827 TrueFalseEditControl was recently broken and the last fix do…

### DIFF
--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/CheckEditControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/CheckEditControl.cs
@@ -51,6 +51,22 @@ namespace DotNetNuke.UI.WebControls
             SystemType = "System.Boolean";
         }
 
+        public override bool LoadPostData(string postDataKey, NameValueCollection postCollection)
+        {
+            string postedValue = postCollection[postDataKey];
+            bool boolValue = false;
+            if (!(postedValue == null || postedValue == string.Empty))
+            {
+                boolValue = true;
+            }
+            if (!BooleanValue.Equals(boolValue))
+            {
+                Value = boolValue;
+                return true;
+            }
+            return false;
+        }
+
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/TrueFalseEditControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/TrueFalseEditControl.cs
@@ -208,23 +208,6 @@ namespace DotNetNuke.UI.WebControls
             writer.Write(Localization.GetString("False", Localization.SharedResourceFile));
             writer.RenderEndTag();
         }
-
-        public override bool LoadPostData(string postDataKey, NameValueCollection postCollection)
-        {
-            var postedValue = postCollection[postDataKey];
-            if (string.IsNullOrEmpty(postedValue))
-            {
-                Value = false;
-                return true;
-            }
-            else
-            {
-                bool flag = (postedValue == "1" || postedValue == "true") ? true : false;
-                Value = flag;
-                return true;
-            }
-        }
-
 		
 		#endregion
     }


### PR DESCRIPTION
…es not quite restore the expected behaviour

partially rolled back changes (in CheckEditControl and TrueFalseControl)  that were done in this commit: https://github.com/dnnsoftware/Dnn.Platform/commit/f28493fea5bd24f569037a27f9d3ef71cb54de6d

Tested  TrueFalse control - value can be saved successfully.