### PR TITLE
DNN-7393 support for enable/disable oauth at portal level

### DIFF
--- a/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.designer.cs
+++ b/Website/DesktopModules/Admin/Portals/SiteSettings.ascx.designer.cs
@@ -1768,6 +1768,15 @@ namespace DesktopModules.Admin.Portals {
         protected global::System.Web.UI.WebControls.Label OAuthSitesettingsSecretLabel;
         
         /// <summary>
+        /// plOAuthWarning control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label plOAuthWarning;
+        
+        /// <summary>
         /// cmdOAuth control.
         /// </summary>
         /// <remarks>

--- a/Website/DesktopModules/Admin/Portals/sitesettings.ascx
+++ b/Website/DesktopModules/Admin/Portals/sitesettings.ascx
@@ -531,6 +531,11 @@
 			            <div class="dnnFormItem" runat="server" id="OAuthSecret">
                         <dnn:label id="plOAuthSitesettingsSecret" runat="server" controlname="OAuthSitesettingsSecretLabel" />
                         <asp:Label runat="server" ID="OAuthSitesettingsSecretLabel" />
+                            <div class="dnnFormItem psPageStateWarning dnnClear">
+                        <asp:Label ID="plOAuthWarning" runat="server" CssClass="dnnFormMessage dnnFormWarning"
+                            resourcekey="plOAuthWarning" Visible="false" />
+                    </div>
+
                     </div>
                         <ul class="dnnActions dnnClear">
                             <li>


### PR DESCRIPTION
also add's a warning message if the oauth server library is not installed.

Note: this needs to be done after #857 as it shares the same resource key