### PR TITLE
DNN-7311 - Core Messaging: Mark as Unread/Read

### DIFF
--- a/DNN Platform/Modules/CoreMessaging/Scripts/CoreMessaging.js
+++ b/DNN Platform/Modules/CoreMessaging/Scripts/CoreMessaging.js
@@ -388,11 +388,11 @@
             var previousNewThreads = self.TotalNewThreads();
 
             if (messageconversationView.Read() === true) {
-                messageconversationView.NewThreadCount(messageconversationView.ThreadCount());
+                messageconversationView.NewThreadCount(0);
                 self.TotalNewThreads(previousNewThreads + messageconversationView.NewThreadCount());
             } else {
                 self.TotalNewThreads(previousNewThreads - messageconversationView.NewThreadCount());
-                messageconversationView.NewThreadCount(0);
+                messageconversationView.NewThreadCount(1);
             }
         };
 
@@ -416,10 +416,12 @@
         };
 
         self.markAsRead = function (messageconversationView) {
+            messageconversationView.NewThreadCount(0);
             self.changeState(messageconversationView, baseServicepath + 'MarkRead');
         };
 
         self.markAsUnread = function (messageconversationView) {
+            messageconversationView.NewThreadCount(1);
             self.changeState(messageconversationView, baseServicepath + 'MarkUnRead');
         };
 


### PR DESCRIPTION
Added logic to pass in thread count when marking as read/unread. If read, count is 0, and unread, count is 1.