### PR TITLE
DNN-8176 - DNNImagehandler does not close handle to source image

### DIFF
--- a/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
@@ -80,7 +80,11 @@ namespace DotNetNuke.Services.GeneratedImage
 
                     var fi = new System.IO.FileInfo(_defaultImageFile);
                     ContentType = GetImageFormat(fi.Extension);
-                    return new Bitmap(Image.FromFile(fullFilePath, true));
+
+                    using (var stream = new FileStream(fullFilePath, FileMode.Open))
+                    {
+                        return Image.FromStream(stream, true);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/DNN Platform/Library/Services/GeneratedImage/StartTransform/ImageFileTransform.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/StartTransform/ImageFileTransform.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.IO;
 using System.Net;
 
 namespace DotNetNuke.Services.GeneratedImage.StartTransform
@@ -55,7 +56,10 @@ namespace DotNetNuke.Services.GeneratedImage.StartTransform
         {
             try
             {
-                return new Bitmap(ImageFilePath);
+                using (var stream = new FileStream(ImageFilePath, FileMode.Open))
+                {
+                    return Image.FromStream(stream);
+                }
             }
             catch (Exception ex)
             {

--- a/DNN Platform/Library/Services/GeneratedImage/StartTransform/SecureFileTransform.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/StartTransform/SecureFileTransform.cs
@@ -51,21 +51,32 @@ namespace DotNetNuke.Services.GeneratedImage.StartTransform
         {
             // if SecureFile is no ImageFile return FileType-Image instead
             if (!IsImageExtension(SecureFile.Extension))
-		    {
-		        var replaceFile = Globals.ApplicationMapPath +"\\" + 
-                    PortalSettings.Current.DefaultIconLocation.Replace("/","\\") + "\\"+
-                    "Ext" + SecureFile.Extension + "_32x32_Standard.png";
-
-		        return File.Exists(replaceFile) ? 
-                    new Bitmap(replaceFile) : 
-                    EmptyImage;
-		    }
+            {
+                return GetSecureFileExtensionIconImage();
+            }
 
             using (var content = FileManager.Instance.GetFileContent(SecureFile))
             {
                 return new Bitmap(content);
             }
 		}
+
+        private Image GetSecureFileExtensionIconImage()
+        {
+            var extensionImageAbsolutePath = Globals.ApplicationMapPath + "\\" +
+                       PortalSettings.Current.DefaultIconLocation.Replace("/", "\\") + "\\" +
+                       "Ext" + SecureFile.Extension + "_32x32_Standard.png";
+
+            if (!File.Exists(extensionImageAbsolutePath))
+            {
+                return EmptyImage;
+            }
+
+            using (var stream = new FileStream(extensionImageAbsolutePath, FileMode.Open))
+            {
+                return Image.FromStream(stream);
+            }
+        }
 
         /// <summary>
         /// Checks if the current user have READ permission on a given folder

--- a/DNN Platform/Library/Services/GeneratedImage/StartTransform/UserProfilePicTransform.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/StartTransform/UserProfilePicTransform.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.IO;
 using DotNetNuke.Common;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
@@ -68,7 +69,11 @@ namespace DotNetNuke.Services.GeneratedImage.StartTransform
         /// <returns></returns>
         public Bitmap GetNoAvatarImage()
         {
-            return new Bitmap(Globals.ApplicationMapPath + @"\images\no_avatar.gif");
+            var avatarAbsolutePath = Globals.ApplicationMapPath + @"\images\no_avatar.gif";
+            using (var stream = new FileStream(avatarAbsolutePath, FileMode.Open))
+            {
+                return new Bitmap(Image.FromStream(stream));
+            }
         }
 
         /// <summary>
@@ -135,7 +140,7 @@ namespace DotNetNuke.Services.GeneratedImage.StartTransform
             return imageExtensions.Contains(extension.ToUpper());
         }
 
-        private Image CopyImage(System.IO.Stream imgStream)
+        private Image CopyImage(Stream imgStream)
         {
             using (Image srcImage = new Bitmap(imgStream))
             {


### PR DESCRIPTION
I revisited all the place where a bitmap is created from a file path and changed the new Bitmap(filepath) to Image.FromStream. The previous method locks the file until the image is disponsed (see https://msdn.microsoft.com/en-us/library/0cbhe98f(v=vs.110).aspx). As part of this issue I have also add image.disponse() when found possible to ask the Garbage Collector to release memory as soon as possible.