### PR TITLE
DNN-7500: add property accessor to get client capabilities values.

### DIFF
--- a/DNN Platform/Library/Services/ClientCapability/ClientCapability.cs
+++ b/DNN Platform/Library/Services/ClientCapability/ClientCapability.cs
@@ -94,7 +94,8 @@ namespace DotNetNuke.Services.ClientCapability
 
         /// <summary>
         /// A key-value collection containing all capabilities supported by requester
-        /// </summary>        
+        /// </summary>
+        [Obsolete("This method is not memory efficient and should be avoided as the Match class now exposes an accessor keyed on property name.")]         
         public IDictionary<string, string> Capabilities { get; set; }
 
         /// <summary>
@@ -111,6 +112,19 @@ namespace DotNetNuke.Services.ClientCapability
         ///   Http server variable used for SSL offloading - if this value is empty offloading is not enabled
         /// </summary>
         public string SSLOffload { get; set; }
+
+        /// <summary>
+        /// Get client capability value by property name.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public virtual string this[string name] 
+        {
+            get
+            {
+                throw new NotImplementedException("");
+            }
+        }
 
         #endregion
     }

--- a/DNN Platform/Library/Services/ClientCapability/IClientCapability.cs
+++ b/DNN Platform/Library/Services/ClientCapability/IClientCapability.cs
@@ -20,6 +20,7 @@
 #endregion
 #region Usings
 
+using System;
 using System.Collections.Generic;
 using System.Web;
 #endregion
@@ -91,7 +92,8 @@ namespace DotNetNuke.Services.ClientCapability
 
         /// <summary>
         /// A key-value collection containing all capabilities supported by requester
-        /// </summary>        
+        /// </summary>    
+        [Obsolete("This method is not memory efficient and should be avoided as the Match class now exposes an accessor keyed on property name.")]    
         IDictionary<string, string> Capabilities { get; set; }
 
         /// <summary>
@@ -103,5 +105,12 @@ namespace DotNetNuke.Services.ClientCapability
         ///   Http server variable used for SSL offloading - if this value is empty offloading is not enabled
         /// </summary>
         string SSLOffload { get; set; }
+
+        /// <summary>
+        /// Get client capability value by property name.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        string this[string name] { get; }
     }
 }

--- a/DNN Platform/Library/Services/Mobile/RedirectionController.cs
+++ b/DNN Platform/Library/Services/Mobile/RedirectionController.cs
@@ -701,9 +701,9 @@ namespace DotNetNuke.Services.Mobile
                 int matchCount = 0;
                 foreach (IMatchRule rule in redirection.MatchRules)
                 {
-                    if (clientCapability.Capabilities != null && clientCapability.Capabilities.ContainsKey(rule.Capability))
+                    if (!string.IsNullOrEmpty(clientCapability[rule.Capability]))
                     {
-                        if (clientCapability.Capabilities[rule.Capability].Equals(rule.Expression, StringComparison.InvariantCultureIgnoreCase))
+                        if (clientCapability[rule.Capability].Equals(rule.Expression, StringComparison.InvariantCultureIgnoreCase))
                         {
                             matchCount++;
                         }

--- a/DNN Platform/Providers/ClientCapabilityProviders/Provider.FiftyOneClientCapabilityProvider/FiftyOneClientCapability.cs
+++ b/DNN Platform/Providers/ClientCapabilityProviders/Provider.FiftyOneClientCapabilityProvider/FiftyOneClientCapability.cs
@@ -43,6 +43,37 @@ namespace DotNetNuke.Providers.FiftyOneClientCapabilityProvider
 
         #endregion
 
+        #region Properties
+
+        public override string this[string name]
+        {
+            get
+            {
+                if (_match != null)
+                {
+                    return string.Join(Constants.ValueSeperator, _match[name]);
+                }
+                else if (_profiles != null && _profiles.Any())
+                {
+                    return string.Join(Constants.ValueSeperator, _profiles[0][name]);
+                }
+                else if(_caps != null)
+                {
+                    var capabilities =
+                        _caps.Capabilities[Constants.FiftyOneDegreesProperties] as SortedList<string, string[]>;
+
+                    if (capabilities != null)
+                    {
+                        return string.Join(Constants.ValueSeperator, capabilities[name]);
+                    }
+                }
+
+                return string.Empty;
+            }
+        }
+
+        #endregion
+
         #region Constructor
 
         /// <summary>


### PR DESCRIPTION
in commit https://github.com/dnnsoftware/Dnn.Platform/commit/deea18c2d3bfae9c4c34dd292b327513e3b3313d it drop the use of Capabilities property(not fill it so it will always empty) as its not memory efficient.
for the purpose to read client capabilities value, i add a new property accessor in this pull request, and obsolete the collections one.