### PR TITLE
DNN-7068 Don't decode URL

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -2579,7 +2579,6 @@ namespace DotNetNuke.Entities.Urls
                                 rewritePathOnly = rewritePathOnly.Substring(pathAliasEnd + result.PortalAlias.HTTPAlias.Length);
                             }
                             
-                            rewritePathOnly = HttpUtility.UrlDecode(rewritePathOnly, Encoding.UTF8);
                             //now check to see if need to remove /default.aspx from the end of the requested Url
                             string requestedUrl = fullUrl;
                             int requestedUrlAliasEnd = requestedUrl.IndexOf(result.PortalAlias.HTTPAlias, StringComparison.InvariantCultureIgnoreCase) 


### PR DESCRIPTION
When there are properly encoded entities in a URL, this incorrectly decodes them.  For example, if there is an encoded URL being passed as a query-string parameter (e.g. a return URL), this will unencode any ampersands in the URL (transforming e.g. %2F%3Ffoo1%3Dbar1%26foo2%3Dbar2 into /?foo1=bar1&foo2=bar2), causing those encoded parameters to be interpreted as being query-string parameters of the URL.

See [DNN-7068](https://dnntracker.atlassian.net/browse/DNN-7068).

This pull request needs review from someone who knows what AUM is trying to do here (or, at least, someone able to run the URL integration tests and make sure that this doesn't break anything)