### PR TITLE
7053 incorrect affiliate id email

### DIFF
--- a/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
+++ b/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
@@ -87,7 +87,6 @@
     </Compile>
     <Compile Include="View.ascx.cs">
       <DependentUpon>View.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="View.ascx.designer.cs">
       <DependentUpon>View.ascx</DependentUpon>

--- a/DNN Platform/Modules/DigitalAssets/DotNetNuke.Modules.DigitalAssets.csproj
+++ b/DNN Platform/Modules/DigitalAssets/DotNetNuke.Modules.DigitalAssets.csproj
@@ -99,9 +99,7 @@
     <Compile Include="Components\Controllers\Models\PageViewModel.cs" />
     <Compile Include="Components\Controllers\Models\PermissionViewModel.cs" />
     <Compile Include="Components\ExtensionPoint\IFieldsControl.cs" />
-    <Compile Include="Components\ExtensionPoint\PropertiesTabContentControl.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="Components\ExtensionPoint\PropertiesTabContentControl.cs" />
     <Compile Include="Components\ExtensionPoint\ToolBarButton\UnlinkToolbarButtonExtensionPoint.cs" />
     <Compile Include="Components\ExtensionPoint\ToolBarButton\ManageFolderTypesToolBarButtonExtensionPoint.cs" />
     <Compile Include="Components\ExtensionPoint\ToolBarButton\UnzipFileToolBarButtonExtensionPoint.cs" />
@@ -112,14 +110,12 @@
     <Compile Include="Components\ExtensionPoint\UserControls\SearchBoxExtensionPoint.cs" />
     <Compile Include="FileFieldsControl.ascx.cs">
       <DependentUpon>FileFieldsControl.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="FileFieldsControl.ascx.designer.cs">
       <DependentUpon>FileFieldsControl.ascx</DependentUpon>
     </Compile>
     <Compile Include="FolderProperties.ascx.cs">
       <DependentUpon>FolderProperties.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="FolderProperties.ascx.designer.cs">
       <DependentUpon>FolderProperties.ascx</DependentUpon>
@@ -157,21 +153,18 @@
     <Compile Include="Components\Controllers\Models\Field.cs" />
     <Compile Include="EditFolderMapping.ascx.cs">
       <DependentUpon>EditFolderMapping.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="EditFolderMapping.ascx.designer.cs">
       <DependentUpon>EditFolderMapping.ascx</DependentUpon>
     </Compile>
     <Compile Include="FileProperties.ascx.cs">
       <DependentUpon>FileProperties.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="FileProperties.ascx.designer.cs">
       <DependentUpon>FileProperties.ascx</DependentUpon>
     </Compile>
     <Compile Include="FolderMappings.ascx.cs">
       <DependentUpon>FolderMappings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="FolderMappings.ascx.designer.cs">
       <DependentUpon>FolderMappings.ascx</DependentUpon>
@@ -179,7 +172,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SearchBoxControl.ascx.cs">
       <DependentUpon>SearchBoxControl.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="SearchBoxControl.ascx.designer.cs">
       <DependentUpon>SearchBoxControl.ascx</DependentUpon>
@@ -206,14 +198,12 @@
     <Compile Include="Services\Factory.cs" />
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
     </Compile>
     <Compile Include="View.ascx.cs">
       <DependentUpon>View.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="View.ascx.designer.cs">
       <DependentUpon>View.ascx</DependentUpon>

--- a/DNN Platform/Modules/HTML/DotNetNuke.Modules.Html.csproj
+++ b/DNN Platform/Modules/HTML/DotNetNuke.Modules.Html.csproj
@@ -116,28 +116,24 @@
     <Compile Include="Components\WorkflowStatePermissionInfo.cs" />
     <Compile Include="EditHtml.ascx.cs">
       <DependentUpon>EditHtml.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="EditHtml.ascx.designer.cs">
       <DependentUpon>EditHtml.ascx</DependentUpon>
     </Compile>
     <Compile Include="HtmlModule.ascx.cs">
       <DependentUpon>HtmlModule.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="HtmlModule.ascx.designer.cs">
       <DependentUpon>HtmlModule.ascx</DependentUpon>
     </Compile>
     <Compile Include="MyWork.ascx.cs">
       <DependentUpon>MyWork.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="MyWork.ascx.designer.cs">
       <DependentUpon>MyWork.ascx</DependentUpon>
     </Compile>
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>

