### PR TITLE
DNN-5979: as the request always redirect by profile definitions.

### DIFF
--- a/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.cs
@@ -1587,16 +1587,21 @@ namespace DesktopModules.Admin.Portals
 
                     DataCache.ClearPortalCache(PortalId, false);
 
-                    //Because portal info changed, we need update current portal setting to load the correct value.
-                    HttpContext.Current.Items["PortalSettings"] = new PortalSettings(TabId, PortalSettings.PortalAlias);
+                    
 
                     //Redirect to this site to refresh only if admin skin changed or either of the images have changed
                     if (refreshPage)
                     {
                         Response.Redirect(Request.RawUrl, true);
                     }
-                    
-                    BindPortal(_portalId, SelectedCultureCode);
+                    else if (!Response.IsRequestBeingRedirected)
+	                {
+						//Because portal info changed, we need update current portal setting to load the correct value.
+						HttpContext.Current.Items["PortalSettings"] = new PortalSettings(TabId, PortalSettings.PortalAlias);
+						PortalSettingsController.Instance().ConfigureActiveTab(PortalSettings);
+
+		                BindPortal(_portalId, SelectedCultureCode);
+	                }
                 }
                 catch (ThreadAbortException)
                 {


### PR DESCRIPTION
as the request always redirect by profile definitions. for code impact in future, only rebind portal when response haven't call redirect, also config active tab to avoid error in this situation.
