### PR TITLE
DNN-7742 exception editing dynamic content item

### DIFF
--- a/DNN Platform/Library/Collections/CollectionExtensions.cs
+++ b/DNN Platform/Library/Collections/CollectionExtensions.cs
@@ -166,7 +166,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="ArgumentException"><paramref name="collection"/> does not contain a value for <paramref name="key"/></exception>
         public static T GetValue<T>(this NameValueCollection collection, string key)
         {
-            return collection.ToLookup().GetValue<T>(key);
+            return collection.ToLookup(false).GetValue<T>(key);
         }
 
         /// <summary>Gets the value from the XML node's child elements.</summary>
@@ -245,7 +245,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="ArgumentException"><paramref name="collection"/> does not contain a value for <paramref name="key"/></exception>
         public static T GetValue<T>(this NameValueCollection collection, string key, Func<object, T> converter)
         {
-            return collection.ToLookup().GetValue(key, converter);
+            return collection.ToLookup(false).GetValue(key, converter);
         }
 
         /// <summary>Gets the value from the XML node's child elements.</summary>
@@ -312,7 +312,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="ArgumentException"><paramref name="collection"/> does not contain a value for <paramref name="key"/></exception>
         public static T GetValue<T>(this NameValueCollection collection, string key, Func<string, T> converter)
         {
-            return collection.ToLookup().GetValue(key, converter);
+            return collection.ToLookup(false).GetValue(key, converter);
         }
 
         /// <summary>Gets the value from the XML node's child elements.</summary>
@@ -395,7 +395,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="InvalidOperationException"><paramref name="collection"/> has multiple values for the given <paramref name="key"/></exception>
         public static T GetValueOrDefault<T>(this NameValueCollection collection, string key)
         {
-            return collection.ToLookup().GetValueOrDefault<T>(key);
+            return collection.ToLookup(false).GetValueOrDefault<T>(key);
         }
 
         /// <summary>Gets the value from the XML node's child elements, returning the default value of <typeparamref key="T" /> if the value doesn't exist.</summary>
@@ -481,7 +481,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="InvalidOperationException"><paramref name="collection"/> has multiple values for the given <paramref name="key"/></exception>
         public static T GetValueOrDefault<T>(this NameValueCollection collection, string key, T defaultValue)
         {
-            return collection.ToLookup().GetValueOrDefault(key, defaultValue);
+            return collection.ToLookup(false).GetValueOrDefault(key, defaultValue);
         }
 
         /// <summary>Gets the value from the XML node's child elements, returning <paramref name="defaultValue"/>  if the value doesn't exist.</summary>
@@ -548,7 +548,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="InvalidOperationException"><paramref name="collection"/> has multiple values for the given <paramref name="key"/></exception>
         public static T GetValueOrDefault<T>(this NameValueCollection collection, string key, Func<object, T> converter)
         {
-            return collection.ToLookup().GetValueOrDefault(key, converter);
+            return collection.ToLookup(false).GetValueOrDefault(key, converter);
         }
 
         /// <summary>Gets the value from the XML node's child elements, returning the default value of <typeparamref key="T" /> if the value doesn't exist.</summary>
@@ -610,7 +610,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="InvalidOperationException"><paramref name="collection"/> has multiple values for the given <paramref name="key"/></exception>
         public static T GetValueOrDefault<T>(this NameValueCollection collection, string key, Func<string, T> converter)
         {
-            return collection.ToLookup().GetValueOrDefault(key, converter);
+            return collection.ToLookup(false).GetValueOrDefault(key, converter);
         }
 
         /// <summary>Gets the value from the XML node's child elements, returning the default value of <typeparamref key="T" /> if the value doesn't exist.</summary>
@@ -676,7 +676,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="InvalidOperationException"><paramref name="collection"/> has multiple values for the given <paramref name="key"/></exception>
         public static T GetValueOrDefault<T>(this NameValueCollection collection, string key, T defaultValue, Func<string, T> converter)
         {
-            return collection.ToLookup().GetValueOrDefault(key, defaultValue, converter);
+            return collection.ToLookup(false).GetValueOrDefault(key, defaultValue, converter);
         }
 
         /// <summary>Gets the value from the XML node's child elements, returning <paramref name="defaultValue"/> if the value doesn't exist.</summary>
