### PR TITLE
Support for better settings management in modules

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -190,6 +190,11 @@
     <Compile Include="Data\ControllerBase.cs" />
     <Compile Include="Entities\Modules\InstalledModuleInfo.cs" />
     <Compile Include="Entities\Modules\InstalledModulesController.cs" />
+    <Compile Include="Entities\Modules\Settings\ISettingsStore.cs" />
+    <Compile Include="Entities\Modules\Settings\ModuleScopedSettings.cs" />
+    <Compile Include="Entities\Modules\Settings\PortalScopedSettings.cs" />
+    <Compile Include="Entities\Modules\Settings\StringBasedSettings.cs" />
+    <Compile Include="Entities\Modules\Settings\TabModuleScopedSettings.cs" />
     <Compile Include="Obsolete\Arg.cs" />
     <Compile Include="Entities\Content\ContentTypeMemberNameFixer.cs" />
     <Compile Include="Collections\EnumerableExtensions.cs" />

--- a/DNN Platform/Library/Entities/Modules/Settings/ISettingsStore.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/ISettingsStore.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace DotNetNuke.Entities.Modules.Settings
+{
+    public interface ISettingsStore
+    {
+        T Get<T>(T @default = default(T), [CallerMemberName] string name = null);
+        void Set<T>(T value, [CallerMemberName] string name = null);
+        void Save();
+    }
+}

--- a/DNN Platform/Library/Entities/Modules/Settings/ModuleScopedSettings.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/ModuleScopedSettings.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+
+namespace DotNetNuke.Entities.Modules.Settings
+{
+    public class ModuleScopedSettings : StringBasedSettings
+    {
+        public ModuleScopedSettings(int moduleId, Hashtable moduleSettings)
+            : base(
+                name => moduleSettings[name] as string,
+                (name, value) => new ModuleController().UpdateModuleSetting(moduleId, name, value)
+                ) { }
+    }
+}

--- a/DNN Platform/Library/Entities/Modules/Settings/PortalScopedSettings.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/PortalScopedSettings.cs
@@ -1,0 +1,14 @@
+﻿using DotNetNuke.Entities.Portals;
+
+namespace DotNetNuke.Entities.Modules.Settings
+{
+    public class PortalScopedSettings : StringBasedSettings
+    {
+        public PortalScopedSettings(int portalId)
+            : base(
+                name => PortalController.GetPortalSetting(name, portalId, ""),
+                (name, value) => PortalController.UpdatePortalSetting(portalId, name, value, true)
+                )
+        { }
+    }
+}

--- a/DNN Platform/Library/Entities/Modules/Settings/StringBasedSettings.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/StringBasedSettings.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using DotNetNuke.Common;
+
+namespace DotNetNuke.Entities.Modules.Settings
+{
+    public class StringBasedSettings : ISettingsStore
+    {
+        Dictionary<string, string> _cache;
+        Dictionary<string, Action> _dirty;
+        Func<string, string> _get;
+        Action<string, string> _set;
+
+        /// <param name="get">Function to get a value out of your setting store</param>
+        /// <param name="set">Action to save a value back to the setting store</param>
+        public StringBasedSettings(Func<string, string> get, Action<string, string> set)
+        {
+            Requires.NotNull("Get", get);
+            Requires.NotNull("Set", set);
+
+            _get = get;
+            _set = set;
+            _cache = new Dictionary<string, string>();
+            _dirty = new Dictionary<string, Action>();
+        }
+
+        // All changes to the settings are recorded and get only executed on demand 
+        public void Save()
+        {
+            foreach (var save in _dirty.Values) save();
+            _dirty.Clear();
+        }
+
+        // CallerMemberName is used for the name of the setting. No more magic strings
+        public string Get(string @default = default(string), [CallerMemberName] string name = null)
+        {
+            Requires.NotNull("Name", name);
+
+            if (_cache.ContainsKey(name))
+            {
+                return _cache[name];
+            }
+            else
+            {
+                var value = _get(name) ?? @default;
+                _cache[name] = value;
+                return value;
+            }
+        }
+
+        public T Get<T>(T @default = default(T), [CallerMemberName] string name = null)
+        {
+            //required to behave Get and Get<string> the same
+            if (typeof(T) == typeof(string)) return (T)(object)Get((string)(object)@default, name);
+
+            var converter = TypeDescriptor.GetConverter(typeof(T));
+            Requires.NotNull("Converter for T", converter);
+
+            try
+            {
+                var defaultValueAsString = converter.ConvertToInvariantString(@default);
+                string value = Get(defaultValueAsString, name);
+                return (T)converter.ConvertFromInvariantString(value);
+            }
+            catch
+            {
+                return @default;
+            }
+        }
+
+        public void Set(string value, [CallerMemberName] string name = null)
+        {
+            Requires.NotNull("Name", name);
+            var modified = !(_cache.ContainsKey(name) && _cache[name] == value);
+
+            if (modified)
+            {
+                _cache[name] = value;
+                _dirty[name] = () => _set(name, value);
+            };
+        }
+
+        public void Set<T>(T value, [CallerMemberName] string name = null)
+        {
+            //required to behave Set and Set<string> the same
+            if (typeof(T) == typeof(string))
+                Set((string)(object)value, name);
+            else
+            {
+                var converter = TypeDescriptor.GetConverter(typeof(T));
+                Requires.NotNull("Converter for T", converter);
+
+                Set(converter.ConvertToInvariantString(value), name);
+            }
+        }
+    }
+}

--- a/DNN Platform/Library/Entities/Modules/Settings/TabModuleScopedSettings.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/TabModuleScopedSettings.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+
+namespace DotNetNuke.Entities.Modules.Settings
+{
+    public class TabModuleScopedSettings : StringBasedSettings
+    {
+        public TabModuleScopedSettings(int tabModuleId, Hashtable tabModuleSettings)
+            : base(
+                name => tabModuleSettings[name] as string,
+                (name, value) => new ModuleController().UpdateTabModuleSetting(tabModuleId, name, value)
+                ) { }
+    }
+}


### PR DESCRIPTION
To simplify module development we need better support for how we deal with settings. Too often developers use the bare bones hashtable that is in PortalModuleBase. This is "dirty" and can be done in a more concise way helping developers avoid errors in their code.

The code is the work of Stefan Cullman with review by Brian Dukes and myself.