### PR TITLE
DNN-6330 Create FolderName for Packages for types that were not being…

### DIFF
--- a/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
@@ -531,6 +531,9 @@ namespace DotNetNuke.Services.Installer.Installers
                     if (foldernameNav != null) Package.FolderName = Globals.glbSkinsPath + Util.ReadElement(foldernameNav, "skinName").Replace('\\', '/');
                     break;
                 default:
+                    //copied from "Module" without the extra OR condition
+                    folderNameValue = PackageController.GetSpecificFolderName(manifestNav, "components/component/resourceFiles", "basePath", "DesktopModules");
+                    if (!String.IsNullOrEmpty(folderNameValue)) Package.FolderName = folderNameValue.Replace('\\', '/');
                     break;
             }
 


### PR DESCRIPTION
This needs to be cherry-picked into 7.4.2 as it is affecting CONTENT-5218, which in turn affecting translation of packages that are of type Library or EvoqConnector