### PR TITLE
DNN-7550 Add ability to create custom tokens in SPA modules

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Application\AssemblyStatusAttribute.cs" />
     <Compile Include="Application\DotNetNukeContext.cs" />
     <Compile Include="Data\ControllerBase.cs" />
+    <Compile Include="Entities\Modules\ICustomTokenProvider.cs" />
     <Compile Include="Entities\Modules\InstalledModuleInfo.cs" />
     <Compile Include="Entities\Modules\InstalledModulesController.cs" />
     <Compile Include="Obsolete\Arg.cs" />

--- a/DNN Platform/Library/Entities/Modules/ICustomTokenProvider.cs
+++ b/DNN Platform/Library/Entities/Modules/ICustomTokenProvider.cs
@@ -1,0 +1,12 @@
+﻿using System.Web.UI;
+using System.Collections.Generic;
+using DotNetNuke.UI.Modules;
+using DotNetNuke.Services.Tokens;
+
+namespace DotNetNuke.Entities.Modules
+{
+    public interface ICustomTokenProvider
+    {
+        IDictionary<string, IPropertyAccess> GetTokens(Page page, ModuleInstanceContext moduleContext);
+    }
+}

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Components/BusinessController.cs
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Components/BusinessController.cs
@@ -4,21 +4,25 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Web.UI;
+using System.Collections.Generic;
 using Dnn.DynamicContent;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.Entities.Modules;
-using DotNetNuke.Entities.Modules.Definitions;
+using DotNetNuke.UI.Modules;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
-using DotNetNuke.Services.FileSystem;
+using DotNetNuke.Services.Tokens;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Modules;
 using DotNetNuke.Services.Upgrade;
+using DotNetNuke.Services.FileSystem;
+using DotNetNuke.Entities.Modules.Definitions;
 using FileInfo = DotNetNuke.Services.FileSystem.FileInfo;
 
 #pragma warning disable 1591
 
 namespace Dnn.Modules.DynamicContentManager.Components
 {
-    public class BusinessController : IUpgradeable
+    public class BusinessController : IUpgradeable, ICustomTokenProvider
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(BusinessController));
 
@@ -125,6 +129,14 @@ namespace Dnn.Modules.DynamicContentManager.Components
 
                 return "Failed";
             }
+        }
+
+        public IDictionary<string, IPropertyAccess> GetTokens(Page page, ModuleInstanceContext moduleContext)
+        {
+            var tokens = new Dictionary<string, IPropertyAccess>();
+
+            tokens["icon"] = new FontPropertyAccess();
+            return tokens;
         }
     }
 }

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Components/FontPropertyAccess.cs
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Components/FontPropertyAccess.cs
@@ -1,0 +1,29 @@
+﻿using DotNetNuke.Entities.Users;
+using DotNetNuke.Services.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Web;
+
+namespace Dnn.Modules.DynamicContentManager.Components
+{
+    public class FontPropertyAccess : IPropertyAccess
+    {
+        public FontPropertyAccess()
+        {
+        }
+
+        public virtual CacheLevel Cacheability
+        {
+            get { return CacheLevel.fullyCacheable; }
+        }
+
+        public string GetProperty(string propertyName, string format, CultureInfo formatProvider, UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound)
+        {
+            var rootName = "dnni dnni-{0}";
+
+            return string.Format(rootName, propertyName.ToLower());
+        }
+    }
+}

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Dnn.Modules.DynamicContentManager.csproj
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Dnn.Modules.DynamicContentManager.csproj
@@ -94,6 +94,7 @@
       <Link>SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="Components\BusinessController.cs" />
+    <Compile Include="Components\FontPropertyAccess.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\BaseController.cs" />
     <Compile Include="Services\ContentTypeController.cs" />

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Manager.html
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Manager.html
@@ -22,7 +22,7 @@
 <div id="DCCmanager-[ModuleContext:ModuleId]" class="dccContainer">
     <div class="dccHeading">
         <span>[Resx:{key:"DCC_Admin"}]</span>
-        <a class="dccIcon" data-bind="visible: $root.showCloseIcon(), click: closeEdit"><i class="dnni dnni-home"></i></a>
+        <a class="dccIcon" data-bind="visible: $root.showCloseIcon(), click: closeEdit"><i class="[Icon:home]"></i></a>
     </div>
     <div class="dccBody">
         <div class="dccMenu">
@@ -68,11 +68,11 @@
                         <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected}">
                             <span data-bind="text: created"></span>
                         </td>
-                        <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }"><i class="dnni dnni-check" data-bind="visible: isSystem"></i></td>
+                        <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }"><i class="[Icon:check]" data-bind="visible: isSystem"></i></td>
                         <td width="100px" data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }">
