### PR TITLE
Added code which prevent adding context.Items["UserInfo"] equal to null.

### DIFF
--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -163,9 +163,9 @@ namespace DotNetNuke.HttpModules.Membership
 
                 //save userinfo object in context
                 if (context.Items["UserInfo"] != null)
-                    context.Items["UserInfo"] = userInfo; //update
+                    context.Items["UserInfo"] = userInfo == null ? new UserInfo() : userInfo; //update
                 else
-                    context.Items.Add("UserInfo", userInfo); //set new
+                    context.Items.Add("UserInfo", userInfo == null ? new UserInfo() : userInfo); //set new
 
                 //Localization.SetLanguage also updates the user profile, so this needs to go after the profile is loaded
                 if (userInfo != null)


### PR DESCRIPTION
Key "UserInfo" that exist but it's equal to null leads to exception: Item has already been added. Key in dictionary: 'UserInfo'  Key being added: 'UserInfo'