--- a/DNN Platform/Modules/HtmlEditorManager/DotNetNuke.Modules.HtmlEditorManager.csproj
+++ b/DNN Platform/Modules/HtmlEditorManager/DotNetNuke.Modules.HtmlEditorManager.csproj
@@ -88,7 +88,6 @@
     <Compile Include="Presenters\ProviderConfigurationPresenter.cs" />
     <Compile Include="Controls\InvalidConfiguration.ascx.cs">
       <DependentUpon>InvalidConfiguration.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Controls\InvalidConfiguration.ascx.designer.cs">
       <DependentUpon>InvalidConfiguration.ascx</DependentUpon>
@@ -97,7 +96,6 @@
     <Compile Include="Views\IProviderConfigurationView.cs" />
     <Compile Include="Views\ProviderConfiguration.ascx.cs">
       <DependentUpon>ProviderConfiguration.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Views\ProviderConfiguration.ascx.designer.cs">

--- a/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
+++ b/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
@@ -87,14 +87,12 @@
     <Compile Include="Services\MemberDirectoryServiceRouteMapper.cs" />
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
     </Compile>
     <Compile Include="View.ascx.cs">
       <DependentUpon>View.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="View.ascx.designer.cs">
       <DependentUpon>View.ascx</DependentUpon>

--- a/DNN Platform/Modules/MobileManagement/DotNetNuke.Modules.MobileManagement.csproj
+++ b/DNN Platform/Modules/MobileManagement/DotNetNuke.Modules.MobileManagement.csproj
@@ -93,21 +93,18 @@
     <Compile Include="Views\IRedirectionSettingsView.cs" />
     <Compile Include="Views\RedirectionManagerView.ascx.cs">
       <DependentUpon>RedirectionManagerView.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Views\RedirectionManagerView.ascx.designer.cs">
       <DependentUpon>RedirectionManagerView.ascx</DependentUpon>
     </Compile>
     <Compile Include="Views\RedirectionSettingsView.ascx.cs">
       <DependentUpon>RedirectionSettingsView.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Views\RedirectionSettingsView.ascx.designer.cs">
       <DependentUpon>RedirectionSettingsView.ascx</DependentUpon>
     </Compile>
     <Compile Include="Views\SimpleSettingsView.ascx.cs">
       <DependentUpon>SimpleSettingsView.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Views\SimpleSettingsView.ascx.designer.cs">
       <DependentUpon>SimpleSettingsView.ascx</DependentUpon>

--- a/DNN Platform/Modules/PreviewProfileManagement/DotNetNuke.Modules.PreviewProfileManagement.csproj
+++ b/DNN Platform/Modules/PreviewProfileManagement/DotNetNuke.Modules.PreviewProfileManagement.csproj
@@ -84,7 +84,6 @@
     <Compile Include="Presenters\ProfileManagerPresenter.cs" />
     <Compile Include="Views\ProfileManagerView.ascx.cs">
       <DependentUpon>ProfileManagerView.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Views\ProfileManagerView.ascx.designer.cs">
       <DependentUpon>ProfileManagerView.ascx</DependentUpon>

--- a/DNN Platform/Modules/RazorHost/DotNetNuke.Modules.RazorHost.csproj
+++ b/DNN Platform/Modules/RazorHost/DotNetNuke.Modules.RazorHost.csproj
@@ -103,28 +103,24 @@
     </Compile>
     <Compile Include="AddScript.ascx.cs">
       <DependentUpon>AddScript.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="CreateModule.ascx.designer.cs">
       <DependentUpon>CreateModule.ascx</DependentUpon>
     </Compile>
     <Compile Include="CreateModule.ascx.cs">
       <DependentUpon>CreateModule.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="EditScript.ascx.designer.cs">
       <DependentUpon>EditScript.ascx</DependentUpon>
     </Compile>
     <Compile Include="EditScript.ascx.cs">
       <DependentUpon>EditScript.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="RazorHost.ascx.designer.cs">
       <DependentUpon>RazorHost.ascx</DependentUpon>
     </Compile>
     <Compile Include="RazorHost.ascx.cs">
       <DependentUpon>RazorHost.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="RazorHostSettingsExtensions.cs" />
     <Compile Include="Settings.ascx.designer.cs">
