### PR TITLE
DNN-7104 update platform to support an edition specific list of template

### DIFF
--- a/Website/Portals/_default/Blank Website.template.de-DE.resx
+++ b/Website/Portals/_default/Blank Website.template.de-DE.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">leere Website</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Standardvorlage für Websites</value>
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Dies ist ein Platzhalter für die globale Hauptgruppe</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">de-DE</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright DNN Corp, [year]</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Sorry, the page you are looking for cannot be found and might have been removed, had its name changed, or is temporarily unavailable. It is recommended that you start again from the homepage. Feel free to contact us if the problem persists or if you definitely cannot find what you’re looking for.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">Page cannot be found</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+  <data name="Tab.About.RightPane.OtherModule.Content.8.Text">
+    <value xml:space="preserve">Teilen Sie uns Ihre Meinung mit</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Erweiterte Konfiguration</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Erweiterte Konfiguration</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Erweiterte Konfiguration</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Erweiterte Konfiguration</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.0.Text">
+    <value xml:space="preserve">Sehen Sie unser "Getting Started"-Video (in engl. Sprache)</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.1.Text">
+    <value xml:space="preserve">zur Startseite wechseln</value>
+  </data>
+  <data name="Tab.GettingStarted.Header.Module.Title.Text">
+    <value xml:space="preserve">&lt;strong&gt;Fast fertig!&lt;/strong&gt; Sie haben soeben Ihre DotNetNuke-Installation abgeschlossen. &lt;strong&gt;Wie möchten Sie fortfahren?&lt;/strong&gt;</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">Das folgende Video (in engl. Sprache) soll Ihnen eine &lt;strong&gt; Hilfe bei den ersten Schritten&lt;/strong&gt; zum Aufbau Ihrer Website sein. Mit DotNetNuke können Sie einfach und schnell Ihre neue Website mit Ihren Inhalten füllen und online bringen.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Einführungs-Video</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.10.Text">
+    <value xml:space="preserve">Funktionen hinzufügen</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.11.Text">
+    <value xml:space="preserve">Erweitern sie den Funktionsumfang Ihrer Website, z.B. durch E-Commerce.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.12.Text">
+    <value xml:space="preserve">Besuchen Sie den DotNetNuke-Store</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.13.Text">
+    <value xml:space="preserve">Sponsoren</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Erfahren Sie mehr über die Verbesserungen und Neuheiten in DotNetNuke 7.0 (in engl. Sprache)</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">DotNetNuke 7.0-Video</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Passen Sie Ihre Website individuell an</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Sind Sie bereit, Ihre eigene Website zu erstellen?</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Wir haben die Werkzeuge und Erweiterungen, mit denen Sie alle denkbaren Anforderungen umsetzen können.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.7.Text">
+    <value xml:space="preserve">Ich möchte ...</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.8.Text">
+    <value xml:space="preserve">das Design der Website ändern</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.9.Text">
+    <value xml:space="preserve">Sie finden faszinierende Website-Designs im DNN-Store.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.0.Text">
+    <value xml:space="preserve">Neue Features in Version 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.1.Text">
+    <value xml:space="preserve">Erste Schritte mit DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.Name.Text">
+    <value xml:space="preserve">Einführung</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Sie sind bereits ein DNN-Experte?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.1.Text">
+    <value xml:space="preserve">Richten Sie Ihren Mail-Server ein, installieren Sie Sprachen und andere Erweiterungen.</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Erweiterte Einstellungen vornehmen</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Sie haben Fragen?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.4.Text">
+    <value xml:space="preserve">Sie haben Fragen oder Verbesserungsvorschläge? Oder wollen Sie sich nur mit anderen DotNetNuke-Anwendern und Experten austauschen?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.5.Text">
+    <value xml:space="preserve">Antworten suchen</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.6.Text">
+    <value xml:space="preserve">Vorschläge einreichen</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.7.Text">
+    <value xml:space="preserve">Wir freuen uns immer über Ihr Feedback</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.8.Text">
+    <value xml:space="preserve">Wir würden uns freuen, wenn Sie und Ihre Erfahrungen und Meinungen mitteilen</value>
+  </data>
+  <data name="Tab.GettingStarted.Title.Text">
+    <value xml:space="preserve">Willkommen in Ihrer DotNetNuke-Website</value>
+  </data>
+  <data name="Tab.Home.Description.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Keywords.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Name.Text">
+    <value xml:space="preserve">Start</value>
+  </data>
+  <data name="Tab.Home.PageHeadText.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Title.Text">
+    <value />
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Website-Suche</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Website-Suche</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Blank Website.template.es-ES.resx
+++ b/Website/Portals/_default/Blank Website.template.es-ES.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Sitio web en blanco</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Plantilla de sitio web en blanco</value>
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Un grupo de roles que representa los roles globales</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">es-ES</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] DNN Corp</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Lo sentimos, la página que esta buscando no se ha encontrado. Puede que la página se haya borrado, su nombre haya cambiado o bien esté temporalmente desactivada. Le sugerimos que empieze de nuevo en la página inicial. Póngase en contacto con nosotros si el problema persiste o no puede encontrar lo que necesita.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">La página no se puede encontrar</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">Página de error 404</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">Página de error 404</value>
+  </data>
+  <data name="Tab.About.RightPane.OtherModule.Content.8.Text">
+    <value xml:space="preserve">Comparta sus comentarios</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.0.Text">
+    <value xml:space="preserve">Ver el vídeo de introducción</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.1.Text">
+    <value xml:space="preserve">¡Empezar ya!</value>
+  </data>
+  <data name="Tab.GettingStarted.Header.Module.Title.Text">
+    <value xml:space="preserve">&lt;strong&gt;¡Perfecto!&lt;/strong&gt; Acaba de completar su instalación de DotNetNuke. &lt;strong&gt;¿Qué quiere hacer a continuación?&lt;/strong&gt;</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">El siguiente vídeo &lt;strong&gt; le ayudará a empezar &lt;/strong&gt; a construir su nuevo sitio web DotNetNuke. Trabajar con DotNetNuke es rápido y fácil y en pocos minutos puede tener su sitio web funcionando con contenidos reales.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Ver en vídeo de introducción</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.10.Text">
+    <value xml:space="preserve">Añadir nuevas funcionalidades</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.11.Text">
+    <value xml:space="preserve">Mejore las funciones de su sitio web con una tienda online</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.12.Text">
+    <value xml:space="preserve">Visite la tienda DotNetNuke Store</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.13.Text">
+    <value xml:space="preserve">Patrocinadores</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Vea las mejoras y novedades introducidas en DotNetNuke 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Ver el vídeo</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Personalice su DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">¿Está preparado para personalizar DotNetNuke a su gusto?</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Tenemos todos los recursos y herramientas para hacer cualquier cosa que pueda imaginar.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.7.Text">
+    <value xml:space="preserve">Hoy quiero...</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.8.Text">
+    <value xml:space="preserve">Cambiar el aspecto de mi sitio</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.9.Text">
+    <value xml:space="preserve">Encuentre nuevos diseños para su sitio web en la DNN Store</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.0.Text">
+    <value xml:space="preserve">Novedades de la versión 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.1.Text">
+    <value xml:space="preserve">Aprenda lo principal para trabajar con DNN</value>
+  </data>
+  <data name="Tab.GettingStarted.Name.Text">
+    <value xml:space="preserve">Primeros pasos</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.0.Text">
+    <value xml:space="preserve">¿Ya es un experto?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.1.Text">
+    <value xml:space="preserve">Configure su email, instale idiomas y otras tareas avanzadas</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.3.Text">
+    <value xml:space="preserve">¿Buscando respuestas?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.4.Text">
+    <value xml:space="preserve">¿Tiene alguna pregunta, ideas de mejoras o quiere encontrarse con otros miembros de la comunidad DotNetNuke?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.5.Text">
+    <value xml:space="preserve">Encuentre respuestas</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.6.Text">
+    <value xml:space="preserve">Envie sus ideas</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.7.Text">
+    <value xml:space="preserve">Sus comentarios serán bienvenidos</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.8.Text">
+    <value xml:space="preserve">Nos gustaría saber como lo hacemos</value>
+  </data>
+  <data name="Tab.GettingStarted.Title.Text">
+    <value xml:space="preserve">Bienvenido a su instalación DotNetNuke</value>
+  </data>
+  <data name="Tab.Home.Description.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Keywords.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Name.Text">
+    <value xml:space="preserve">Inicio</value>
+  </data>
+  <data name="Tab.Home.PageHeadText.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Title.Text">
+    <value />
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Administración de búsquedas</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Administración de búsquedas</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Blank Website.template.fr-FR.resx
+++ b/Website/Portals/_default/Blank Website.template.fr-FR.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Site Web vide</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">fr-FR</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] DNN Corp</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Modèle vierge</value>
+  </data>
+  <data name="Tab.Home.Description.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Keywords.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Name.Text">
+    <value xml:space="preserve">Accueil</value>
+  </data>
+  <data name="Tab.Home.PageHeadText.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Title.Text">
+    <value />
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Un groupe de rôle factice qui représente les rôles globaux</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.0.Text">
+    <value xml:space="preserve">Regarder la vidéo de mise en route</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.1.Text">
+    <value xml:space="preserve">C'est parti !</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">La vidéo ci-dessous vous permettra &lt;strong&gt;de bien démarrer&lt;/strong&gt; la création de votre nouveau site DotNetNuke. Utiliser DotNetNuke est simple et rapide, obtenez un site fonctionnel avec un véritable contenu en seulement quelques minutes</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Regarder la vidéo</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.0.Text">
+    <value xml:space="preserve">Nouveautés de la version 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.Name.Text">
+    <value xml:space="preserve">Pour commencer</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Déjà un expert ?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.1.Text">
+    <value xml:space="preserve">Configurer votre courriel, installer des packs de langues et autres paramètres avancés</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Définir des paramètres avancés</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Vous cherchez des réponses ?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.4.Text">
+    <value xml:space="preserve">Vous avez des questions, des idées d'améliorations ou souhaitez simplement rencontrer d'autres membres de DotNetNuke ?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.5.Text">
+    <value xml:space="preserve">Trouver une réponse</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.6.Text">
+    <value xml:space="preserve">Soumettre une idée</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.7.Text">
+    <value xml:space="preserve">Nous apprécions toujours vos commentaires</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.8.Text">
+    <value xml:space="preserve">Nous serions ravis d'avoir votre avis</value>
+  </data>
+  <data name="Tab.GettingStarted.Title.Text">
+    <value xml:space="preserve">Bienvenue dans votre installation de DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.1.Text">
+    <value xml:space="preserve">Apprenez les bases du travail avec DNN</value>
+  </data>
+  <data name="Tab.GettingStarted.Header.Module.Title.Text">
+    <value xml:space="preserve">&lt;strong&gt;Et voilà&lt;/strong&gt; vous venez de terminer l’installation de DotNetNuke. &lt;strong&gt;Qu’aimeriez-vous faire ensuite ?&lt;/strong&gt;</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Découvrez quelles améliorations et ajouts nous avons apporté à DotNetNuke 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Regarder la vidéo</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.10.Text">
+    <value xml:space="preserve">Ajouter nouvelle fonctionnalité</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.11.Text">
+    <value xml:space="preserve">Améliorer votre site avec des fonctionnalités telles que le commerce en ligne.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.12.Text">
+    <value xml:space="preserve">Visiter la boutique DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.13.Text">
+    <value xml:space="preserve">Sponsors</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Personnaliser votre DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Êtes-vous prêt pour faire votre propre DotNetNuke ?</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Nous avons les ressources et les outils pour faire tout ce que vous pouvez imaginer.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.7.Text">
+    <value xml:space="preserve">Je veux...</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.8.Text">
+    <value xml:space="preserve">Changer le look de mon site</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.9.Text">
+    <value xml:space="preserve">Trouver de nouveaux thèmes pour votre site Web sur la boutique DotNetNuke.</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.About.RightPane.OtherModule.Content.8.Text">
+    <value xml:space="preserve">Donnez votre avis</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Recherche Admin</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Recherche Admin</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Sorry, the page you are looking for cannot be found and might have been removed, had its name changed, or is temporarily unavailable. It is recommended that you start again from the homepage. Feel free to contact us if the problem persists or if you definitely cannot find what you’re looking for.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">Page cannot be found</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Blank Website.template.it-IT.resx
+++ b/Website/Portals/_default/Blank Website.template.it-IT.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Sito Web Vuoto</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">it-IT</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] by DNN Corp</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Template Vuoto</value>
+  </data>
+  <data name="Tab.Home.Description.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Keywords.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Name.Text">
+    <value xml:space="preserve">Home</value>
+  </data>
+  <data name="Tab.Home.PageHeadText.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Title.Text">
+    <value />
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Un Gruppo fittizio che rappresenta i ruoli globali</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.0.Text">
+    <value xml:space="preserve">Guarda il Video Introduttivo</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.1.Text">
+    <value xml:space="preserve">Inizia ad Usarlo</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">Il video qui sotto vi &lt;strong&gt; aiuterà ad iniziare &lt;/strong&gt; a costruire il nuovo sito in DotNetNuke. Usare DotNetNuke è facile e veloce e si può avere il nuovo sito attivo e funzionante con il contenuto reale in pochi minuti.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Guarda il Video di Introduzione</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.0.Text">
+    <value xml:space="preserve">Novità su DNN 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.Name.Text">
+    <value xml:space="preserve">Per Iniziare</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Sei già un esperto?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.1.Text">
+    <value xml:space="preserve">Imposta la tua e-mail, installare altre lingue, e altre impostazioni di configurazione avanzata</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Definire Impostazioni di Configurazione Avanzata</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Alla ricerca di risposte?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.4.Text">
+    <value xml:space="preserve">Avete delle domande, idee per migliorare o semplicemente vorreste incontrare altri membri DotNetNuke?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.5.Text">
+    <value xml:space="preserve">Trova una risposta</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.6.Text">
+    <value xml:space="preserve">Potete sottoporci le vostre Idee</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.7.Text">
+    <value xml:space="preserve">Apprezziamo sempre il vostro feedback</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.8.Text">
+    <value xml:space="preserve">Ci piacerebbe sapere cosa pensi del nostro operato.</value>
+  </data>
+  <data name="Tab.GettingStarted.Title.Text">
+    <value xml:space="preserve">Benvenuto nella tua installazione di DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.1.Text">
+    <value xml:space="preserve">Imparare le basi per lavorare con DNN</value>
+  </data>
+  <data name="Tab.GettingStarted.Header.Module.Title.Text">
+    <value xml:space="preserve">&lt;strong&gt;Fatto!&lt;/strong&gt; Hai appena completato la nuova Installazione del Prodotto; &lt;strong&gt;cosa ti piacerebbe fare ora?&lt;/strong&gt;</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Scopri quali cambiamenti e migliorie abbiamo effettuato con DotNetNuke 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Guarda il Video</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.10.Text">
+    <value xml:space="preserve">Aggiungi Nuove Funzionalità</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.11.Text">
+    <value xml:space="preserve">Arricchisci il tuo sito con funzionalità e-commerce.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.12.Text">
+    <value xml:space="preserve">Visita DotNetNuke Store</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.13.Text">
+    <value xml:space="preserve">Sponsors</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Personalizza il tuo DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Sei pronto a fare tuo DotNetNuke?</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Abbiamo le risorse e gli strumenti per fare tutto quello che si possa immaginare.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.7.Text">
+    <value xml:space="preserve">Voglio...</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.8.Text">
+    <value xml:space="preserve">Cambia il look del tuo sito</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.9.Text">
+    <value xml:space="preserve">Find new themes for your website on the DNN Store.</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Impostazioni Configurazione Avanzata</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Impostazioni Configurazione Avanzata</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Impostazioni Configurazione Avanzata</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Impostazioni Configurazione Avanzata</value>
+  </data>
+  <data name="Tab.About.RightPane.OtherModule.Content.8.Text">
+    <value xml:space="preserve">Condividi i tuoi feedback</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Ricerca Admin</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Ricerca Admin</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Sorry, the page you are looking for cannot be found and might have been removed, had its name changed, or is temporarily unavailable. It is recommended that you start again from the homepage. Feel free to contact us if the problem persists or if you definitely cannot find what you’re looking for.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">Page cannot be found</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Blank Website.template.nl-NL.resx
+++ b/Website/Portals/_default/Blank Website.template.nl-NL.resx
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Lege Website</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">nl-NL</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] by DNN corp</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Lege Template</value>
+  </data>
+  <data name="Tab.Home.Description.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Keywords.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Name.Text">
+    <value xml:space="preserve">Home</value>
+  </data>
+  <data name="Tab.Home.PageHeadText.Text">
+    <value />
+  </data>
+  <data name="Tab.Home.Title.Text">
+    <value />
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Een dummy rol groep die de globale rollen vertegenwoordigd</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.0.Text">
+    <value xml:space="preserve">Bekijk de introductie video</value>
+  </data>
+  <data name="Tab.GettingStarted.Actions.Module.Content.1.Text">
+    <value xml:space="preserve">Beginnen (video overslaan)</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">De video hieronder zal&lt;strong&gt; u helpen &lt;/strong&gt; met de bouw van uw nieuwe DotNetNuke site. Met behulp van DotNetNuke is u uw nieuwe site snel en gemakkelijk actief met echte inhoud in slechts een kwestie van minuten.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Bekijk de introductie video</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.0.Text">
+    <value xml:space="preserve"> Wat is nieuw met 7.0</value>
+  </data>
+  <data name="Tab.GettingStarted.Name.Text">
+    <value xml:space="preserve">Aan de slag</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.0.Text">
+    <value xml:space="preserve"> Al een expert?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.1.Text">
+    <value xml:space="preserve">Opstartprocedure van uw e-mail, installeer talen en andere geavanceerde configuratie instellingen.</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen instellen</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Op zoek naar antwoorden?</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.4.Text">
+    <value xml:space="preserve">Hebt u vragen, ideeën voor verbetering of wilt u gewoon  enkele andere leden van de DotNetNuke ontmoeten?
+</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.5.Text">
+    <value xml:space="preserve">Vind een antwoord</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.6.Text">
+    <value xml:space="preserve">Uw ideeën indienen</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.7.Text">
+    <value xml:space="preserve">Wij waarderen altijd uw terugkoppeling</value>
+  </data>
+  <data name="Tab.GettingStarted.RightPane.Module.Content.8.Text">
+    <value xml:space="preserve">We zouden graag horen hoe we het doen</value>
+  </data>
+  <data name="Tab.GettingStarted.Title.Text">
+    <value xml:space="preserve">Welkom bij uw DotNetNuke installatie</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Title.1.Text">
+    <value xml:space="preserve">Leer de grondbeginselen van het werken met DNN</value>
+  </data>
+  <data name="Tab.GettingStarted.Header.Module.Title.Text">
+    <value xml:space="preserve">&lt;strong&gt;Klaar om te starten!&lt;/strong&gt; u heeft zojuist uw installatie van DotNetNuke voltooid; &lt;strong&gt;wat wilt u als volgende doen?&lt;/strong&gt;</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Ontdek welke verbeteringen en toevoegingen we hebben aangebracht in DotNetNuke 7.0
+</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Bekijk de video</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.10.Text">
+    <value xml:space="preserve">Nieuwe functionaliteit toevoegen</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.11.Text">
+    <value xml:space="preserve">Verbeter uw site met mogelijkheden zoals e-commerce.</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.12.Text">
+    <value xml:space="preserve">Bezoek de DotNetNuke Store</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.13.Text">
+    <value xml:space="preserve">Sponsors</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Personaliseer uw DotNetNuke</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Bent u klaar DotNetNuke je eigen te maken?</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">We hebben de middelen en instrumenten om  zo  ongeveer alles te doen wat  u zich kunt voorstellen.
+. </value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.7.Text">
+    <value xml:space="preserve">Ik wil ...</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.8.Text">
+    <value xml:space="preserve">Het uiterlijk van mijn site wijzigen</value>
+  </data>
+  <data name="Tab.GettingStarted.LeftPane.Module.Content.9.Text">
+    <value xml:space="preserve">Vind nieuwe thema ontwerpen voor uw website op de DotNetNuke Store.</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.About.RightPane.OtherModule.Content.8.Text">
+    <value xml:space="preserve">Share your feedback</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Zoek Admin</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Zoek Admin</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Sorry, the page you are looking for cannot be found and might have been removed, had its name changed, or is temporarily unavailable. It is recommended that you start again from the homepage. Feel free to contact us if the problem persists or if you definitely cannot find what you’re looking for.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">Page cannot be found</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">404 Error Page</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Default Website.template.de-DE.resx
+++ b/Website/Portals/_default/Default Website.template.de-DE.resx
@@ -1,0 +1,974 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Standard-Website</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Standardvorlage für Websites</value>
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Dies ist ein Platzhalter für die globale Hauptgruppe</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">de-DE</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright DNN Corp, [year]</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Wir bitten um Entschuldigung, aber die von Ihnen gesuchte Seite wurde nicht gefunden, evtl. wurde sie verschoben, umbenannt oder gelöscht. Wir empfehlen, auf die Startseite zu wechseln. Bei Fragen steht Ihnen unser Team gerne zur Verfügung und hilft Ihnen bei Ihrer Suche.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">Seite nicht gefunden</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">Fehlerseite 404</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">Fehlerseite 404</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.JournalModule.Title.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.ProfileModule.Title.Text">
+    <value xml:space="preserve">Profil anzeigen</value>
+  </data>
+  <data name="Tab.ActivityFeed.Content.Text">
+    <value xml:space="preserve">Aktivitäten</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Firmengeschichte</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Stellenangebote</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">AGB</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Firma</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Off-Road</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Schwerkraft</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Über Land</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Stadt</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Allwetter</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produkte</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gebrauchsanleitungen</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Produktkataloge</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Produktarchiv</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Produkt-Support</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Gewährleistung</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Kundendienst</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Netzwerke</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.1.Text">
+    <value xml:space="preserve">
+3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Telefon: (555) 555-4563</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Kontakt</value>
+  </data>
+  <data name="Tab.ActivityFeed.Name.Text">
+    <value xml:space="preserve">Activitäten</value>
+  </data>
+  <data name="Tab.ActivityFeed.RightPane.Module.Title.Text">
+    <value xml:space="preserve">Mitgliederverzeichnis</value>
+  </data>
+  <data name="Tab.ActivityFeed.Title.Text">
+    <value xml:space="preserve">Aktivitäten</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Erweiterte Einstellungen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Erweiterte Einstellungen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Erweiterte Einstellungen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Erweiterte Einstellungen</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Erweiterte URL-Verwaltung</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.Description.Text">
+    <value xml:space="preserve">Erweiterte URL-Einstellungen vornehmen</value>
+  </data>
+  <data name="Tab.ContentStaging.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Content-Staging</value>
+  </data>
+  <data name="Tab.ContentStaging.Description.Text">
+    <value xml:space="preserve">Verwalten Sie die Vorbereiteten Inhalte für Ihre Website</value>
+  </data>
+  <data name="Tab.ContentStaging.Name.Text">
+    <value xml:space="preserve">Content-Staging</value>
+  </data>
+  <data name="Tab.DevicePreview.Content.Text">
+    <value xml:space="preserve">Mobilvorschau</value>
+  </data>
+  <data name="Tab.DevicePreview.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Mobilvorschau</value>
+  </data>
+  <data name="Tab.DevicePreview.Description.Text">
+    <value xml:space="preserve">Darstellung der Website auf mobilen Geräten simulieren.</value>
+  </data>
+  <data name="Tab.DevicePreview.Name.Text">
+    <value xml:space="preserve">Mobilvorschau</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Content.Text">
+    <value xml:space="preserve">Dateiverwaltung</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Dateiverwaltung</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Description.Text">
+    <value xml:space="preserve">Dateien auf Ihrer Website verwalten.</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Name.Text">
+    <value xml:space="preserve">Dateiverwaltung</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Title.Text">
+    <value xml:space="preserve">Dateiverwaltung</value>
+  </data>
+  <data name="Tab.Extensions.Content.Text">
+    <value xml:space="preserve">Erweiterungen</value>
+  </data>
+  <data name="Tab.Extensions.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Erweiterungen</value>
+  </data>
+  <data name="Tab.Extensions.Description.Text">
+    <value xml:space="preserve">Installieren und bearbeiten von Erweiterungen wie Module, Sprachpakete und Seitenlayouts.</value>
+  </data>
+  <data name="Tab.Extensions.Name.Text">
+    <value xml:space="preserve">Erweiterungen</value>
+  </data>
+  <data name="Tab.Extensions.Title.Text">
+    <value xml:space="preserve">Erweiterungen</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Content.Text">
+    <value xml:space="preserve">Google-Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Google-Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Description.Text">
+    <value xml:space="preserve">Konfigurieren Sie den Einsatz von Google Analytics auf Ihrer Website.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Name.Text">
+    <value xml:space="preserve">Google-Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Title.Text">
+    <value xml:space="preserve">Google-Analytics</value>
+  </data>
+  <data name="Tab.Languages.Content.Text">
+    <value xml:space="preserve">Sprachen</value>
+  </data>
+  <data name="Tab.Languages.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Sprachen verwalten</value>
+  </data>
+  <data name="Tab.Languages.Description.Text">
+    <value xml:space="preserve">Sprachen und Übersetzungen verwalten</value>
+  </data>
+  <data name="Tab.Languages.Name.Text">
+    <value xml:space="preserve">Sprachen</value>
+  </data>
+  <data name="Tab.Languages.Title.Text">
+    <value xml:space="preserve">Sprachen</value>
+  </data>
+  <data name="Tab.Lists.Content.Text">
+    <value xml:space="preserve">Listen</value>
+  </data>
+  <data name="Tab.Lists.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Listen</value>
+  </data>
+  <data name="Tab.Lists.Description.Text">
+    <value xml:space="preserve">Allgemeine Liste bearbeiten</value>
+  </data>
+  <data name="Tab.Lists.Name.Text">
+    <value xml:space="preserve">Listen</value>
+  </data>
+  <data name="Tab.Lists.Title.Text">
+    <value xml:space="preserve">Listen</value>
+  </data>
+  <data name="Tab.LogViewer.Content.Text">
+    <value xml:space="preserve">Ereignisprotokoll</value>
+  </data>
+  <data name="Tab.LogViewer.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Ereignisprotokoll</value>
+  </data>
+  <data name="Tab.LogViewer.Description.Text">
+    <value xml:space="preserve">Lassen Sie sich das Protokoll der Ereignisse auf der Website anzeigen, wie Ausnahmen, Anmeldungen, Modul- und Seitenänderungen etc.</value>
+  </data>
+  <data name="Tab.LogViewer.Name.Text">
+    <value xml:space="preserve">Ereignisprotokoll</value>
+  </data>
+  <data name="Tab.LogViewer.Title.Text">
+    <value xml:space="preserve">Ereignisprotokoll</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Mitgliederverzeichnis</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Profil anzeigen</value>
+  </data>
+  <data name="Tab.MyFriends.Content.Text">
+    <value xml:space="preserve">Freunde</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Firmengeschichte</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Stellenangebote</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">AGB</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Firma</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Off-Road</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Schwerkraft</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">über Land</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Stadt</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Allwetter</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produkte</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gebrauchsanleitung</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Produktkataloge</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Produktarchiv</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Produkt-Support</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Gewährleistung</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Kundendienst</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Netzwerke</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.1.Text">
+    <value xml:space="preserve">
+3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Telefon: (555) 555-4563</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Kontakt</value>
+  </data>
+  <data name="Tab.MyFriends.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Profil anzeigen</value>
+  </data>
+  <data name="Tab.MyFriends.Name.Text">
+    <value xml:space="preserve">Freunde</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Mitgliederverzeichnis</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigation</value>
+  </data>
+  <data name="Tab.MyFriends.Title.Text">
+    <value xml:space="preserve">Freunde</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.MessageCenterModule.Title.Text">
+    <value xml:space="preserve">Nachrichten</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Profil anzeigen</value>
+  </data>
+  <data name="Tab.MyMessages.Content.Text">
+    <value xml:space="preserve">Nachrichten</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Firmengeschichte</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Stellenangebote</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">AGB</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Unsere Firma</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Off-Road</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Schwerkraft</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">über Land</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Stadt</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Allwetter</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produkte</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gebrauchsanleitung</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Produktkataloge</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Produktarchiv</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Produkt-Support</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Gewährleistung</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Kundendienst</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Netzwerke</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.1.Text">
+    <value xml:space="preserve">
+3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Telefon: (555) 555-4563</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Kontakt</value>
+  </data>
+  <data name="Tab.MyMessages.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Profile anzeigen</value>
+  </data>
+  <data name="Tab.MyMessages.Name.Text">
+    <value xml:space="preserve">Nachrichten</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Mitgliederverzeichnis</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigation</value>
+  </data>
+  <data name="Tab.MyMessages.Title.Text">
+    <value xml:space="preserve">Nachrichten</value>
+  </data>
+  <data name="Tab.MyProfile.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Profil anzeigen</value>
+  </data>
+  <data name="Tab.MyProfile.Content.Text">
+    <value xml:space="preserve">Eigenes Profil</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Firmengeschichte</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Stellenangebote</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">AGB</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Unsere Firma</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Off-Road</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Schwerkraft</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Über Land</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Stadt</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Allwetter</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produkte</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gebrauchsanleitungen</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Produktkataloge</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Produktarchiv</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Produkt-Support</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Gewährleistung</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Kundendienst</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Netzwerke</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.1.Text">
+    <value xml:space="preserve">
+3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.2.Text">
+    <value xml:space="preserve">Telefon: (555) 555-4563</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.3.Text">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Kontakt</value>
+  </data>
+  <data name="Tab.MyProfile.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Profile anzeigen</value>
+  </data>
+  <data name="Tab.MyProfile.Name.Text">
+    <value xml:space="preserve">Eigenes Profil</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Mitgliederverzeichnis</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigation</value>
+  </data>
+  <data name="Tab.MyProfile.Title.Text">
+    <value xml:space="preserve">Eigenes Profil</value>
+  </data>
+  <data name="Tab.Newsletters.Content.Text">
+    <value xml:space="preserve">Serien-E-Mails</value>
+  </data>
+  <data name="Tab.Newsletters.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Serien-E-Mails</value>
+  </data>
+  <data name="Tab.Newsletters.Description.Text">
+    <value xml:space="preserve">Verschicken Sie E-Mails an die Mitglieder Ihrer Website oder einzelner Benutzergrupen.</value>
+  </data>
+  <data name="Tab.Newsletters.Name.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.Newsletters.Title.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.PageManagement.Content.Text">
+    <value xml:space="preserve">Seitenverwaltung</value>
+  </data>
+  <data name="Tab.PageManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Seitenverwaltung</value>
+  </data>
+  <data name="Tab.PageManagement.Description.Text">
+    <value xml:space="preserve">Verwalten Sie die Struktur und Seiten Ihrer Website.</value>
+  </data>
+  <data name="Tab.PageManagement.Name.Text">
+    <value xml:space="preserve">Seitenverwaltung</value>
+  </data>
+  <data name="Tab.PageManagement.Title.Text">
+    <value xml:space="preserve">Seitenverwaltung</value>
+  </data>
+  <data name="Tab.PortalAdministration.Content.Text">
+    <value xml:space="preserve">Website-Einstellungen</value>
+  </data>
+  <data name="Tab.PortalAdministration.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Allgemeine Funktionen</value>
+  </data>
+  <data name="Tab.PortalAdministration.Name.Text">
+    <value xml:space="preserve">Administration</value>
+  </data>
+  <data name="Tab.PortalAdministration.Title.Text">
+    <value xml:space="preserve">Website-Einstellungen</value>
+  </data>
+  <data name="Tab.RecycleBin.Content.Text">
+    <value xml:space="preserve">Papierkorb</value>
+  </data>
+  <data name="Tab.RecycleBin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Papierkorb</value>
+  </data>
+  <data name="Tab.RecycleBin.Description.Text">
+    <value xml:space="preserve">Sie sehen hier die gelöschten Module und Seiten Ihrer Website und können diese einfach wieder herstellen oder endgültig entfernen.</value>
+  </data>
+  <data name="Tab.RecycleBin.Name.Text">
+    <value xml:space="preserve">Papierkorb</value>
+  </data>
+  <data name="Tab.RecycleBin.Title.Text">
+    <value xml:space="preserve">Papierkorb</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Suchindizierung</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Suchindizierung</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Content.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Ergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Name.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Title.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Ergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Name.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Title.Text">
+    <value xml:space="preserve">Suchergebnisse</value>
+  </data>
+  <data name="Tab.SecurityRoles.Content.Text">
+    <value xml:space="preserve">Benutzergruppen</value>
+  </data>
+  <data name="Tab.SecurityRoles.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Benutzergruppen</value>
+  </data>
+  <data name="Tab.SecurityRoles.Description.Text">
+    <value xml:space="preserve">Verwalten Sie die Benutzergruppen Ihrer Website.</value>
+  </data>
+  <data name="Tab.SecurityRoles.Name.Text">
+    <value xml:space="preserve">Benutzergruppen</value>
+  </data>
+  <data name="Tab.SecurityRoles.Title.Text">
+    <value xml:space="preserve">Benutzergruppen</value>
+  </data>
+  <data name="Tab.Sharepoint.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">SharePoint-Verbindung</value>
+  </data>
+  <data name="Tab.Sharepoint.Description.Text">
+    <value xml:space="preserve">Mit der SharePoint-Verbindung.</value>
+  </data>
+  <data name="Tab.Sharepoint.Name.Text">
+    <value xml:space="preserve">SharePoint-Verbindung</value>
+  </data>
+  <data name="Tab.SiteLog.Content.Text">
+    <value xml:space="preserve">Zugriffsstatistik</value>
+  </data>
+  <data name="Tab.SiteLog.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Zugriffsstatistik</value>
+  </data>
+  <data name="Tab.SiteLog.Description.Text">
+    <value xml:space="preserve">Lassen Sie sich statistische Auswertungen über die Aufrufe Ihrer Website anzeigen.</value>
+  </data>
+  <data name="Tab.SiteLog.Name.Text">
+    <value xml:space="preserve">Zugriffsstatistik</value>
+  </data>
+  <data name="Tab.SiteLog.Title.Text">
+    <value xml:space="preserve">Zugriffsstatistik</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Content.Text">
+    <value xml:space="preserve">SiteMaps für Suchmaschinen</value>
+  </data>
+  <data name="Tab.SiteMapSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">SiteMaps für Suchmaschinen</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Description.Text">
+    <value xml:space="preserve">Legen Sie fest, wie Sitemaps für Suchmaschinen generiert werden</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Name.Text">
+    <value xml:space="preserve">SiteMaps für Suchmaschinen</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Title.Text">
+    <value xml:space="preserve">SiteMaps für Suchmaschinen</value>
+  </data>
+  <data name="Tab.SiteRedirection.Content.Text">
+    <value xml:space="preserve">Weiterleitungen für Mobilgeräte</value>
+  </data>
+  <data name="Tab.SiteRedirection.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Weiterleitungen für Mobilgeräte</value>
+  </data>
+  <data name="Tab.SiteRedirection.Description.Text">
+    <value xml:space="preserve">Weiterleitungen für Mobilgeräte</value>
+  </data>
+  <data name="Tab.SiteRedirection.Name.Text">
+    <value xml:space="preserve">Weiterleitungen für Mobilgeräte</value>
+  </data>
+  <data name="Tab.SiteSettings.Content.Text">
+    <value xml:space="preserve">Website-Einstellungen</value>
+  </data>
+  <data name="Tab.SiteSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Website-Einstellungen</value>
+  </data>
+  <data name="Tab.SiteSettings.Description.Text">
+    <value xml:space="preserve">Legen Sie die wichtigsten Einstellungen für Ihre Website fest.</value>
+  </data>
+  <data name="Tab.SiteSettings.Name.Text">
+    <value xml:space="preserve">Website-Einstellungen</value>
+  </data>
+  <data name="Tab.SiteSettings.Title.Text">
+    <value xml:space="preserve">Website-Einstellungen</value>
+  </data>
+  <data name="Tab.SiteWizard.Content.Text">
+    <value xml:space="preserve">Website-Assistent</value>
+  </data>
+  <data name="Tab.SiteWizard.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Website-Assistent</value>
+  </data>
+  <data name="Tab.SiteWizard.Description.Text">
+    <value xml:space="preserve">Legen Sie Schritt für Schritt die wichtigsten Einstellungen für Websitefest und wenden Sie eine Website-Vorlage an.</value>
+  </data>
+  <data name="Tab.SiteWizard.Name.Text">
+    <value xml:space="preserve">Website-Assistent</value>
+  </data>
+  <data name="Tab.SiteWizard.Title.Text">
+    <value xml:space="preserve">Website-Assistent</value>
+  </data>
+  <data name="Tab.Skins.Content.Text">
+    <value xml:space="preserve">Seitenlayouts</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinDesignerModule.Title.Text">
+    <value xml:space="preserve">Seitenlayout-Designer</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinEditorModule.Title.Text">
+    <value xml:space="preserve">Seitenlayout-Editor</value>
+  </data>
+  <data name="Tab.Skins.Description.Text">
+    <value xml:space="preserve">Layouts für Seiten und Modulrahmen verwalten</value>
+  </data>
+  <data name="Tab.Skins.Name.Text">
+    <value xml:space="preserve">Seitenlayouts</value>
+  </data>
+  <data name="Tab.Skins.Title.Text">
+    <value xml:space="preserve">Seitenlayouts</value>
+  </data>
+  <data name="Tab.Taxonomy.Content.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Taxonomien verwalten</value>
+  </data>
+  <data name="Tab.Taxonomy.Description.Text">
+    <value xml:space="preserve">Verwalten Sie Schlagworte und Kataloge.</value>
+  </data>
+  <data name="Tab.Taxonomy.Name.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.Title.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.UserAccounts.Content.Text">
+    <value xml:space="preserve">Benutzerkonten</value>
+  </data>
+  <data name="Tab.UserAccounts.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Benutzerkonten</value>
+  </data>
+  <data name="Tab.UserAccounts.Description.Text">
+    <value xml:space="preserve">Verwalten sie die Benutzerkonten in Ihrer Website</value>
+  </data>
+  <data name="Tab.UserAccounts.Name.Text">
+    <value xml:space="preserve">Benutzerkonten</value>
+  </data>
+  <data name="Tab.UserAccounts.Title.Text">
+    <value xml:space="preserve">Benutzerkonten</value>
+  </data>
+  <data name="Tab.Vendors.Content.Text">
+    <value xml:space="preserve">Bannerwerbung</value>
+  </data>
+  <data name="Tab.Vendors.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Bannerwerbung</value>
+  </data>
+  <data name="Tab.Vendors.Description.Text">
+    <value xml:space="preserve">Verwalten Sie Werbepartner und Bannerwerbung auf Ihrer Website.</value>
+  </data>
+  <data name="Tab.Vendors.Name.Text">
+    <value xml:space="preserve">Bannerwerbung</value>
+  </data>
+  <data name="Tab.Vendors.Title.Text">
+    <value xml:space="preserve">Bannerwerbung</value>
+  </data>
+  <data name="Tab.Home.CompanyIntro.Text">
+    <value>DNN (vormals DotNetNuke) bietet eine Suite von Lösungen an, mit denen Sie eine unvergleichliche Online-Experience für Ihre Kunden, Partner und Mitarbeiter anbieten können. Die DNN-Produkte und -Technologien stellen die Basis für über 750.000 Websites weltweit dar. Zusätzlich zu den kommerziellen Produkten für CMS und Social Communities betreut DNN die Weiterentwicklung der DNN Open Source Plattform.</value>
+  </data>
+  <data name="Tab.Home.Header.Content">
+    <value>DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt; macht Ihnen die Installation und Nutzung der DNN Plattform einfach, egal ob Sie diese in der Cloud testen, auf Ihrem eigenen Server installieren oder lokal in Ihre Entwicklungsumgebung integrieren wollen. In allen Fällen sind es nur wenige Klicks, bis Sie loslegen können.</value>
+  </data>
+  <data name="Tab.Home.Header.Title">
+    <value>Jeder lange Weg beginnt mit dem ersten Schritt</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Link">
+    <value>http://www.dnnsoftware.com/community-blog?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=blog&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.SubLink.Text">
+    <value>Das Community-Blog lesen</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Title">
+    <value>Blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Tooltip">
+    <value>Informativ und unterhaltsam, herausfordernd und lehrreich - das DNN Community-Blog bietet immer aktuelle Inhalte, neue Ideen und ausgeprägte Meinungen. Einfach mal eintauchen... (in engl. Sprache, deutschsprachige Inhalte auf www.dnn-usergroup.de)</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Link">
+    <value>http://www.dnnsoftware.com/forums?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=forums&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.SubLink.Text">
+    <value>Im DNN-Forum mitdiskutieren</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Title">
+    <value>Foren</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Tooltip">
+    <value>In der antiken römischen Gesellschaft war das Forum der zentrale Platz für öffentliche Reden, Handel und Gerichtsbarkeit. Das DNN-Forum spielt eine ähnlich zentrale Rolle in der DNN-Community.</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Link">
+    <value>http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.SubLink.Text">
+    <value>Wer ist am aktivsten in der DNN-Community?</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Title">
+    <value>Bestenliste</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Tooltip">
+    <value>Aktive Beteiligung soll belohnt werden! Sehen Sie, wer die eifrigsten Mitglieder sind. Und wenn Sie sich auch beteiligen, finden Sie Ihren Namen hier auch...</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Link">
+    <value>http://www.dnnsoftware.com/help?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=online-help&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.SubLink.Text">
+    <value>Online-Hilfe aufrufen</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Title">
+    <value>Online-Hilfe</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Tooltip">
+    <value>Auch wenn die Software weitgehend selbsterklärend ist, braucht man manchmal eine Erklärung. Hier hilft die Online-Hilfe, in der alle Funktionen detailliert beschrieben sind. (in engl. Sprache)</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Link">
+    <value>http://www.dnnsoftware.com/answers?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=q%26a&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.QA.SubLink.Text">
+    <value>Q&amp;A besuchen</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Title">
+    <value>Q &amp; A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Tooltip">
+    <value>Manchmal bleiben fragen, die man sich selbst nicht beantworten kann. Diese können Sie im Q&amp;A-Bereich loswerden. (in engl. Sprache, deutschsprachige Foren auf www.dnn-usergroup.de)</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Link">
+    <value>http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.SubLink.Text">
+    <value>Im DNN-Store einkaufen</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Title">
+    <value>Shop</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Tooltip">
+    <value>Man muss nicht alles selber programmieren, viele leistungsfähige Module und atemberaubende Designs können Sie im DNN-Store preiswert erwerben. Schneller geht es nicht..</value>
+  </data>
+  <data name="Tab.Home.Main.Title">
+    <value>In der Community lernen und Gleichgesinnte finden</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Link">
+    <value>http://www.dnnsoftware.com/videos?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=videos&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.SubLink.Text">
+    <value>DNN-Videos schauen</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Title">
+    <value>Videos</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Tooltip">
+    <value>Visuell lernt es sich am leichtesten: Einfach zurücklehnen und sich alle Funktionen in den DNN-Videos erklären lassen (in engl. Sprache).</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Link">
+    <value>http://www.dnnsoftware.com/about/resources/webinars?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=webinars&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.SubLink.Text">
+    <value>Ein DNN-Webinar besuchen</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Title">
+    <value>Webinare</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Tooltip">
+    <value>Im Webinar profitieren Sie vom Wissen der besten DNN-Experten weltweit - so erfahren Sie die Geheimnisse der Platform und Ihrer Anwendung.</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Link">
+    <value>http://www.dnnsoftware.com/wiki?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=wiki&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.SubLink.Text">
+    <value>Im DNN-Wiki recherchieren</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Title">
+    <value>Wiki</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Tooltip">
+    <value>Das DNN-Wiki enthält stets aktuelle Informationen zu allen technischen Aspekten der Plattform. Gerne dürfen Sie dies auch um eigene Beiträge erweitern.</value>
+  </data>
+  <data name="Tab.Home.PageName.Content">
+    <value>Home</value>
+  </data>
+  <data name="Tab.Home.PageName.Title">
+    <value>Home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link">
+    <value>http://www.dnnsoftware.com/solutions/evoq-content-management-system?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-content&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link.Title">
+    <value>Inhalt erstellen und verwalten</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Text">
+    <value>Umfangreiche Inhalte &lt;br /&gt;und höchste Sicherheit &lt;br /&gt;optimal für Google, Bing &amp; Co&lt;br /&gt;schnell erreicht.</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link">
+    <value>http://www.dnnsoftware.com/solutions/evoq-social-online-community-management?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-social&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link.Title">
+    <value>Große Communities aufbauen</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Text">
+    <value>Durch Online-Communities können Sie Ihre Zielgruppe binden und nutzergenerierte Inhalte nutzen</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Facebook.Link">
+    <value>http://facebook.com/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.LinkedIn.Link">
+    <value>http://www.linkedin.com/company/207975</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Title">
+    <value>Mit DNN in Verbindung bleiben</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Twitter.Link">
+    <value>http://twitter.com/dnncorp</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Youtube.Link">
+    <value>http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Default Website.template.es-ES.resx
+++ b/Website/Portals/_default/Default Website.template.es-ES.resx
@@ -1,0 +1,928 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Sitio web predeterminado</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Plantilla de sitio web por omisión</value>
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Grupo de roles que representa los roles globales del portal</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">es-ES</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] DNN Corp</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Lo sentimos, la página que esta buscando no se ha encontrado. Puede que la página se haya borrado, su nombre haya cambiado o bien esté temporalmente desactivada. Le sugerimos que empieze de nuevo en la página inicial. Póngase en contacto con nosotros si el problema persiste o no puede encontrar lo que necesita.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">La página no se ha encontrado.</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">Página de error 404</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">Página de error 404</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.JournalModule.Title.Text">
+    <value xml:space="preserve">Actividad</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.ProfileModule.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.ActivityFeed.Content.Text">
+    <value xml:space="preserve">Actividad</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historia</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Empleos</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legal</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Empresa</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Productos</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">Preguntas frecuentes</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuales</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catálogo de productos</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivo de productos</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Soporte de productos</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garantía</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Soporte</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Conectar</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contacto</value>
+  </data>
+  <data name="Tab.ActivityFeed.Name.Text">
+    <value xml:space="preserve">Actividad</value>
+  </data>
+  <data name="Tab.ActivityFeed.RightPane.Module.Title.Text">
+    <value xml:space="preserve">Directorio de miembros</value>
+  </data>
+  <data name="Tab.ActivityFeed.Title.Text">
+    <value xml:space="preserve">Actividad</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Configuración avanzada</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión avanzada de URLs</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.Description.Text">
+    <value xml:space="preserve">Gestión avanzada de la configuración de URLs</value>
+  </data>
+  <data name="Tab.ContentStaging.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Contenido provisional</value>
+  </data>
+  <data name="Tab.ContentStaging.Description.Text">
+    <value xml:space="preserve">Gestionar el contenido provisinal del sitio</value>
+  </data>
+  <data name="Tab.ContentStaging.Name.Text">
+    <value xml:space="preserve">Contenido provisional</value>
+  </data>
+  <data name="Tab.DevicePreview.Content.Text">
+    <value xml:space="preserve">Gestión de previsualización de dispositivos</value>
+  </data>
+  <data name="Tab.DevicePreview.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión de previsualización de dispositivos</value>
+  </data>
+  <data name="Tab.DevicePreview.Description.Text">
+    <value xml:space="preserve">Gestión de previsualización de dispositivos.</value>
+  </data>
+  <data name="Tab.DevicePreview.Name.Text">
+    <value xml:space="preserve">Gestión de previsualización de dispositivos</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Content.Text">
+    <value xml:space="preserve">Gestión de archivos</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión de archivos</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Description.Text">
+    <value xml:space="preserve">Gestión de activos del portal.</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Name.Text">
+    <value xml:space="preserve">Gestión de archivos</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Title.Text">
+    <value xml:space="preserve">Gestión de archivos</value>
+  </data>
+  <data name="Tab.Extensions.Content.Text">
+    <value xml:space="preserve">Extensiones</value>
+  </data>
+  <data name="Tab.Extensions.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Extensiones</value>
+  </data>
+  <data name="Tab.Extensions.Name.Text">
+    <value xml:space="preserve">Extensiones</value>
+  </data>
+  <data name="Tab.Extensions.Title.Text">
+    <value xml:space="preserve">Extensiones</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Content.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Description.Text">
+    <value xml:space="preserve">Configuración de Google Analytics para el sitio web.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Name.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Title.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.Home.CompanyIntro.Text">
+    <value xml:space="preserve">DNN (antes DotNetNuke) proporciona un conjunto de soluciones para la creación de sitios online enriquecedores para los clientes, proveedores y empleados. La productos y la tecnologías DNN se basan en más de 750.000 sitios online en todo el mundo. Además de nuestro CMS comercial y la solución para comunidades Sociales, DNN es el promotor del proyecto Open Source DotNetNuke.</value>
+  </data>
+  <data name="Tab.Home.Header.Content">
+    <value xml:space="preserve">DNN &lt;sup&gt;&amp;reg;&lt;/sup&gt; le facilita las opciones de instalación y uso de DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt; Platform. Tenemos múltiples opciones para satisfacer sus necesidades, tanto si quiere probar el CMS en la nube, como si lo quiere instalar en su propio servidor, o utilizarlo para desarrollo en su ordernador personal. Está a sólo un clic de empezar con DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt;.</value>
+  </data>
+  <data name="Tab.Home.Header.Title">
+    <value xml:space="preserve">Todos los viajes empiezan con el primer paso.</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/community-blog?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=blog&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.SubLink.Text">
+    <value xml:space="preserve">Lea el Blog de la Comunidad</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Title">
+    <value xml:space="preserve">Blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Tooltip">
+    <value xml:space="preserve">Informativo y entretenido, desafiante y educativo, el Blog de Comunidad dispone de contenido actualizado continuamente, ideas frescas y opiniones nuevas. ¡Empieze ya!</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/forums?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=forums&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.SubLink.Text">
+    <value xml:space="preserve">Visite el Foro de DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Title">
+    <value xml:space="preserve">Foro</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Tooltip">
+    <value xml:space="preserve">El antiguo Foro Romano era un espacio para conversaciones públicas, transaccciones comerciales y luchas de gladiadores. El Foro DNN es igualmente importante.</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.SubLink.Text">
+    <value xml:space="preserve">Vea el panel de contribuciones</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Title">
+    <value xml:space="preserve">Panel de contribuciones</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Tooltip">
+    <value xml:space="preserve">Las contribuciones merecen un reconocimiento. Verique su posición en el panel de contribuciones. Participe y avance posiciones. A todos nos gusta un poco de competición amigable.</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/help?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=online-help&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.SubLink.Text">
+    <value xml:space="preserve">Vea la ayuda online</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Title">
+    <value xml:space="preserve">Ayuda online</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Tooltip">
+    <value xml:space="preserve">No podemos vivir sin un poco de ayuda de nuestros amigos. O un poco de ayuda de la extensa biblioteca de DNN.</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/answers?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=q%26a&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.QA.SubLink.Text">
+    <value xml:space="preserve">Visitar Q&amp;A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Title">
+    <value xml:space="preserve">Q &amp; A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Tooltip">
+    <value xml:space="preserve">Seguro que en algún momento tendrá algunas preguntas. Incluso puede tener algunas respuestas para contribuir. En cualquier caso, visite nuestra página de Preguntas y Respuestas (Q &amp; A)</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.SubLink.Text">
+    <value xml:space="preserve">De compras en la DNN Store</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Title">
+    <value xml:space="preserve">Tienda</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Tooltip">
+    <value xml:space="preserve">Podría escribir un montón de código nuevo para crear este nuevo sitio genial. O simplemente puede comprar su billete hacía el éxito en la tienda DNN. Va a llegar más rápido.</value>
+  </data>
+  <data name="Tab.Home.Main.Title">
+    <value xml:space="preserve">Únase a la Comunidad para interactuar y aprender</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/videos?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=videos&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.SubLink.Text">
+    <value xml:space="preserve">Vea vídeos de DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Title">
+    <value xml:space="preserve">Vídeos</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Tooltip">
+    <value xml:space="preserve">Siempre es más fácil aprender viendo ejemplos. Lo mejor es que puede ver nuestros vídeos online y seguir trabajando. La biblioteca de vídeos de DNN es un enorme tesoro de información.</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/about/resources/webinars?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=webinars&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.SubLink.Text">
+    <value xml:space="preserve">Asista a un Webinar</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Title">
+    <value xml:space="preserve">Webinars</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Tooltip">
+    <value xml:space="preserve">Entre en el mundo de los Webinars DNN donde los mejores especialistas comparten sus conocimientos. Es una gran base de conocimiento lista para que la pueda utilizar y aprender de ella.</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/wiki?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=wiki&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.SubLink.Text">
+    <value xml:space="preserve">Lea el Wiki de DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Title">
+    <value xml:space="preserve">Wiki</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Tooltip">
+    <value xml:space="preserve">El Wiki de DNN está en continua expansión, como el universo. A diferencia del universo se puede visitar todo el Wiki y mejorarlo con su 
+colaboración.</value>
+  </data>
+  <data name="Tab.Home.PageName.Content">
+    <value xml:space="preserve">Inicio</value>
+  </data>
+  <data name="Tab.Home.PageName.Title">
+    <value xml:space="preserve">Inicio</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/solutions/evoq-content-management-system?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-content&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link.Title">
+    <value xml:space="preserve">CREAR &amp; GESTIONAR CONTENIDO</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Text">
+    <value xml:space="preserve">Contenido más rico, &lt;br /&gt;seguridad mejorada y &lt;br/&gt;SEO potente&lt;br/&gt; justo a su alcance</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/solutions/evoq-social-online-community-management?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-social&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link.Title">
+    <value xml:space="preserve">CONSTRUIR &amp; EXTENDER COMUNIDADES</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Text">
+    <value xml:space="preserve">Augmente sus usuarios, gestione contenido con crowdsourcing y fidelice su audiencia con comunidades online.</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Facebook.Link">
+    <value xml:space="preserve">http://facebook.com/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.LinkedIn.Link">
+    <value xml:space="preserve">http://www.linkedin.com/company/207975</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Title">
+    <value xml:space="preserve">Manténgase en contacto con DNN</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Twitter.Link">
+    <value xml:space="preserve">http://twitter.com/dnncorp</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Youtube.Link">
+    <value xml:space="preserve">http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Languages.Content.Text">
+    <value xml:space="preserve">Idiomas</value>
+  </data>
+  <data name="Tab.Languages.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión de idiomas</value>
+  </data>
+  <data name="Tab.Languages.Description.Text">
+    <value xml:space="preserve">Gestión de recursos de idiomas.</value>
+  </data>
+  <data name="Tab.Languages.Name.Text">
+    <value xml:space="preserve">Idiomas</value>
+  </data>
+  <data name="Tab.Languages.Title.Text">
+    <value xml:space="preserve">Idiomas</value>
+  </data>
+  <data name="Tab.Lists.Content.Text">
+    <value xml:space="preserve">Listas</value>
+  </data>
+  <data name="Tab.Lists.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Listas</value>
+  </data>
+  <data name="Tab.Lists.Description.Text">
+    <value xml:space="preserve">Gestión de listas generales</value>
+  </data>
+  <data name="Tab.Lists.Name.Text">
+    <value xml:space="preserve">Listas</value>
+  </data>
+  <data name="Tab.Lists.Title.Text">
+    <value xml:space="preserve">Listas</value>
+  </data>
+  <data name="Tab.LogViewer.Content.Text">
+    <value xml:space="preserve">Visor de eventos</value>
+  </data>
+  <data name="Tab.LogViewer.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Visor de eventos</value>
+  </data>
+  <data name="Tab.LogViewer.Description.Text">
+    <value xml:space="preserve">Ver el registro de eventos del sitio: eventos del programador, errores, identificación de usuarios, cambios en módulos y páginas, actividad de usuarios, etc.</value>
+  </data>
+  <data name="Tab.LogViewer.Name.Text">
+    <value xml:space="preserve">Visor de eventos</value>
+  </data>
+  <data name="Tab.LogViewer.Title.Text">
+    <value xml:space="preserve">Visor de eventos</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Directorio de miembros</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.MyFriends.Content.Text">
+    <value xml:space="preserve">Mis amistades</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historia</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Empleos</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legal</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Empresa</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Productos</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">Preguntas frecuentes</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuales</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catálogo de productos</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivo de productos</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Soporte de productos</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garantía</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Soporte</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Conectar</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contacto</value>
+  </data>
+  <data name="Tab.MyFriends.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.MyFriends.Name.Text">
+    <value xml:space="preserve">Amistades</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Directorio de miembros</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navegación</value>
+  </data>
+  <data name="Tab.MyFriends.Title.Text">
+    <value xml:space="preserve">Mis amistades</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.MessageCenterModule.Title.Text">
+    <value xml:space="preserve">Centro de mensajería</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.MyMessages.Content.Text">
+    <value xml:space="preserve">Mis mensajes</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historia</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Empleos</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legal</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Empresa</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Productos</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">Preguntas frecuentes</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuales</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catálogo de productos</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivo de productos</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Soporte de productos</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garantía</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Soporte</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Conectar</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contacto</value>
+  </data>
+  <data name="Tab.MyMessages.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.MyMessages.Name.Text">
+    <value xml:space="preserve">Mensajes</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Directorio de miembros</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navegación</value>
+  </data>
+  <data name="Tab.MyMessages.Title.Text">
+    <value xml:space="preserve">Mis mensajes</value>
+  </data>
+  <data name="Tab.MyProfile.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.MyProfile.Content.Text">
+    <value xml:space="preserve">Mi perfil</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historia</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Empleos</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legal</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Empresa</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Productos</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">Preguntas frecuentes</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuales</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catálogo de productos</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivo de productos</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Soporte de productos</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garantía</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Soporte</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Conectar</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contacto</value>
+  </data>
+  <data name="Tab.MyProfile.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Ver perfil</value>
+  </data>
+  <data name="Tab.MyProfile.Name.Text">
+    <value xml:space="preserve">Mi perfil</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Directorio de miembros</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navegación</value>
+  </data>
+  <data name="Tab.MyProfile.Title.Text">
+    <value xml:space="preserve">Mi perfil</value>
+  </data>
+  <data name="Tab.Newsletters.Content.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.Newsletters.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.Newsletters.Description.Text">
+    <value xml:space="preserve">Enviar correos a usuarios, roles y direcciones específicas.</value>
+  </data>
+  <data name="Tab.Newsletters.Name.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.Newsletters.Title.Text">
+    <value xml:space="preserve">Boletines</value>
+  </data>
+  <data name="Tab.PageManagement.Content.Text">
+    <value xml:space="preserve">Gestión de páginas</value>
+  </data>
+  <data name="Tab.PageManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión de páginas</value>
+  </data>
+  <data name="Tab.PageManagement.Description.Text">
+    <value xml:space="preserve">Gestión de páginas del sitio.</value>
+  </data>
+  <data name="Tab.PageManagement.Name.Text">
+    <value xml:space="preserve">Páginas</value>
+  </data>
+  <data name="Tab.PageManagement.Title.Text">
+    <value xml:space="preserve">Gestión de páginas</value>
+  </data>
+  <data name="Tab.PortalAdministration.Content.Text">
+    <value xml:space="preserve">Administración del sitio</value>
+  </data>
+  <data name="Tab.PortalAdministration.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Funciones básicas</value>
+  </data>
+  <data name="Tab.PortalAdministration.Name.Text">
+    <value xml:space="preserve">Administración</value>
+  </data>
+  <data name="Tab.PortalAdministration.Title.Text">
+    <value xml:space="preserve">Administración del sitio</value>
+  </data>
+  <data name="Tab.RecycleBin.Content.Text">
+    <value xml:space="preserve">Papelera</value>
+  </data>
+  <data name="Tab.RecycleBin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Papelera</value>
+  </data>
+  <data name="Tab.RecycleBin.Description.Text">
+    <value xml:space="preserve">Ver, restaurar o eliminar definitivamente páginas y módulos borrados.</value>
+  </data>
+  <data name="Tab.RecycleBin.Name.Text">
+    <value xml:space="preserve">Papelera</value>
+  </data>
+  <data name="Tab.RecycleBin.Title.Text">
+    <value xml:space="preserve">Papelera</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Administración de búsquedas</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Administración de búsquedas</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Content.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Resultados</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Name.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Title.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Resultados</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Name.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Title.Text">
+    <value xml:space="preserve">Resultados de la búsqueda</value>
+  </data>
+  <data name="Tab.SecurityRoles.Content.Text">
+    <value xml:space="preserve">Roles de seguridad</value>
+  </data>
+  <data name="Tab.SecurityRoles.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Roles de seguridad</value>
+  </data>
+  <data name="Tab.SecurityRoles.Description.Text">
+    <value xml:space="preserve">Gestión de roles de seguridad del sitio.</value>
+  </data>
+  <data name="Tab.SecurityRoles.Name.Text">
+    <value xml:space="preserve">Roles de seguridad</value>
+  </data>
+  <data name="Tab.SecurityRoles.Title.Text">
+    <value xml:space="preserve">Roles de seguridad</value>
+  </data>
+  <data name="Tab.Sharepoint.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Conector SharePoint</value>
+  </data>
+  <data name="Tab.Sharepoint.Description.Text">
+    <value xml:space="preserve">El conector SharePoint permite conectar y sincronizar archivos entre SharePoint y un servidor DNN.</value>
+  </data>
+  <data name="Tab.Sharepoint.Name.Text">
+    <value xml:space="preserve">Conector SharePoint</value>
+  </data>
+  <data name="Tab.SiteLog.Content.Text">
+    <value xml:space="preserve">Registro del sitio</value>
+  </data>
+  <data name="Tab.SiteLog.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Registro del sitio</value>
+  </data>
+  <data name="Tab.SiteLog.Description.Text">
+    <value xml:space="preserve">Informes y estadísticas de uso y actividad del sitio web.</value>
+  </data>
+  <data name="Tab.SiteLog.Name.Text">
+    <value xml:space="preserve">Registro del sitio</value>
+  </data>
+  <data name="Tab.SiteLog.Title.Text">
+    <value xml:space="preserve">Registro del sitio</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Content.Text">
+    <value xml:space="preserve">Mapa SEO del sitio</value>
+  </data>
+  <data name="Tab.SiteMapSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Mapa SEO del sitio</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Description.Text">
+    <value xml:space="preserve">Configuración del mapa SEO para los buscadores.</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Name.Text">
+    <value xml:space="preserve">Mapa SEO del sitio</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Title.Text">
+    <value xml:space="preserve">Mapa SEO del sitio</value>
+  </data>
+  <data name="Tab.SiteRedirection.Content.Text">
+    <value xml:space="preserve">Gestión de redirecciones</value>
+  </data>
+  <data name="Tab.SiteRedirection.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión de redirecciones</value>
+  </data>
+  <data name="Tab.SiteRedirection.Description.Text">
+    <value xml:space="preserve">Gestión de redirecciones</value>
+  </data>
+  <data name="Tab.SiteRedirection.Name.Text">
+    <value xml:space="preserve">Gestión de redirecciones</value>
+  </data>
+  <data name="Tab.SiteSettings.Content.Text">
+    <value xml:space="preserve">Configuración del sitio</value>
+  </data>
+  <data name="Tab.SiteSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Configuración del sitio</value>
+  </data>
+  <data name="Tab.SiteSettings.Description.Text">
+    <value xml:space="preserve">Gestión de la configuración del sitio web.</value>
+  </data>
+  <data name="Tab.SiteSettings.Name.Text">
+    <value xml:space="preserve">Configuración del sitio</value>
+  </data>
+  <data name="Tab.SiteSettings.Title.Text">
+    <value xml:space="preserve">Configuración del sitio</value>
+  </data>
+  <data name="Tab.SiteWizard.Content.Text">
+    <value xml:space="preserve">Asistente</value>
+  </data>
+  <data name="Tab.SiteWizard.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Asistente</value>
+  </data>
+  <data name="Tab.SiteWizard.Description.Text">
+    <value xml:space="preserve">Configuración de los parámetros del sitio, diseño de página y carga de plantillas de sitio con un asistente paso a paso.</value>
+  </data>
+  <data name="Tab.SiteWizard.Name.Text">
+    <value xml:space="preserve">Asistente</value>
+  </data>
+  <data name="Tab.SiteWizard.Title.Text">
+    <value xml:space="preserve">Asistente</value>
+  </data>
+  <data name="Tab.Skins.Content.Text">
+    <value xml:space="preserve">Temas</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinDesignerModule.Title.Text">
+    <value xml:space="preserve">Diseñador de temas</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinEditorModule.Title.Text">
+    <value xml:space="preserve">Editor de temas</value>
+  </data>
+  <data name="Tab.Skins.Description.Text">
+    <value xml:space="preserve">Gestión de los temas.</value>
+  </data>
+  <data name="Tab.Skins.Name.Text">
+    <value xml:space="preserve">Temas</value>
+  </data>
+  <data name="Tab.Skins.Title.Text">
+    <value xml:space="preserve">Temas</value>
+  </data>
+  <data name="Tab.Taxonomy.Content.Text">
+    <value xml:space="preserve">Taxonomía</value>
+  </data>
+  <data name="Tab.Taxonomy.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestión de taxonomía</value>
+  </data>
+  <data name="Tab.Taxonomy.Description.Text">
+    <value xml:space="preserve">Gestión de la taxonomía del sitio.</value>
+  </data>
+  <data name="Tab.Taxonomy.Name.Text">
+    <value xml:space="preserve">Taxonomía</value>
+  </data>
+  <data name="Tab.Taxonomy.Title.Text">
+    <value xml:space="preserve">Taxonomía</value>
+  </data>
+  <data name="Tab.UserAccounts.Content.Text">
+    <value xml:space="preserve">Cuentas de usuarios</value>
+  </data>
+  <data name="Tab.UserAccounts.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Cuentas de usuarios</value>
+  </data>
+  <data name="Tab.UserAccounts.Description.Text">
+    <value xml:space="preserve">Gestión de las cuentas de usuarios del sitio web.</value>
+  </data>
+  <data name="Tab.UserAccounts.Name.Text">
+    <value xml:space="preserve">Cuentas de usuarios</value>
+  </data>
+  <data name="Tab.UserAccounts.Title.Text">
+    <value xml:space="preserve">Cuentas de usuarios</value>
+  </data>
+  <data name="Tab.Vendors.Content.Text">
+    <value xml:space="preserve">Anunciantes</value>
+  </data>
+  <data name="Tab.Vendors.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Anunciantes</value>
+  </data>
+  <data name="Tab.Vendors.Description.Text">
+    <value xml:space="preserve">Gestión de las cuentas de anunciantes, banners y afiliados.</value>
+  </data>
+  <data name="Tab.Vendors.Name.Text">
+    <value xml:space="preserve">Anunciantes</value>
+  </data>
+  <data name="Tab.Vendors.Title.Text">
+    <value xml:space="preserve">Anunciantes</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Default Website.template.fr-FR.resx
+++ b/Website/Portals/_default/Default Website.template.fr-FR.resx
@@ -1,0 +1,1076 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text" xml:space="preserve">
+    <value xml:space="preserve">Site Web par défaut</value>
+  </data>
+  <data name="PortalDescription.Text" xml:space="preserve">
+    <value xml:space="preserve">Modèle de site Web par défaut</value>
+  </data>
+  <data name="RoleGroup.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Un groupe de rôle factice qui représente les rôles globaux</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">fr-FR</value>
+  </data>
+  <data name="Setting.FooterText.Text" xml:space="preserve">
+    <value xml:space="preserve">Copyright [year] DNN Corp</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Désolé, la page que vous cherchez est introuvable, elle a peut-être été supprimée, son nom a peut être changé ou elle est temporairement indisponible. Il est recommandé de réessayer d’y accéder directement depuis la page d’accueil. N'hésitez pas à nous contacter si le problème persiste ou si vous ne pouvez vraiment pas trouver ce que vous cherchez.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Page introuvable</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Page d'erreur 404</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Page d'erreur 404</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.JournalModule.Title.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.ProfileModule.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.ActivityFeed.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Flux d'activité</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historique</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrières</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridique</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Société</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Montagne</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravité</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Route</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Ville</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Chemin / Route</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produits</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">Manuels de vélos</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Catalogues de produits</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Archive de produit</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.4.Text" xml:space="preserve">
+    <value xml:space="preserve">Assistance produit</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Garantie de vélo</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Support client</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightOuterPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Se connecter</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.0.Text" xml:space="preserve">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Phone: (555) 555-4563</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Nous contacter</value>
+  </data>
+  <data name="Tab.ActivityFeed.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Flux d'activité</value>
+  </data>
+  <data name="Tab.ActivityFeed.RightPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Liste des membres</value>
+  </data>
+  <data name="Tab.ActivityFeed.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Flux d'activité</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Paramètres de configuration avancés</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion avancée des URL</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les paramètres d'URL avancés.</value>
+  </data>  
+  <data name="Tab.ContentStaging.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Pré-publication</value>
+  </data>
+  <data name="Tab.ContentStaging.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer la plateforme de contenu pour votre site</value>
+  </data>
+  <data name="Tab.ContentStaging.Name.Text">
+    <value xml:space="preserve">Pré-publication</value>
+  </data>
+  <data name="Tab.DevicePreview.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des prévisualisations de dispositif</value>
+  </data>
+  <data name="Tab.DevicePreview.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des prévisualisations de dispositif</value>
+  </data>
+  <data name="Tab.DevicePreview.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion de l'aperçu des dispositifs</value>
+  </data>
+  <data name="Tab.DevicePreview.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des prévisualisations de dispositif</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des fichiers</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des fichiers</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les actifs au sein du portail.</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des fichiers</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des fichiers</value>
+  </data>
+  <data name="Tab.Extensions.Content.Text">
+    <value xml:space="preserve">Extensions</value>
+  </data>
+  <data name="Tab.Extensions.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Extensions</value>
+  </data>
+  <data name="Tab.Extensions.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Installer, ajouter, modifier et supprimer des extensions, comme les modules, les thèmes et les packs de langue.</value>
+  </data>
+  <data name="Tab.Extensions.Name.Text">
+    <value xml:space="preserve">Extensions</value>
+  </data>
+  <data name="Tab.Extensions.Title.Text">
+    <value xml:space="preserve">Extensions</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Google Analytics.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Google Analytics.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurer les paramètres de Site Google Analytics.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Google Analytics.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Google Analytics.</value>
+  </data>
+  <data name="Tab.Home.CompanyIntro.Text" xml:space="preserve">
+    <value>DNN (anciennement DotNetNuke) fournit une gamme de solutions pour la création d’expériences en ligne enrichissantes pour les clients, partenaires et employés. Les produits et la technologie DNN sont à l’origine de plus de 750 000 sites à travers le monde. En plus de nos solutions de CMS communautaire et commercial, DNN est l'intendant du projet Open Source DotNetNuke.</value>
+  </data>
+  <data name="Tab.Home.Header.Content" xml:space="preserve">
+    <value>DNN &lt;sup&gt;&amp;reg; &lt;/ sup&gt; rend l’installation et l’utilisation de la plateforme DNN&lt;sup&gt;&amp;reg; &lt;/ sup&gt;  très simple. Nous avons différentes options pour répondre à vos besoins, si vous souhaitez essayer le CMS dans le cloud, l'installer sur votre propre serveur ou l'utiliser sur votre bureau pour du développement. Vous n’êtes qu’à un clic pour démarrer avec DNN &lt;sup&gt;&amp;reg; &lt;/ sup&gt;.</value>
+  </data>
+  <data name="Tab.Home.Header.Title" xml:space="preserve">
+    <value>Chaque voyage commence par un premier pas.</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Link">
+    <value>http://www.dnnsoftware.com/community-blog?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=blog&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Title">
+    <value>Blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Tooltip" xml:space="preserve">
+    <value>Informatif et divertissant, stimulant et éducatif, le blog de la communauté DNN a toujours de nouveaux contenus, de nouvelles idées et de nouveaux avis. Plongez à l’intérieur !</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Link">
+    <value>http://www.dnnsoftware.com/forums?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=forums&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Title">
+    <value>Forums</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Tooltip" xml:space="preserve">
+    <value>L'ancien Forum romain était un lieu de discours publics, de transactions commerciales et de matchs de gladiateurs. Participer au forum DNN est tout aussi important.</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Link">
+    <value>http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Title">
+    <value>Classement</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Tooltip" xml:space="preserve">
+    <value>Les contributions apportent la reconnaissance. Regardez votre position sur le classement. Contribuez un peu ou laissez les autres sur le carreau. Tout le monde aime participer à une petite compétition amicale.</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Link">
+    <value>http://www.dnnsoftware.com/help?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=online-help&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Title" xml:space="preserve">
+    <value>Aide en ligne</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Tooltip" xml:space="preserve">
+    <value>Vous ne pouvez pas vous en sortir sans un peu d'aide de vos amis, ou un peu d'aide de la vaste bibliothèque DNN.</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Link">
+    <value>http://www.dnnsoftware.com/answers?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=q%26a&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Title" xml:space="preserve">
+    <value>Questions &amp; Réponses</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Tooltip" xml:space="preserve">
+    <value>Vous ne pouvez pas arriver jusqu’ici sans quelques questions. Vous pourriez même avoir quelques réponses à apporter. Dans tous les cas vous allez être redirigé vers la page des questions &amp; réponses.</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Link">
+    <value>http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Title">
+    <value>Boutique</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Tooltip" xml:space="preserve">
+    <value>Vous pouvez écrire du nouveau code pour améliorer votre site web ou tout simplement gagner du temps en passant par la boutique DNN.</value>
+  </data>
+  <data name="Tab.Home.Main.Title" xml:space="preserve">
+    <value>Rejoindre la communauté pour interagir et apprendre</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Link">
+    <value>http://www.dnnsoftware.com/videos?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=videos&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Title">
+    <value>Vidéos</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Tooltip" xml:space="preserve">
+    <value>Tout le monde apprend en regardant. Quoi de mieux que de regarder une vidéo en ligne tout en continuant à travailler ? La bibliothèque de vidéos DNN est une mine d’or pour l’apprentissage.</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Link">
+    <value>http://www.dnnsoftware.com/about/resources/webinars?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=webinars&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Title">
+    <value>Webinaires</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Tooltip" xml:space="preserve">
+    <value>Entrez dans le monde des webinaires DNN dans lequel les gens les plus informés partagent leurs connaissances. Tout un tas de connaissances à votre portée !</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Link">
+    <value>http://www.dnnsoftware.com/wiki?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=wiki&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Title">
+    <value>Wiki</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Tooltip" xml:space="preserve">
+    <value>Le wiki DNN est en constante expansion, comme l'univers, à la différence près que notre wiki peut être visité entièrement et que vous pouvez apporter une pierre à l’édifice.</value>
+  </data>
+  <data name="Tab.Home.PageName.Content">
+    <value>Accueil</value>
+  </data>
+  <data name="Tab.Home.PageName.Title">
+    <value>Accueil</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link">
+    <value>http://www.dnnsoftware.com/solutions/evoq-content-management-system?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-content&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link.Title" xml:space="preserve">
+    <value>CRÉER &amp; GÉRER DU CONTENU</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Text" xml:space="preserve">
+    <value>Un contenu plus riche&lt;br /&gt;une sécurité renforcée&lt;br /&gt;et une amélioration du SEO&lt;br/&gt;juste au bout de vos doigts</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link">
+    <value>http://www.dnnsoftware.com/solutions/evoq-social-online-community-management?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-social&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link.Title" xml:space="preserve">
+    <value>CONSTRUIRE &amp; DÉVELOPPER DES COMMUNAUTÉS</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Text" xml:space="preserve">
+    <value>Développez l’aspect social de votre site web à travers les communautés en ligne.</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Facebook.Link">
+    <value>http://facebook.com/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.LinkedIn.Link">
+    <value>http://www.linkedin.com/company/207975</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Title" xml:space="preserve">
+    <value>Rester en contact avec DNN</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Twitter.Link">
+    <value>http://twitter.com/dnncorp</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Youtube.Link">
+    <value>http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Languages.Content.Text">
+    <value xml:space="preserve">Langues</value>
+  </data>
+  <data name="Tab.Languages.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion des langues</value>
+  </data>
+  <data name="Tab.Languages.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les ressources de la langue.</value>
+  </data>
+  <data name="Tab.Languages.Name.Text">
+    <value xml:space="preserve">Langues</value>
+  </data>
+  <data name="Tab.Languages.Title.Text">
+    <value xml:space="preserve">Langues</value>
+  </data>
+  <data name="Tab.Lists.Content.Text">
+    <value xml:space="preserve">Listes</value>
+  </data>
+  <data name="Tab.Lists.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Listes</value>
+  </data>
+  <data name="Tab.Lists.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les listes</value>
+  </data>
+  <data name="Tab.Lists.Name.Text">
+    <value xml:space="preserve">Listes</value>
+  </data>
+  <data name="Tab.Lists.Title.Text">
+    <value xml:space="preserve">Listes</value>
+  </data>
+  <data name="Tab.LogViewer.Content.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.LogViewer.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.LogViewer.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Afficher un journal historique des événements de la base de données tels que les événements, exceptions, connexions, module et changements de page...</value>
+  </data>
+  <data name="Tab.LogViewer.Name.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.LogViewer.Title.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.MemberDirectoryModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Liste des membres</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.MyFriends.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Mes amis</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historique</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrières</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridique</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Société</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Montagne</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravité</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Route</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Ville</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Chemin / Route</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produits</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">Manuels de vélos</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Catalogues de produits</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Archive de produit</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.4.Text" xml:space="preserve">
+    <value xml:space="preserve">Assistance produit</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Garantie de vélo</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Support client</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightOuterPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Se connecter</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.0.Text" xml:space="preserve">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Phone: (555) 555-4563</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Nous contacter</value>
+  </data>
+  <data name="Tab.MyFriends.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.MyFriends.Name.Text">
+    <value xml:space="preserve">Amis</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.MemberDirectoryModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Liste des membres</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigation</value>
+  </data>
+  <data name="Tab.MyFriends.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Mes amis</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.MessageCenterModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Centre de messages</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.MyMessages.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Mes messages</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historique</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrières</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridique</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Société</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Montagne</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravité</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Route</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Ville</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Chemin / Route</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produits</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">Manuels de vélos</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Catalogues de produits</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Archive de produit</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.4.Text" xml:space="preserve">
+    <value xml:space="preserve">Assistance produit</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Garantie de vélo</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Support client</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightOuterPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Se connecter</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.0.Text" xml:space="preserve">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Phone: (555) 555-4563</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Nous contacter</value>
+  </data>
+  <data name="Tab.MyMessages.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.MyMessages.Name.Text">
+    <value xml:space="preserve">Messages</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.MemberDirectoryModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Liste des membres</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigation</value>
+  </data>
+  <data name="Tab.MyMessages.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Mes messages</value>
+  </data>
+  <data name="Tab.MyProfile.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.MyProfile.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Mon profil</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Historique</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrières</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridique</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Société</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Montagne</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravité</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Route</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">Ville</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Chemin / Route</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Produits</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">Manuels de vélos</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Catalogues de produits</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Archive de produit</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.4.Text" xml:space="preserve">
+    <value xml:space="preserve">Assistance produit</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.5.Text" xml:space="preserve">
+    <value xml:space="preserve">Garantie de vélo</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Support client</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightOuterPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Se connecter</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.0.Text" xml:space="preserve">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.1.Text" xml:space="preserve">
+    <value xml:space="preserve">3457 W. Somewhere Street.
+Someplace, CA 12345</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.2.Text" xml:space="preserve">
+    <value xml:space="preserve">Phone: (555) 555-4563</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.3.Text" xml:space="preserve">
+    <value xml:space="preserve">Fax: (555) 555-4564</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Nous contacter</value>
+  </data>
+  <data name="Tab.MyProfile.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">ViewProfile</value>
+  </data>
+  <data name="Tab.MyProfile.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Mon profil</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.MemberDirectoryModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Liste des membres</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigation</value>
+  </data>
+  <data name="Tab.MyProfile.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Mon profil</value>
+  </data>
+  <data name="Tab.Newsletters.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Lettres d'informations</value>
+  </data>
+  <data name="Tab.Newsletters.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Lettres d'informations</value>
+  </data>
+  <data name="Tab.Newsletters.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Envoyer des messages électroniques aux utilisateurs, les rôles de sécurité et les adresses e-mail spécifiques.</value>
+  </data>
+  <data name="Tab.Newsletters.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Lettres d'informations</value>
+  </data>
+  <data name="Tab.Newsletters.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Lettres d'informations</value>
+  </data>
+  <data name="Tab.PageManagement.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Pages personnalisées</value>
+  </data>
+  <data name="Tab.PageManagement.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Pages personnalisées</value>
+  </data>
+  <data name="Tab.PageManagement.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les pages du site.</value>
+  </data>
+  <data name="Tab.PageManagement.Name.Text">
+    <value xml:space="preserve">Pages</value>
+  </data>
+  <data name="Tab.PageManagement.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Pages personnalisées</value>
+  </data>
+  <data name="Tab.PortalAdministration.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Administration du site web</value>
+  </data>
+  <data name="Tab.PortalAdministration.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Caractéristiques de base</value>
+  </data>
+  <data name="Tab.PortalAdministration.Name.Text">
+    <value xml:space="preserve">Admin</value>
+  </data>
+  <data name="Tab.PortalAdministration.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Administration du site web</value>
+  </data>
+  <data name="Tab.RecycleBin.Content.Text">
+    <value xml:space="preserve">Corbeille</value>
+  </data>
+  <data name="Tab.RecycleBin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Corbeille</value>
+  </data>
+  <data name="Tab.RecycleBin.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Afficher, restaurer ou recycler en permanence des pages et modules qui ont été supprimés à partir du portail.</value>
+  </data>
+  <data name="Tab.RecycleBin.Name.Text">
+    <value xml:space="preserve">Corbeille</value>
+  </data>
+  <data name="Tab.RecycleBin.Title.Text">
+    <value xml:space="preserve">Corbeille</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Indexation</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Indexation</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Résultats</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.SearchResultsModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Résultats</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.SearchResultsModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Résultats de recherche</value>
+  </data>
+  <data name="Tab.SecurityRoles.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Rôles et Groupes</value>
+  </data>
+  <data name="Tab.SecurityRoles.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Rôles et Groupes</value>
+  </data>
+  <data name="Tab.SecurityRoles.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les rôles de sécurité pour le portail.</value>
+  </data>
+  <data name="Tab.SecurityRoles.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Rôles et Groupes</value>
+  </data>
+  <data name="Tab.SecurityRoles.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Rôles et Groupes</value>
+  </data>
+  <data name="Tab.Sharepoint.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Connecteur SharePoint</value>
+  </data>
+  <data name="Tab.Sharepoint.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Le module de connecteur SharePoint permet aux utilisateurs de se connecter et de synchroniser des fichiers entre SharePoint et le serveur DNN.</value>
+  </data>
+  <data name="Tab.Sharepoint.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Connecteur SharePoint</value>
+  </data>
+  <data name="Tab.SiteLog.Content.Text">
+    <value xml:space="preserve">Statistiques</value>
+  </data>
+  <data name="Tab.SiteLog.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Statistiques</value>
+  </data>
+  <data name="Tab.SiteLog.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Afficher des rapports statistiques sur l'activité du site portail.</value>
+  </data>
+  <data name="Tab.SiteLog.Name.Text">
+    <value xml:space="preserve">Statistiques</value>
+  </data>
+  <data name="Tab.SiteLog.Title.Text">
+    <value xml:space="preserve">Statistiques</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Paramètres du Site Map</value>
+  </data>
+  <data name="Tab.SiteMapSettings.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Plan du site pour les moteurs de recherche</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurer le plan du site pour la soumission aux moteurs de recherche.</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Plan du site pour les moteurs de recherche</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Paramètres du Site Map</value>
+  </data>
+  <data name="Tab.SiteRedirection.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Redirections de site</value>
+  </data>
+  <data name="Tab.SiteRedirection.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Redirections de site</value>
+  </data>
+  <data name="Tab.SiteRedirection.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestion redirection de site.</value>
+  </data>
+  <data name="Tab.SiteRedirection.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Redirections de site</value>
+  </data>
+  <data name="Tab.SiteSettings.Content.Text">
+    <value xml:space="preserve">Paramétrage</value>
+  </data>
+  <data name="Tab.SiteSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Paramétrage</value>
+  </data>
+  <data name="Tab.SiteSettings.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les paramètres de configuration pour le portail.</value>
+  </data>
+  <data name="Tab.SiteSettings.Name.Text">
+    <value xml:space="preserve">Paramétrage</value>
+  </data>
+  <data name="Tab.SiteSettings.Title.Text">
+    <value xml:space="preserve">Paramétrage</value>
+  </data>
+  <data name="Tab.SiteWizard.Content.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurateur de site</value>
+  </data>
+  <data name="Tab.SiteWizard.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurateur de site</value>
+  </data>
+  <data name="Tab.SiteWizard.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurer les paramètres de portails, conception de pages et appliquer un modèle de site à l'aide d'un assistant étape par étape.</value>
+  </data>
+  <data name="Tab.SiteWizard.Name.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurateur de site</value>
+  </data>
+  <data name="Tab.SiteWizard.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Configurateur de site</value>
+  </data>
+  <data name="Tab.Skins.Content.Text">
+    <value xml:space="preserve">Thèmes</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinDesignerModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Concepteur de thème</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinEditorModule.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Éditeur de thème</value>
+  </data>
+  <data name="Tab.Skins.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les ressources de thème</value>
+  </data>
+  <data name="Tab.Skins.Name.Text">
+    <value xml:space="preserve">Thèmes</value>
+  </data>
+  <data name="Tab.Skins.Title.Text">
+    <value xml:space="preserve">Thèmes</value>
+  </data>
+  <data name="Tab.Taxonomy.Content.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.ContentPane.Module.Title.Text" xml:space="preserve">
+    <value xml:space="preserve">Gestionnaire de la taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer la taxonomie pour votre Site.</value>
+  </data>
+  <data name="Tab.Taxonomy.Name.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.Title.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.UserAccounts.Content.Text">
+    <value xml:space="preserve">Utilisateurs</value>
+  </data>
+  <data name="Tab.UserAccounts.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Utilisateurs</value>
+  </data>
+  <data name="Tab.UserAccounts.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les comptes utilisateurs du portail.</value>
+  </data>
+  <data name="Tab.UserAccounts.Name.Text">
+    <value xml:space="preserve">Utilisateurs</value>
+  </data>
+  <data name="Tab.UserAccounts.Title.Text">
+    <value xml:space="preserve">Utilisateurs</value>
+  </data>
+  <data name="Tab.Vendors.Content.Text">
+    <value xml:space="preserve">Annonceurs</value>
+  </data>
+  <data name="Tab.Vendors.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Annonceurs</value>
+  </data>
+  <data name="Tab.Vendors.Description.Text" xml:space="preserve">
+    <value xml:space="preserve">Gérer les comptes du vendeur, bannière publicitaire et affiliation du portail.</value>
+  </data>
+  <data name="Tab.Vendors.Name.Text">
+    <value xml:space="preserve">Annonceurs</value>
+  </data>
+  <data name="Tab.Vendors.Title.Text">
+    <value xml:space="preserve">Annonceurs</value>
+  </data>
+
+  <data name="Tab.Home.Main.Blog.SubLink.Text" xml:space="preserve">
+    <value>Lire le blog de la communauté</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.SubLink.Text" xml:space="preserve">
+    <value>Visiter le Forum DNN</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.SubLink.Text" xml:space="preserve">
+    <value>Vérifier le classement</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.SubLink.Text" xml:space="preserve">
+    <value>Afficher l'aide en ligne</value>
+  </data>
+  <data name="Tab.Home.Main.QA.SubLink.Text" xml:space="preserve">
+    <value>Voir les Questions &amp; Réponses</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.SubLink.Text" xml:space="preserve">
+    <value>Acheter dans le magasin DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.SubLink.Text" xml:space="preserve">
+    <value>Visionner les vidéos DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.SubLink.Text" xml:space="preserve">
+    <value>Assister à un webinaire DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.SubLink.Text" xml:space="preserve">
+    <value>Lire le wiki DNN</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Default Website.template.it-IT.resx
+++ b/Website/Portals/_default/Default Website.template.it-IT.resx
@@ -1,0 +1,927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Sito Web Predefinito</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Template Sito Web Predefinito</value>
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Un gruppo di ruoli fittizio che rappresenta gli ruoli Globali</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">it-IT</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] by DNN Corp</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Spiacente, la pagina che state cercando non può essere trovata e potrebbe essere stata rimossa, aver cambiato nome, o è temporaneamente non disponibile. Si consiglia di iniziare nuovamente dalla home page. Non esitate a contattarci se il problema persiste o non doveste riuscire a trovare quello che state cercando.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">La pagina non può essere trovata</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">Errore Pagina 404 </value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">Errore Pagina 404 </value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.JournalModule.Title.Text">
+    <value xml:space="preserve">Journal</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.ProfileModule.Title.Text">
+    <value xml:space="preserve">VediProfilo</value>
+  </data>
+  <data name="Tab.ActivityFeed.Content.Text">
+    <value xml:space="preserve">Feed Attività</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Storico</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Lavora con noi</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legale</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Azienda</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Prodotti</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuale Bici</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catalogo Prodotti </value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivio Prodotti </value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Assistenza Prodotti </value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garanzia Bici</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Assistenza Clienti</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Connettiti</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contattaci</value>
+  </data>
+  <data name="Tab.ActivityFeed.Name.Text">
+    <value xml:space="preserve">Feed Attività</value>
+  </data>
+  <data name="Tab.ActivityFeed.RightPane.Module.Title.Text">
+    <value xml:space="preserve">Elenco Iscritti</value>
+  </data>
+  <data name="Tab.ActivityFeed.Title.Text">
+    <value xml:space="preserve">Feed Attività</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Configurazione Impostazioni Avanzate</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Configurazione Impostazioni Avanzate</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Configurazione Impostazioni Avanzate</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Configurazione Impostazioni Avanzate</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione URL Avanzato</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.Description.Text">
+    <value xml:space="preserve">Gestione Impostazioni URL avanzato.</value>
+  </data>
+  <data name="Tab.ContentStaging.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Content Staging</value>
+  </data>
+  <data name="Tab.ContentStaging.Description.Text">
+    <value xml:space="preserve">Gestione dello Staging dei Contenuti per il tuo Sito</value>
+  </data>
+  <data name="Tab.ContentStaging.Name.Text">
+    <value xml:space="preserve">Content Staging</value>
+  </data>
+  <data name="Tab.DevicePreview.Content.Text">
+    <value xml:space="preserve">Gestione Anteprima Dispositivo</value>
+  </data>
+  <data name="Tab.DevicePreview.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione Anteprima Dispositivo</value>
+  </data>
+  <data name="Tab.DevicePreview.Description.Text">
+    <value xml:space="preserve">Gestione Anteprima Dispositivo.</value>
+  </data>
+  <data name="Tab.DevicePreview.Name.Text">
+    <value xml:space="preserve">Gestione Anteprima Dispositivo</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Content.Text">
+    <value xml:space="preserve">Gestione File</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione File</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Description.Text">
+    <value xml:space="preserve">Gestire le attività all'interno del portale.</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Name.Text">
+    <value xml:space="preserve">Gestione File</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Title.Text">
+    <value xml:space="preserve">Gestione File</value>
+  </data>
+  <data name="Tab.Extensions.Content.Text">
+    <value xml:space="preserve">Estensioni</value>
+  </data>
+  <data name="Tab.Extensions.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Estensioni</value>
+  </data>
+  <data name="Tab.Extensions.Name.Text">
+    <value xml:space="preserve">Estensioni</value>
+  </data>
+  <data name="Tab.Extensions.Title.Text">
+    <value xml:space="preserve">Estensioni</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Content.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Description.Text">
+    <value xml:space="preserve">Configura impostazioni Google Analytics Sito.</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Name.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Title.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.Home.CompanyIntro.Text">
+    <value xml:space="preserve">DNN (precedentemente DotNetNuke) fornisce una suite di soluzioni per la creazione di ricche e gratificanti esperienze online per clienti, partner e dipendenti. I prodotti e la tecnologia di DNN sono la base per 750.000 + siti in tutto il mondo. Oltre al nostro CMS commerciale e la nostra soluzione di social community, DNN è il punto cardine dei progetti DotNetNuke Open Source.</value>
+  </data>
+  <data name="Tab.Home.Header.Content">
+    <value xml:space="preserve">DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt; rende facile per voi per installare e utilizzare DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt; Platform. Abbiamo diverse opzioni per soddisfare le vostre esigenze, se si vuole provare il CMS al di fuori del cloud, installarlo sul proprio server, o utilizzarlo sul vostro desktop per lo sviluppo. Serve solo un click per iniziare a utilizzare DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt;.</value>
+  </data>
+  <data name="Tab.Home.Header.Title">
+    <value xml:space="preserve">Ogni viaggio inizia con il primo passo.</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/community-blog?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=blog&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.SubLink.Text">
+    <value xml:space="preserve">Leggi il Community Blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Title">
+    <value xml:space="preserve">Blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Tooltip">
+    <value xml:space="preserve">Illuminante e divertente, stimolante ed educativo, il blog DNN Community è sempre ricco di nuovi contenuti, nuove idee e nuove opinioni. Tuffatevi dentro.</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/forums?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=forums&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.SubLink.Text">
+    <value xml:space="preserve">Visita il Forum DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Title">
+    <value xml:space="preserve">Forum</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Tooltip">
+    <value xml:space="preserve">L'antico Foro Romano era un luogo per discorsi pubblici, transazioni commerciali e lotte tra gladiatori. È altrettanto importante partecipare al Forum DNN. </value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.SubLink.Text">
+    <value xml:space="preserve">Controlla la Classifica</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Title">
+    <value xml:space="preserve">Classifica</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Tooltip">
+    <value xml:space="preserve">I contributi guadagnano riconoscimenti. Vedi dove sei posizionato in classifica. Contribuisci e sorpassa gli altri nella corsa. Tutti amano un po' di competizione amichevole.</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/help?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=online-help&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.SubLink.Text">
+    <value xml:space="preserve">Visuaizza Guida On-line</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Title">
+    <value xml:space="preserve">Guida On-line</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Tooltip">
+    <value xml:space="preserve">Non si può fare a meno di un piccolo aiuto da parte dei tuoi amici. Oppure di un piccolo aiuto dalla vasta libreria DNN. </value>
+  </data>
+  <data name="Tab.Home.Main.QA.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/answers?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=q%26a&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.QA.SubLink.Text">
+    <value xml:space="preserve">Visita Q &amp; A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Title">
+    <value xml:space="preserve">Q &amp; A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Tooltip">
+    <value xml:space="preserve">Non è possibile che tu sia arrivato a questo punto senza porti neanche una domanda. Potresti anche essere in grado di contibuire con alcune risposte. In entrambi i casi, sei diretto alla pagina Q&amp;A.</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.SubLink.Text">
+    <value xml:space="preserve">Acquista presso il negozio DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Title">
+    <value xml:space="preserve">Acquista</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Tooltip">
+    <value xml:space="preserve">Si potrebbe scrivere un sacco di nuovo codice per rendere bello un nuovo sito. Oppure puoi semplicemente acquistare la strada verso il successo nello store DNN. Potrai arrivare a rendere il tuo sito di successo più velocemente.</value>
+  </data>
+  <data name="Tab.Home.Main.Title">
+    <value xml:space="preserve">Partecipa alla Community per Interagire e Imparare</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/videos?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=videos&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.SubLink.Text">
+    <value xml:space="preserve">Guarda i Video DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Title">
+    <value xml:space="preserve">Video</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Tooltip">
+    <value xml:space="preserve">Ognuno di noi ha un'apprendimento visivo. Cosa c'è di meglio che guardare video online mentre si sta lavorando. La videoteca DNN è un immenso tesoro informazioni. </value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/about/resources/webinars?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=webinars&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.SubLink.Text">
+    <value xml:space="preserve">Partecipa ai Webinar DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Title">
+    <value xml:space="preserve">Webinar</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Tooltip">
+    <value xml:space="preserve">Entra nel mondo dei Webinar DNN, dove persone competenti condividono le loro vaste conoscenze e sono lì per farti imparare.</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/wiki?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=wiki&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.SubLink.Text">
+    <value xml:space="preserve">Leggi la Wiki DNN</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Title">
+    <value xml:space="preserve">Wiki</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Tooltip">
+    <value xml:space="preserve">Il Wiki DNN, come l'Universo, è in continua espansione. Al suo contrario, è possibile visitare tutti i Wiki e lasciare un segno con il tuo contributo.</value>
+  </data>
+  <data name="Tab.Home.PageName.Content">
+    <value xml:space="preserve">Home</value>
+  </data>
+  <data name="Tab.Home.PageName.Title">
+    <value xml:space="preserve">Home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/solutions/evoq-content-management-system?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-content&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link.Title">
+    <value xml:space="preserve">CREA &amp; GESTISCI CONTENUTI</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Text">
+    <value xml:space="preserve">Ricchi contenuti, maggiore&lt;br /&gt;sicurezza e un migliore&lt;br /&gt;SEO sono a&lt;br /&gt;portata di mano </value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/solutions/evoq-social-online-community-management?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-social&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link.Title">
+    <value xml:space="preserve">CREA &amp; AMPLIA LE COMMUNITY</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Text">
+    <value xml:space="preserve">Fai crescere gli utenti, fai generare contenuti e coinvolgi il pubblico attraverso le community on-line.</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Facebook.Link">
+    <value xml:space="preserve">http://facebook.com/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.LinkedIn.Link">
+    <value xml:space="preserve">http://www.linkedin.com/company/207975</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Title">
+    <value xml:space="preserve">Rimani in contatto con DNN </value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Twitter.Link">
+    <value xml:space="preserve">http://twitter.com/dnncorp</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Youtube.Link">
+    <value xml:space="preserve">http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Languages.Content.Text">
+    <value xml:space="preserve">Lingue</value>
+  </data>
+  <data name="Tab.Languages.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione Lingue</value>
+  </data>
+  <data name="Tab.Languages.Description.Text">
+    <value xml:space="preserve">Gestione Risorse Lingue.</value>
+  </data>
+  <data name="Tab.Languages.Name.Text">
+    <value xml:space="preserve">Lingue</value>
+  </data>
+  <data name="Tab.Languages.Title.Text">
+    <value xml:space="preserve">Lingue</value>
+  </data>
+  <data name="Tab.Lists.Content.Text">
+    <value xml:space="preserve">Elenchi</value>
+  </data>
+  <data name="Tab.Lists.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Elenchi</value>
+  </data>
+  <data name="Tab.Lists.Description.Text">
+    <value xml:space="preserve">Gestione elenchi comuni</value>
+  </data>
+  <data name="Tab.Lists.Name.Text">
+    <value xml:space="preserve">Elenchi</value>
+  </data>
+  <data name="Tab.Lists.Title.Text">
+    <value xml:space="preserve">Elenchi</value>
+  </data>
+  <data name="Tab.LogViewer.Content.Text">
+    <value xml:space="preserve">Visualizza Registro</value>
+  </data>
+  <data name="Tab.LogViewer.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Visualizza Registro</value>
+  </data>
+  <data name="Tab.LogViewer.Description.Text">
+    <value xml:space="preserve">Visualizza un registro cronologico degli eventi del database come la pianificazione degli eventi, le eccezioni, i login account, le modifiche di moduli e pagine, le attività degli utenti, le attività dei ruoli di sicurezza, ecc</value>
+  </data>
+  <data name="Tab.LogViewer.Name.Text">
+    <value xml:space="preserve">Visualizza Registro</value>
+  </data>
+  <data name="Tab.LogViewer.Title.Text">
+    <value xml:space="preserve">Visualizza Registro</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Elenco Iscritti</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">VediProfilo</value>
+  </data>
+  <data name="Tab.MyFriends.Content.Text">
+    <value xml:space="preserve">Miei Amici</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Storico</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Lavora con noi</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legale</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Azienda</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Prodotti</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuale Bici</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catalogo Prodotti </value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivio Prodotti </value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Assistenza Prodotti </value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garanzia Bici</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Assistenza Clienti</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Connettiti</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contattaci</value>
+  </data>
+  <data name="Tab.MyFriends.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">VediProfilo</value>
+  </data>
+  <data name="Tab.MyFriends.Name.Text">
+    <value xml:space="preserve">Amici</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Elenco Iscritti</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigazione</value>
+  </data>
+  <data name="Tab.MyFriends.Title.Text">
+    <value xml:space="preserve">Miei Amici</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.MessageCenterModule.Title.Text">
+    <value xml:space="preserve">Centro Messaggi</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">VediProfilo</value>
+  </data>
+  <data name="Tab.MyMessages.Content.Text">
+    <value xml:space="preserve">Miei Messaggi</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Storico</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Lavora con noi</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legale</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Azienda</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Prodotti</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuale Bici</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catalogo Prodotti </value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivio Prodotti </value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Assistenza Prodotti </value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garanzia Bici</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Assistenza Clienti</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Connettiti</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contattaci</value>
+  </data>
+  <data name="Tab.MyMessages.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">VediProfilo</value>
+  </data>
+  <data name="Tab.MyMessages.Name.Text">
+    <value xml:space="preserve">Messaggi</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Elenco Iscritti</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigazione</value>
+  </data>
+  <data name="Tab.MyMessages.Title.Text">
+    <value xml:space="preserve">Miei Messaggi</value>
+  </data>
+  <data name="Tab.MyProfile.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">VediProfilo</value>
+  </data>
+  <data name="Tab.MyProfile.Content.Text">
+    <value xml:space="preserve">Mio Profilo</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Storico</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Lavora con noi</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Legale</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Azienda</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Road</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Prodotti</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Manuale Bici</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Catalogo Prodotti </value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Archivio Prodotti </value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Assistenza Prodotti </value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Garanzia Bici</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Assistenza Clienti</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Connettiti</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contattaci</value>
+  </data>
+  <data name="Tab.MyProfile.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Contattaci</value>
+  </data>
+  <data name="Tab.MyProfile.Name.Text">
+    <value xml:space="preserve">Mio Profilo</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Elenco Iscritti</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigazione</value>
+  </data>
+  <data name="Tab.MyProfile.Title.Text">
+    <value xml:space="preserve">Mio Profilo</value>
+  </data>
+  <data name="Tab.Newsletters.Content.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.Newsletters.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.Newsletters.Description.Text">
+    <value xml:space="preserve">Invia e-mail a utenti, ruoli di sicurezza e indirizzi e-mail specifici.</value>
+  </data>
+  <data name="Tab.Newsletters.Name.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.Newsletters.Title.Text">
+    <value xml:space="preserve">Newsletter</value>
+  </data>
+  <data name="Tab.PageManagement.Content.Text">
+    <value xml:space="preserve">Gestione Pagine</value>
+  </data>
+  <data name="Tab.PageManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione Pagine</value>
+  </data>
+  <data name="Tab.PageManagement.Description.Text">
+    <value xml:space="preserve">Gestione pagine all'interno del sito.</value>
+  </data>
+  <data name="Tab.PageManagement.Name.Text">
+    <value xml:space="preserve">Pagine</value>
+  </data>
+  <data name="Tab.PageManagement.Title.Text">
+    <value xml:space="preserve">Gestione Pagine</value>
+  </data>
+  <data name="Tab.PortalAdministration.Content.Text">
+    <value xml:space="preserve">Amministrazione Sito Web</value>
+  </data>
+  <data name="Tab.PortalAdministration.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Funzioni di Base</value>
+  </data>
+  <data name="Tab.PortalAdministration.Name.Text">
+    <value xml:space="preserve">Admin</value>
+  </data>
+  <data name="Tab.PortalAdministration.Title.Text">
+    <value xml:space="preserve">Amministrazione Sito Web</value>
+  </data>
+  <data name="Tab.RecycleBin.Content.Text">
+    <value xml:space="preserve">Cestino</value>
+  </data>
+  <data name="Tab.RecycleBin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Cestino</value>
+  </data>
+  <data name="Tab.RecycleBin.Description.Text">
+    <value xml:space="preserve">Visualizza, ripristina o elimina definitivamente pagine e moduli che sono stati eliminati dal portale.</value>
+  </data>
+  <data name="Tab.RecycleBin.Name.Text">
+    <value xml:space="preserve">Cestino</value>
+  </data>
+  <data name="Tab.RecycleBin.Title.Text">
+    <value xml:space="preserve">Cestino</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Ricerca Admin</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Ricerca Admin</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Content.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Risultati </value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Name.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Title.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Risultati </value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Name.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Title.Text">
+    <value xml:space="preserve">Risultati Ricerca</value>
+  </data>
+  <data name="Tab.SecurityRoles.Content.Text">
+    <value xml:space="preserve">Ruoli Sicurezza</value>
+  </data>
+  <data name="Tab.SecurityRoles.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Ruoli Sicurezza</value>
+  </data>
+  <data name="Tab.SecurityRoles.Description.Text">
+    <value xml:space="preserve">Gestione ruoli di sicurezza del portale.</value>
+  </data>
+  <data name="Tab.SecurityRoles.Name.Text">
+    <value xml:space="preserve">Ruoli Sicurezza</value>
+  </data>
+  <data name="Tab.SecurityRoles.Title.Text">
+    <value xml:space="preserve">Ruoli Sicurezza</value>
+  </data>
+  <data name="Tab.Sharepoint.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Connettore SharePoint</value>
+  </data>
+  <data name="Tab.Sharepoint.Description.Text">
+    <value xml:space="preserve">Il SharePoint Connector è un modulo che consente agli utenti di connettersi e sincronizzare i file tra SharePoint e Server DNN.</value>
+  </data>
+  <data name="Tab.Sharepoint.Name.Text">
+    <value xml:space="preserve">Connettore SharePoint</value>
+  </data>
+  <data name="Tab.SiteLog.Content.Text">
+    <value xml:space="preserve">Registro Sito</value>
+  </data>
+  <data name="Tab.SiteLog.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Registro Sito</value>
+  </data>
+  <data name="Tab.SiteLog.Description.Text">
+    <value xml:space="preserve">Visualizza i report statistici sulle attività del sito per il portale.</value>
+  </data>
+  <data name="Tab.SiteLog.Name.Text">
+    <value xml:space="preserve">Registro Sito</value>
+  </data>
+  <data name="Tab.SiteLog.Title.Text">
+    <value xml:space="preserve">Registro Sito</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Content.Text">
+    <value xml:space="preserve">Impostazioni Site Map</value>
+  </data>
+  <data name="Tab.SiteMapSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Motore Ricerca SiteMap</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Description.Text">
+    <value xml:space="preserve">Configura la mappa del sito per la presentazione ai più comuni motori di ricerca.</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Name.Text">
+    <value xml:space="preserve">Motore Ricerca SiteMap</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Title.Text">
+    <value xml:space="preserve">Impostazioni Site Map</value>
+  </data>
+  <data name="Tab.SiteRedirection.Content.Text">
+    <value xml:space="preserve">Gestione Reindirizzamento Sito</value>
+  </data>
+  <data name="Tab.SiteRedirection.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione Reindirizzamento Sito</value>
+  </data>
+  <data name="Tab.SiteRedirection.Description.Text">
+    <value xml:space="preserve">Gestione Reindirizzamento Sito.</value>
+  </data>
+  <data name="Tab.SiteRedirection.Name.Text">
+    <value xml:space="preserve">Gestione Reindirizzamento Sito</value>
+  </data>
+  <data name="Tab.SiteSettings.Content.Text">
+    <value xml:space="preserve">Impostazioni Sito</value>
+  </data>
+  <data name="Tab.SiteSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Impostazioni Sito</value>
+  </data>
+  <data name="Tab.SiteSettings.Description.Text">
+    <value xml:space="preserve">Gestione configurazione impostazioni del portale.</value>
+  </data>
+  <data name="Tab.SiteSettings.Name.Text">
+    <value xml:space="preserve">Impostazioni Sito</value>
+  </data>
+  <data name="Tab.SiteSettings.Title.Text">
+    <value xml:space="preserve">Impostazioni Sito</value>
+  </data>
+  <data name="Tab.SiteWizard.Content.Text">
+    <value xml:space="preserve">Procedura Guidata</value>
+  </data>
+  <data name="Tab.SiteWizard.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Procedura Guidata</value>
+  </data>
+  <data name="Tab.SiteWizard.Description.Text">
+    <value xml:space="preserve">Configura le impostazioni del portale, il design della pagina e applica un template al sito utilizzando una procedura guidata passo-passo.</value>
+  </data>
+  <data name="Tab.SiteWizard.Name.Text">
+    <value xml:space="preserve">Procedura Guidata</value>
+  </data>
+  <data name="Tab.SiteWizard.Title.Text">
+    <value xml:space="preserve">Procedura Guidata</value>
+  </data>
+  <data name="Tab.Skins.Content.Text">
+    <value xml:space="preserve">Skin</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinDesignerModule.Title.Text">
+    <value xml:space="preserve">Skin Designer</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinEditorModule.Title.Text">
+    <value xml:space="preserve">Editor Skin </value>
+  </data>
+  <data name="Tab.Skins.Description.Text">
+    <value xml:space="preserve">Gestione Risorse Skin.</value>
+  </data>
+  <data name="Tab.Skins.Name.Text">
+    <value xml:space="preserve">Skin</value>
+  </data>
+  <data name="Tab.Skins.Title.Text">
+    <value xml:space="preserve">Skin</value>
+  </data>
+  <data name="Tab.Taxonomy.Content.Text">
+    <value xml:space="preserve">Tassonomia</value>
+  </data>
+  <data name="Tab.Taxonomy.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gestione Tassonomia</value>
+  </data>
+  <data name="Tab.Taxonomy.Description.Text">
+    <value xml:space="preserve">Gestione Tassonomia per il tuo Sito.</value>
+  </data>
+  <data name="Tab.Taxonomy.Name.Text">
+    <value xml:space="preserve">Tassonomia</value>
+  </data>
+  <data name="Tab.Taxonomy.Title.Text">
+    <value xml:space="preserve">Tassonomia</value>
+  </data>
+  <data name="Tab.UserAccounts.Content.Text">
+    <value xml:space="preserve">Account Utenti</value>
+  </data>
+  <data name="Tab.UserAccounts.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Account Utenti</value>
+  </data>
+  <data name="Tab.UserAccounts.Description.Text">
+    <value xml:space="preserve">Gestione account utenti per il portale.</value>
+  </data>
+  <data name="Tab.UserAccounts.Name.Text">
+    <value xml:space="preserve">Account Utenti</value>
+  </data>
+  <data name="Tab.UserAccounts.Title.Text">
+    <value xml:space="preserve">Account Utenti</value>
+  </data>
+  <data name="Tab.Vendors.Content.Text">
+    <value xml:space="preserve">Venditori</value>
+  </data>
+  <data name="Tab.Vendors.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Venditori</value>
+  </data>
+  <data name="Tab.Vendors.Description.Text">
+    <value xml:space="preserve">Gestione account venditore, banner pubblicitari e di affiliazione all'interno del portale.</value>
+  </data>
+  <data name="Tab.Vendors.Name.Text">
+    <value xml:space="preserve">Venditori</value>
+  </data>
+  <data name="Tab.Vendors.Title.Text">
+    <value xml:space="preserve">Venditori</value>
+  </data>
+</root>

