### PR TITLE
DNN bug 7811

### DIFF
--- a/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
@@ -38,10 +38,10 @@ namespace DotNetNuke.Services.Tokens
     public abstract class BaseTokenReplace
     {
         private const string ExpressionDefault =
-            "(?:\\[(?:(?<object>[^\\]\\[:]+):(?<property>[^\\]\\[\\|]+))(?:\\|(?:(?<format>[^\\]\\[]+)\\|(?<ifEmpty>[^\\]\\[]+))|\\|(?:(?<format>[^\\|\\]\\[]+)))?\\])|(?<text>\\[[^\\]\\[]+\\])|(?<text>[^\\]\\[]+)";
+            "(?:(?<text>\\[\\])|\\[(?:(?<object>[^\\]\\[:]+):(?<property>[^\\]\\[\\|]+))(?:\\|(?:(?<format>[^\\]\\[]+)\\|(?<ifEmpty>[^\\]\\[]+))|\\|(?:(?<format>[^\\|\\]\\[]+)))?\\])|(?<text>\\[[^\\]\\[]+\\])|(?<text>[^\\]\\[]+)";
 
         private const string ExpressionObjectLess =
-            "(?:\\[(?:(?<object>[^\\]\\[:]+):(?<property>[^\\]\\[\\|]+))(?:\\|(?:(?<format>[^\\]\\[]+)\\|(?<ifEmpty>[^\\]\\[]+))|\\|(?:(?<format>[^\\|\\]\\[]+)))?\\])" +
+            "(?:(?<text>\\[\\])|\\[(?:(?<object>[^\\]\\[:]+):(?<property>[^\\]\\[\\|]+))(?:\\|(?:(?<format>[^\\]\\[]+)\\|(?<ifEmpty>[^\\]\\[]+))|\\|(?:(?<format>[^\\|\\]\\[]+)))?\\])" +
             "|(?:(?<object>\\[)(?<property>[A-Z0-9._]+)(?:\\|(?:(?<format>[^\\]\\[]+)\\|(?<ifEmpty>[^\\]\\[]+))|\\|(?:(?<format>[^\\|\\]\\[]+)))?\\])" + "|(?<text>\\[[^\\]\\[]+\\])" +
             "|(?<text>[^\\]\\[]+)";
 


### PR DESCRIPTION
When creating a SPA module some valid angularjs code is removed from the
HTML page due to the code in the Html5HostControl. This isn't just an
angularJS issue, it is just javascript. So this issue could effect
others with SPA modules.

These are two examples of valid angularJS code.

var sbApp = angular.module('sbApp', []);
...
$scope.orders = [];

However when the html module is rendered to the browser the empty [] is removed and the code looks like this.

var sbApp = angular.module('sbApp', );
...
$scope.orders = ;

This creates a JS error and stops the module from working. The issue that DNN have used the square brackets to allow token replacement to add modulecontext information, resource string etc.
However the RegEx statement and code in the DNN Platform\Library\Services\Tokens\BaseTokenReplace.cs does not handle the case when it locates an empty bracket statement like [] and instead wrongly removes it.
The [] can be used to define an empty array in JS for example. So these shouldn't be removed the from the html module.

https://dnntracker.atlassian.net/browse/DNN-7811