### PR TITLE
DNN-7408 & DNN-7409: Make RetryTimeLapse optional

### DIFF
--- a/Website/DesktopModules/Admin/Scheduler/App_LocalResources/EditSchedule.ascx.resx
+++ b/Website/DesktopModules/Admin/Scheduler/App_LocalResources/EditSchedule.ascx.resx
@@ -240,9 +240,6 @@
   <data name="RetryTimeLapseValidator.ErrorMessage" xml:space="preserve">
     <value>Retry Frequency range is from 1 to 999999</value>
   </data>
-  <data name="RetryTimeLapseRequired.ErrorMessage" xml:space="preserve">
-    <value>You must set Retry Frequency value</value>
-  </data>
   <data name="plScheduleStartDate.Text" xml:space="preserve">
     <value>Schedule Start Date/Time:</value>
   </data>

--- a/Website/DesktopModules/Admin/Scheduler/EditSchedule.ascx.cs
+++ b/Website/DesktopModules/Admin/Scheduler/EditSchedule.ascx.cs
@@ -108,7 +108,7 @@ namespace DotNetNuke.Modules.Admin.Scheduler
                 {
                     ddlTimeLapseMeasurement.FindItemByValue(scheduleItem.TimeLapseMeasurement).Selected = true;
                 }
-                txtRetryTimeLapse.Text = Convert.ToString(scheduleItem.RetryTimeLapse);
+                txtRetryTimeLapse.Text = scheduleItem.RetryTimeLapse == Null.NullInteger ? string.Empty : Convert.ToString(scheduleItem.RetryTimeLapse);
                 if (ddlRetryTimeLapseMeasurement.FindItemByValue(scheduleItem.RetryTimeLapseMeasurement) != null)
                 {
                     ddlRetryTimeLapseMeasurement.FindItemByValue(scheduleItem.RetryTimeLapseMeasurement).Selected = true;
@@ -130,10 +130,6 @@ namespace DotNetNuke.Modules.Admin.Scheduler
                 chkCatchUpEnabled.Checked = scheduleItem.CatchUpEnabled;
                 txtObjectDependencies.Text = scheduleItem.ObjectDependencies;
                 txtServers.Text = scheduleItem.Servers.Trim(',');
-                if (Convert.ToInt32(txtRetryTimeLapse.Text) <= 0)
-                {
-                    ddlRetryTimeLapseMeasurement.Visible = false;
-                }
             }
             else
             {
@@ -148,10 +144,10 @@ namespace DotNetNuke.Modules.Admin.Scheduler
             var scheduleItem = new ScheduleItem();
             scheduleItem.TypeFullName = txtType.Text.Replace(" ", "");
             scheduleItem.FriendlyName = txtFriendlyName.Text;
-            //DNN-4964 - values for time lapse and retry frequency can't be set to 0, -1 or left empty (client side validation has been added)
+            //DNN-4964 - values for time lapse can't be set to 0, -1 or left empty (client side validation has been added)
             scheduleItem.TimeLapse = Convert.ToInt32(txtTimeLapse.Text);
             scheduleItem.TimeLapseMeasurement = ddlTimeLapseMeasurement.SelectedItem.Value;
-            scheduleItem.RetryTimeLapse = Convert.ToInt32(txtRetryTimeLapse.Text);
+            scheduleItem.RetryTimeLapse = string.IsNullOrWhiteSpace(txtRetryTimeLapse.Text) ? Null.NullInteger : Convert.ToInt32(txtRetryTimeLapse.Text);
             scheduleItem.RetryTimeLapseMeasurement = ddlRetryTimeLapseMeasurement.SelectedItem.Value;
             scheduleItem.RetainHistoryNum = Convert.ToInt32(ddlRetainHistoryNum.SelectedItem.Value);
             scheduleItem.AttachToEvent = ddlAttachToEvent.SelectedItem.Value;
@@ -300,9 +296,10 @@ namespace DotNetNuke.Modules.Admin.Scheduler
             {
                 objScheduleItem.ScheduleID = Convert.ToInt32(ViewState["ScheduleID"]);
                 var scheduleItem = SchedulingProvider.Instance().GetSchedule(Convert.ToInt32(Request.QueryString["ScheduleID"]));
-                if ((startScheduleDatePicker.SelectedDate != scheduleItem.ScheduleStartDate) || (chkEnabled.Checked) ||
+                if ((startScheduleDatePicker.SelectedDate != scheduleItem.ScheduleStartDate) || 
+                    (chkEnabled.Checked) ||
                     (txtTimeLapse.Text != Convert.ToString(scheduleItem.TimeLapse)) ||
-                    (txtRetryTimeLapse.Text != Convert.ToString(scheduleItem.RetryTimeLapse)) ||
+                    (txtRetryTimeLapse.Text.Trim() != (scheduleItem.RetryTimeLapse == Null.NullInteger ? string.Empty : Convert.ToString(scheduleItem.RetryTimeLapse))) ||
                     (ddlRetryTimeLapseMeasurement.SelectedValue != scheduleItem.RetryTimeLapseMeasurement) ||
                     (ddlTimeLapseMeasurement.SelectedValue != scheduleItem.TimeLapseMeasurement))
                 {
@@ -330,6 +327,9 @@ namespace DotNetNuke.Modules.Admin.Scheduler
 
         private bool VerifyValidTimeLapseRetry()
         {
+            // Do not validate, if retry time lapse is not defined
+            if (string.IsNullOrWhiteSpace(txtRetryTimeLapse.Text)) return true;
+            
             var timeLapse = CalculateTime(Convert.ToInt32(txtTimeLapse.Text), ddlTimeLapseMeasurement.SelectedItem.Value);
             var retry = CalculateTime(Convert.ToInt32(txtRetryTimeLapse.Text), ddlRetryTimeLapseMeasurement.SelectedItem.Value);
             if (retry > timeLapse)

--- a/Website/DesktopModules/Admin/Scheduler/EditSchedule.ascx.designer.cs
+++ b/Website/DesktopModules/Admin/Scheduler/EditSchedule.ascx.designer.cs
@@ -157,15 +157,6 @@ namespace DotNetNuke.Modules.Admin.Scheduler {
         protected global::System.Web.UI.WebControls.TextBox txtRetryTimeLapse;
         
         /// <summary>
-        /// RetryTimeLapseRequireValidator control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RequiredFieldValidator RetryTimeLapseRequireValidator;
-        
-        /// <summary>
         /// RetryTimeLapseValidator control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Admin/Scheduler/editschedule.ascx
+++ b/Website/DesktopModules/Admin/Scheduler/editschedule.ascx
@@ -39,10 +39,9 @@
             </dnn:DnnComboBox>
         </div>
         <div class="dnnFormItem timeMeasurement">
-            <dnn:Label ID="plRetryTimeLapse" runat="server" ControlName="txtRetryTimeLapse" CssClass="dnnFormRequired" />
-            <asp:TextBox ID="txtRetryTimeLapse" runat="server" MaxLength="10" CssClass="dnnSmallSizeComboBox"/>
-            <asp:RequiredFieldValidator ID="RetryTimeLapseRequireValidator" CssClass="dnnFormMessage dnnFormError" EnableViewState="false" runat="server" resourcekey="RetryTimeLapseRequired.ErrorMessage" Display="Dynamic" ControlToValidate="txtRetryTimeLapse" />
-            <asp:RangeValidator runat="server" ControlToValidate="txtRetryTimeLapse" Display="Dynamic" ID="RetryTimeLapseValidator" EnableViewState="false" MinimumValue="0" MaximumValue="999999" Type="Integer" CssClass="dnnFormMessage dnnFormError" resourcekey="RetryTimeLapseValidator.ErrorMessage"></asp:RangeValidator>
+            <dnn:Label ID="plRetryTimeLapse" runat="server" ControlName="txtRetryTimeLapse" />
+            <asp:TextBox ID="txtRetryTimeLapse" runat="server" MaxLength="10" CssClass="dnnSmallSizeComboBox" />
+            <asp:RangeValidator runat="server" ControlToValidate="txtRetryTimeLapse" Display="Dynamic" ID="RetryTimeLapseValidator" EnableViewState="false" MinimumValue="1" MaximumValue="999999" Type="Integer" CssClass="dnnFormMessage dnnFormError" resourcekey="RetryTimeLapseValidator.ErrorMessage"></asp:RangeValidator>
             <dnn:DnnComboBox ID="ddlRetryTimeLapseMeasurement" runat="server" CssClass="dnnSmallSizeComboBox">
                 <Items>
                     <dnn:DnnComboBoxItem resourcekey="Seconds" Value="s" />


### PR DESCRIPTION
This is a follow-up pull request to https://github.com/dnnsoftware/Dnn.Platform/pull/725 and https://github.com/dnnsoftware/Dnn.Platform/pull/726. I think the "retry time lapse" property should be optional and not mandatory.