### PR TITLE
DNN-7116

### DIFF
--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -138,6 +138,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
         protected TimeSpan AuthTokenExpiry { get; set; }
         protected Uri MeGraphEndpoint { get; set; }
         protected Uri TokenEndpoint { get; set; }
+        protected string OAuthHeaderCode { get; set; }
 
         //oAuth 2
         protected string AuthTokenName { get; set; }        
@@ -357,6 +358,14 @@ namespace DotNetNuke.Services.Authentication.OAuth
                 request.ContentType = "application/x-www-form-urlencoded";
                 //request.ContentType = "text/xml";
                 request.ContentLength = byteArray.Length;
+				
+				if (!String.IsNullOrEmpty(OAuthHeaderCode))
+				{ 
+					byte[] API64 = Encoding.UTF8.GetBytes(APIKey + ":" + APISecret); 
+					string Api64Encoded = System.Convert.ToBase64String(API64); 
+					//Authentication providers needing an "Authorization: Basic/bearer base64(clientID:clientSecret)" header. OAuthHeaderCode might be: Basic/Bearer/empty.
+					request.Headers.Add("Authorization: " + OAuthHeaderCode + " " + Api64Encoded); 
+				}
 
                 if (!String.IsNullOrEmpty(parameters))
                 {

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -143,6 +143,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
         //oAuth 2
         protected string AuthTokenName { get; set; }        
         protected string Scope { get; set; }
+		protected string AccessToken { get; set; }
         protected string VerificationCode
         {
             get { return HttpContext.Current.Request.Params[OAuthCodeKey]; }
@@ -739,8 +740,10 @@ namespace DotNetNuke.Services.Authentication.OAuth
             }
 
             string responseText = (OAuthVersion == "1.0")
-                ? ExecuteAuthorizedRequest(HttpMethod.GET, MeGraphEndpoint) 
-                : ExecuteWebRequest(HttpMethod.GET, new Uri(MeGraphEndpoint + "?" + "access_token=" + AuthToken), null, String.Empty);
+                            ? ExecuteAuthorizedRequest(HttpMethod.GET, MeGraphEndpoint)
+                            : string.IsNullOrEmpty(AccessToken)
+                                ? ExecuteWebRequest(HttpMethod.GET, new Uri(MeGraphEndpoint + "?" + "access_token=" + AuthToken), null, String.Empty)
+                                : ExecuteWebRequest(HttpMethod.GET, new Uri(MeGraphEndpoint + "?" + AccessToken + "=" + AuthToken), null, String.Empty);
             var user = Json.Deserialize<TUserData>(responseText);
             return user;
         }


### PR DESCRIPTION
From this post:
http://www.dnnsoftware.com/forums/forumid/160/postid/520548/scope/posts#520548

And this pull request:
https://github.com/dnnsoftware/Dnn.Platform/pull/598

We hope you consider our code for 7.4.2, here it's only the modified oauthclientbase.cs.
The rest of the code, around 800 lines can be dismissed for now.

Added variable OAuthHeaderCode so people can include their own
authentication providers using basic or bearer authorization.

On any client.cs, we can fill OAuthHeaderCode with "Basic", this will
turn APIkey:APIsecret into base64 to send it as header as example below:

Authorization: Basic x54xffaftOHJFg3GGHr78=