### PR TITLE
DNN-7637 Add warning text to host settings that flags if oauth extension is not installed

### DIFF
--- a/Website/DesktopModules/Admin/HostSettings/App_LocalResources/HostSettings.ascx.resx
+++ b/Website/DesktopModules/Admin/HostSettings/App_LocalResources/HostSettings.ascx.resx
@@ -786,6 +786,9 @@
   <data name="plPsWarning.Text" xml:space="preserve">
     <value>Warning: Memory page state persistence can cause Ajax issues</value>
   </data>
+  <data name="plOAuthWarning.Text" xml:space="preserve">
+    <value>Warning: The OAuth library must be installed for OAuth server support to work</value>
+  </data>
   <data name="ModuleCacheProvider.Help" xml:space="preserve">
     <value>Select the default module caching provider.  This setting can be overridden by each individual module.</value>
   </data>

--- a/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.cs
+++ b/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.cs
@@ -51,6 +51,7 @@ using DotNetNuke.Security.Membership;
 using DotNetNuke.Services.Cache;
 using DotNetNuke.Services.Exceptions;
 using DotNetNuke.Services.Installer;
+using DotNetNuke.Services.Installer.Packages;
 using DotNetNuke.Services.Localization;
 using DotNetNuke.Services.Log.EventLog;
 using DotNetNuke.Services.Mail;
@@ -387,6 +388,14 @@ namespace DotNetNuke.Modules.Admin.Host
             chkDebugMode.Checked = Entities.Host.Host.DebugMode;
             chkCriticalErrors.Checked = Entities.Host.Host.ShowCriticalErrors;
             chkEnableOAuth.Checked = Entities.Host.Host.EnableOAuthAuthorization;
+            if (chkEnableOAuth.Checked)
+            {
+                var package = PackageController.Instance.GetExtensionPackage(-1, p => p.Name == "DNNOAuth");
+                if (package == null)
+                {
+                    plOAuthWarning.Visible = true;
+                }
+            }
             txtBatch.Text = Entities.Host.Host.MessageSchedulerBatchSize.ToString();
             txtMaxUploadSize.Text = (Config.GetMaxUploadSize() / (1024 * 1024)).ToString();
 			txtAsyncTimeout.Text = Entities.Host.Host.AsyncTimeout.ToString();

--- a/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.designer.cs
+++ b/Website/DesktopModules/Admin/HostSettings/HostSettings.ascx.designer.cs
@@ -2290,6 +2290,15 @@ namespace DotNetNuke.Modules.Admin.Host {
         protected global::System.Web.UI.WebControls.CheckBox chkEnableOAuth;
         
         /// <summary>
+        /// plOAuthWarning control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label plOAuthWarning;
+        
+        /// <summary>
         /// plLogs control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Admin/HostSettings/hostsettings.ascx
+++ b/Website/DesktopModules/Admin/HostSettings/hostsettings.ascx
@@ -662,6 +662,10 @@
                 <div class="dnnFormItem">
                     <dnn:label id="plEnableOAuth" controlname="chkEnableOAuth" runat="server" />
                     <asp:CheckBox ID="chkEnableOAuth" runat="server" />
+                    <div class="dnnFormItem psPageStateWarning dnnClear">
+                        <asp:Label ID="plOAuthWarning" runat="server" CssClass="dnnFormMessage dnnFormWarning"
+                            resourcekey="plOAuthWarning" Visible="false" />
+                    </div>
                 </div>
             </fieldset>
         </div>


### PR DESCRIPTION
This item will show a warning message is oauth server support is enabled at the host settings level but the oauth server library is not installed.