### PR TITLE
DNN-7008 Update code to avoid use of deprecated jQuery UI proprety

### DIFF
--- a/Website/Resources/Shared/scripts/dnn.jquery.js
+++ b/Website/Resources/Shared/scripts/dnn.jquery.js
@@ -101,7 +101,6 @@
                         open: function () {
                             $('.ui-dialog-buttonpane').find('button:contains("' + opts.noText + '")').addClass('dnnConfirmCancel');
                         },
-                        position: 'center',
                         draggable: false,
                         buttons: [
                         {


### PR DESCRIPTION
A previous pull request updated DNN to use jQuery 1.11 - this version removes the deprecated position option that was being used in dnnConfirm dialogs,

This change removes the use of the deprecated option and reverts to the default which is the required behavior.