### PR TITLE
DNN-7103 Ensure that translators provide valid countrylist resx files

### DIFF
--- a/Website/App_GlobalResources/List_Country.resx
+++ b/Website/App_GlobalResources/List_Country.resx
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
provide empty "stub" file to ensure that translators are aware a file needs translated and tools pick it up - en-us translations still come from countrylistbox so resx has no entries.