-                            <a class="dccIcon" data-bind="visible: selected() && !canEdit(), click: $parent.editContentType"><i class="dnni dnni-search"></i></a>
-                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: $parent.editContentType"><i class="dnni dnni-pencil"></i></a>
-                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: deleteContentType"><i class="dnni dnni-trash-o"></i></a>
+                            <a class="dccIcon" data-bind="visible: selected() && !canEdit(), click: $parent.editContentType"><i class="[Icon:search]"></i></a>
+                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: $parent.editContentType"><i class="[Icon:pencil]"></i></a>
+                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: deleteContentType"><i class="[Icon:trash-o]"></i></a>
                         </td>
                     </tr>
                     </tbody>
@@ -108,7 +108,7 @@
                         <div data-bind="css: rootViewModel.fieldStatus(localizedNames())">
                             <label>[Resx:{key:"Name"}]</label>
                             <input type="text" data-bind="value: name, enable: canEdit" />
-                            <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
+                            <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
                         </div>
                         <div class="toggle" data-bind="css: { disabled: !(parentViewModel.isSystemUser && isAddMode()) }">
                             <span><input type="checkbox" data-bind="checked: isSystem, enable: parentViewModel.isSystemUser && isAddMode()"></span>
@@ -119,7 +119,7 @@
                         <div data-bind="css: rootViewModel.fieldStatus(localizedDescriptions())">
                             <label>[Resx:{key:"Description"}]</label>
                             <textarea class="dccTextArea" type="text" data-bind="value: description, enable: canEdit"></textarea>
-                            <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedDescriptions())}"></i>
+                            <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedDescriptions())}"></i>
                         </div>
                     </div>
 
@@ -155,9 +155,9 @@
                                     <span data-bind="text: fieldType()"></span>
                                 </td>
                                 <td width="100px" data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }">
-                                    <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit(), click: $parent.editContentField"><i class="dnni dnni-pencil"></i></a>
-                                    <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit(), click: deleteContentField"><i class="dnni dnni-trash-o"></i></a>
-                                    <a class="dccIcon dccMove" data-bind="visible: selected() && $parent.parentViewModel.canEdit() && $parent.contentFields().length > 1"><i class="dnni dnni-arrows"></i></a>
+                                    <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit(), click: $parent.editContentField"><i class="[Icon:pencil]"></i></a>
+                                    <a class="dccIcon" data-bind="visible: selected() && $parent.parentViewModel.canEdit(), click: deleteContentField"><i class="[Icon:trash-o]"></i></a>
+                                    <a class="dccIcon dccMove" data-bind="visible: selected() && $parent.parentViewModel.canEdit() && $parent.contentFields().length > 1"><i class="[Icon:arrows]"></i></a>
                                 </td>
                             </tr>
                             </tbody>
@@ -190,12 +190,12 @@
                             <div class="dccExtraMargin" data-bind="css: rootViewModel.fieldStatus(localizedNames())">
                                 <label>[Resx:{key:"Name"}]</label>
                                 <input type="text" data-bind="value: name">
-                                <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
+                                <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
                             </div>
                             <div class="dccExtraMargin" data-bind="css: rootViewModel.fieldStatus(localizedLabels())">
                                 <label>[Resx:{key:"Label"}]</label>
                                 <input type="text" data-bind="value: label">
-                                <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedLabels())}"></i>
+                                <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedLabels())}"></i>
                             </div>
                             <div>
                                 <label>[Resx:{key:"FieldType"}]</label>
@@ -212,7 +212,7 @@
                             <div data-bind="css: rootViewModel.fieldStatus(localizedDescriptions())">
                                 <label>[Resx:{key:"Description"}]</label>
                                 <textarea  class="dccTextArea" type="text" data-bind="value: description"></textarea>
-                                <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedDescriptions())}"></i>
+                                <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedDescriptions())}"></i>
                             </div>
                         </div>
 
@@ -241,7 +241,7 @@
                         <th>[Resx:{key:"Created"}]</th>
                         <th>[Resx:{key:"System"}]</th>
                         <th width="20px">
-                            <i class="dnni dnni-caret-down"></i>
+                            <i class="[Icon:caret-down]"></i>
                         </th>
                     </tr>
                     </thead>
@@ -250,12 +250,12 @@
                         <td data-bind="text: name"></td>
                         <td data-bind="text: created"></td>
                         <td>
-                            <i class="dnni dnni-check-square-o" data-bind="visible: isSystem"></i>
-                            <i class="dnni dnni-square-o" data-bind="visible: !isSystem"></i>
+                            <i class="[Icon:check-square-o]" data-bind="visible: isSystem"></i>
+                            <i class="[Icon:square-o]" data-bind="visible: !isSystem"></i>
                         </td>
                         <td>
-                            <i class="dnni dnni-caret-down"></i>
-                            <i class="dnni dnni-caret-up"></i>
+                            <i class="[Icon:caret-down]"></i>
+                            <i class="[Icon:caret-up"></i>
                         </td>
                     </tr>
                     </tbody>
