### PR TITLE
DNN-7701 Register JS libraries later in page lifecycle

### DIFF
--- a/DNN Platform/Library/Framework/PageBase.cs
+++ b/DNN Platform/Library/Framework/PageBase.cs
@@ -334,8 +334,6 @@ namespace DotNetNuke.Framework
             //    jQuery.RegisterHoverIntent(Page);
             //}
 
-            JavaScript.Register(Page);
-
             if(ServicesFrameworkInternal.Instance.IsAjaxAntiForgerySupportRequired)
             {
                 ServicesFrameworkInternal.Instance.RegisterAjaxAntiForgery(Page);

--- a/Website/Default.aspx.cs
+++ b/Website/Default.aspx.cs
@@ -606,6 +606,7 @@ namespace DotNetNuke.Framework
 
             // DataBind common paths for the client resource loader
             ClientResourceLoader.DataBind();
+            ClientResourceLoader.PreRender += (sender, args) => JavaScript.Register(Page);
 
             //check for and read skin package level doctype
             SetSkinDoctype();


### PR DESCRIPTION
This moved the JS registration from PageBase into Default.aspx, I'm not sure if
anything needs to be added to support the use of JavaScript Libraries in pages
other than Default.aspx that inherit from PageBase