### PR TITLE
DNN-5882 Attempt to add a page when on Host > Extensions fails with l…

### DIFF
--- a/Website/DesktopModules/Admin/Tabs/ManageTabs.ascx.cs
+++ b/Website/DesktopModules/Admin/Tabs/ManageTabs.ascx.cs
@@ -930,7 +930,7 @@ namespace DotNetNuke.Modules.Admin.Tabs
                 }
 
                 //Create Localized versions
-                if (PortalSettings.ContentLocalizationEnabled && cultureTypeList.SelectedValue == "Localized")
+                if (PortalSettings.ContentLocalizationEnabled && cultureTypeList.SelectedValue == "Localized" && Tab.PortalID != -1)
                 {
                     TabController.Instance.CreateLocalizedCopies(Tab);
                     //Refresh tab
@@ -1545,8 +1545,21 @@ namespace DotNetNuke.Modules.Admin.Tabs
                 }
 
                 CheckLocalizationVisibility();
-
-                BindLocalization(false);
+                //DNN-5882 if parent page is a superTab - hide localization options
+                if (PortalSettings.ActiveTab.IsSuperTab && PortalSettings.ActiveTab.ParentId != -1)
+                {
+                    localizationTab.Visible = false;
+                    cmdUpdateLocalization.Visible = false;
+                    MakeTranslatable.Visible = false;
+                    MakeNeutral.Visible = false;
+                    AddMissing.Visible = false;
+                    readyForTranslationButton.Visible = false;
+                }
+                else
+                {
+                    BindLocalization(false);
+                }
+                
 
                 cancelHyperLink.NavigateUrl = Globals.NavigateURL();
 


### PR DESCRIPTION
…ocalization related error
To prevent exception I've added additional condition for creating localized pages, but PM needs to decide
what to do with Localization tab when adding new page.
Essentially host pages can't be localized as they do not belong to any portal.
My suggestion is to fully hide localization info (Localization tab) when parent page is a host tab (IsSuperTab==true).
This means when Host page is selected and user adds new page localization will be visible (as parent page would be set to None), but
when any child page of the Host page is selected then user won't see localization when adding new tab - page created would be neutral.