### PR TITLE
DNN-7502 - EVOQCONTENT - DAM: UNC folder provider - folder remains in…

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderProvider.cs
@@ -282,12 +282,11 @@ namespace DotNetNuke.Services.FileSystem
             Requires.NotNull("folderMapping", folderMapping);
 
             var folderProvider = Instance(folderMapping.FolderProviderType);
-
-            AddFolderAndMoveFiles(folderPath, newFolderPath, folderMapping);
-
             var folder = FolderManager.Instance.GetFolder(folderMapping.PortalID, folderPath);
             var folderManager = new FolderManager();
             var subFolders = folderManager.GetFolderMappingFoldersRecursive(folderMapping, folder).Skip(1).Reverse();
+
+            AddFolderAndMoveFiles(folderPath, newFolderPath, folderMapping);
 
             foreach (var subFolderPath in subFolders.Select(s => s.Key))
             {


### PR DESCRIPTION
… DAM after it was deleted in the remote server

- Reverted bad fix for DNN-6402
- Removed try/catch that was preventing sync failing and unexpected behaviors (as folder deletion reported in DNN-6402) when remote folder provider was not working properly or offline
- changed order of operations in MoveFolder folder provider method to ensure that if GetFolderMappingFoldersRecursive thrown an exception, due to have removed the try/catch commented above, the operation does not leave an inconsistent move state