### PR TITLE
DNN-8125 - updating Newtonsoft to version 7

### DIFF
--- a/DNN Platform/Dnn.DynamicContent/Dnn.DynamicContent.csproj
+++ b/DNN Platform/Dnn.DynamicContent/Dnn.DynamicContent.csproj
@@ -37,8 +37,8 @@
       <HintPath>..\Library\bin\DotNetNuke.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/DNN Platform/Dnn.DynamicContent/packages.config
+++ b/DNN Platform/Dnn.DynamicContent/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Deprecated/DotNetNuke.Web.Deprecated.csproj
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/DotNetNuke.Web.Deprecated.csproj
@@ -74,8 +74,9 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations">

--- a/DNN Platform/DotNetNuke.Web.Deprecated/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.0" targetFramework="net45" userInstalled="true" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" userInstalled="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" />
   <package id="WebFormsMvp" version="1.4.1" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -121,8 +121,8 @@
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PetaPoco">

--- a/DNN Platform/Library/packages.config
+++ b/DNN Platform/Library/packages.config
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="QuickIO.NET" version="2.6.2.0" targetFramework="net40" />
 </packages>

--- a/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
+++ b/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
@@ -26,6 +26,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\Evoq.Content\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -62,8 +63,8 @@
       <HintPath>..\..\DotNetNuke.Web.Client\bin\DotNetNuke.Web.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -125,6 +126,13 @@
     </None>
     <Content Include="Module.build" />
     <Content Include="packages.config" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="ie-messages.css" />

--- a/DNN Platform/Modules/CoreMessaging/packages.config
+++ b/DNN Platform/Modules/CoreMessaging/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Modules/DigitalAssets/DotNetNuke.Modules.DigitalAssets.csproj
+++ b/DNN Platform/Modules/DigitalAssets/DotNetNuke.Modules.DigitalAssets.csproj
@@ -80,8 +80,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.WebUtility\bin\DotNetNuke.WebUtility.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -332,6 +332,15 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/DNN Platform/Modules/DigitalAssets/packages.config
+++ b/DNN Platform/Modules/DigitalAssets/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Dnn.Modules.DynamicContentManager.csproj
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/Dnn.Modules.DynamicContentManager.csproj
@@ -58,8 +58,8 @@
       <HintPath>..\..\DotNetNuke.Web\bin\DotNetNuke.Web.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
@@ -168,6 +168,13 @@
     <Content Include="module.css.map">
       <DependentUpon>module.css</DependentUpon>
     </Content>
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/packages.config
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentManager/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" userInstalled="true" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" userInstalled="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentViewer/Dnn.Modules.DynamicContentViewer.csproj
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentViewer/Dnn.Modules.DynamicContentViewer.csproj
@@ -62,8 +62,8 @@
       <HintPath>..\..\DotNetNuke.Web.Razor\bin\DotNetNuke.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />

--- a/DNN Platform/Modules/Dnn.Modules.DynamicContentViewer/packages.config
+++ b/DNN Platform/Modules/Dnn.Modules.DynamicContentViewer/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Modules/Groups/DotNetNuke.Modules.Groups.csproj
+++ b/DNN Platform/Modules/Groups/DotNetNuke.Modules.Groups.csproj
@@ -49,8 +49,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.Web.Client\bin\DotNetNuke.Web.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -206,6 +207,13 @@
     <None Include="module.css" />
     <None Include="ReleaseNotes.txt" />
     <None Include="License.txt" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Create.ascx" />

--- a/DNN Platform/Modules/Groups/packages.config
+++ b/DNN Platform/Modules/Groups/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Modules/Journal/DotNetNuke.Modules.Journal.csproj
+++ b/DNN Platform/Modules/Journal/DotNetNuke.Modules.Journal.csproj
@@ -25,6 +25,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\Evoq.Content\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,8 +55,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.Web.Client\bin\DotNetNuke.Web.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -198,6 +200,13 @@
     <Content Include="packages.config" />
     <None Include="ReleaseNotes.txt" />
     <None Include="License.txt" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Edit.ascx" />

--- a/DNN Platform/Modules/Journal/packages.config
+++ b/DNN Platform/Modules/Journal/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
+++ b/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
@@ -26,6 +26,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\Evoq.Content\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,8 +62,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.Web.Client\bin\DotNetNuke.Web.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -131,6 +133,13 @@
     </None>
     <Content Include="packages.config" />
     <Content Include="Module.build" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="ie-member-directory.css" />

--- a/DNN Platform/Modules/MemberDirectory/packages.config
+++ b/DNN Platform/Modules/MemberDirectory/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net40" />
 </packages>