@@ -730,7 +730,7 @@ namespace DotNetNuke.Collections
         /// <exception cref="InvalidOperationException"><paramref name="collection"/> has multiple values for the given <paramref name="key"/></exception>
         public static T GetValueOrDefault<T>(this NameValueCollection collection, string key, T defaultValue, Func<object, T> converter)
         {
-            return collection.ToLookup().GetValueOrDefault(key, defaultValue, converter);
+            return collection.ToLookup(false).GetValueOrDefault(key, defaultValue, converter);
         }
 
         /// <summary>Gets the value from the XML node's child elements, returning <paramref name="defaultValue"/> if the value doesn't exist.</summary>
@@ -831,9 +831,19 @@ namespace DotNetNuke.Collections
         /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <c>null</c></exception>
         public static ILookup<string, string> ToLookup(this NameValueCollection collection)
         {
+            return collection.ToLookup(true);
+        }
+
+        /// <summary>Converts the <paramref name="collection" /> to an <see cref="ILookup{TKey,TElement}" />.</summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="splitValues">If <c>true</c>, treats values in the <paramref name="collection"/> as comma-delimited lists of items (e.g. from a <see cref="NameValueCollection"/>)</param>
+        /// <returns>An <see cref="ILookup{TKey,TElement}" /> instance.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="collection" /> is <c>null</c></exception>
+        public static ILookup<string, string> ToLookup(this NameValueCollection collection, bool splitValues)
+        {
             Requires.NotNull("collection", collection);
             return collection.AllKeys
-                             .SelectMany(key => ParseValues(key, collection.GetValues(key)))
+                             .SelectMany(key => ParseValues(key, collection.GetValues(key), splitValues))
                              .ToLookup(pair => pair.Key, pair => pair.Value);
         }
 
