### PR TITLE
Fix Bug7857 - WebAPI TabIsInPortal always returns true

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Api/Internal/DnnContextMessageHandler.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Internal/DnnContextMessageHandler.cs
@@ -67,8 +67,7 @@ namespace DotNetNuke.Web.Api.Internal
         private static bool TabIsInPortal(int tabId, int portalId)
         {
             var tab = TabController.Instance.GetTab(tabId, portalId);
-
-            return tab != null;
+            return tab != null && tab.PortalID == portalId;
         }
 
         private static void ValidateTabAndModuleContext(HttpRequestMessage request, int portalId, out int tabId)


### PR DESCRIPTION
fix to bug 7857,  before this would always return true regardless of the
portalId.

The method GetTab will work out the correct portalId to locate the tab
if the tabId doesn't existing in the portal. Therefore we need to test
to see if the returned TabInfo object has the portalId as the expected
value.

If this pull request is accepted then its import to apply pull request #952 since without this additional pull then anyone with a child portal won't be able to call the webAPI. This is due to the code needing an additional fix to correct the fact that portalId is wrong when called via a child portal.