### PR TITLE
DNN-7424 DCC Admin - Sorting the fields should use the "Move" handle

### DIFF
--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Manager.html
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Manager.html
@@ -132,7 +132,7 @@
                                 <th width="100px">[Resx:{key:"Actions"}]</th>
                             </tr>
                             </thead>
-                            <tbody data-bind="sortable: { data: contentFields(), afterMove: moveContentField }">
+                            <tbody data-bind="sortable: { data: contentFields(), afterMove: moveContentField, options: { handle: '.dccMove'} }">
                             <tr>
                                 <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }">
                                     <span data-bind="text: name"></span>
@@ -146,7 +146,7 @@
                                 <td width="100px" data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }">
                                     <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit(), click: $parent.editContentField"><i class="fa fa-pencil"></i></a>
                                     <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit(), click: deleteContentField"><i class="fa fa-trash-o"></i></a>
-                                    <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit()"><i class="fa fa-arrows"></i></a>
+                                    <a class="dccIcon dccMove" data-bind="visible: selected() && $parent.parentViewModel.canEdit()"><i class="fa fa-arrows"></i></a>
                                 </td>
                             </tr>
                             </tbody>


### PR DESCRIPTION
Updated the sortable binding to use the Move icon as a handle for the sorting