@@ -901,7 +911,17 @@ namespace DotNetNuke.Collections
         /// <returns>A sequence of <see cref="KeyValuePair{TKey,TValue}"/> instances.</returns>
         private static IEnumerable<KeyValuePair<string, string>> ParseValues(string key, string[] values)
         {
-            return (values.Length == 1
+            return ParseValues(key, values, true);
+        }
+
+        /// <summary>Wraps the <paramref name="values"/> into <see cref="KeyValuePair{TKey,TValue}"/> instances.</summary>
+        /// <param name="key">The key.</param>
+        /// <param name="values">The values.</param>
+        /// <param name="splitSingleValue">If <c>true</c>, treats a single item in <paramref name="values"/> as a comma-delimited list of items (e.g. from a <see cref="NameValueCollection"/>)</param>
+        /// <returns>A sequence of <see cref="KeyValuePair{TKey,TValue}"/> instances.</returns>
+        private static IEnumerable<KeyValuePair<string, string>> ParseValues(string key, string[] values, bool splitSingleValue)
+        {
+            return (splitSingleValue && values.Length == 1
                         ? values[0].Split(',')
                         : values).Select(value => new KeyValuePair<string, string>(key, value));
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/CollectionExtensionTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/CollectionExtensionTests.cs
@@ -368,6 +368,16 @@ namespace DotNetNuke.Tests.Core.Collections
         }
 
         [Test]
+        public void can_get_value_containing_comma_from_namevaluecollection()
+        {
+            var collection = new NameValueCollection { { "question", "what, is it?" } };
+
+            var value = collection.GetValue<string>("question");
+
+            Expect(value, Is.EqualTo("what, is it?"));
+        }
+
+        [Test]
         public void can_get_multiple_values_from_namevaluecollection()
         {
             var collection = new NameValueCollection { { "state", "CA" }, { "state", "BC" }, };


### PR DESCRIPTION
[DNN-7742](https://dnntracker.atlassian.net/browse/DNN-7742)

>When saving a content item in the DCC Viewer module, if there is a string data field with a comma in the value, there is an error thrown.  This does not affect Rich Text or Markdown, because they are handled differently.  It would also, theoretically, affect Integer or Float fields if a comma was in the value (e.g. as a decimal or thousands separator).
>
>The culprit is the `GetValueOrDefault` call in `ViewerController.ProcessFields`, which uses `ToLookup`, which splits values on commas (in `ParseValues`).
>
>For example, but the DCC Viewer module on the page, select _Employee_ as the content type, and save.  Reload the page, then select _Edit Content_ from the action menu.  Enter content with a comma into one of the text fields (e.g. set the Title to _Vice President, Marketing and Sales_), and click the Save button.  You should see a couple of errors, one that looks like this:
>
>```DotNetNuke.Services.Exceptions.ModuleLoadException: There were multiple values for the given key ---> 
System.InvalidOperationException: There were multiple values for the given key ---> 
System.ArgumentException: An item with the same key has already been added.  
 at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)  
 at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)  
 at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
 at System.Linq.Enumerable.ToDictionary[TSource,TKey](IEnumerable`1 source, Func`2 keySelector)
 at DotNetNuke.Collections.CollectionExtensions.ToDictionary(ILookup`2 lookup, String key) in C:\inetpub\wwwroot\proposal.local\DNN Platform\Library\Collections\CollectionExtensions.cs:line 940
 --- End of inner exception stack trace ---
 at DotNetNuke.Collections.CollectionExtensions.ToDictionary(ILookup`2 lookup, String key) in C:\inetpub\wwwroot\proposal.local\DNN Platform\Library\Collections\CollectionExtensions.cs:line 945
 at DotNetNuke.Collections.CollectionExtensions.GetValueOrDefault[T](ILookup`2 lookup, String key, T defaultValue) in C:\inetpub\wwwroot\proposal.local\DNN Platform\Library\Collections\CollectionExtensions.cs:line 449
 at DotNetNuke.Collections.CollectionExtensions.GetValueOrDefault[T](NameValueCollection collection, String key, T defaultValue) in C:\inetpub\wwwroot\proposal.local\DNN Platform\Library\Collections\CollectionExtensions.cs:line 484
 at Dnn.Modules.DynamicContentViewer.Controllers.ViewerController.ProcessFields(DynamicContentPart contentPart, FormCollection collection, String prefix) in C:\inetpub\wwwroot\proposal.local\DNN Platform\Modules\Dnn.Modules.DynamicContentViewer\Controllers\ViewerController.cs:line 257
 at Dnn.Modules.DynamicContentViewer.Controllers.ViewerController.Edit(FormCollection collection) in C:\inetpub\wwwroot\proposal.local\DNN Platform\Modules\Dnn.Modules.DynamicContentViewer\Controllers\ViewerController.cs:line 67
 at lambda_method(Closure , ControllerBase , Object[] ) at System.Web.Mvc.ReflectedActionDescriptor.Execute(ControllerContext controllerContext, IDictionary`2 parameters) at System.Web.Mvc.ControllerActionInvoker.InvokeActionMethod(ControllerContext controllerContext, ActionDescriptor actionDescriptor, IDictionary`2 parameters)
 at System.Web.Mvc.ControllerActionInvoker.<>c__DisplayClass15.<InvokeActionMethodWithFilters>b__12()
 at System.Web.Mvc.ControllerActionInvoker.InvokeActionMethodFilter(IActionFilter filter, ActionExecutingContext preContext, Func`1 continuation)
 at System.Web.Mvc.ControllerActionInvoker.InvokeAction(ControllerContext controllerContext, String actionName)
 at System.Web.Mvc.Controller.ExecuteCore() at System.Web.Mvc.ControllerBase.Execute(RequestContext requestContext)
 at DotNetNuke.Web.Mvc.Framework.Modules.ModuleApplication.ExecuteRequest(ModuleRequestContext context) in C:\inetpub\wwwroot\proposal.local\DNN Platform\DotNetNuke.Web.Mvc\Framework\Modules\ModuleApplication.cs:line 97
 at DotNetNuke.Web.Mvc.Framework.Modules.ModuleExecutionEngine.ExecuteModule(ModuleRequestContext moduleRequestContext) in C:\inetpub\wwwroot\proposal.local\DNN Platform\DotNetNuke.Web.Mvc\Framework\Modules\ModuleExecutionEngine.cs:line 38
 at DotNetNuke.Web.Mvc.MvcHostControl.OnInit(EventArgs e) in C:\inetpub\wwwroot\proposal.local\DNN Platform\DotNetNuke.Web.Mvc\MvcHostControl.cs:line 179```


When getting a single value from a `NameValueCollection`, the collection is first
converted into an `ILookup<string,string>` and then converted into a
`Dictionary<string,string>`.  However, during the conversion to `ILookup`, any
single value is treated as a comma-delimited list, and so values with commas
produce multiple values for a single key in the `ILookup`.  When converting that
into a `Dictionary`, there is an error thrown, because there cannot be multiple
values per key in a `Dictionary`.

This PR adds an overload to `ToLookup` which takes a `bool` value,
indicating whether to treat single values as comma-delimited lists. It then
uses this overload, passing `false`, whenever `GetValue` or `GetValueOrDefault` is
called after `ToLookup` (as those two methods use `ToDictionary` under the hood).