@@ -267,7 +267,7 @@
                                     <div data-bind="css: rootViewModel.fieldStatus(localizedNames())">
                                         <label>[Resx:{key:"Name"}]</label>
                                         <input type="text" data-bind="value: name, enable: !isSystem() || parentViewModel.isSystemUser" />
-                                        <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
+                                        <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
                                     </div>
                                     <div>
                                         <label>[Resx:{key:"BaseType"}]</label>
@@ -340,11 +340,11 @@
                         <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected}">
                             <span data-bind="text: contentType()"></span>
                         </td>
-                        <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }"><i class="dnni dnni-check" data-bind="visible: isSystem"></i></td>
+                        <td data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }"><i class="[Icon:check]" data-bind="visible: isSystem"></i></td>
                         <td width="100px" data-bind="event: { mouseover: toggleSelected, mouseout: toggleSelected }">
-                            <a class="dccIcon" data-bind="visible: selected() && !canEdit(), click: $parent.editTemplate"><i class="dnni dnni-search"></i></a>
-                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: $parent.editTemplate"><i class="dnni dnni-pencil"></i></a>
-                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: deleteTemplate"><i class="dnni dnni-trash-o"></i></a>
+                            <a class="dccIcon" data-bind="visible: selected() && !canEdit(), click: $parent.editTemplate"><i class="[Icon:search]"></i></a>
+                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: $parent.editTemplate"><i class="[Icon:pencil]"></i></a>
+                            <a class="dccIcon" data-bind="visible: selected() && canEdit(), click: deleteTemplate"><i class="[Icon:trash-o]"></i></a>
                         </td>
                     </tr>
                     </tbody>
@@ -380,7 +380,7 @@
                         <div class="dccExtraMargin" data-bind="css: rootViewModel.fieldStatus(localizedNames())">
                             <label>[Resx:{key:"Name"}]</label>
                             <input type="text" data-bind="value: name, enable: canEdit" />
-                            <i class="dnni dnni-exclamation" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
+                            <i class="[Icon:exclamation]" data-bind="attr: { title: rootViewModel.fieldMessage(localizedNames())}"></i>
                         </div>
                         <div>
                             <label>[Resx:{key:"ContentType"}]</label>

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/dnn_DCCManager.dnn
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/dnn_DCCManager.dnn
@@ -20,7 +20,9 @@
           <desktopModule>
             <moduleName>Dnn.DynamicContentManager</moduleName>
             <foldername>Dnn/DynamicContentManager</foldername>
-            <businessControllerClass/>
+            <businessControllerClass>
+              Dnn.Modules.DynamicContentManager.Components.BusinessController
+            </businessControllerClass>
             <supportedFeatures />
             <moduleDefinitions>
               <moduleDefinition>
@@ -43,15 +45,15 @@
               </moduleDefinition>
             </moduleDefinitions>
           </desktopModule>
-        	<eventMessage>
-						<processorType>DotNetNuke.Entities.Modules.EventMessageProcessor, DotNetNuke</processorType>
-						<processorCommand>UpgradeModule</processorCommand>
-						<attributes>
-							<businessControllerClass>Dnn.Modules.DynamicContentManager.Components.BusinessController, Dnn.Modules.DynamicContentManager</businessControllerClass>
-							<desktopModuleID>[DESKTOPMODULEID]</desktopModuleID>
-							<upgradeVersionsList>Install,Upgrade</upgradeVersionsList>
-						</attributes>
-					</eventMessage>
+          <eventMessage>
+            <processorType>DotNetNuke.Entities.Modules.EventMessageProcessor, DotNetNuke</processorType>
+            <processorCommand>UpgradeModule</processorCommand>
+            <attributes>
+              <businessControllerClass>Dnn.Modules.DynamicContentManager.Components.BusinessController, Dnn.Modules.DynamicContentManager</businessControllerClass>
+              <desktopModuleID>[DESKTOPMODULEID]</desktopModuleID>
+              <upgradeVersionsList>Install,Upgrade</upgradeVersionsList>
+            </attributes>
+          </eventMessage>
         </component>
         <component type="Assembly">
           <assemblies>


### PR DESCRIPTION
This change adds the ability to use custom Tokens in your SPA modules.  A new Interface was created which adds a GetTokens method.  If you implement this interface in the BusinessControllerClass, then the HTML5TokenReplace class will call the GetTokens methods and add your tokens to the list that is processed as part of your HTML views.

This change also adds a sample implementation to the Dynamic Content Type Manager which implements an [Icon] token that takes the name of an icon defined in the [DNN Icons project](http://dnncommunity.github.io/dnnicons/) and outputs the full class implementation for a given icon.  For example the token [Icon:home] will output "dnni dnni-home".  This abstracts away any web font implementations so that if we choose to change the dnni prefix, we only have one place to make the change in the module.