### PR TITLE
FakeCachingProvider - Fix null reference exception when key is not present in the dictionary.

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Fakes/FakeCachingProvider.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Fakes/FakeCachingProvider.cs
@@ -24,7 +24,7 @@ namespace DotNetNuke.Tests.Utilities.Fakes
 
         public override object GetItem(string cacheKey)
         {
-            return _dictionary[cacheKey];
+            return _dictionary.ContainsKey(cacheKey) ? _dictionary[cacheKey] : null;
         }
     }
 }


### PR DESCRIPTION
This does not require any Jira as it's part of the unit tests utility class. Fixing this will help some of the tests in Content