### PR TITLE
DNN-8078: Restricted the max date assignment to endDatePicker.MaxDate

### DIFF
--- a/DNN Platform/Admin Modules/Dnn.Modules.Tabs/ManageTabs.ascx.cs
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Tabs/ManageTabs.ascx.cs
@@ -395,7 +395,7 @@ namespace Dnn.Modules.Tabs
                 }
                 if (!Null.IsNull(Tab.EndDate))
                 {
-                    endDatePicker.SelectedDate = Tab.EndDate;
+                    endDatePicker.SelectedDate = Tab.EndDate.Date.Equals(DateTime.MaxValue.Date) ? endDatePicker.MaxDate: Tab.EndDate;
                 }
 
                 endDatePicker.MinDate = DateTime.Now;


### PR DESCRIPTION
because of raddatetimepicker max date restrictions.