### PR TITLE
DNN-7432 Remove references to DNNMenuNavigationProvider

### DIFF
--- a/Website/development.config
+++ b/Website/development.config
@@ -268,10 +268,10 @@
             <add name="DotNetNuke.RadEditorProvider" type="DotNetNuke.Providers.RadEditorProvider.EditorProvider, DotNetNuke.RadEditorProvider" providerPath="~/DesktopModules/Admin/RadEditorProvider" />
         </providers>
     </htmlEditor>
-    <navigationControl defaultProvider="DNNMenuNavigationProvider">
+    <navigationControl defaultProvider="DDRMenuNavigationProvider">
       <providers>
         <clear/>
-        <add name="DNNMenuNavigationProvider" type="DotNetNuke.NavigationControl.DNNMenuNavigationProvider, DotNetNuke.DNNMenuNavigationProvider" providerPath="~\Providers\NavigationProviders\DNNMenuNavigationProvider\"/>
+        <add name="DDRMenuNavigationProvider" type="DotNetNuke.Web.DDRMenu.DDRMenuNavigationProvider, DotNetNuke.Web.DDRMenu" />
       </providers>
     </navigationControl>
     <searchIndex defaultProvider="ModuleIndexProvider">

--- a/Website/release.config
+++ b/Website/release.config
@@ -269,10 +269,10 @@
         <add name="DotNetNuke.RadEditorProvider" type="DotNetNuke.Providers.RadEditorProvider.EditorProvider, DotNetNuke.RadEditorProvider" providerPath="~/DesktopModules/Admin/RadEditorProvider" />
       </providers>
     </htmlEditor>
-    <navigationControl defaultProvider="DNNMenuNavigationProvider">
+    <navigationControl defaultProvider="DDRMenuNavigationProvider">
       <providers>
         <clear/>
-        <add name="DNNMenuNavigationProvider" type="DotNetNuke.NavigationControl.DNNMenuNavigationProvider, DotNetNuke.DNNMenuNavigationProvider" providerPath="~\Providers\NavigationProviders\DNNMenuNavigationProvider\"/>
+        <add name="DDRMenuNavigationProvider" type="DotNetNuke.Web.DDRMenu.DDRMenuNavigationProvider, DotNetNuke.Web.DDRMenu" />
       </providers>
     </navigationControl>
     <searchIndex defaultProvider="ModuleIndexProvider">


### PR DESCRIPTION
The DDRMenuNavigationProvider should be the default provider and the only provider installed in a standard DNN installation. 