--- a/DNN Platform/Modules/Taxonomy/DotNetNuke.Modules.Taxonomy.csproj
+++ b/DNN Platform/Modules/Taxonomy/DotNetNuke.Modules.Taxonomy.csproj
@@ -29,6 +29,7 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\Evoq.Content\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -78,8 +79,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.Web.Client\bin\DotNetNuke.Web.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations">
@@ -194,6 +196,13 @@
     <Content Include="packages.config" />
     <Content Include="Module.build" />
     <None Include="Taxonomy.dnn" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Import Include="System" />

--- a/DNN Platform/Modules/Taxonomy/packages.config
+++ b/DNN Platform/Modules/Taxonomy/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net40" />
 </packages>

--- a/DNN Platform/Tests/Dnn.Tests.DynamicContent.IntegrationTests/Dnn.Tests.DynamicContent.IntegrationTests.csproj
+++ b/DNN Platform/Tests/Dnn.Tests.DynamicContent.IntegrationTests/Dnn.Tests.DynamicContent.IntegrationTests.csproj
@@ -48,8 +48,8 @@
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/Dnn.Tests.DynamicContent.IntegrationTests/packages.config
+++ b/DNN Platform/Tests/Dnn.Tests.DynamicContent.IntegrationTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Tests/Dnn.Tests.DynamicContent.UnitTests/Dnn.Tests.DynamicContent.UnitTests.csproj
+++ b/DNN Platform/Tests/Dnn.Tests.DynamicContent.UnitTests/Dnn.Tests.DynamicContent.UnitTests.csproj
@@ -44,8 +44,8 @@
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/Dnn.Tests.DynamicContent.UnitTests/packages.config
+++ b/DNN Platform/Tests/Dnn.Tests.DynamicContent.UnitTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1502.911" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/DotNetNuke.Tests.Content.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/DotNetNuke.Tests.Content.csproj
@@ -65,8 +65,8 @@
     <Reference Include="Moq">
       <HintPath>..\..\..\Packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/app.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="NUnit">
@@ -6,7 +6,7 @@
     </sectionGroup>
   </configSections>
   <connectionStrings>
-    <clear/>
+    <clear />
     <add name="PetaPoco" connectionString="Data Source=Test.sdf" providerName="System.Data.SqlServerCe.4.0" />
     <add name="Test" connectionString="Data Source=Test.sdf" providerName="System.Data.SqlServerCe.4.0" />
   </connectionStrings>
@@ -16,4 +16,12 @@
       <add key="ApartmentState" value="STA" />
     </TestRunner>
   </NUnit>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" userInstalled="true" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" userInstalled="true" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" userInstalled="true" />
   <package id="NUnit" version="2.6.2" targetFramework="net4" userInstalled="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Taxonomy/DotNetNuke.Tests.Taxonomy.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Taxonomy/DotNetNuke.Tests.Taxonomy.csproj
@@ -65,8 +65,9 @@
     <Reference Include="Moq">
       <HintPath>..\..\..\Packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Taxonomy/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Taxonomy/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
   <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net40" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
@@ -40,8 +40,8 @@
     <Reference Include="Moq">
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
   <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net40" />
 </packages>

--- a/DNN Platform/Website/Install/Config/08.00.00.30.config
+++ b/DNN Platform/Website/Install/Config/08.00.00.30.config
@@ -1,0 +1,13 @@
+<configuration>
+  <nodes configfile="web.config">
+    <node path="/configuration/runtime/ab:assemblyBinding" action="update"
+          targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='Newtonsoft.Json']"
+          collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </node>
+      
+  </nodes>
+</configuration>

--- a/Website/DotNetNuke.Website.csproj
+++ b/Website/DotNetNuke.Website.csproj
@@ -109,8 +109,8 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PetaPoco">

--- a/Website/Providers/DataProviders/SqlDataProvider/08.00.00.30.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/08.00.00.30.SqlDataProvider
@@ -1,0 +1,4 @@
+/* DNN-5820 */
+INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] (PackageID, AssemblyName, Version)
+VALUES (NULL, 'Newtonsoft.Json.dll', '7.0.1')
+GO

--- a/Website/development.config
+++ b/Website/development.config
@@ -259,6 +259,10 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 

--- a/Website/packages.config
+++ b/Website/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/Website/release.config
+++ b/Website/release.config
@@ -1,4 +1,4 @@
-<configuration>
+﻿<configuration>
   <!-- register local configuration handlers -->
   <configSections>
     <sectionGroup name="dotnetnuke">
@@ -259,6 +259,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This PR updates all NuGet Newtonsoft versions to v7. It also adds the correct binding in the web.config for Newtonsoft. I ran the tests in the platform solution and they all turned out fine.