### PR TITLE
DNN-7261 DCC - Host cannot edit an existing Content Field within a Content Type

### DIFF
--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/ClientScripts/contentTypes.js
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/ClientScripts/contentTypes.js
@@ -308,6 +308,7 @@ dcc.contentFieldViewModel = function(parentViewModel, config) {
     self.selected = ko.observable(false);
 
     self.dataTypes = ko.observableArray([]);
+
     self.localizedDescriptions = ko.observableArray([]);
     self.localizedLabels = ko.observableArray([]);
     self.localizedNames = ko.observableArray([]);
@@ -434,6 +435,8 @@ dcc.contentFieldViewModel = function(parentViewModel, config) {
         util.loadLocalizedValues(self.localizedNames, data.localizedNames);
         util.loadLocalizedValues(self.localizedLabels, data.localizedLabels);
         util.loadLocalizedValues(self.localizedDescriptions, data.localizedDescriptions);
+
+        getDataTypes();
     }
 
     self.saveContentField = function(data, e) {


### PR DESCRIPTION
Call getDataTypes  in both init (for add Field) and load (for edit Field) functions of ContentFieldViewModel object.