--- a/Website/Portals/_default/Default Website.template.nl-NL.resx
+++ b/Website/Portals/_default/Default Website.template.nl-NL.resx
@@ -1,0 +1,929 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocalizedTemplateName.Text">
+    <value xml:space="preserve">Default Website</value>
+  </data>
+  <data name="PortalDescription.Text">
+    <value xml:space="preserve">Standaard Website Template</value>
+  </data>
+  <data name="RoleGroup.Description.Text">
+    <value xml:space="preserve">Een dummy rolgroep die de globale rollen vertegenwoordigd</value>
+  </data>
+  <data name="Setting.DefaultLanguage.Text">
+    <value xml:space="preserve">nl-NL</value>
+  </data>
+  <data name="Setting.FooterText.Text">
+    <value xml:space="preserve">Copyright [year] DNN Corp</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Content.Text">
+    <value xml:space="preserve">Sorry, De gevraaagde pagina kan niet worden gevonden en kan zijn verwijderd, is hernoemd, of is tijdelijk niet beschikbaar. U kunt het vanaf de Home pagina opnieuw proberen.  Neem contact met ons op als dit probleem blijft aanhouden.</value>
+  </data>
+  <data name="Tab.404ErrorPage..Module.Title.Text">
+    <value xml:space="preserve">De gevraagde pagina kan niet worden gevonden</value>
+  </data>
+  <data name="Tab.404ErrorPage.Content.Text">
+    <value xml:space="preserve">404 Error Pagina</value>
+  </data>
+  <data name="Tab.404ErrorPage.Title.Text">
+    <value xml:space="preserve">404 Error Pagina</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.JournalModule.Title.Text">
+    <value xml:space="preserve">Dagboek</value>
+  </data>
+  <data name="Tab.ActivityFeed.CenterPane.ProfileModule.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.ActivityFeed.Content.Text">
+    <value xml:space="preserve">Activiteitentoevoer</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Geschiedenis</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrière</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridische</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Bedrijf</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Weg</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Producten</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Fiets handleidingen</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Product Catalogi</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Product Archief</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Product ondersteuning</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Fiets garantie</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Nieuwsbrief</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Klanten Support</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Verbind</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.ActivityFeed.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contact ons</value>
+  </data>
+  <data name="Tab.ActivityFeed.Name.Text">
+    <value xml:space="preserve">Activiteitentoevoer</value>
+  </data>
+  <data name="Tab.ActivityFeed.RightPane.Module.Title.Text">
+    <value xml:space="preserve"> Ledenlijst</value>
+  </data>
+  <data name="Tab.ActivityFeed.Title.Text">
+    <value xml:space="preserve">Activiteitentoevoer</value>
+  </data>
+  <data name="Tab.AdvancedSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Description.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Name.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvancedSettings.Title.Text">
+    <value xml:space="preserve">Geavanceerde configuratie instellingen</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Geavanceerd URL Management</value>
+  </data>
+  <data name="Tab.AdvUrlManagement.Description.Text">
+    <value xml:space="preserve">Beheer geavanceerde url instellingen.</value>
+  </data>
+  <data name="Tab.ContentStaging.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Inhoud overbrengen</value>
+  </data>
+  <data name="Tab.ContentStaging.Description.Text">
+    <value xml:space="preserve">Het in beeld brengen van de inhoud beheren</value>
+  </data>
+  <data name="Tab.ContentStaging.Name.Text">
+    <value xml:space="preserve">Inhoud overbrengen</value>
+  </data>
+  <data name="Tab.DevicePreview.Content.Text">
+    <value xml:space="preserve">Apparaatbeheer voorbeeld weergeven</value>
+  </data>
+  <data name="Tab.DevicePreview.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Apparaatbeheer voorbeeld weergeven</value>
+  </data>
+  <data name="Tab.DevicePreview.Description.Text">
+    <value xml:space="preserve">Apparaatbeheer voorbeeld weergeven</value>
+  </data>
+  <data name="Tab.DevicePreview.Name.Text">
+    <value xml:space="preserve">Apparaatbeheer voorbeeld weergeven</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Content.Text">
+    <value xml:space="preserve">Bestandsbeheer</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Bestandsbeheer</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Description.Text">
+    <value xml:space="preserve">Beheer assets binnen het portaal.</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Name.Text">
+    <value xml:space="preserve">Bestandsbeheer</value>
+  </data>
+  <data name="Tab.DigitalAssetsManagement.Title.Text">
+    <value xml:space="preserve">Bestandsbeheer</value>
+  </data>
+  <data name="Tab.Extensions.Content.Text">
+    <value xml:space="preserve">Extensies</value>
+  </data>
+  <data name="Tab.Extensions.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Extensies</value>
+  </data>
+  <data name="Tab.Extensions.Name.Text">
+    <value xml:space="preserve">Extensies</value>
+  </data>
+  <data name="Tab.Extensions.Title.Text">
+    <value xml:space="preserve">Extensies</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Content.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Description.Text">
+    <value xml:space="preserve">Site Google Analytics-instellingen configureren.
+</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Name.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.GoogleAnalytics.Title.Text">
+    <value xml:space="preserve">Google Analytics</value>
+  </data>
+  <data name="Tab.Home.CompanyIntro.Text">
+    <value xml:space="preserve">DNN (Voorheen DotNetNuke) biedt een pakket van oplossingen voor het creëren van rijke, belonende online ervaringen voor klanten, partners en medewerkers. DNN producten en technologie zijn de fundering voor meer als 750.000 websites wereldwijd. In de lijn van onze commerciele CMS en Social community oplossingen. DNN is de ondersteuner van het DotNetNuke open source project.</value>
+  </data>
+  <data name="Tab.Home.Header.Content">
+    <value xml:space="preserve">DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt;maakt de installatie en het gebruik makkelijk voor jou.&lt;sup&gt;&amp;reg;&lt;/sup&gt;We hebben meerdere opties om aan te sluiten bij uw behoefte, Of u het CMS nu wilt proberen in de Cloud, of wilt installeren op uw eigen server of op uw lokale computer voor ontwikkeling. U bent slechts een klik verwijderd van uw start met DNN&lt;sup&gt;&amp;reg;&lt;/sup&gt;.</value>
+  </data>
+  <data name="Tab.Home.Header.Title">
+    <value xml:space="preserve">Elke tocht begint met de eerste stap</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/community-blog?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=blog&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.SubLink.Text">
+    <value xml:space="preserve">Lees het Community blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Title">
+    <value xml:space="preserve">Blog</value>
+  </data>
+  <data name="Tab.Home.Main.Blog.Tooltip">
+    <value xml:space="preserve">Informatief en vermakelijk, uitdagend en educatief, het DNN community blog heeft altijd verse content. verse ideeën en nieuwe meningen. Duik er direct in. </value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/forums?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=forums&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.SubLink.Text">
+    <value xml:space="preserve">Bezoek het DNN forum</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Title">
+    <value xml:space="preserve">Forum</value>
+  </data>
+  <data name="Tab.Home.Main.Forums.Tooltip">
+    <value xml:space="preserve">Het oude Roman Forum was de plaats voor publiek spreekers, commerciele transacties en gladiarotische gevechten. Het DNN forum is niet zo belangrijk om aan deel te nemen.</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.SubLink.Text">
+    <value xml:space="preserve">Bekijk het Leiderbord</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Title">
+    <value xml:space="preserve">Leiderbord</value>
+  </data>
+  <data name="Tab.Home.Main.LeaderBoard.Tooltip">
+    <value xml:space="preserve">Contributies verdienen erkenning. Dus waar kom jij op het leiderbord. Draag een stukje bij, en betrek andere in de race. Iedereen houdt wel van een beetje vriendeschappelijke competitie.</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.SubLink.Text">
+    <value xml:space="preserve">Bekijk de online help</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Title">
+    <value xml:space="preserve">Online help</value>
+  </data>
+  <data name="Tab.Home.Main.OnlineHelp.Tooltip">
+    <value xml:space="preserve">Je kunt gewoon niet zonder een beetje hulp van je vrienden. Of zonder een beetje hulp van de uitgebreide DNN library</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/leaderboard?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=leaderboard&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.QA.SubLink.Text">
+    <value xml:space="preserve">Bezoek Q&amp;A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Title">
+    <value xml:space="preserve">Q &amp; A</value>
+  </data>
+  <data name="Tab.Home.Main.QA.Tooltip">
+    <value xml:space="preserve">U kunt niet tot dit punt komen zonder een aantal vragen. U heeft misschien zelfs wel een paar antwoorden om te delen. Hoe dan ook, u gaat richting de Q&amp;A pagina. </value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.SubLink.Text">
+    <value xml:space="preserve">Winkel in de DNN shop</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Title">
+    <value xml:space="preserve">Shop</value>
+  </data>
+  <data name="Tab.Home.Main.Shop.Tooltip">
+    <value xml:space="preserve">U kunt veel nieuwe code schrijven om deze nieuwe website geweldig te maken. Of u koopt gewoon uw toegang tot succes in de DNN shop. Zo bent u er sneller.</value>
+  </data>
+  <data name="Tab.Home.Main.Title">
+    <value xml:space="preserve">Sluit je aan bij de Community om interactie te hebben of om te leren.</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.SubLink.Text">
+    <value xml:space="preserve">Bekijk DNN video's</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Title">
+    <value xml:space="preserve">Video's</value>
+  </data>
+  <data name="Tab.Home.Main.Videos.Tooltip">
+    <value xml:space="preserve">Iedereen leert visueel. Wat is er beter dan het online bekijken van een video terwijl je door kunt werken. De DNN Video bibliotheek is een grote bron van How-to informatie.</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.SubLink.Text">
+    <value xml:space="preserve">Woon een webinar bij</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Title">
+    <value xml:space="preserve">Webinar</value>
+  </data>
+  <data name="Tab.Home.Main.Webinars.Tooltip">
+    <value xml:space="preserve">Betreed de wereld van de DNN webinars waar mensen met kennis deze met je delen. Dat is veel kennis, en het is is bedoeld om uw kennis te vergroten.</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.SubLink.Text">
+    <value xml:space="preserve">Lees de DNN wiki</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Title">
+    <value xml:space="preserve">Wiki</value>
+  </data>
+  <data name="Tab.Home.Main.Wikis.Tooltip">
+    <value xml:space="preserve">De DNN wiki is constant aan het groeien, net als het universum. Maar in tegenstelling tot het universum kunt u alles bezoeken binnen de wiki en uw kenmerk achterlaten doormiddel van een bijdrage.</value>
+  </data>
+  <data name="Tab.Home.PageName.Content">
+    <value xml:space="preserve">Home</value>
+  </data>
+  <data name="Tab.Home.PageName.Title">
+    <value xml:space="preserve">Home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link">
+    <value xml:space="preserve">http://store.dnnsoftware.com/?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=shop&amp;utm_content=7.3-tile&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Link.Title">
+    <value xml:space="preserve">Maak en beheer Inhoud</value>
+  </data>
+  <data name="Tab.Home.Product.Content.Text">
+    <value xml:space="preserve">Rijkere inhoud, sterkere &lt;br/&gt;beveiliging en verbeterde&lt;br/&gt;SEO direct onder &lt;br/&gt; uw vingertoppen</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link">
+    <value xml:space="preserve">http://www.dnnsoftware.com/solutions/evoq-social-online-community-management?utm_source=dnn-platform-install&amp;utm_medium=web-link&amp;utm_term=evoq-social&amp;utm_content=7.3-banner&amp;utm_campaign=dnn-platform-home</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Link.Title">
+    <value xml:space="preserve">Bouw en vergroot communities</value>
+  </data>
+  <data name="Tab.Home.Product.Social.Text">
+    <value xml:space="preserve">Laat uw gebruikers groeien, verzamel content en heb interactie met uw bezoekers via online communities.</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Facebook.Link">
+    <value xml:space="preserve">http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.LinkedIn.Link">
+    <value xml:space="preserve">http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Title">
+    <value xml:space="preserve">Blijf in contact met DNN</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Twitter.Link">
+    <value xml:space="preserve">http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Home.SocialLinks.Youtube.Link">
+    <value xml:space="preserve">http://www.youtube.com/user/dotnetnuke</value>
+  </data>
+  <data name="Tab.Languages.Content.Text">
+    <value xml:space="preserve">Talen</value>
+  </data>
+  <data name="Tab.Languages.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Taal management</value>
+  </data>
+  <data name="Tab.Languages.Description.Text">
+    <value xml:space="preserve">Taalbronnen beheren</value>
+  </data>
+  <data name="Tab.Languages.Name.Text">
+    <value xml:space="preserve">Talen</value>
+  </data>
+  <data name="Tab.Languages.Title.Text">
+    <value xml:space="preserve">Talen</value>
+  </data>
+  <data name="Tab.Lists.Content.Text">
+    <value xml:space="preserve">Lijsten</value>
+  </data>
+  <data name="Tab.Lists.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Lijsten</value>
+  </data>
+  <data name="Tab.Lists.Description.Text">
+    <value xml:space="preserve">Gemeenschappelijke lijsten beheren</value>
+  </data>
+  <data name="Tab.Lists.Name.Text">
+    <value xml:space="preserve">Lijsten</value>
+  </data>
+  <data name="Tab.Lists.Title.Text">
+    <value xml:space="preserve">Lijsten</value>
+  </data>
+  <data name="Tab.LogViewer.Content.Text">
+    <value xml:space="preserve">Viewer voor logbestanden</value>
+  </data>
+  <data name="Tab.LogViewer.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Viewer voor logbestanden</value>
+  </data>
+  <data name="Tab.LogViewer.Description.Text">
+    <value xml:space="preserve">Bekijk een historisch logboek van een database gebeurtenis, zoals gebeurtenis planningen, uitzonderingen, account aanmeldingen, module en pagina wijzigingen, account activiteiten van de gebruiker, beveiligings rol activiteiten, enz.</value>
+  </data>
+  <data name="Tab.LogViewer.Name.Text">
+    <value xml:space="preserve">Viewer voor logbestanden</value>
+  </data>
+  <data name="Tab.LogViewer.Title.Text">
+    <value xml:space="preserve">Viewer voor logbestanden</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Lid van directory</value>
+  </data>
+  <data name="Tab.MyFriends.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.MyFriends.Content.Text">
+    <value xml:space="preserve">Mijn vrienden</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Geschiedenis</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrière</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridisch</value>
+  </data>
+  <data name="Tab.MyFriends.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Bedrijf</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Weg</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Producten</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Fiets handleidingen</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Product catalogi</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Product archief</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Product ondersteunin</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Fiest garantie</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Nieuwsbrief</value>
+  </data>
+  <data name="Tab.MyFriends.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Klanten support</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Connect</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyFriends.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contact ons</value>
+  </data>
+  <data name="Tab.MyFriends.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.MyFriends.Name.Text">
+    <value xml:space="preserve">Vrienden</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Lid van directory</value>
+  </data>
+  <data name="Tab.MyFriends.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigatie</value>
+  </data>
+  <data name="Tab.MyFriends.Title.Text">
+    <value xml:space="preserve">Mijn vrienden</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.MessageCenterModule.Title.Text">
+    <value xml:space="preserve">Berichten center</value>
+  </data>
+  <data name="Tab.MyMessages.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.MyMessages.Content.Text">
+    <value xml:space="preserve">Mijn berichten</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Geschiedenis</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrière</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridisch</value>
+  </data>
+  <data name="Tab.MyMessages.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Bedrijf</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Weg</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Producten</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Fiets handleidingen</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Product catalogi</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Product archief</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">Product ondersteuning</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Fiets garantie</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Nieuwsbrief</value>
+  </data>
+  <data name="Tab.MyMessages.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Klanten support</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Verbind</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyMessages.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contact ons</value>
+  </data>
+  <data name="Tab.MyMessages.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.MyMessages.Name.Text">
+    <value xml:space="preserve">Berichten</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">LId van directory</value>
+  </data>
+  <data name="Tab.MyMessages.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigatie</value>
+  </data>
+  <data name="Tab.MyMessages.Title.Text">
+    <value xml:space="preserve">Mijn bercihten</value>
+  </data>
+  <data name="Tab.MyProfile.CenterPane.ViewProfileModule.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.MyProfile.Content.Text">
+    <value xml:space="preserve">Mijn profiel</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Geschiedenis</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Carrière</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Juridisch</value>
+  </data>
+  <data name="Tab.MyProfile.FooterCenterPane.Module.Title.Text">
+    <value xml:space="preserve">Bedrijf</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.0.Text">
+    <value xml:space="preserve">Mountain</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.1.Text">
+    <value xml:space="preserve">Gravity</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.2.Text">
+    <value xml:space="preserve">Weg</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.3.Text">
+    <value xml:space="preserve">City</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.4.Text">
+    <value xml:space="preserve">Junior</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Content.5.Text">
+    <value xml:space="preserve">Dirt/ Street</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Producten</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.0.Text">
+    <value xml:space="preserve">FAQ</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.1.Text">
+    <value xml:space="preserve">Fiets handleidingen</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.2.Text">
+    <value xml:space="preserve">Product catalogi</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.3.Text">
+    <value xml:space="preserve">Product archief</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.4.Text">
+    <value xml:space="preserve">product ondersteuning</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.5.Text">
+    <value xml:space="preserve">Fiets garantie</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Content.6.Text">
+    <value xml:space="preserve">Niewsbrief</value>
+  </data>
+  <data name="Tab.MyProfile.FooterLeftPane.Module.Title.Text">
+    <value xml:space="preserve">Klanten support</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightOuterPane.Module.Title.Text">
+    <value xml:space="preserve">Verbind</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Content.0.Text">
+    <value xml:space="preserve">Awesome Cycles, Inc.</value>
+  </data>
+  <data name="Tab.MyProfile.FooterRightPane.Module.Title.Text">
+    <value xml:space="preserve">Contact ons</value>
+  </data>
+  <data name="Tab.MyProfile.LeftPane.Module.Title.Text">
+    <value xml:space="preserve">Bekijk profiel</value>
+  </data>
+  <data name="Tab.MyProfile.Name.Text">
+    <value xml:space="preserve">Mijn profiel</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.MemberDirectoryModule.Title.Text">
+    <value xml:space="preserve">Lid van directory</value>
+  </data>
+  <data name="Tab.MyProfile.RightPane.NavigationModule.Title.Text">
+    <value xml:space="preserve">Navigatie</value>
+  </data>
+  <data name="Tab.MyProfile.Title.Text">
+    <value xml:space="preserve">Mijn profiel</value>
+  </data>
+  <data name="Tab.Newsletters.Content.Text">
+    <value xml:space="preserve">Nieuwsbrief</value>
+  </data>
+  <data name="Tab.Newsletters.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Niewsbrief</value>
+  </data>
+  <data name="Tab.Newsletters.Description.Text">
+    <value xml:space="preserve">E-mail berichten verzenden naar gebruikers, beveiligingsrollen en specifieke e-mailadressen.</value>
+  </data>
+  <data name="Tab.Newsletters.Name.Text">
+    <value xml:space="preserve">Nieuwsbrieven</value>
+  </data>
+  <data name="Tab.Newsletters.Title.Text">
+    <value xml:space="preserve">Nieuwsbrieven</value>
+  </data>
+  <data name="Tab.PageManagement.Content.Text">
+    <value xml:space="preserve">Pagina beheer</value>
+  </data>
+  <data name="Tab.PageManagement.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Pagina beheer</value>
+  </data>
+  <data name="Tab.PageManagement.Description.Text">
+    <value xml:space="preserve">Pagina's binnen de site beheren.</value>
+  </data>
+  <data name="Tab.PageManagement.Name.Text">
+    <value xml:space="preserve">Pagina's</value>
+  </data>
+  <data name="Tab.PageManagement.Title.Text">
+    <value xml:space="preserve">Pagina beheer</value>
+  </data>
+  <data name="Tab.PortalAdministration.Content.Text">
+    <value xml:space="preserve">Portaal Administratie</value>
+  </data>
+  <data name="Tab.PortalAdministration.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Basisfuncties</value>
+  </data>
+  <data name="Tab.PortalAdministration.Name.Text">
+    <value xml:space="preserve">Admin</value>
+  </data>
+  <data name="Tab.PortalAdministration.Title.Text">
+    <value xml:space="preserve">Portaal Administratie</value>
+  </data>
+  <data name="Tab.RecycleBin.Content.Text">
+    <value xml:space="preserve">Prullenmand</value>
+  </data>
+  <data name="Tab.RecycleBin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Prullenmand</value>
+  </data>
+  <data name="Tab.RecycleBin.Description.Text">
+    <value xml:space="preserve">Bekijken, herstellen of permanent hergebruik pagina's en modules die zijn verwijderd uit de portaal. </value>
+  </data>
+  <data name="Tab.RecycleBin.Name.Text">
+    <value xml:space="preserve">Prullenmand</value>
+  </data>
+  <data name="Tab.RecycleBin.Title.Text">
+    <value xml:space="preserve">Prullenmand</value>
+  </data>
+  <data name="Tab.SearchAdmin.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Zoek Admin</value>
+  </data>
+  <data name="Tab.SearchAdmin.Description.Text">
+    <value xml:space="preserve">Zoek Admin</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Content.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsCE.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Name.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsCE.Title.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.ResultsModule.Title.Text">
+    <value xml:space="preserve">Resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsPro.ContentPane.SearchResultsModule.Title.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Name.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SearchResultsPro.Title.Text">
+    <value xml:space="preserve">Zoek resultaten</value>
+  </data>
+  <data name="Tab.SecurityRoles.Content.Text">
+    <value xml:space="preserve">Beveligingsrollen</value>
+  </data>
+  <data name="Tab.SecurityRoles.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Beveligingsrollen</value>
+  </data>
+  <data name="Tab.SecurityRoles.Description.Text">
+    <value xml:space="preserve">Beveiligingsrollen voor het portaal beheren.</value>
+  </data>
+  <data name="Tab.SecurityRoles.Name.Text">
+    <value xml:space="preserve">Beveiligingsrollen</value>
+  </data>
+  <data name="Tab.SecurityRoles.Title.Text">
+    <value xml:space="preserve">Beveiligingsrollen</value>
+  </data>
+  <data name="Tab.Sharepoint.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">SharePoint Connector</value>
+  </data>
+  <data name="Tab.Sharepoint.Description.Text">
+    <value xml:space="preserve">Met de module SharePoint Connector kunnen gebruikers verbinding maken met en bestanden tussen SharePoint en DNN Server synchroniseren.</value>
+  </data>
+  <data name="Tab.Sharepoint.Name.Text">
+    <value xml:space="preserve">SharePoint Connector</value>
+  </data>
+  <data name="Tab.SiteLog.Content.Text">
+    <value xml:space="preserve">Site Logboek</value>
+  </data>
+  <data name="Tab.SiteLog.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Site Logboek</value>
+  </data>
+  <data name="Tab.SiteLog.Description.Text">
+    <value xml:space="preserve">Statistische rapporten bekijken op de website activiteit voor het portal.
+</value>
+  </data>
+  <data name="Tab.SiteLog.Name.Text">
+    <value xml:space="preserve">Site Logboek</value>
+  </data>
+  <data name="Tab.SiteLog.Title.Text">
+    <value xml:space="preserve">Site Logboek</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Content.Text">
+    <value xml:space="preserve">Instellingen voor websiteoverzicht</value>
+  </data>
+  <data name="Tab.SiteMapSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Zoekmachine websiteoverzicht </value>
+  </data>
+  <data name="Tab.SiteMapSettings.Description.Text">
+    <value xml:space="preserve">Configureer de websiteoverzicht  voor voorlegging aan gemeenschappelijke zoekmachines.</value>
+  </data>
+  <data name="Tab.SiteMapSettings.Name.Text">
+    <value xml:space="preserve">Zoekmachine websiteoverzicht </value>
+  </data>
+  <data name="Tab.SiteMapSettings.Title.Text">
+    <value xml:space="preserve">Instellingen voor websiteoverzicht</value>
+  </data>
+  <data name="Tab.SiteRedirection.Content.Text">
+    <value xml:space="preserve">Site omleiding beheer</value>
+  </data>
+  <data name="Tab.SiteRedirection.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Site omleiding beheer</value>
+  </data>
+  <data name="Tab.SiteRedirection.Description.Text">
+    <value xml:space="preserve">Site omleiding beheer</value>
+  </data>
+  <data name="Tab.SiteRedirection.Name.Text">
+    <value xml:space="preserve">Site omleiding beheer</value>
+  </data>
+  <data name="Tab.SiteSettings.Content.Text">
+    <value xml:space="preserve">Site instellingen</value>
+  </data>
+  <data name="Tab.SiteSettings.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Site instellingen</value>
+  </data>
+  <data name="Tab.SiteSettings.Description.Text">
+    <value xml:space="preserve">Configuratie-instellingen voor het portaal beheren.</value>
+  </data>
+  <data name="Tab.SiteSettings.Name.Text">
+    <value xml:space="preserve">Site instellingen</value>
+  </data>
+  <data name="Tab.SiteSettings.Title.Text">
+    <value xml:space="preserve">Site instellingen</value>
+  </data>
+  <data name="Tab.SiteWizard.Content.Text">
+    <value xml:space="preserve">Website Wizard</value>
+  </data>
+  <data name="Tab.SiteWizard.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Website Wizard</value>
+  </data>
+  <data name="Tab.SiteWizard.Description.Text">
+    <value xml:space="preserve">Portaal-instellingen, pagina-ontwerp configureren en toepassen van een sitesjabloon met een stapsgewijze wizard.</value>
+  </data>
+  <data name="Tab.SiteWizard.Name.Text">
+    <value xml:space="preserve">Website Wizard</value>
+  </data>
+  <data name="Tab.SiteWizard.Title.Text">
+    <value xml:space="preserve">Website Wizard</value>
+  </data>
+  <data name="Tab.Skins.Content.Text">
+    <value xml:space="preserve">Skins</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinDesignerModule.Title.Text">
+    <value xml:space="preserve">Skin ontwerper</value>
+  </data>
+  <data name="Tab.Skins.ContentPane.SkinEditorModule.Title.Text">
+    <value xml:space="preserve">Skin redacteur</value>
+  </data>
+  <data name="Tab.Skins.Description.Text">
+    <value xml:space="preserve">Skin bronnen beheren.</value>
+  </data>
+  <data name="Tab.Skins.Name.Text">
+    <value xml:space="preserve">Skins</value>
+  </data>
+  <data name="Tab.Skins.Title.Text">
+    <value xml:space="preserve">Skins</value>
+  </data>
+  <data name="Tab.Taxonomy.Content.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Taxonomie beheerder</value>
+  </data>
+  <data name="Tab.Taxonomy.Description.Text">
+    <value xml:space="preserve">De taxonomie voor uw Site beheren.</value>
+  </data>
+  <data name="Tab.Taxonomy.Name.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.Taxonomy.Title.Text">
+    <value xml:space="preserve">Taxonomie</value>
+  </data>
+  <data name="Tab.UserAccounts.Content.Text">
+    <value xml:space="preserve">Gebruikersaccounts</value>
+  </data>
+  <data name="Tab.UserAccounts.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Gebruikersaccounts</value>
+  </data>
+  <data name="Tab.UserAccounts.Description.Text">
+    <value xml:space="preserve">Gebruikersaccounts voor het portaal beheren.</value>
+  </data>
+  <data name="Tab.UserAccounts.Name.Text">
+    <value xml:space="preserve">Gebruikersaccounts</value>
+  </data>
+  <data name="Tab.UserAccounts.Title.Text">
+    <value xml:space="preserve">Gebruikersaccounts</value>
+  </data>
+  <data name="Tab.Vendors.Content.Text">
+    <value xml:space="preserve">Leveranciers</value>
+  </data>
+  <data name="Tab.Vendors.ContentPane.Module.Title.Text">
+    <value xml:space="preserve">Leveranciers</value>
+  </data>
+  <data name="Tab.Vendors.Description.Text">
+    <value xml:space="preserve">Leveranciers accounts beheren, banner reclame en affiliate verwijzingen binnen het portaal.</value>
+  </data>
+  <data name="Tab.Vendors.Name.Text">
+    <value xml:space="preserve">Leveranciers</value>
+  </data>
+  <data name="Tab.Vendors.Title.Text">
+    <value xml:space="preserve">Leveranciers</value>
+  </data>
+</root>


### PR DESCRIPTION
At present language specific templates are added manually to the templates folder - this means that updates are difficult and the process is error-prone. The decision was made to add the language specific templates to the portals/_default folder and at language pack creation time we will delete the unneeded templates