### PR TITLE
DNN-8355: Show "Shared Module" indicator for cross-page module sharing

### DIFF
--- a/Website/App_GlobalResources/SharedResources.resx
+++ b/Website/App_GlobalResources/SharedResources.resx
@@ -1962,4 +1962,7 @@ If you expect this addition, then just ignore this email; otherwise, an immediat
   <data name="RestrictFileMail_Subject.Text" xml:space="preserve">
     <value>Potentially dangerous file added to your website</value>
   </data>
+  <data name="ModuleShared.Text" xml:space="preserve">
+    <value>Shared Module</value>
+  </data>
 </root>

--- a/Website/admin/Menus/ModuleActions/ModuleActions.ascx
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.ascx
@@ -53,6 +53,7 @@
                     yesText: '<%= Localization.GetSafeJSString("Yes.Text", Localization.SharedResourceFile) %>',
                     noText: '<%= Localization.GetSafeJSString("No.Text", Localization.SharedResourceFile) %>',
                     confirmTitle: '<%= Localization.GetSafeJSString("Confirm.Text", Localization.SharedResourceFile) %>',
+                    sharedText: '<%= Localization.GetSafeJSString("ModuleShared.Text", Localization.SharedResourceFile) %>',
                     rootFolder: '<%= Page.ResolveClientUrl("~/") %>',
                     supportsMove: <% = SupportsMove.ToString().ToLower() %>,
                     supportsQuickSettings: supportsQuickSettings,

--- a/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -28,6 +28,7 @@ using DotNetNuke.Common;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Modules.Actions;
 using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Framework;
 using DotNetNuke.Framework.JavaScriptLibraries;
 using DotNetNuke.Security;
@@ -187,7 +188,9 @@ namespace DotNetNuke.Admin.Containers
                             }
                         }
                     }
-                    IsShared = PortalGroupController.Instance.IsModuleShared(ModuleContext.ModuleId, PortalController.Instance.GetPortal(PortalSettings.PortalId));
+                    IsShared = ModuleContext.Configuration.AllTabs
+                        || PortalGroupController.Instance.IsModuleShared(ModuleContext.ModuleId, PortalController.Instance.GetPortal(PortalSettings.PortalId))
+                        || TabController.Instance.GetTabsByModuleID(ModuleContext.ModuleId).Count > 1;
                 }
             }
             catch (Exception exc) //Module failed to load

--- a/Website/admin/Menus/ModuleActions/ModuleActions.css
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.css
@@ -176,18 +176,13 @@ div.actionMenu ul.dnn_mact > li.actionQuickSettings div.qsFooter a.secondarybtn 
 }
 div.actionMenu ul.dnn_mact li.dnn_shared {
   display: inline-block;
-  width: 20px;
-  height: 100px;
-  background-color: #ffffff;
 }
 div.actionMenu ul.dnn_mact li.dnn_shared > div {
   display: inline-block;
-  width: 20px;
-  height: 20px;
-  writing-mode: tb-rl;
-  -webkit-transform: rotate(90deg);
-  -moz-transform: rotate(90deg);
-  -o-transform: rotate(90deg);
+  padding: 0.5em 0;
+  -webkit-writing-mode: vertical-rl;
+  -ms-writing-mode: tb-rl;
+  writing-mode: vertical-rl;
   white-space: nowrap;
   color: white;
   background-color: #000;

--- a/Website/admin/Menus/ModuleActions/ModuleActions.js
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.js
@@ -384,7 +384,7 @@
                 }
 
                 if (isShared) {
-                    buildSharedMenu(menuRoot, "Shared Module", "dnn_shared");
+                    buildSharedMenu(menuRoot, opts.sharedText, "dnn_shared");
                 }
                 watchResize(moduleId);
             }


### PR DESCRIPTION
This is an alternative implementation of #1256.

[DNN-8355](https://dnntracker.atlassian.net/browse/DNN-8355)

> Like with the "Shared Module" indicator in module actions for cross-site sharing withing a portal group, site administrators need to know if the module they're going to edit is shared by other pages on the same site.
> ### Steps to Reproduce
> 1. Add a module to a page
> 2. Create a new page
> 3. Select _Add Existing Module_ from the _Modules_ menu
> 4. Choose the page from step 1
> 5. Ensure _Make a Copy_ is unchecked
> 6. Choose the module from step 1 and add it to a pane
> ### Expected Results
> - There is an indication that the module is shared with the other page
> ### Actual Results
> - There is no indication