@@ -132,7 +128,6 @@
     </Compile>
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/DNN Platform/Modules/Taxonomy/DotNetNuke.Modules.Taxonomy.csproj
+++ b/DNN Platform/Modules/Taxonomy/DotNetNuke.Modules.Taxonomy.csproj
@@ -133,14 +133,12 @@
     </Compile>
     <Compile Include="CreateVocabulary.ascx.cs">
       <DependentUpon>CreateVocabulary.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="CreateVocabulary.ascx.designer.cs">
       <DependentUpon>CreateVocabulary.ascx</DependentUpon>
     </Compile>
     <Compile Include="EditVocabulary.ascx.cs">
       <DependentUpon>EditVocabulary.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="EditVocabulary.ascx.designer.cs">
       <DependentUpon>EditVocabulary.ascx</DependentUpon>
@@ -153,7 +151,6 @@
     <Compile Include="Validators\VocabularyNameValidator.cs" />
     <Compile Include="VocabularyList.ascx.cs">
       <DependentUpon>VocabularyList.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="VocabularyList.ascx.designer.cs">
       <DependentUpon>VocabularyList.ascx</DependentUpon>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/DotNetNuke.Authentication.Facebook.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/DotNetNuke.Authentication.Facebook.csproj
@@ -77,7 +77,6 @@
     <Compile Include="Components\FacebookUserData.cs" />
     <Compile Include="Login.ascx.cs">
       <DependentUpon>Login.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Login.ascx.designer.cs">
       <DependentUpon>Login.ascx</DependentUpon>
@@ -85,7 +84,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/DotNetNuke.Authentication.Google.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/DotNetNuke.Authentication.Google.csproj
@@ -70,7 +70,6 @@
     <Compile Include="Components\GoogleUserData.cs" />
     <Compile Include="Login.ascx.cs">
       <DependentUpon>Login.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Login.ascx.designer.cs">
       <DependentUpon>Login.ascx</DependentUpon>
@@ -78,7 +77,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/DotNetNuke.Authentication.LiveConnect.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/DotNetNuke.Authentication.LiveConnect.csproj
@@ -68,7 +68,6 @@
     <Compile Include="Components\LiveUserData.cs" />
     <Compile Include="Login.ascx.cs">
       <DependentUpon>Login.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Login.ascx.designer.cs">
       <DependentUpon>Login.ascx</DependentUpon>
@@ -76,7 +75,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/DotNetNuke.Authentication.Twitter.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/DotNetNuke.Authentication.Twitter.csproj
@@ -68,7 +68,6 @@
     <Compile Include="Components\TwitterUserData.cs" />
     <Compile Include="Login.ascx.cs">
       <DependentUpon>Login.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Login.ascx.designer.cs">
       <DependentUpon>Login.ascx</DependentUpon>
@@ -77,7 +76,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Settings.ascx.designer.cs">
       <DependentUpon>Settings.ascx</DependentUpon>

--- a/DNN Platform/Providers/ClientCapabilityProviders/Provider.FiftyOneClientCapabilityProvider/Provider.FiftyOneClientCapabilityProvider.csproj
+++ b/DNN Platform/Providers/ClientCapabilityProviders/Provider.FiftyOneClientCapabilityProvider/Provider.FiftyOneClientCapabilityProvider.csproj
@@ -79,7 +79,6 @@
     </Compile>
     <Compile Include="Administration.ascx.cs">
       <DependentUpon>Administration.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Administration.ascx.designer.cs">
       <DependentUpon>Administration.ascx</DependentUpon>

--- a/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/DotNetNuke.RadEditorProvider.csproj
+++ b/DNN Platform/Providers/HtmlEditorProviders/RadEditorProvider/DotNetNuke.RadEditorProvider.csproj
@@ -103,9 +103,7 @@
     <Compile Include="Components\DnnEditor.cs" />
     <Compile Include="SimulateIsNumeric.cs" />
     <Compile Include="Components\DialogParams.cs" />
-    <Compile Include="Components\EditorProvider.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="Components\EditorProvider.cs" />
     <Compile Include="Components\ErrorCodes.cs" />
     <Compile Include="Components\FileManagerException.cs" />
     <Compile Include="Components\FileSystemValidation.cs" />
