### PR TITLE
DNN-8012 Ensuring that containerSrc is taken from the tab

### DIFF
--- a/DNN Platform/Library/UI/Skins/Pane.cs
+++ b/DNN Platform/Library/UI/Skins/Pane.cs
@@ -368,6 +368,17 @@ namespace DotNetNuke.UI.Skins
                     }
                 }
 
+                //error loading container - load from tab
+                if (container == null)
+                {
+                    containerSrc = PortalSettings.ActiveTab.ContainerSrc;
+                    if (!String.IsNullOrEmpty(containerSrc))
+                    {
+                        containerSrc = SkinController.FormatSkinSrc(containerSrc, PortalSettings);
+                        container = LoadContainerByPath(containerSrc);
+                    }
+                }
+
                 //error loading container - load default
                 if (container == null)
                 {


### PR DESCRIPTION
Ensuring that containerSrc is taken from the tab if it is still empty in the code flow.
(Preventive measure).