### PR TITLE
DNN-8355: Add a message to module that's referenced on other pages

### DIFF
--- a/DNN Platform/Library/UI/Containers/Container.cs
+++ b/DNN Platform/Library/UI/Containers/Container.cs
@@ -36,6 +36,7 @@ using DotNetNuke.Entities.Host;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Modules.Actions;
 using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Framework;
 using DotNetNuke.Framework.JavaScriptLibraries;
 using DotNetNuke.Instrumentation;
@@ -47,14 +48,13 @@ using DotNetNuke.UI.Containers.EventListeners;
 using DotNetNuke.UI.Modules;
 using DotNetNuke.UI.Skins;
 using DotNetNuke.UI.WebControls;
+using DotNetNuke.Web.Client;
 using DotNetNuke.Web.Client.ClientResourceManagement;
 
 #endregion
 
 namespace DotNetNuke.UI.Containers
 {
-    using Web.Client;
-
     /// <summary>
     /// Container is the base for the Containers
     /// </summary>
@@ -191,6 +191,11 @@ namespace DotNetNuke.UI.Containers
             ContentPane.Controls.Add(new LiteralControl(string.Format("<div class=\"dnnFormMessage dnnFormInfo dnnFormInfoAdminErrMssg\">{0}</div>", message)));
         }
 
+        private void AddModuleSharedHighlighting(string message)
+        {
+            ContentPane.Controls.Add(new LiteralControl(string.Format("<div class=\"dnnFormMessage dnnFormInfo dnnFormInfoModuleSharedMssg\">{0}</div>", message)));
+        }
+
         /// -----------------------------------------------------------------------------
         /// <summary>
         /// ProcessChildControls parses all the controls in the container, and if the
@@ -281,6 +286,11 @@ namespace DotNetNuke.UI.Containers
             if (showMessage)
             {
                 AddAdministratorOnlyHighlighting(adminMessage);
+            }
+            if (PortalSettings.UserMode == PortalSettings.Mode.Edit && (ModuleConfiguration.AllTabs || TabController.Instance.GetTabsByModuleID(ModuleConfiguration.ModuleID).Count > 1))
+            {
+                var sharedModuleMessage = Localization.GetString("ModuleAddedToMultiplePages.Text");
+                AddModuleSharedHighlighting(sharedModuleMessage);
             }
         }
 

--- a/Website/App_GlobalResources/SharedResources.resx
+++ b/Website/App_GlobalResources/SharedResources.resx
@@ -1962,4 +1962,7 @@ If you expect this addition, then just ignore this email; otherwise, an immediat
   <data name="RestrictFileMail_Subject.Text" xml:space="preserve">
     <value>Potentially dangerous file added to your website</value>
   </data>
+  <data name="ModuleAddedToMultiplePages.Text" xml:space="preserve">
+    <value>This module has been added to other pages.  Changes you make here will apply also to those pages.</value>
+  </data>
 </root>


### PR DESCRIPTION
[DNN-8355](https://dnntracker.atlassian.net/browse/DNN-8355)

> Like with the "Shared Module" indicator in module actions for cross-site sharing withing a portal group, site administrators need to know if the module they're going to edit is shared by other pages on the same site.
> ### Steps to Reproduce
> 1. Add a module to a page
> 2. Create a new page
> 3. Select _Add Existing Module_ from the _Modules_ menu
> 4. Choose the page from step 1
> 5. Ensure _Make a Copy_ is unchecked
> 6. Choose the module from step 1 and add it to a pane
> ### Expected Results
> - There is an indication that the module is shared with the other page
> ### Actual Results
> - There is no indication