@@ -127,7 +125,6 @@
     </Compile>
     <Compile Include="Dialogs\SaveTemplate.aspx.cs">
       <DependentUpon>SaveTemplate.aspx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="DotNetNukeDialogHandler.cs">
       <SubType>ASPXCodeBehind</SubType>
@@ -148,7 +145,6 @@
     </Compile>
     <Compile Include="ProviderConfig.ascx.cs">
       <DependentUpon>ProviderConfig.ascx</DependentUpon>
-      <SubType>ASPXCodeBehind</SubType>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/DNN Platform/Providers/NavigationProviders/ASP2MenuNavigationProvider/Provider.ASP2MenuNavigationProvider.csproj
+++ b/DNN Platform/Providers/NavigationProviders/ASP2MenuNavigationProvider/Provider.ASP2MenuNavigationProvider.csproj
@@ -63,9 +63,7 @@
     <Compile Include="..\..\..\..\SolutionInfo.cs">
       <Link>SolutionInfo.cs</Link>
     </Compile>
-    <Compile Include="ASP2MenuNavigationProvider.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="ASP2MenuNavigationProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DNN Platform/Providers/NavigationProviders/DNNDropDownNavigationProvider/Provider.DNNDropDownNavigationProvider.csproj
+++ b/DNN Platform/Providers/NavigationProviders/DNNDropDownNavigationProvider/Provider.DNNDropDownNavigationProvider.csproj
@@ -68,9 +68,7 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="DNNDropDownNavigationProvider.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="DNNDropDownNavigationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Library\DotNetNuke.Library.csproj">

--- a/DNN Platform/Providers/NavigationProviders/DNNMenuNavigationProvider/Provider.DNNMenuNavigationProvider.csproj
+++ b/DNN Platform/Providers/NavigationProviders/DNNMenuNavigationProvider/Provider.DNNMenuNavigationProvider.csproj
@@ -70,9 +70,7 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="DNNMenuNavigationProvider.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="DNNMenuNavigationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\DotNetNuke.WebUtility\DotNetNuke.WebUtility.vbproj">

--- a/DNN Platform/Providers/NavigationProviders/DNNTreeNavigationProvider/Provider.DNNTreeNavigationProvider.csproj
+++ b/DNN Platform/Providers/NavigationProviders/DNNTreeNavigationProvider/Provider.DNNTreeNavigationProvider.csproj
@@ -68,9 +68,7 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="DNNTreeNavigationProvider.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="DNNTreeNavigationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\DotNetNuke.WebUtility\DotNetNuke.WebUtility.vbproj">

--- a/DNN Platform/Providers/NavigationProviders/SolpartMenuNavigationProvider/Provider.SolpartMenuNavigationProvider.csproj
+++ b/DNN Platform/Providers/NavigationProviders/SolpartMenuNavigationProvider/Provider.SolpartMenuNavigationProvider.csproj
@@ -74,9 +74,7 @@
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="SolpartMenuNavigationProvider.cs">
-      <SubType>ASPXCodeBehind</SubType>
-    </Compile>
+    <Compile Include="SolpartMenuNavigationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Library\DotNetNuke.Library.csproj">

--- a/Website/DesktopModules/Admin/Vendors/EditAffiliate.ascx.cs
+++ b/Website/DesktopModules/Admin/Vendors/EditAffiliate.ascx.cs
@@ -197,7 +197,7 @@ namespace DotNetNuke.Modules.Admin.Vendors
                     var custom = new ArrayList
                                      {
                                          objVendor.VendorName,
-                                         Globals.GetPortalDomainName(PortalSettings.PortalAlias.HTTPAlias, Request, true) + "/" + Globals.glbDefaultPage + "?AffiliateId=" + VendorId
+                                         Globals.GetPortalDomainName(PortalSettings.PortalAlias.HTTPAlias, Request, true) + "/" + Globals.glbDefaultPage + "?AffiliateId=" + AffiliateId
                                      };
                     var errorMsg = Mail.SendMail(PortalSettings.Email,
                                                     objVendor.Email,


### PR DESCRIPTION
Fixed email  passing VendorID instead of AffiliateID in the affiliate send email notification.