### PR TITLE
DNN-7941 - DAM module on Host File Management page shows error

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Api/Internal/DnnContextMessageHandler.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Internal/DnnContextMessageHandler.cs
@@ -63,11 +63,16 @@ namespace DotNetNuke.Web.Api.Internal
             request.GetHttpContext().Items["PortalSettings"] = portalSettings;
             return portalSettings;
         }
-
-        private static bool TabIsInPortal(int tabId, int portalId)
+        
+        private static bool TabIsInPortalOrHost(int tabId, int portalId)
         {
             var tab = TabController.Instance.GetTab(tabId, portalId);
-            return tab != null && tab.PortalID == portalId;
+            return tab != null && (tab.PortalID == portalId || IsHostTab(tab));
+        }
+
+        private static bool IsHostTab(TabInfo tab)
+        {
+            return tab.PortalID == Null.NullInteger;
         }
 
         private static void ValidateTabAndModuleContext(HttpRequestMessage request, int portalId, out int tabId)
@@ -76,7 +81,7 @@ namespace DotNetNuke.Web.Api.Internal
 
             if (tabId != Null.NullInteger)
             {
-                if (!TabIsInPortal(tabId, portalId))
+                if (!TabIsInPortalOrHost(tabId, portalId))
                 {
                     throw new HttpResponseException(request.CreateErrorResponse(HttpStatusCode.BadRequest, Localization.GetString("TabNotInPortal", Localization.ExceptionsResourceFile)));
                 }


### PR DESCRIPTION
The fix in the DNN Platform\DotNetNuke.Web\Api\Internal\DnnContextMessageHandler.cs TabIsInPortal method did in DNN-7857 does not handling properly host pages. Unfortunately there is no way in the DnnContextMessageHandler to know if a web method request is done in the context of an host tab. The portal id is based on the alias so this will always set a valid portal Id.
I have fixed extended the logic added in DNN-7857 returning true in the method if the tab is an Host tab. The private method has been renamed from *TabIsInPortal *to *TabIsInPortalOrHost*