### PR TITLE
DNN-7581 Add missing multiplex JavaScript reference

### DIFF
--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Manager.html
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Manager.html
@@ -14,6 +14,7 @@
 [JavaScript:{ path: "~/Resources/Shared/components/CodeEditor/mode/css/css.js", priority: 55}]
 [JavaScript:{ path: "~/Resources/Shared/components/CodeEditor/mode/xml/xml.js", priority: 55}]
 [JavaScript:{ path: "~/Resources/Shared/components/CodeEditor/mode/htmlmixed/htmlmixed.js", priority: 60}]
+[JavaScript:{ path: "~/Resources/Shared/components/CodeEditor/addon/mode/multiplex.js", priority: 60}]
 [JavaScript:{ path: "~/Resources/Shared/components/CodeEditor/mode/htmlembedded/htmlembedded.js", priority: 65}]
 [Css:{ path: "//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"}]
 [Css:{ path: "~/Resources/Shared/components/CodeEditor/lib/codemirror.css"}]


### PR DESCRIPTION
The CodeMirror update changed the way the HtmlEmbedded mode works and it now requires an additional JavaScript file get loaded.  There is still a rendering bug which will be handled in a separate issue.