### PR TITLE
DNN-8348 Fixed the issue by removing MVC cache and using own cache key

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Framework\ActionResults\IDnnViewResult.cs" />
     <Compile Include="Framework\Controllers\DnnController.cs" />
     <Compile Include="Framework\Controllers\IDnnController.cs" />
+    <Compile Include="Framework\ViewEngineCollectionExt.cs" />
     <Compile Include="Framework\DnnWebViewPage.cs" />
     <Compile Include="Framework\DnnWebViewPageOfT.cs" />
     <Compile Include="Framework\ModuleDelegatingViewEngine.cs" />

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ModuleDelegatingViewEngine.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ModuleDelegatingViewEngine.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Web.Mvc.Framework
         /// <param name="controllerContext">The controller context.</param><param name="partialViewName">The name of the partial view.</param><param name="useCache">true to specify that the view engine returns the cached view, if a cached view exists; otherwise, false.</param>
         public ViewEngineResult FindPartialView(ControllerContext controllerContext, string partialViewName, bool useCache)
         {
-            return RunAgainstModuleViewEngines(controllerContext, e => e.FindPartialView(controllerContext, partialViewName));
+            return RunAgainstModuleViewEngines(controllerContext, e => e.FindPartialView(controllerContext, partialViewName, useCache));
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace DotNetNuke.Web.Mvc.Framework
         /// <param name="controllerContext">The controller context.</param><param name="viewName">The name of the view.</param><param name="masterName">The name of the master.</param><param name="useCache">true to specify that the view engine returns the cached view, if a cached view exists; otherwise, false.</param>
         public ViewEngineResult FindView(ControllerContext controllerContext, string viewName, string masterName, bool useCache)
         {
-            return RunAgainstModuleViewEngines(controllerContext, e => e.FindView(controllerContext, viewName, masterName));
+            return RunAgainstModuleViewEngines(controllerContext, e => e.FindView(controllerContext, viewName, masterName, useCache));
         }
 
         /// <summary>

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ViewEngineCollectionExt.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ViewEngineCollectionExt.cs
@@ -23,10 +23,7 @@ namespace DotNetNuke.Web.Mvc.Framework
         {
             try
             {
-                var cacheKey = string.Format(CultureInfo.InvariantCulture, ":ViewCacheEntry:{0}:{1}:{2}:{3}:{4}:",
-                    ((string[]) controllerContext.RouteData.DataTokens["namespaces"]).FirstOrDefault()
-                    , "View", viewName, controllerContext.RouteData.Values["controller"], masterName);
-
+                var cacheKey = CreateCacheKey(controllerContext, "View", viewName, masterName);
                 var cachArg = new CacheItemArgs(cacheKey, 120, CacheItemPriority.Default,
                     "Find", viewEngineCollection,
                     new object[]
@@ -50,10 +47,7 @@ namespace DotNetNuke.Web.Mvc.Framework
         {
             try
             {
-                var cacheKey = string.Format(CultureInfo.InvariantCulture, ":ViewCacheEntry:{0}:{1}:{2}:{3}:{4}:",
-                    ((string[]) controllerContext.RouteData.DataTokens["namespaces"]).FirstOrDefault()
-                    , "Partial", partialViewName, controllerContext.RouteData.Values["controller"], "");
-
+                var cacheKey = CreateCacheKey(controllerContext, "Partial", partialViewName, string.Empty);
                 var cachArg = new CacheItemArgs(cacheKey, 120, CacheItemPriority.Default,
                     "Find", viewEngineCollection,
                     new object[]
@@ -81,6 +75,12 @@ namespace DotNetNuke.Web.Mvc.Framework
                 factoryType.InvokeMember(name,
                     BindingFlags.Instance | BindingFlags.InvokeMethod | BindingFlags.NonPublic, null, target, parameters)
                     as ViewEngineResult;
+        }
+
+        private static string CreateCacheKey(ControllerContext controllerContext, string section, string name, string areaName)
+        {
+            return string.Format(CultureInfo.InvariantCulture, ":ViewCacheEntry:{0}:{1}:{2}:{3}:{4}:",
+                ((string[])controllerContext.RouteData.DataTokens["namespaces"]).FirstOrDefault(), section, name, controllerContext.RouteData.Values["controller"], areaName);
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ViewEngineCollectionExt.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ViewEngineCollectionExt.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using DotNetNuke.Framework;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Caching;
+using System.Web.Mvc;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Web.Mvc.Framework.Controllers;
+
+namespace DotNetNuke.Web.Mvc.Framework
+{
+    public static class ViewEngineCollectionExt
+    {
+        //Enable the call to ViewEngineCollection FindView method with useCache=false
+        public static ViewEngineResult FindView(this ViewEngineCollection viewEngineCollection,
+            ControllerContext controllerContext,
+            string viewName, string masterName, bool useCache)
+        {
+            try
+            {
+                var cacheKey = string.Format(CultureInfo.InvariantCulture, ":ViewCacheEntry:{0}:{1}:{2}:{3}:{4}:",
+                    ((string[]) controllerContext.RouteData.DataTokens["namespaces"]).FirstOrDefault()
+                    , "View", viewName, controllerContext.RouteData.Values["controller"], masterName);
+
+                var cachArg = new CacheItemArgs(cacheKey, 120, CacheItemPriority.Default,
+                    "Find", viewEngineCollection,
+                    new object[]
+                    {
+                        new Func<IViewEngine, ViewEngineResult>(
+                            e => e.FindView(controllerContext, viewName, masterName, false)),
+                        false
+                    });
+
+                return useCache ? CBO.GetCachedObject<ViewEngineResult>(cachArg, CallFind) : CallFind(cachArg);
+            }
+            catch (Exception ex)
+            {
+                return viewEngineCollection.FindView(controllerContext, viewName, masterName);
+            }
+        }
+
+        //Enable the call to ViewEngineCollection FindPartialView method with useCache=false
+        public static ViewEngineResult FindPartialView(this ViewEngineCollection viewEngineCollection,
+            ControllerContext controllerContext, string partialViewName, bool useCache)
+        {
+            try
+            {
+                var cacheKey = string.Format(CultureInfo.InvariantCulture, ":ViewCacheEntry:{0}:{1}:{2}:{3}:{4}:",
+                    ((string[]) controllerContext.RouteData.DataTokens["namespaces"]).FirstOrDefault()
+                    , "Partial", partialViewName, controllerContext.RouteData.Values["controller"], "");
+
+                var cachArg = new CacheItemArgs(cacheKey, 120, CacheItemPriority.Default,
+                    "Find", viewEngineCollection,
+                    new object[]
+                    {
+                        new Func<IViewEngine, ViewEngineResult>(
+                            e => e.FindPartialView(controllerContext, partialViewName, false)),
+                        false
+                    });
+
+                return useCache ? CBO.GetCachedObject<ViewEngineResult>(cachArg, CallFind) : CallFind(cachArg);
+            }
+            catch (Exception ex)
+            {
+                return viewEngineCollection.FindPartialView(controllerContext, partialViewName);
+            }
+        }
+
+        private static ViewEngineResult CallFind(CacheItemArgs cacheItem)
+        {
+            var factoryType = Reflection.CreateType("System.Web.Mvc.ViewEngineCollection");
+            var name = cacheItem.Params[0] as string;
+            var target = cacheItem.Params[1];
+            var parameters = cacheItem.Params[2] as object[];
+            return
+                factoryType.InvokeMember(name,
+                    BindingFlags.Instance | BindingFlags.InvokeMethod | BindingFlags.NonPublic, null, target, parameters)
+                    as ViewEngineResult;
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcHostControl.cs
@@ -181,18 +181,7 @@ namespace DotNetNuke.Web.Mvc
                 ModuleActions = LoadActions(_result);
 
                 httpContext.SetModuleRequestResult(_result);
-            }
-            catch (Exception exc)
-            {
-                Exceptions.ProcessModuleLoadException(this, exc);
-            }
 
-        }
-
-        protected override void OnLoad(EventArgs e)
-        {
-            try
-            {
                 if (_result != null)
                 {
                     Controls.Add(new LiteralControl(RenderModule(_result).ToString()));
@@ -202,8 +191,6 @@ namespace DotNetNuke.Web.Mvc
             {
                 Exceptions.ProcessModuleLoadException(this, exc);
             }
-
-            base.OnLoad(e);
         }
 
         private MvcHtmlString RenderModule(ModuleRequestResult moduleResult)


### PR DESCRIPTION
The issue was happening due to MVC cache key. Since MVC is designed to work on single site architecture and does not expect multiple modules and views folders.
The cache key has been modified to include the namespace in it so that each module is treated differently.
Also the call render module has been moved from onload to oninit because in onload case the if the page has different modules and then the view locations are overwritten to the last module at the time of onload. So all the other modules are not found and throws exception