### PR TITLE
DNN-7080 Log exception during portal creation

### DIFF
--- a/Website/DesktopModules/Admin/Portals/Signup.ascx.cs
+++ b/Website/DesktopModules/Admin/Portals/Signup.ascx.cs
@@ -465,6 +465,8 @@ namespace DotNetNuke.Modules.Admin.Portals
                         }
                         catch (Exception ex)
                         {
+                            Logger.Error(ex);
+
                             intPortalId = Null.NullInteger;
                             message = ex.Message;
                         }


### PR DESCRIPTION
[DNN-7080](https://dnntracker.atlassian.net/browse/DNN-7080)

>When an exception occurs during portal creation, the module catches but does not log the error, meaning that there are no records anywhere of what caused the error (except for showing the user the error's message, but when it's "Object reference not set to an instance of an object," that's not much help).
>The caught exception should be logged so that follow-up investigation into unexpected errors can be done.
