### PR TITLE
DNN-6924 SuperUsers - Deleting Unauthorized SuperUser accounts fails

### DIFF
--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -899,7 +899,8 @@ namespace DotNetNuke.Entities.Users
         /// -----------------------------------------------------------------------------
         public static void DeleteUnauthorizedUsers(int portalId)
         {
-	        var arrUsers = GetUnAuthorizedUsers(portalId);
+            //DNN-6924 for superusers call GetUsers(includeDeleted, superUsersOnly, portalId)
+	        var arrUsers = (portalId == -1) ? GetUsers(true, true, portalId) : GetUnAuthorizedUsers(portalId);
             for (int i = 0; i < arrUsers.Count; i++)
             {
                 var user = arrUsers[i] as UserInfo;


### PR DESCRIPTION
Delete of unauthorized superusers fails because GetUnAuthorizedUsers(portalId) can't return unauthorized superusers.
SuperUser accounts are not assigned to any portal and do not store Authorized value in the vw_Users (as Authorized value is joined from UserPortals table that has no records for super users).
To resolve this, method selection should be based on the portalId value.