### PR TITLE
DNN-7740: Retrieve a compiled resx file as a dictionary

### DIFF
--- a/DNN Platform/Library/Services/Localization/ILocalizationProvider.cs
+++ b/DNN Platform/Library/Services/Localization/ILocalizationProvider.cs
@@ -19,6 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System.Collections.Generic;
 using DotNetNuke.Entities.Portals;
 
 namespace DotNetNuke.Services.Localization
@@ -47,5 +48,15 @@ namespace DotNetNuke.Services.Localization
         /// <returns>If the value could be saved then true will be returned, otherwise false.</returns>
         /// <exception cref="System.Exception">Any file io error or similar will lead to exceptions</exception>
         bool SaveString(string key, string value, string resourceFileRoot, string language, PortalSettings portalSettings, DotNetNuke.Services.Localization.LocalizationProvider.CustomizedLocale resourceType, bool addFile, bool addKey);
+
+        /// <summary>
+        /// Gets a compiled resource file for a specific language and portal. This takes the original resource file 
+        /// and overwrites it with any keys found in localized and overridden resource files according to .net and DNN rules.
+        /// </summary>
+        /// <param name="portalSettings">The portal settings for the requesting portal. Only used to retrieve PortalId and DefaultLanguage.</param>
+        /// <param name="resourceFile">The resource file to be retrieved. Relative path from DNN's root starting with /.</param>
+        /// <param name="locale">The requested locale. You should use the thread locale by default.</param>
+        /// <returns>Dictionary of key value pairs where the keys are the localization keys and the values the localized texts.</returns>
+        Dictionary<string, string> GetCompiledResourceFile(PortalSettings portalSettings, string resourceFile, string locale);
     }
 }


### PR DESCRIPTION
Takes the original system resx file, loads all variations over it and returns that as a dictionary for further use.