### PR TITLE
(DOC) - Documented the user related signatures

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -516,6 +516,8 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
+        /// <summary>Gets the currently logged in user identifier.</summary>
+        /// <value>The user identifier.</value>
 		public int UserId
 		{
 			get
@@ -528,6 +530,8 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
+        /// <summary>Gets the currently logged in user.</summary>
+        /// <value>The current user information.</value>
 		public UserInfo UserInfo
 		{
 			get


### PR DESCRIPTION
Added documentation to avoid confusion about users related properties being related to portal administrator as they are not.