### PR TITLE
DefaultValue not needed. 

### DIFF
--- a/DNN Platform/Library/Entities/Modules/Settings/ParameterAttributeBase.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/ParameterAttributeBase.cs
@@ -7,8 +7,6 @@ namespace DotNetNuke.Entities.Modules.Settings
     /// </summary>
     public abstract class ParameterAttributeBase : Attribute
     {
-        public object DefaultValue { get; set; }
-
         public string ParameterName { get; set; }
     }
 }

--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -127,9 +127,9 @@ namespace DotNetNuke.Entities.Modules.Settings
                 if (attribute is PortalSettingAttribute)
                 {
                     settingValue = PortalController.GetPortalSetting(mapping.ParameterName, ctlModule.PortalID, null);
-                    if (string.IsNullOrWhiteSpace((string)settingValue) && (attribute.DefaultValue != null))
+                    if (string.IsNullOrWhiteSpace((string)settingValue))
                     {
-                        settingValue = attribute.DefaultValue;
+                        settingValue = null;
                     }
                 }
                 else if (attribute is TabModuleSettingAttribute && ctlModule.TabModuleSettings.ContainsKey(mapping.ParameterName))
@@ -140,11 +140,6 @@ namespace DotNetNuke.Entities.Modules.Settings
                 {
                     settingValue = ctlModule.ModuleSettings[mapping.ParameterName];
                 }
-                else if (attribute.DefaultValue != null)
-                {
-                    settingValue = attribute.DefaultValue;
-                }
-
                 if (settingValue != null && property.CanWrite)
                 {
                     this.WriteProperty(settings, property, settingValue);


### PR DESCRIPTION
Initialize a property  instead, and don't  set it if the setting is null.

        [ModuleSetting(Prefix = "Foo_")]
        public DateTime Bar { get; set; } = DateTime.Now;