### PR TITLE
DNN-5387: Improve cacheability for unauthenticated (public) pages.

### DIFF
--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -90,6 +90,14 @@ namespace DotNetNuke.Entities.Host
             }
         }
 
+        public static string UnauthenticatedCacheability
+        {
+            get
+            {
+                return HostController.Instance.GetString("UnauthenticatedCacheability", "4");
+            }
+        }
+
         /// <summary>
         /// gets whether or not CDN has been enabled for all registered javascript libraries
         /// </summary>

--- a/Website/Default.aspx.cs
+++ b/Website/Default.aspx.cs
@@ -227,29 +227,28 @@ namespace DotNetNuke.Framework
                     Exceptions.ProcessHttpException(Request);
                 }
             }
-            if (Request.IsAuthenticated)
+            string cacheability = Request.IsAuthenticated ? Host.AuthenticatedCacheability : Host.UnauthenticatedCacheability;
+
+            switch (cacheability)
             {
-                switch (Host.AuthenticatedCacheability)
-                {
-                    case "0":
-                        Response.Cache.SetCacheability(HttpCacheability.NoCache);
-                        break;
-                    case "1":
-                        Response.Cache.SetCacheability(HttpCacheability.Private);
-                        break;
-                    case "2":
-                        Response.Cache.SetCacheability(HttpCacheability.Public);
-                        break;
-                    case "3":
-                        Response.Cache.SetCacheability(HttpCacheability.Server);
-                        break;
-                    case "4":
-                        Response.Cache.SetCacheability(HttpCacheability.ServerAndNoCache);
-                        break;
-                    case "5":
-                        Response.Cache.SetCacheability(HttpCacheability.ServerAndPrivate);
-                        break;
-                }
+                case "0":
+                    Response.Cache.SetCacheability(HttpCacheability.NoCache);
+                    break;
+                case "1":
+                    Response.Cache.SetCacheability(HttpCacheability.Private);
+                    break;
+                case "2":
+                    Response.Cache.SetCacheability(HttpCacheability.Public);
+                    break;
+                case "3":
+                    Response.Cache.SetCacheability(HttpCacheability.Server);
+                    break;
+                case "4":
+                    Response.Cache.SetCacheability(HttpCacheability.ServerAndNoCache);
+                    break;
+                case "5":
+                    Response.Cache.SetCacheability(HttpCacheability.ServerAndPrivate);
+                    break;
             }
 
             //page comment

--- a/Website/DesktopModules/Admin/HostSettings/App_LocalResources/HostSettings.ascx.resx
+++ b/Website/DesktopModules/Admin/HostSettings/App_LocalResources/HostSettings.ascx.resx
@@ -546,6 +546,12 @@
   <data name="plEnableHelp.Help" xml:space="preserve">
     <value>You can enable or disable the Online Help Action Menu for Modules.  If enabled, you will need to provide the Help URL for the module, in the Module Definitions, although this may have been provided by the developer of the module.</value>
   </data>
+  <data name="plcboUnauthCacheability.Text" xml:space="preserve">
+    <value>Unauthenticated Cacheability:</value>
+  </data>
+  <data name="plcboUnauthCacheability.Help" xml:space="preserve">
+    <value>Sets the Cache-Control HTTP header value for unauthenticated users.</value>
+  </data>
   <data name="plCacheability.Text" xml:space="preserve">
     <value>Authenticated Cacheability:</value>
   </data>

--- a/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.cs
+++ b/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.cs
@@ -876,6 +876,7 @@ namespace DotNetNuke.Modules.Admin.Host
                     HostController.Instance.Update("PerformanceSetting", cboPerformance.SelectedItem.Value, false);
                     Entities.Host.Host.PerformanceSetting = (Globals.PerformanceSettings)Enum.Parse(typeof(Globals.PerformanceSettings), cboPerformance.SelectedItem.Value);
                     HostController.Instance.Update("AuthenticatedCacheability", cboCacheability.SelectedItem.Value, false);
+                    HostController.Instance.Update("UnauthenticatedCacheability", cboUnauthCacheability.SelectedItem.Value, false);
                     HostController.Instance.Update("PageStatePersister", cboPageState.SelectedItem.Value); 
                     HostController.Instance.Update("ModuleCaching", cboModuleCacheProvider.SelectedItem.Value, false);
                     if (PageCacheRow.Visible)

--- a/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.designer.cs
+++ b/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.designer.cs
@@ -1192,6 +1192,24 @@ namespace DotNetNuke.Modules.Admin.Host {
         protected global::DotNetNuke.Web.UI.WebControls.DnnComboBox cboCacheability;
         
         /// <summary>
+        /// plcboUnauthCacheability control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::DotNetNuke.UI.UserControls.LabelControl plcboUnauthCacheability;
+        
+        /// <summary>
+        /// cboUnauthCacheability control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::DotNetNuke.Web.UI.WebControls.DnnComboBox cboUnauthCacheability;
+        
+        /// <summary>
         /// plJQueryVersion control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Admin/HostSettings/hostsettings.ascx
+++ b/Website/DesktopModules/Admin/HostSettings/hostsettings.ascx
@@ -360,6 +360,19 @@
                         </Items>
                     </dnn:dnncombobox>
                 </div>
+                <div class="dnnFormItem">
+                    <dnn:label id="plcboUnauthCacheability" controlname="cboUnauthCacheability" runat="server" />
+                    <dnn:dnncombobox id="cboUnauthCacheability" runat="server">
+                        <Items>
+                        <dnn:DnnComboBoxItem resourcekey="NoCache" Value="0" />
+                        <dnn:DnnComboBoxItem resourcekey="Private" Value="1" />
+                        <dnn:DnnComboBoxItem resourcekey="Public" Value="2" />
+                        <dnn:DnnComboBoxItem resourcekey="Server" Value="3" />
+                        <dnn:DnnComboBoxItem resourcekey="ServerAndNoCache" Value="4" />
+                        <dnn:DnnComboBoxItem resourcekey="ServerAndPrivate" Value="5" />
+                        </Items>
+                    </dnn:dnncombobox>
+                </div>
             </fieldset>
             <h2 id="Panel-JQuery" class="dnnFormSectionHead"><a href="#" class=""><%=LocalizeString("JQuery")%></a></h2>
             <fieldset>

--- a/Website/Install/DotNetNuke.install.config.resources
+++ b/Website/Install/DotNetNuke.install.config.resources
@@ -24,6 +24,7 @@
   </license>
   <settings>
     <AuthenticatedCacheability>4</AuthenticatedCacheability>
+    <UnauthenticatedCacheability>4</UnauthenticatedCacheability>
     <AutoAccountUnlockDuration>10</AutoAccountUnlockDuration>
     <AutoAddPortalAlias>Y</AutoAddPortalAlias>
     <CheckUpgrade>Y</CheckUpgrade>


### PR DESCRIPTION
Public pages can now emit a admin set HTTP Cache Control. 

Settings available in the host area. 