### PR TITLE
DNN-7242: fixes that make sure re-index button clicks work as expected.

### DIFF
--- a/DNN Platform/Library/Services/Search/Internals/SearchHelperImpl.cs
+++ b/DNN Platform/Library/Services/Search/Internals/SearchHelperImpl.cs
@@ -321,11 +321,14 @@ namespace DotNetNuke.Services.Search.Internals
 
             if (!string.IsNullOrEmpty(lastValue))
             {
-                DateTime.TryParseExact(lastValue, Constants.ReindexDateTimeFormat, null, DateTimeStyles.None, out lastSuccessfulDateTime);
-
-                if (lastSuccessfulDateTime <= SqlDateTime.MinValue.Value)
+                if (!DateTime.TryParseExact(lastValue, Constants.ReindexDateTimeFormat, null, DateTimeStyles.None, out lastSuccessfulDateTime))
+                {
                     lastSuccessfulDateTime = SqlDateTime.MinValue.Value.AddDays(1);
-                else if (lastSuccessfulDateTime >= SqlDateTime.MaxValue.Value)
+                }
+
+                if (lastSuccessfulDateTime < SqlDateTime.MinValue.Value.AddDays(1))
+                    lastSuccessfulDateTime = SqlDateTime.MinValue.Value.AddDays(1);
+                else if (lastSuccessfulDateTime > SqlDateTime.MaxValue.Value.AddDays(-1))
                     lastSuccessfulDateTime = SqlDateTime.MaxValue.Value.AddDays(-1);
             }
 

--- a/DNN Platform/Library/Services/Search/SearchEngineScheduler.cs
+++ b/DNN Platform/Library/Services/Search/SearchEngineScheduler.cs
@@ -76,7 +76,7 @@ namespace DotNetNuke.Services.Search
                 Logger.Trace("Search: Site Crawler - Starting. Content change start time " + lastSuccessFulDateTime.ToString("g"));
                 ScheduleHistoryItem.AddLogNote(string.Format("Starting. Content change start time <b>{0:g}</b>", lastSuccessFulDateTime));
 
-                var searchEngine = new SearchEngine();
+                var searchEngine = new SearchEngine(lastSuccessFulDateTime);
                 try
                 {
                     searchEngine.DeleteOldDocsBeforeReindex(lastSuccessFulDateTime);


### PR DESCRIPTION
If REINDEX button clicked while the scheduler is running, the fix makes sure it doesn't affect the currently running indexing cutoff date.

This pull request must accompany the previous request for bug/DNN-7238.