### PR TITLE
DNN-8325 Removed the code to remove Set-Cookie header

### DIFF
--- a/DNN Platform/HttpModules/Services/ServicesModule.cs
+++ b/DNN Platform/HttpModules/Services/ServicesModule.cs
@@ -44,10 +44,11 @@ namespace DotNetNuke.HttpModules.Services
                 // they reveal too much info and are security risk
                 var headers = app.Response.Headers;
                 headers.Remove("Server");
-                if (ServiceApi.IsMatch(app.Context.Request.RawUrl.ToLowerInvariant()))
-                {
-                    headers.Remove("Set-Cookie");
-                }
+                //DNN-8325
+                //if (ServiceApi.IsMatch(app.Context.Request.RawUrl.ToLowerInvariant()))
+                //{
+                //    headers.Remove("Set-Cookie");
+                //}
             }
         }
 


### PR DESCRIPTION
The Set-Cookie was being removed from headers as per JIRA DNN-8204 but it affected the functionality of persona bar add page
where a new page was going entering into edit mode automatically.