### PR TITLE
DNN-7744 Add missing members to DnnHtmlHelper and DnnUrlHelper

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelper.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using DotNetNuke.Framework;
 using DotNetNuke.UI.Modules;
 using DotNetNuke.Web.Mvc.Framework.Controllers;
-
-// ReSharper disable ConvertPropertyToExpressionBody
 
 namespace DotNetNuke.Web.Mvc.Helpers
 {
@@ -48,14 +47,32 @@ namespace DotNetNuke.Web.Mvc.Helpers
 
         public ModuleInstanceContext ModuleContext { get; set; }
 
-        public RouteCollection RouteCollection { get { return HtmlHelper.RouteCollection; } }
+        public RouteCollection RouteCollection => HtmlHelper.RouteCollection;
 
-        public dynamic ViewBag { get { return HtmlHelper.ViewBag; } }
+        public dynamic ViewBag => HtmlHelper.ViewBag;
 
-        public ViewContext ViewContext { get { return HtmlHelper.ViewContext; } }
+        public ViewContext ViewContext => HtmlHelper.ViewContext;
 
-        public ViewDataDictionary ViewData { get { return HtmlHelper.ViewData; } }
+        public ViewDataDictionary ViewData => HtmlHelper.ViewData;
 
-        public IViewDataContainer ViewDataContainer { get { return HtmlHelper.ViewDataContainer; } }
+        public IViewDataContainer ViewDataContainer => HtmlHelper.ViewDataContainer;
+
+        public string AttributeEncode(string value) => HtmlHelper.AttributeEncode(value);
+
+        public string AttributeEncode(object value) => HtmlHelper.AttributeEncode(value);
+
+        public string Encode(string value) => HtmlHelper.Encode(value);
+
+        public string Encode(object value) => HtmlHelper.Encode(value);
+
+        public string FormatValue(object value, string format) => HtmlHelper.FormatValue(value, format);
+
+        public MvcHtmlString HttpMethodOverride(HttpVerbs httpVerb) => HtmlHelper.HttpMethodOverride(httpVerb);
+
+        public MvcHtmlString HttpMethodOverride(string httpVerb) => HtmlHelper.HttpMethodOverride(httpVerb);
+
+        public IHtmlString Raw(string value) => HtmlHelper.Raw(value);
+
+        public IHtmlString Raw(object value) => HtmlHelper.Raw(value);
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelperOfT.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelperOfT.cs
@@ -20,9 +20,10 @@ namespace DotNetNuke.Web.Mvc.Helpers
         {
         }
 
-        public new ViewDataDictionary<TModel> ViewData
-        {
-            get { return ((HtmlHelper<TModel>)HtmlHelper).ViewData; }
-        }        
+        internal new HtmlHelper<TModel> HtmlHelper => (HtmlHelper<TModel>)base.HtmlHelper;
+
+        public new object ViewBag => HtmlHelper.ViewBag;
+
+        public new ViewDataDictionary<TModel> ViewData => HtmlHelper.ViewData;
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) DNN Software. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using DotNetNuke.Common;
@@ -32,6 +33,11 @@ namespace DotNetNuke.Web.Mvc.Helpers
         }
 
         public ModuleInstanceContext ModuleContext { get; set; }
+
+        public virtual string Encode(string url)
+        {
+            return HttpUtility.UrlEncode(url);
+        }
 
         public virtual string Action()
         {


### PR DESCRIPTION
[DNN-7744](https://dnntracker.atlassian.net/browse/DNN-7744)

>The `DnnWebViewPage<TModel>` base class that MVC views and DCC templates use overrides the standard MVC helpers, `Html` and `Url`. There are some methods and properties available through those helpers in MVC that are not accessible in DNN's versions.
>
>For example, using `@Html.Raw(Dnn.ViewData.Model.Content.Fields["ProposalTitle"].Value)` in a DCC template gives an error that "`DotNetNuke.Web.Mvc.Helpers.DnnHtmlHelper<dynamic>` does not contain a definition for `Raw`"
