### PR TITLE
It should be possible to remove Google Analytics

### DIFF
--- a/Website/DesktopModules/Admin/Analytics/GoogleAnalyticsSettings.ascx
+++ b/Website/DesktopModules/Admin/Analytics/GoogleAnalyticsSettings.ascx
@@ -6,7 +6,6 @@
         <div class="dnnFormItem">
             <dnn:label id="lblTrackingId" runat="server" controlname="txtTrackingId" />
             <asp:textbox id="txtTrackingId" runat="server" Width="280px" />
-            <asp:RequiredFieldValidator ID="valTrackingId" runat="server" CssClass="dnnFormMessage dnnFormError" ControlToValidate="txtTrackingId" Display="Dynamic" resourcekey="valTrackingId" />
         </div>
         <div class="dnnFormItem">
             <dnn:label id="lblUrlParameter" runat="server" controlname="txtUrlParameter" suffix=":" />

--- a/Website/DesktopModules/Admin/Analytics/GoogleAnalyticsSettings.ascx.designer.cs
+++ b/Website/DesktopModules/Admin/Analytics/GoogleAnalyticsSettings.ascx.designer.cs
@@ -31,15 +31,6 @@ namespace DotNetNuke.Modules.Admin.Analytics {
         protected global::System.Web.UI.WebControls.TextBox txtTrackingId;
         
         /// <summary>
-        /// valTrackingId control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RequiredFieldValidator valTrackingId;
-        
-        /// <summary>
         /// lblUrlParameter control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Removed the "required" validator attached to the trackingId field of the
google analytics settings controller. This should allow users to remove
Google Analytics from their website if they so wish.

https://dnntracker.atlassian.net/browse/DNN-3547