### PR TITLE
DNN-6796 Cannot add existing module from hidden page as non-admin user.

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/ItemListServiceController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ItemListServiceController.cs
@@ -432,8 +432,7 @@ namespace DotNetNuke.Web.InternalServices
 
             if (portalId > -1)
             {
-                var includeHiddenTabs = PortalSettings.UserInfo.IsSuperUser || PortalSettings.UserInfo.IsInRole("Administrators");
-                tabs = TabController.GetPortalTabs(portalId, (includeActive) ? Null.NullInteger : PortalSettings.ActiveTab.TabID, false, null, includeHiddenTabs, false, false, true, false)
+                tabs = TabController.GetPortalTabs(portalId, (includeActive) ? Null.NullInteger : PortalSettings.ActiveTab.TabID, false, null, true, false, false, true, false)
                                  .Where(tab => searchFunc(tab) 
                                             && tab.ParentId == parentId 
                                             && (includeDisabled || !tab.DisableLink) 
@@ -511,11 +510,9 @@ namespace DotNetNuke.Web.InternalServices
 
             if (portalId > -1)
             {
-                var includeHiddenTabs = PortalSettings.UserInfo.IsSuperUser || PortalSettings.UserInfo.IsInRole("Administrators");
 
                 tabs = TabController.Instance.GetTabsByPortal(portalId).Where(tab =>
                                         (includeActive || tab.Value.TabID != PortalSettings.ActiveTab.TabID)
-                                        && (includeHiddenTabs || tab.Value.IsVisible)
                                         && (includeDisabled || !tab.Value.DisableLink) 
                                         && (includeAllTypes || tab.Value.TabType == TabType.Normal) 
                                         && searchFunc(tab.Value)
@@ -580,8 +577,7 @@ namespace DotNetNuke.Web.InternalServices
 
             if (portalId > -1)
             {
-                var includeHiddenTabs = PortalSettings.UserInfo.IsSuperUser || PortalSettings.UserInfo.IsInRole("Administrators");
-				tabs = TabController.GetPortalTabs(portalId, (includeActive) ? Null.NullInteger : PortalSettings.ActiveTab.TabID, false, null, includeHiddenTabs, false, includeAllTypes, true, false)
+      		tabs = TabController.GetPortalTabs(portalId, (includeActive) ? Null.NullInteger : PortalSettings.ActiveTab.TabID, false, null, true, false, includeAllTypes, true, false)
 					.Where(t => (!t.DisableLink || includeDisabled) && !t.IsSystem)
                     .ToList();
 


### PR DESCRIPTION
Hidden Pages are not security relevant - they are just not included in the menu. There can be tons of reasons for that. This change is strongly requested from my power users.