### PR TITLE
DNN-7362 Improve MobileRedirectModule performance by doing ClientCapability checks only when needed

### DIFF
--- a/DNN Platform/Library/Services/Mobile/RedirectionController.cs
+++ b/DNN Platform/Library/Services/Mobile/RedirectionController.cs
@@ -178,8 +178,9 @@ namespace DotNetNuke.Services.Mobile
             {
                 return redirectUrl;
             }
-			
-			var clientCapability = ClientCapabilityProvider.Instance().GetClientCapability(userAgent);
+
+            IClientCapability clientCapability = null;
+           
 			foreach (var redirection in redirections)
 			{
 				if (redirection.Enabled)
@@ -215,6 +216,10 @@ namespace DotNetNuke.Services.Mobile
 
 					if (checkFurther)
 					{
+					    if (clientCapability == null)
+					    {
+                            clientCapability = ClientCapabilityProvider.Instance().GetClientCapability(userAgent);
+					    }
 						//check if client capability matches with this rule
 						if (DoesCapabilityMatchWithRule(clientCapability, redirection))
 						{


### PR DESCRIPTION
DNN by default has a definition for the MobileRedirect httpmodule which runs for all .net requests (except for install/upgrade requests).

As part of it's logic it checks to see if a redirect rule exists and if so checks if it applies to the page (and a few other pieces of validation). Before this check loop the clientcapabilities are read from 51degrees even though they may not later be checked against (e.g. if the current page does not have a redirect rule). This has been refactored to ensure the capabilities are only loaded if needed
