### PR TITLE
DNN-8289 - Updated "more" valuation for search results.

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/SearchServiceController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/SearchServiceController.cs
@@ -236,7 +236,7 @@ namespace DotNetNuke.Web.InternalServices
         {
             var searchResults = SearchController.Instance.SiteSearch(searchQuery);
             totalHits = searchResults.TotalHits;
-            more = searchResults.Results.Count == searchQuery.PageSize;
+            more = searchResults.Results.Count > searchQuery.PageSize;
 
             var groups = new List<GroupedDetailView>();
             var tabGroups = new Dictionary<string, IList<SearchResult>>();


### PR DESCRIPTION
Old evaluation is == (which does not make sense).
More should only be true if the search result count is more than the page size.