### PR TITLE
DNN-7598 Allow releases without an initial incremental file to support incremental upgrades

### DIFF
--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -655,10 +655,7 @@ namespace DotNetNuke.Common
                 if (Directory.Exists(providerpath))
                 {
                     var incrementalcount = Directory.GetFiles(providerpath, Upgrade.GetStringVersion(version) + ".*." + Upgrade.DefaultProvider).Length;
-                    if (
-                        incrementalcount == 1)
-                    {
-                        return false;}
+                   
                     if (incrementalcount > Globals.GetLastAppliedIteration(version))
                     {
                         return true;


### PR DESCRIPTION


When a DNN website has an application domain recycle a check is made to see if an incremental file exists to see if an incremental upgrade may occur (i.e. where the DNN version has not changed but an xx.xx.xx.xx.sqldataprovider exists)

At present this check has a few short-circuits to ensure it doesn't affect performance after app domain recycle. For instance if the dotnetnuke.dll assembly version is less than 7.4.2 then an incremental check is not done as incremental updates did not exist in that version.

A second check occurs to see if more than 1 incremental exists - this is based on the assumption that a release that will support incremental updates will have at least one xx.xx.xx.xx.sqldataprovider initially so that the "increment" column in the "version" table is populated. If more than 1 file of that naming structure exists we then run a stored procedure to see if the last applied increment is < than the number of incremental files (and if not then run the code to apply the incremental sql, config and cleanup changes). By doing this second check we can avoid doing the stored procedure call for the case where only 1 incremental file exists.

However the 7.4.2 beta release did not contain a xx.xx.xx.xx.sqldataprovider file so this second check returns false (as only 1 incremental file exists and it assumes that's been applied by the beta). We need to remove this second check to support 7.4.2 beta being upgraded and to support any future releases that do not contain an incremental file when releasing an upgradeable beta/ctp.
