### PR TITLE
Allow locking site/instance DNN-8374

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
@@ -29,6 +29,7 @@ using System.Net.Http;
 using System.Web.Http;
 using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Controllers;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Modules.Definitions;
@@ -47,15 +48,13 @@ using DotNetNuke.Web.Client.ClientResourceManagement;
 
 namespace DotNetNuke.Web.InternalServices
 {
-    using DotNetNuke.Entities.Controllers;
-
     [DnnAuthorize]
     public class ControlBarController : DnnApiController
     {
-    	private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (ControlBarController));
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ControlBarController));
         private const string DefaultExtensionImage = "icon_extensions_32px.png";
         private readonly Components.Controllers.IControlBarController Controller;
-		private IDictionary<string, string> _nameDics;
+        private IDictionary<string, string> _nameDics;
 
         public ControlBarController()
         {
@@ -151,7 +150,7 @@ namespace DotNetNuke.Web.InternalServices
             }).ToList();
             return Request.CreateResponse(HttpStatusCode.OK, result);
         }
-        
+
         [HttpGet]
         [DnnPageEditor]
         public HttpResponseMessage GetPageList(string portal)
@@ -168,12 +167,12 @@ namespace DotNetNuke.Web.InternalServices
                 var groups = PortalGroupController.Instance.GetPortalGroups().ToArray();
 
                 var mygroup = (from @group in groups
-                              select PortalGroupController.Instance.GetPortalsByGroup(@group.PortalGroupId)
+                               select PortalGroupController.Instance.GetPortalsByGroup(@group.PortalGroupId)
                                   into portals
-                                  where portals.Any(x => x.PortalID == PortalSettings.Current.PortalId)
-                                  select portals.ToArray()).FirstOrDefault();
+                               where portals.Any(x => x.PortalID == PortalSettings.Current.PortalId)
+                               select portals.ToArray()).FirstOrDefault();
 
-                if(mygroup != null && mygroup.Any(p=>p.PortalID == portalSettings.PortalId))
+                if (mygroup != null && mygroup.Any(p => p.PortalID == portalSettings.PortalId))
                 {
                     tabList = TabController.GetPortalTabs(portalSettings.PortalId, Null.NullInteger, false, string.Empty, true, false, false, false, false);
                 }
@@ -210,15 +209,16 @@ namespace DotNetNuke.Web.InternalServices
                     var pageModules = GetModules(tabID);
 
                     Dictionary<int, string> resultDict = pageModules.ToDictionary(module => module.ModuleID, module => module.ModuleTitle);
-                    result.AddRange(from kvp in resultDict let imageUrl = GetTabModuleImage(tabID, kvp.Key) 
-                                    select new ModuleDefDTO {ModuleID = kvp.Key, ModuleName = kvp.Value, ModuleImage = imageUrl}
+                    result.AddRange(from kvp in resultDict
+                                    let imageUrl = GetTabModuleImage(tabID, kvp.Key)
+                                    select new ModuleDefDTO { ModuleID = kvp.Key, ModuleName = kvp.Value, ModuleImage = imageUrl }
                                     );
                 }
                 return Request.CreateResponse(HttpStatusCode.OK, result);
             }
 
             return Request.CreateResponse(HttpStatusCode.InternalServerError);
-        } 
+        }
 
         private IList<ModuleInfo> GetModules(int tabID)
         {
@@ -592,7 +592,7 @@ namespace DotNetNuke.Web.InternalServices
                                where tabMods.Value.ModuleID == moduleId
                                select pkgs.IconFile).FirstOrDefault();
 
-            imageUrl = String.IsNullOrEmpty(imageUrl) ? Globals.ImagePath + DefaultExtensionImage : imageUrl; 
+            imageUrl = String.IsNullOrEmpty(imageUrl) ? Globals.ImagePath + DefaultExtensionImage : imageUrl;
             return System.Web.VirtualPathUtility.ToAbsolute(imageUrl);
         }
 
@@ -771,12 +771,12 @@ namespace DotNetNuke.Web.InternalServices
 
             items.Sort();
 
-            if(items.Count > sort)
+            if (items.Count > sort)
             {
                 var itemOrder = items[sort];
                 return itemOrder - 1;
             }
-            else if(items.Count > 0)
+            else if (items.Count > 0)
             {
                 return items.Last() + 1;
             }
@@ -799,7 +799,7 @@ namespace DotNetNuke.Web.InternalServices
                 Exceptions.LogException(ex);
             }
 
-	        var tabModuleId = Null.NullInteger;
+            var tabModuleId = Null.NullInteger;
             foreach (ModuleDefinitionInfo objModuleDefinition in
                 ModuleDefinitionController.GetModuleDefinitionsByDesktopModuleID(desktopModuleId).Values)
             {
@@ -843,27 +843,27 @@ namespace DotNetNuke.Web.InternalServices
 
                 ModuleController.Instance.AddModule(objModule);
 
-				if (tabModuleId == Null.NullInteger)
-				{
-					tabModuleId = objModule.ModuleID;
-				}
-				//update the position to let later modules with add after previous one.
+                if (tabModuleId == Null.NullInteger)
+                {
+                    tabModuleId = objModule.ModuleID;
+                }
+                //update the position to let later modules with add after previous one.
                 position = ModuleController.Instance.GetTabModule(objModule.TabModuleID).ModuleOrder + 1;
             }
 
-			return tabModuleId;
+            return tabModuleId;
         }
 
-		private string GetModuleName(string moduleName)
-		{
-			 if (_nameDics == null)
-			 {
-				 _nameDics = new Dictionary<string, string> {{"SearchCrawlerAdmin", "SearchCrawler Admin"}, 
-															 {"SearchCrawlerInput", "SearchCrawler Input"}, 
-															 {"SearchCrawlerResults", "SearchCrawler Results"}};
-			 }
+        private string GetModuleName(string moduleName)
+        {
+            if (_nameDics == null)
+            {
+                _nameDics = new Dictionary<string, string> {{"SearchCrawlerAdmin", "SearchCrawler Admin"},
+                                                             {"SearchCrawlerInput", "SearchCrawler Input"},
+                                                             {"SearchCrawlerResults", "SearchCrawler Results"}};
+            }
 
-			return _nameDics.ContainsKey(moduleName) ? _nameDics[moduleName] : moduleName;
-		}
+            return _nameDics.ContainsKey(moduleName) ? _nameDics[moduleName] : moduleName;
+        }
     }
 }

--- a/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
@@ -487,7 +487,7 @@ namespace DotNetNuke.Web.InternalServices
         [RequireHost]
         public HttpResponseMessage LockInstance(LockingDTO lockingRequest)
         {
-            HostController.Instance.Update("IsLocked", lockingRequest.Lock.ToString(), false);
+            HostController.Instance.Update("IsLocked", lockingRequest.Lock.ToString(), true);
             HostController.Instance.Update("LockedByUserId", this.UserInfo.UserID.ToString(CultureInfo.InvariantCulture), true);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
@@ -497,7 +497,7 @@ namespace DotNetNuke.Web.InternalServices
         [RequireHost]
         public HttpResponseMessage LockSite(LockingDTO lockingRequest)
         {
-            PortalController.UpdatePortalSetting(PortalSettings.PortalId, "IsLocked", lockingRequest.Lock.ToString(), false);
+            PortalController.UpdatePortalSetting(PortalSettings.PortalId, "IsLocked", lockingRequest.Lock.ToString(), true);
             PortalController.UpdatePortalSetting(PortalSettings.PortalId, "LockedByUserId", this.UserInfo.UserID.ToString(CultureInfo.InvariantCulture), true);
             return Request.CreateResponse(HttpStatusCode.OK);
         }

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -1658,6 +1658,22 @@ namespace DotNetNuke.Entities.Host
 			}
 		}
 
+        /// <summary>
+        /// Get the IsLocked value, used to put the entire instance into maintenance mode
+        /// </summary>
+        public static bool IsLocked
+        {
+            get { return HostController.Instance.GetBoolean("IsLocked", false); }
+        }
+
+        public int LockedByUserId
+        {
+            get
+            {
+                return HostController.Instance.GetInteger("LockedByUserId", Null.NullInteger);
+            }
+        }
+
         #endregion
 
         #region Obsolete Members

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -1659,19 +1659,19 @@ namespace DotNetNuke.Entities.Host
 		}
 
         /// <summary>
-        /// Get the IsLocked value, used to put the entire instance into maintenance mode
+        /// Get a value indicating whether to put the entire instance into maintenance mode
         /// </summary>
         public static bool IsLocked
         {
             get { return HostController.Instance.GetBoolean("IsLocked", false); }
         }
 
-        public int LockedByUserId
+        /// <summary>
+        /// Get the ID of the user that locked the entire instance
+        /// </summary>
+        public static int LockedByUserId
         {
-            get
-            {
-                return HostController.Instance.GetInteger("LockedByUserId", Null.NullInteger);
-            }
+            get { return HostController.Instance.GetInteger("LockedByUserId", Null.NullInteger); }
         }
 
         #endregion

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -28,9 +28,9 @@ using System.Globalization;
 using System.Linq;
 using System.Web;
 using DotNetNuke.Common.Utilities;
-using DotNetNuke.Security;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Entities.Users;
+using DotNetNuke.Security;
 using DotNetNuke.Services.Personalization;
 using DotNetNuke.Services.Tokens;
 
@@ -48,35 +48,35 @@ namespace DotNetNuke.Entities.Portals
 	[Serializable]
 	public partial class PortalSettings : BaseEntityInfo, IPropertyAccess
 	{
-        #region ControlPanelPermission enum
+		#region ControlPanelPermission enum
 
-        public enum ControlPanelPermission
-        {
-            TabEditor,
-            ModuleEditor
-        }
+		public enum ControlPanelPermission
+		{
+			TabEditor,
+			ModuleEditor
+		}
 
-        #endregion
+		#endregion
 
-        #region Mode enum
+		#region Mode enum
 
-        public enum Mode
-        {
-            View,
-            Edit,
-            Layout
-        }
+		public enum Mode
+		{
+			View,
+			Edit,
+			Layout
+		}
 
-        #endregion
+		#endregion
 
-        #region PortalAliasMapping enum
+		#region PortalAliasMapping enum
 
-        public enum PortalAliasMapping
-        {
-            None,
-            CanonicalUrl,
-            Redirect
-        }
+		public enum PortalAliasMapping
+		{
+			None,
+			CanonicalUrl,
+			Redirect
+		}
 
 		#endregion
 
@@ -94,6 +94,13 @@ namespace DotNetNuke.Entities.Portals
 		{
 		}
 
+		public PortalSettings(int tabId, int portalId)
+		{
+		    PortalId = portalId;
+            var portal = PortalController.Instance.GetPortal(portalId);
+            BuildPortalSettings(tabId, portal);
+        }
+
 		/// -----------------------------------------------------------------------------
 		/// <summary>
 		/// The PortalSettings Constructor encapsulates all of the logic
@@ -110,13 +117,6 @@ namespace DotNetNuke.Entities.Portals
 		    PortalId = portalAliasInfo.PortalID;
 			PortalAlias = portalAliasInfo;
 			var portal = PortalController.Instance.GetPortal(portalAliasInfo.PortalID);
-            BuildPortalSettings(tabId, portal);
-        }
-
-		public PortalSettings(int tabId, int portalId)
-		{
-		    PortalId = portalId;
-            var portal = PortalController.Instance.GetPortal(portalId);
             BuildPortalSettings(tabId, portal);
         }
 
@@ -160,50 +160,87 @@ namespace DotNetNuke.Entities.Portals
         #region Auto-Properties
 
         public TabInfo ActiveTab { get; set; }
-        public int AdministratorId { get; set; }
-        public int AdministratorRoleId { get; set; }
-        public string AdministratorRoleName { get; set; }
-        public int AdminTabId { get; set; }
-        public string BackgroundFile { get; set; }
-        public int BannerAdvertising { get; set; }
-        public string CultureCode { get; set; }
-        public string Currency { get; set; }
-        public string DefaultLanguage { get; set; }
-        public string Description { get; set; }
-        public string Email { get; set; }
+
+		public int AdministratorId { get; set; }
+
+		public int AdministratorRoleId { get; set; }
+
+		public string AdministratorRoleName { get; set; }
+
+		public int AdminTabId { get; set; }
+
+		public string BackgroundFile { get; set; }
+
+		public int BannerAdvertising { get; set; }
+
+		public string CultureCode { get; set; }
+
+		public string Currency { get; set; }
+
+		public string DefaultLanguage { get; set; }
+
+		public string Description { get; set; }
+
+		public string Email { get; set; }
+
         public DateTime ExpiryDate { get; set; }
-        public string FooterText { get; set; }
-        public Guid GUID { get; set; }
-        public string HomeDirectory { get; set; }
-        
-        public string HomeSystemDirectory { get; set; }
-        public int HomeTabId { get; set; }
-        public float HostFee { get; set; }
-        public int HostSpace { get; set; }
-        public string KeyWords { get; set; }
-        public int LoginTabId { get; set; }
-        public string LogoFile { get; set; }
-        public int PageQuota { get; set; }
-        public int Pages { get; set; }
-        public int PortalId { get; set; }
-        public PortalAliasInfo PortalAlias { get; set; }
-        public PortalAliasInfo PrimaryAlias { get; set; }
-        public string PortalName { get; set; }
-        public int RegisteredRoleId { get; set; }
-        public string RegisteredRoleName { get; set; }
-        public int RegisterTabId { get; set; }
+
+		public string FooterText { get; set; }
+
+		public Guid GUID { get; set; }
+
+		public string HomeDirectory { get; set; }
+
+		public string HomeSystemDirectory { get; set; }
+
+		public int HomeTabId { get; set; }
+
+		public float HostFee { get; set; }
+
+		public int HostSpace { get; set; }
+
+		public string KeyWords { get; set; }
+
+		public int LoginTabId { get; set; }
+
+		public string LogoFile { get; set; }
+
+		public int PageQuota { get; set; }
+
+		public int Pages { get; set; }
+
+		public int PortalId { get; set; }
+
+		public PortalAliasInfo PortalAlias { get; set; }
+
+		public PortalAliasInfo PrimaryAlias { get; set; }
+
+		public string PortalName { get; set; }
+
+		public int RegisteredRoleId { get; set; }
+
+		public string RegisteredRoleName { get; set; }
+
+		public int RegisterTabId { get; set; }
 
         public RegistrationSettings Registration { get; set; }
+
         public int SearchTabId { get; set; }
 
         [Obsolete("Deprecated in 8.0.0")]
         public int SiteLogHistory { get; set; }
-        public int SplashTabId { get; set; }
-        public int SuperTabId { get; set; }
-        public int UserQuota { get; set; }
-        public int UserRegistration { get; set; }
-        public int Users { get; set; }
-        public int UserTabId { get; set; }
+
+		public int SplashTabId { get; set; }
+
+		public int SuperTabId { get; set; }
+
+		public int UserQuota { get; set; }
+
+		public int UserRegistration { get; set; }
+
+		public int Users { get; set; }
+
+		public int UserTabId { get; set; }
 
 		#endregion
 
@@ -227,9 +264,9 @@ namespace DotNetNuke.Entities.Portals
 
         public string DefaultAdminContainer { get; internal set; }
 
-        public string DefaultAuthProvider { get; internal set; }
-
         public string DefaultAdminSkin { get; internal set; }
+
+        public string DefaultAuthProvider { get; internal set; }
 
         public Mode DefaultControlPanelMode { get; internal set; }
 
@@ -276,6 +313,19 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in Platform 7.4.0.")]
         public bool EnableModuleEffect { get; internal set; }
 
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// Gets whether to use the popup.
+        /// </summary>
+        /// <remarks>Defaults to True</remarks>
+        /// -----------------------------------------------------------------------------
+        public bool EnablePopUps { get; internal set; }
+
+        /// <summary>
+        /// Website Administrator whether receive the notification email when new user register.
+        /// </summary>
+        public bool EnableRegisterNotification { get; internal set; }
+
 		/// -----------------------------------------------------------------------------
 		/// <summary>
 		/// Gets whether the Skin Widgets are enabled/supported
@@ -292,6 +342,10 @@ namespace DotNetNuke.Entities.Portals
 		/// -----------------------------------------------------------------------------
         public bool EnableUrlLanguage { get; internal set; }
 
+        public int ErrorPage404 { get; internal set; }
+
+        public int ErrorPage500 { get; internal set; }
+
         /// -----------------------------------------------------------------------------
 		/// <summary>
 		///   Gets whether folders which are hidden or whose name begins with underscore
@@ -303,26 +357,17 @@ namespace DotNetNuke.Entities.Portals
 		/// -----------------------------------------------------------------------------
         public bool HideFoldersEnabled { get; internal set; }
 
-        /// <summary>
-        /// Website Administrator whether receive the notification email when new user register.
-        /// </summary>
-        public bool EnableRegisterNotification { get; internal set; }
-
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Gets whether to use the popup.
+        /// Gets whether hide the login link.
         /// </summary>
-        /// <remarks>Defaults to True</remarks>
+        /// <remarks>Defaults to False.</remarks>
         /// -----------------------------------------------------------------------------
-        public bool EnablePopUps { get; internal set; }
+        public bool HideLoginControl { get; internal set; }
 
         public string HomeDirectoryMapPath { get; internal set; }
 
-        public int ErrorPage404 { get; internal set; }
-
         public string HomeSystemDirectoryMapPath { get; internal set; }
-
-        public int ErrorPage500 { get; internal set; }
 
         /// -----------------------------------------------------------------------------
 		/// <summary>
@@ -331,14 +376,6 @@ namespace DotNetNuke.Entities.Portals
 		/// <remarks>Defaults to True</remarks>
 		/// -----------------------------------------------------------------------------
         public bool InlineEditorEnabled { get; internal set; }
-
-        /// -----------------------------------------------------------------------------
-        /// <summary>
-        /// Gets whether hide the login link.
-        /// </summary>
-        /// <remarks>Defaults to False.</remarks>
-        /// -----------------------------------------------------------------------------
-        public bool HideLoginControl { get; internal set; }
 
 		/// -----------------------------------------------------------------------------
 		/// <summary>
@@ -390,6 +427,10 @@ namespace DotNetNuke.Entities.Portals
 
         public string STDURL { get; internal set; }
 
+        public int SMTPConnectionLimit { get; internal set; }
+
+        public int SMTPMaxIdleTime { get; internal set; }
+
 		#endregion
 
 		#region Public Properties
@@ -402,14 +443,42 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
-        public bool ControlPanelVisible
-        {
-            get
-            {
-                var setting = Convert.ToString(Personalization.GetProfile("Usability", "ControlPanelVisible" + PortalId));
-                return String.IsNullOrEmpty(setting) ? DefaultControlPanelVisibility : Convert.ToBoolean(setting);
-            }
-        }
+		public bool ControlPanelVisible
+		{
+			get
+			{
+				var setting = Convert.ToString(Personalization.GetProfile("Usability", "ControlPanelVisible" + PortalId));
+				return String.IsNullOrEmpty(setting) ? DefaultControlPanelVisibility : Convert.ToBoolean(setting);
+			}
+		}
+
+		public static PortalSettings Current
+		{
+			get
+			{
+				return PortalController.Instance.GetCurrentPortalSettings();
+			}
+		}
+
+		public string DefaultPortalAlias
+		{
+			get
+			{
+				foreach (var alias in PortalAliasController.Instance.GetPortalAliasesByPortalId(PortalId).Where(alias => alias.IsPrimary))
+				{
+					return alias.HTTPAlias;
+				}
+				return String.Empty;
+			}
+		}
+
+		public PortalAliasMapping PortalAliasMappingMode
+		{
+			get
+			{
+                return PortalSettingsController.Instance().GetPortalAliasMappingMode(PortalId);
+			}
+		}
 
         /// <summary>Gets the currently logged in user identifier.</summary>
         /// <value>The user identifier.</value>
@@ -425,18 +494,6 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
-        public int SMTPConnectionLimit { get; internal set; }
-
-        public int SMTPMaxIdleTime { get; internal set; }
-
-        public static PortalSettings Current
-        {
-            get
-            {
-                return PortalController.Instance.GetCurrentPortalSettings();
-            }
-        }
-
         /// <summary>Gets the currently logged in user.</summary>
         /// <value>The current user information.</value>
 		public UserInfo UserInfo
@@ -447,90 +504,143 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
-		public PortalAliasMapping PortalAliasMappingMode
+		public Mode UserMode
 		{
 			get
 			{
-                return PortalSettingsController.Instance().GetPortalAliasMappingMode(PortalId);
+				Mode mode;
+				if (HttpContext.Current != null && HttpContext.Current.Request.IsAuthenticated)
+				{
+					mode = DefaultControlPanelMode;
+					string setting = Convert.ToString(Personalization.GetProfile("Usability", "UserMode" + PortalId));
+					switch (setting.ToUpper())
+					{
+						case "VIEW":
+							mode = Mode.View;
+							break;
+						case "EDIT":
+							mode = Mode.Edit;
+							break;
+						case "LAYOUT":
+							mode = Mode.Layout;
+							break;
+					}
+				}
+				else
+				{
+					mode = Mode.View;
+				}
+				return mode;
 			}
 		}
 
-        public string DefaultPortalAlias
-        {
-            get
-            {
-                foreach (var alias in PortalAliasController.Instance.GetPortalAliasesByPortalId(PortalId).Where(alias => alias.IsPrimary))
-                {
-                    return alias.HTTPAlias;
-                }
-                return String.Empty;
-            }
-        }
-
-        public Mode UserMode
-        {
-            get
-            {
-                Mode mode;
-				if (HttpContext.Current != null && HttpContext.Current.Request.IsAuthenticated)
-                {
-                    mode = DefaultControlPanelMode;
-                    string setting = Convert.ToString(Personalization.GetProfile("Usability", "UserMode" + PortalId));
-                    switch (setting.ToUpper())
-                    {
-                        case "VIEW":
-                            mode = Mode.View;
-                            break;
-                        case "EDIT":
-                            mode = Mode.Edit;
-                            break;
-                        case "LAYOUT":
-                            mode = Mode.Layout;
-                            break;
-                    }
-                }
-                else
-                {
-                    mode = Mode.View;
-                }
-                return mode;
-            }
-        }
-
         /// <summary>
-        /// Get the IsLocked value, used to put the current portal into maintenance mode. This is a flag which can be used to disable any actions which update the database.
+        /// Get a value indicating whether the current portal is in maintenance mode (if either this specific portal or the entire instance is locked). If locked, any actions which update the database should be disabled.
         /// </summary>
         public bool IsLocked
         {
-            get
-            {
-                return this.IsThisPortalLocked || Host.Host.IsLocked;
-            }
+            get { return IsThisPortalLocked || Host.Host.IsLocked; }
         }
 
+        /// <summary>
+        /// Get a value indicating whether the current portal is in maintenance mode (note, the entire instance may still be locked, this only indicates whether this portal is specifically locked). If locked, any actions which update the database should be disabled.
+        /// </summary>
         public bool IsThisPortalLocked
         {
-            get
-            {
-                return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false);
-            }
+            get { return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false); }
         }
 
+        /// <summary>
+        /// Get the ID of the user who locked this portal
+        /// </summary>
         public int LockedByUserId
         {
-            get
-            {
-                return PortalController.GetPortalSettingAsInteger("LockedByUserId", PortalId, Null.NullInteger);
-            }
+            get { return PortalController.GetPortalSettingAsInteger("LockedByUserId", PortalId, Null.NullInteger); }
         }
 
-		public TimeZoneInfo TimeZone
+        public TimeZoneInfo TimeZone
 		{
 			get { return _timeZone; }
 			set
 			{
 				_timeZone = value;
 				PortalController.UpdatePortalSetting(PortalId, "TimeZone", value.Id, true);
+			}
+		}
+
+
+        public string PageHeadText 
+        {
+            get
+            {
+                // For New Install
+                string pageHead = "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"Content-Type\" />";
+                string setting;
+                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("PageHeadText", out setting))
+                {
+                    // Hack to store empty string portalsetting with non empty default value
+                    pageHead = (setting == "false") ? "" : setting;
+                }
+                return pageHead;
+            }
+        }
+
+        /*
+         * add <a name="[moduleid]"></a> on the top of the module
+         * 
+         * Desactivate this remove the html5 compatibility warnings
+         * (and make the output smaller)
+         * 
+         */
+        public bool InjectModuleHyperLink
+        {
+            get
+            {
+                return PortalController.GetPortalSettingAsBoolean("InjectModuleHyperLink", PortalId, true);
+            }
+        }
+        /*
+         * generates a : Page.Response.AddHeader("X-UA-Compatible", "");
+         * 
+         
+         */
+        public string AddCompatibleHttpHeader
+        {
+            get
+            {
+                string CompatibleHttpHeader = "IE=edge";
+                string setting;
+                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("AddCompatibleHttpHeader", out setting))
+                {
+                    // Hack to store empty string portalsetting with non empty default value
+                    CompatibleHttpHeader = (setting == "false") ? "" : setting;
+                }
+                return CompatibleHttpHeader;
+            }
+        }
+
+        /*
+         * add a cachebuster parameter to generated file URI's
+         * 
+         * of the form ver=[file timestame] ie ver=2015-02-17-162255-735
+         * 
+         */
+        public bool AddCachebusterToResourceUris
+        {
+            get
+            {
+                return PortalController.GetPortalSettingAsBoolean("AddCachebusterToResourceUris", PortalId, true);
+            }
+        }
+
+		/// <summary>
+		/// If this is true, then regular users can't send message to specific user/group.
+		/// </summary>
+		public bool DisablePrivateMessage
+		{
+			get
+			{
+				return PortalController.GetPortalSetting("DisablePrivateMessage", PortalId, "N") == "Y";
 			}
 		}
 
@@ -730,82 +840,6 @@ namespace DotNetNuke.Entities.Portals
 				result = PropertyAccess.ContentLocked;
 			}
 			return result;
-		}
-
-
-        public string PageHeadText 
-        {
-            get
-            {
-                // For New Install
-                string pageHead = "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"Content-Type\" />";
-                string setting;
-                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("PageHeadText", out setting))
-                {
-                    // Hack to store empty string portalsetting with non empty default value
-                    pageHead = (setting == "false") ? "" : setting;
-                }
-                return pageHead;
-            }
-        }
-
-        /*
-         * add <a name="[moduleid]"></a> on the top of the module
-         * 
-         * Desactivate this remove the html5 compatibility warnings
-         * (and make the output smaller)
-         * 
-         */
-        public bool InjectModuleHyperLink
-        {
-            get
-            {
-                return PortalController.GetPortalSettingAsBoolean("InjectModuleHyperLink", PortalId, true);
-            }
-        }
-        /*
-         * generates a : Page.Response.AddHeader("X-UA-Compatible", "");
-         * 
-         
-         */
-        public string AddCompatibleHttpHeader
-        {
-            get
-            {
-                string CompatibleHttpHeader = "IE=edge";
-                string setting;
-                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("AddCompatibleHttpHeader", out setting))
-                {
-                    // Hack to store empty string portalsetting with non empty default value
-                    CompatibleHttpHeader = (setting == "false") ? "" : setting;
-                }
-                return CompatibleHttpHeader;
-            }
-        }
-
-        /*
-         * add a cachebuster parameter to generated file URI's
-         * 
-         * of the form ver=[file timestame] ie ver=2015-02-17-162255-735
-         * 
-         */
-        public bool AddCachebusterToResourceUris
-        {
-            get
-            {
-                return PortalController.GetPortalSettingAsBoolean("AddCachebusterToResourceUris", PortalId, true);
-            }
-        }
-
-		/// <summary>
-		/// If this is true, then regular users can't send message to specific user/group.
-		/// </summary>
-		public bool DisablePrivateMessage
-		{
-			get
-			{
-				return PortalController.GetPortalSetting("DisablePrivateMessage", PortalId, "N") == "Y";
-			}
 		}
 
         #endregion

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -530,6 +530,12 @@ namespace DotNetNuke.Entities.Portals
 				{
 					mode = Mode.View;
 				}
+
+				if (mode == Mode.Edit && this.IsLocked)
+				{
+					return Mode.View;
+				}
+
 				return mode;
 			}
 		}

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -28,9 +28,9 @@ using System.Globalization;
 using System.Linq;
 using System.Web;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Security;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Entities.Users;
-using DotNetNuke.Security;
 using DotNetNuke.Services.Personalization;
 using DotNetNuke.Services.Tokens;
 
@@ -48,35 +48,35 @@ namespace DotNetNuke.Entities.Portals
 	[Serializable]
 	public partial class PortalSettings : BaseEntityInfo, IPropertyAccess
 	{
-		#region ControlPanelPermission enum
+        #region ControlPanelPermission enum
 
-		public enum ControlPanelPermission
-		{
-			TabEditor,
-			ModuleEditor
-		}
+        public enum ControlPanelPermission
+        {
+            TabEditor,
+            ModuleEditor
+        }
 
-		#endregion
+        #endregion
 
-		#region Mode enum
+        #region Mode enum
 
-		public enum Mode
-		{
-			View,
-			Edit,
-			Layout
-		}
+        public enum Mode
+        {
+            View,
+            Edit,
+            Layout
+        }
 
-		#endregion
+        #endregion
 
-		#region PortalAliasMapping enum
+        #region PortalAliasMapping enum
 
-		public enum PortalAliasMapping
-		{
-			None,
-			CanonicalUrl,
-			Redirect
-		}
+        public enum PortalAliasMapping
+        {
+            None,
+            CanonicalUrl,
+            Redirect
+        }
 
 		#endregion
 
@@ -94,13 +94,6 @@ namespace DotNetNuke.Entities.Portals
 		{
 		}
 
-		public PortalSettings(int tabId, int portalId)
-		{
-		    PortalId = portalId;
-            var portal = PortalController.Instance.GetPortal(portalId);
-            BuildPortalSettings(tabId, portal);
-        }
-
 		/// -----------------------------------------------------------------------------
 		/// <summary>
 		/// The PortalSettings Constructor encapsulates all of the logic
@@ -117,6 +110,13 @@ namespace DotNetNuke.Entities.Portals
 		    PortalId = portalAliasInfo.PortalID;
 			PortalAlias = portalAliasInfo;
 			var portal = PortalController.Instance.GetPortal(portalAliasInfo.PortalID);
+            BuildPortalSettings(tabId, portal);
+        }
+
+		public PortalSettings(int tabId, int portalId)
+		{
+		    PortalId = portalId;
+            var portal = PortalController.Instance.GetPortal(portalId);
             BuildPortalSettings(tabId, portal);
         }
 
@@ -160,87 +160,50 @@ namespace DotNetNuke.Entities.Portals
         #region Auto-Properties
 
         public TabInfo ActiveTab { get; set; }
-
-		public int AdministratorId { get; set; }
-
-		public int AdministratorRoleId { get; set; }
-
-		public string AdministratorRoleName { get; set; }
-
-		public int AdminTabId { get; set; }
-
-		public string BackgroundFile { get; set; }
-
-		public int BannerAdvertising { get; set; }
-
-		public string CultureCode { get; set; }
-
-		public string Currency { get; set; }
-
-		public string DefaultLanguage { get; set; }
-
-		public string Description { get; set; }
-
-		public string Email { get; set; }
-
+        public int AdministratorId { get; set; }
+        public int AdministratorRoleId { get; set; }
+        public string AdministratorRoleName { get; set; }
+        public int AdminTabId { get; set; }
+        public string BackgroundFile { get; set; }
+        public int BannerAdvertising { get; set; }
+        public string CultureCode { get; set; }
+        public string Currency { get; set; }
+        public string DefaultLanguage { get; set; }
+        public string Description { get; set; }
+        public string Email { get; set; }
         public DateTime ExpiryDate { get; set; }
-
-		public string FooterText { get; set; }
-
-		public Guid GUID { get; set; }
-
-		public string HomeDirectory { get; set; }
-
-		public string HomeSystemDirectory { get; set; }
-
-		public int HomeTabId { get; set; }
-
-		public float HostFee { get; set; }
-
-		public int HostSpace { get; set; }
-
-		public string KeyWords { get; set; }
-
-		public int LoginTabId { get; set; }
-
-		public string LogoFile { get; set; }
-
-		public int PageQuota { get; set; }
-
-		public int Pages { get; set; }
-
-		public int PortalId { get; set; }
-
-		public PortalAliasInfo PortalAlias { get; set; }
-
-		public PortalAliasInfo PrimaryAlias { get; set; }
-
-		public string PortalName { get; set; }
-
-		public int RegisteredRoleId { get; set; }
-
-		public string RegisteredRoleName { get; set; }
-
-		public int RegisterTabId { get; set; }
+        public string FooterText { get; set; }
+        public Guid GUID { get; set; }
+        public string HomeDirectory { get; set; }
+        
+        public string HomeSystemDirectory { get; set; }
+        public int HomeTabId { get; set; }
+        public float HostFee { get; set; }
+        public int HostSpace { get; set; }
+        public string KeyWords { get; set; }
+        public int LoginTabId { get; set; }
+        public string LogoFile { get; set; }
+        public int PageQuota { get; set; }
+        public int Pages { get; set; }
+        public int PortalId { get; set; }
+        public PortalAliasInfo PortalAlias { get; set; }
+        public PortalAliasInfo PrimaryAlias { get; set; }
+        public string PortalName { get; set; }
+        public int RegisteredRoleId { get; set; }
+        public string RegisteredRoleName { get; set; }
+        public int RegisterTabId { get; set; }
 
         public RegistrationSettings Registration { get; set; }
-
         public int SearchTabId { get; set; }
 
         [Obsolete("Deprecated in 8.0.0")]
         public int SiteLogHistory { get; set; }
-
-		public int SplashTabId { get; set; }
-
-		public int SuperTabId { get; set; }
-
-		public int UserQuota { get; set; }
-
-		public int UserRegistration { get; set; }
-
-		public int Users { get; set; }
-
-		public int UserTabId { get; set; }
+        public int SplashTabId { get; set; }
+        public int SuperTabId { get; set; }
+        public int UserQuota { get; set; }
+        public int UserRegistration { get; set; }
+        public int Users { get; set; }
+        public int UserTabId { get; set; }
 
 		#endregion
 
@@ -264,9 +227,9 @@ namespace DotNetNuke.Entities.Portals
 
         public string DefaultAdminContainer { get; internal set; }
 
-        public string DefaultAdminSkin { get; internal set; }
-
         public string DefaultAuthProvider { get; internal set; }
+
+        public string DefaultAdminSkin { get; internal set; }
 
         public Mode DefaultControlPanelMode { get; internal set; }
 
@@ -313,19 +276,6 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in Platform 7.4.0.")]
         public bool EnableModuleEffect { get; internal set; }
 
-        /// -----------------------------------------------------------------------------
-        /// <summary>
-        /// Gets whether to use the popup.
-        /// </summary>
-        /// <remarks>Defaults to True</remarks>
-        /// -----------------------------------------------------------------------------
-        public bool EnablePopUps { get; internal set; }
-
-        /// <summary>
-        /// Website Administrator whether receive the notification email when new user register.
-        /// </summary>
-        public bool EnableRegisterNotification { get; internal set; }
-
 		/// -----------------------------------------------------------------------------
 		/// <summary>
 		/// Gets whether the Skin Widgets are enabled/supported
@@ -342,10 +292,6 @@ namespace DotNetNuke.Entities.Portals
 		/// -----------------------------------------------------------------------------
         public bool EnableUrlLanguage { get; internal set; }
 
-        public int ErrorPage404 { get; internal set; }
-
-        public int ErrorPage500 { get; internal set; }
-
         /// -----------------------------------------------------------------------------
 		/// <summary>
 		///   Gets whether folders which are hidden or whose name begins with underscore
@@ -357,17 +303,26 @@ namespace DotNetNuke.Entities.Portals
 		/// -----------------------------------------------------------------------------
         public bool HideFoldersEnabled { get; internal set; }
 
+        /// <summary>
+        /// Website Administrator whether receive the notification email when new user register.
+        /// </summary>
+        public bool EnableRegisterNotification { get; internal set; }
+
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Gets whether hide the login link.
+        /// Gets whether to use the popup.
         /// </summary>
-        /// <remarks>Defaults to False.</remarks>
+        /// <remarks>Defaults to True</remarks>
         /// -----------------------------------------------------------------------------
-        public bool HideLoginControl { get; internal set; }
+        public bool EnablePopUps { get; internal set; }
 
         public string HomeDirectoryMapPath { get; internal set; }
 
+        public int ErrorPage404 { get; internal set; }
+
         public string HomeSystemDirectoryMapPath { get; internal set; }
+
+        public int ErrorPage500 { get; internal set; }
 
         /// -----------------------------------------------------------------------------
 		/// <summary>
@@ -376,6 +331,14 @@ namespace DotNetNuke.Entities.Portals
 		/// <remarks>Defaults to True</remarks>
 		/// -----------------------------------------------------------------------------
         public bool InlineEditorEnabled { get; internal set; }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// Gets whether hide the login link.
+        /// </summary>
+        /// <remarks>Defaults to False.</remarks>
+        /// -----------------------------------------------------------------------------
+        public bool HideLoginControl { get; internal set; }
 
 		/// -----------------------------------------------------------------------------
 		/// <summary>
@@ -427,10 +390,6 @@ namespace DotNetNuke.Entities.Portals
 
         public string STDURL { get; internal set; }
 
-        public int SMTPConnectionLimit { get; internal set; }
-
-        public int SMTPMaxIdleTime { get; internal set; }
-
 		#endregion
 
 		#region Public Properties
@@ -443,42 +402,14 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
-		public bool ControlPanelVisible
-		{
-			get
-			{
-				var setting = Convert.ToString(Personalization.GetProfile("Usability", "ControlPanelVisible" + PortalId));
-				return String.IsNullOrEmpty(setting) ? DefaultControlPanelVisibility : Convert.ToBoolean(setting);
-			}
-		}
-
-		public static PortalSettings Current
-		{
-			get
-			{
-				return PortalController.Instance.GetCurrentPortalSettings();
-			}
-		}
-
-		public string DefaultPortalAlias
-		{
-			get
-			{
-				foreach (var alias in PortalAliasController.Instance.GetPortalAliasesByPortalId(PortalId).Where(alias => alias.IsPrimary))
-				{
-					return alias.HTTPAlias;
-				}
-				return String.Empty;
-			}
-		}
-
-		public PortalAliasMapping PortalAliasMappingMode
-		{
-			get
-			{
-                return PortalSettingsController.Instance().GetPortalAliasMappingMode(PortalId);
-			}
-		}
+        public bool ControlPanelVisible
+        {
+            get
+            {
+                var setting = Convert.ToString(Personalization.GetProfile("Usability", "ControlPanelVisible" + PortalId));
+                return String.IsNullOrEmpty(setting) ? DefaultControlPanelVisibility : Convert.ToBoolean(setting);
+            }
+        }
 
         /// <summary>Gets the currently logged in user identifier.</summary>
         /// <value>The user identifier.</value>
@@ -494,6 +425,18 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
+        public int SMTPConnectionLimit { get; internal set; }
+
+        public int SMTPMaxIdleTime { get; internal set; }
+
+        public static PortalSettings Current
+        {
+            get
+            {
+                return PortalController.Instance.GetCurrentPortalSettings();
+            }
+        }
+
         /// <summary>Gets the currently logged in user.</summary>
         /// <value>The current user information.</value>
 		public UserInfo UserInfo
@@ -504,35 +447,82 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
-		public Mode UserMode
+		public PortalAliasMapping PortalAliasMappingMode
 		{
 			get
 			{
-				Mode mode;
-				if (HttpContext.Current != null && HttpContext.Current.Request.IsAuthenticated)
-				{
-					mode = DefaultControlPanelMode;
-					string setting = Convert.ToString(Personalization.GetProfile("Usability", "UserMode" + PortalId));
-					switch (setting.ToUpper())
-					{
-						case "VIEW":
-							mode = Mode.View;
-							break;
-						case "EDIT":
-							mode = Mode.Edit;
-							break;
-						case "LAYOUT":
-							mode = Mode.Layout;
-							break;
-					}
-				}
-				else
-				{
-					mode = Mode.View;
-				}
-				return mode;
+                return PortalSettingsController.Instance().GetPortalAliasMappingMode(PortalId);
 			}
 		}
+
+        public string DefaultPortalAlias
+        {
+            get
+            {
+                foreach (var alias in PortalAliasController.Instance.GetPortalAliasesByPortalId(PortalId).Where(alias => alias.IsPrimary))
+                {
+                    return alias.HTTPAlias;
+                }
+                return String.Empty;
+            }
+        }
+
+        public Mode UserMode
+        {
+            get
+            {
+                Mode mode;
+				if (HttpContext.Current != null && HttpContext.Current.Request.IsAuthenticated)
+                {
+                    mode = DefaultControlPanelMode;
+                    string setting = Convert.ToString(Personalization.GetProfile("Usability", "UserMode" + PortalId));
+                    switch (setting.ToUpper())
+                    {
+                        case "VIEW":
+                            mode = Mode.View;
+                            break;
+                        case "EDIT":
+                            mode = Mode.Edit;
+                            break;
+                        case "LAYOUT":
+                            mode = Mode.Layout;
+                            break;
+                    }
+                }
+                else
+                {
+                    mode = Mode.View;
+                }
+                return mode;
+            }
+        }
+
+        /// <summary>
+        /// Get the IsLocked value, used to put the current portal into maintenance mode. This is a flag which can be used to disable any actions which update the database.
+        /// </summary>
+        public bool IsLocked
+        {
+            get
+            {
+                return this.IsThisPortalLocked || Host.Host.IsLocked;
+            }
+        }
+
+        public bool IsThisPortalLocked
+        {
+            get
+            {
+                return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false);
+            }
+        }
+
+        public int LockedByUserId
+        {
+            get
+            {
+                return PortalController.GetPortalSettingAsInteger("LockedByUserId", PortalId, Null.NullInteger);
+            }
+        }
 
 		public TimeZoneInfo TimeZone
 		{
@@ -541,82 +531,6 @@ namespace DotNetNuke.Entities.Portals
 			{
 				_timeZone = value;
 				PortalController.UpdatePortalSetting(PortalId, "TimeZone", value.Id, true);
-			}
-		}
-
-
-        public string PageHeadText 
-        {
-            get
-            {
-                // For New Install
-                string pageHead = "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"Content-Type\" />";
-                string setting;
-                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("PageHeadText", out setting))
-                {
-                    // Hack to store empty string portalsetting with non empty default value
-                    pageHead = (setting == "false") ? "" : setting;
-                }
-                return pageHead;
-            }
-        }
-
-        /*
-         * add <a name="[moduleid]"></a> on the top of the module
-         * 
-         * Desactivate this remove the html5 compatibility warnings
-         * (and make the output smaller)
-         * 
-         */
-        public bool InjectModuleHyperLink
-        {
-            get
-            {
-                return PortalController.GetPortalSettingAsBoolean("InjectModuleHyperLink", PortalId, true);
-            }
-        }
-        /*
-         * generates a : Page.Response.AddHeader("X-UA-Compatible", "");
-         * 
-         
-         */
-        public string AddCompatibleHttpHeader
-        {
-            get
-            {
-                string CompatibleHttpHeader = "IE=edge";
-                string setting;
-                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("AddCompatibleHttpHeader", out setting))
-                {
-                    // Hack to store empty string portalsetting with non empty default value
-                    CompatibleHttpHeader = (setting == "false") ? "" : setting;
-                }
-                return CompatibleHttpHeader;
-            }
-        }
-
-        /*
-         * add a cachebuster parameter to generated file URI's
-         * 
-         * of the form ver=[file timestame] ie ver=2015-02-17-162255-735
-         * 
-         */
-        public bool AddCachebusterToResourceUris
-        {
-            get
-            {
-                return PortalController.GetPortalSettingAsBoolean("AddCachebusterToResourceUris", PortalId, true);
-            }
-        }
-
-		/// <summary>
-		/// If this is true, then regular users can't send message to specific user/group.
-		/// </summary>
-		public bool DisablePrivateMessage
-		{
-			get
-			{
-				return PortalController.GetPortalSetting("DisablePrivateMessage", PortalId, "N") == "Y";
 			}
 		}
 
@@ -816,6 +730,82 @@ namespace DotNetNuke.Entities.Portals
 				result = PropertyAccess.ContentLocked;
 			}
 			return result;
+		}
+
+
+        public string PageHeadText 
+        {
+            get
+            {
+                // For New Install
+                string pageHead = "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"Content-Type\" />";
+                string setting;
+                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("PageHeadText", out setting))
+                {
+                    // Hack to store empty string portalsetting with non empty default value
+                    pageHead = (setting == "false") ? "" : setting;
+                }
+                return pageHead;
+            }
+        }
+
+        /*
+         * add <a name="[moduleid]"></a> on the top of the module
+         * 
+         * Desactivate this remove the html5 compatibility warnings
+         * (and make the output smaller)
+         * 
+         */
+        public bool InjectModuleHyperLink
+        {
+            get
+            {
+                return PortalController.GetPortalSettingAsBoolean("InjectModuleHyperLink", PortalId, true);
+            }
+        }
+        /*
+         * generates a : Page.Response.AddHeader("X-UA-Compatible", "");
+         * 
+         
+         */
+        public string AddCompatibleHttpHeader
+        {
+            get
+            {
+                string CompatibleHttpHeader = "IE=edge";
+                string setting;
+                if (PortalController.Instance.GetPortalSettings(PortalId).TryGetValue("AddCompatibleHttpHeader", out setting))
+                {
+                    // Hack to store empty string portalsetting with non empty default value
+                    CompatibleHttpHeader = (setting == "false") ? "" : setting;
+                }
+                return CompatibleHttpHeader;
+            }
+        }
+
+        /*
+         * add a cachebuster parameter to generated file URI's
+         * 
+         * of the form ver=[file timestame] ie ver=2015-02-17-162255-735
+         * 
+         */
+        public bool AddCachebusterToResourceUris
+        {
+            get
+            {
+                return PortalController.GetPortalSettingAsBoolean("AddCachebusterToResourceUris", PortalId, true);
+            }
+        }
+
+		/// <summary>
+		/// If this is true, then regular users can't send message to specific user/group.
+		/// </summary>
+		public bool DisablePrivateMessage
+		{
+			get
+			{
+				return PortalController.GetPortalSetting("DisablePrivateMessage", PortalId, "N") == "Y";
+			}
 		}
 
         #endregion

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -531,11 +531,6 @@ namespace DotNetNuke.Entities.Portals
 					mode = Mode.View;
 				}
 
-				if (mode == Mode.Edit && this.IsLocked)
-				{
-					return Mode.View;
-				}
-
 				return mode;
 			}
 		}

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -151,7 +151,7 @@ namespace DotNetNuke.UI.Modules
                 //role lookup on every property access (instead caching the result)
                 if (!_isEditable.HasValue)
                 {
-                    bool blnPreview = (PortalSettings.UserMode == PortalSettings.Mode.View);
+                    bool blnPreview = (PortalSettings.UserMode == PortalSettings.Mode.View) || PortalSettings.IsLocked;
                     if (Globals.IsHostTab(PortalSettings.ActiveTab.TabID))
                     {
                         blnPreview = false;

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -510,11 +510,19 @@ namespace DotNetNuke.UI.Modules
             _moduleGenericActions = new ModuleAction(GetNextActionID(), Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
             int maxActionId = Null.NullInteger;
 
+            if (!PortalSettings.Current.IsLocked)
+            {
+
             //check if module Implements Entities.Modules.IActionable interface
             var actionable = _moduleControl as IActionable;
             if (actionable != null)
             {
-                _moduleSpecificActions = new ModuleAction(GetNextActionID(), Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
+                    _moduleSpecificActions = new ModuleAction(
+                        GetNextActionID(),
+                        Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile),
+                        string.Empty,
+                        string.Empty,
+                        string.Empty);
 
                 ModuleActionCollection moduleActions = actionable.ModuleActions;
 
@@ -532,9 +540,15 @@ namespace DotNetNuke.UI.Modules
                         }
                         _moduleSpecificActions.Actions.Add(action);
 
-                        if (!UIUtilities.IsLegacyUI(ModuleId, action.ControlKey, PortalId) && action.Url.Contains("ctl"))
+                            if (!UIUtilities.IsLegacyUI(ModuleId, action.ControlKey, PortalId)
+                                && action.Url.Contains("ctl"))
                         {
-                            action.ClientScript = UrlUtils.PopUpUrl(action.Url, _moduleControl as Control, PortalSettings, true, false);
+                                action.ClientScript = UrlUtils.PopUpUrl(
+                                    action.Url,
+                                    _moduleControl as Control,
+                                    PortalSettings,
+                                    true,
+                                    false);
                         }
                     }
                 }
@@ -559,30 +573,49 @@ namespace DotNetNuke.UI.Modules
             if (Configuration != null && (Configuration.IsShared && Configuration.IsShareableViewOnly)
                     && TabPermissionController.CanAddContentToPage())
             {
-                _moduleGenericActions.Actions.Add(GetNextActionID(),
+                    _moduleGenericActions.Actions.Add(
+                        GetNextActionID(),
                              Localization.GetString("ModulePermissions.Action", Localization.GlobalResourceFile),
                              "ModulePermissions",
                              "",
                              "action_settings.gif",
-                             NavigateUrl(TabId, "ModulePermissions", false, "ModuleId=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
+                        NavigateUrl(
+                            TabId,
+                            "ModulePermissions",
                              false,
+                            "ModuleId=" + ModuleId,
+                            "ReturnURL=" + FilterUrl(request)),
+                        false,
                              SecurityAccessLevel.ViewPermissions,
                              true,
                              false);
             }
             else
             {
-                if (!Globals.IsAdminControl() && ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "DELETE,MANAGE", Configuration))
+                    if (!Globals.IsAdminControl()
+                        && ModulePermissionController.HasModuleAccess(
+                            SecurityAccessLevel.Admin,
+                            "DELETE,MANAGE",
+                            Configuration))
                 {
-                    if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "MANAGE", Configuration))
+                        if (ModulePermissionController.HasModuleAccess(
+                            SecurityAccessLevel.Admin,
+                            "MANAGE",
+                            Configuration))
                     {
-                        _moduleGenericActions.Actions.Add(GetNextActionID(),
+                            _moduleGenericActions.Actions.Add(
+                                GetNextActionID(),
                                                           Localization.GetString(ModuleActionType.ModuleSettings, Localization.GlobalResourceFile),
                                                           ModuleActionType.ModuleSettings,
                                                           "",
                                                           "action_settings.gif",
-                                                          NavigateUrl(TabId, "Module", false, "ModuleId=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
+                                NavigateUrl(
+                                    TabId,
+                                    "Module",
                                                           false,
+                                    "ModuleId=" + ModuleId,
+                                    "ReturnURL=" + FilterUrl(request)),
+                                false,
                                                           SecurityAccessLevel.Edit,
                                                           true,
                                                           false);
@@ -595,29 +628,46 @@ namespace DotNetNuke.UI.Modules
                 //check if module implements IPortable interface, and user has Admin permissions
                 if (Configuration.DesktopModule.IsPortable)
                 {
-                    if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "EXPORT", Configuration))
+                        if (ModulePermissionController.HasModuleAccess(
+                            SecurityAccessLevel.Admin,
+                            "EXPORT",
+                            Configuration))
                     {
-                        _moduleGenericActions.Actions.Add(GetNextActionID(),
+                            _moduleGenericActions.Actions.Add(
+                                GetNextActionID(),
                                      Localization.GetString(ModuleActionType.ExportModule, Localization.GlobalResourceFile),
                                      ModuleActionType.ExportModule,
                                      "",
                                      "action_export.gif",
-                                     NavigateUrl(PortalSettings.ActiveTab.TabID, "ExportModule", false, "moduleid=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
-
+                                NavigateUrl(
+                                    PortalSettings.ActiveTab.TabID,
+                                    "ExportModule",
+                                    false,
+                                    "moduleid=" + ModuleId,
+                                    "ReturnURL=" + FilterUrl(request)),
                                      "",
                                      false,
                                      SecurityAccessLevel.View,
                                      true,
                                      false);
                     }
-                    if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "IMPORT", Configuration))
+                        if (ModulePermissionController.HasModuleAccess(
+                            SecurityAccessLevel.Admin,
+                            "IMPORT",
+                            Configuration))
                     {
-                        _moduleGenericActions.Actions.Add(GetNextActionID(),
+                            _moduleGenericActions.Actions.Add(
+                                GetNextActionID(),
                                      Localization.GetString(ModuleActionType.ImportModule, Localization.GlobalResourceFile),
                                      ModuleActionType.ImportModule,
                                      "",
                                      "action_import.gif",
-                                     NavigateUrl(PortalSettings.ActiveTab.TabID, "ImportModule", false, "moduleid=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
+                                NavigateUrl(
+                                    PortalSettings.ActiveTab.TabID,
+                                    "ImportModule",
+                                    false,
+                                    "moduleid=" + ModuleId,
+                                    "ReturnURL=" + FilterUrl(request)),
                                      "",
                                      false,
                                      SecurityAccessLevel.View,
@@ -634,8 +684,7 @@ namespace DotNetNuke.UI.Modules
             //help module actions available to content editors and administrators
             const string permisisonList = "CONTENT,DELETE,EDIT,EXPORT,IMPORT,MANAGE";
             if (ModulePermissionController.HasModulePermission(Configuration.ModulePermissions, permisisonList) 
-                    && request.QueryString["ctl"] != "Help"
-                    && !Globals.IsAdminControl())
+                    && request.QueryString["ctl"] != "Help" && !Globals.IsAdminControl())
             {
                 AddHelpActions();
             }
@@ -647,15 +696,23 @@ namespace DotNetNuke.UI.Modules
                 AddPrintAction();
             }
 
-            if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Host, "MANAGE", Configuration) && !Globals.IsAdminControl())
+                if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Host, "MANAGE", Configuration)
+                    && !Globals.IsAdminControl())
             {
-                _moduleGenericActions.Actions.Add(GetNextActionID(),
+                    _moduleGenericActions.Actions.Add(
+                        GetNextActionID(),
                              Localization.GetString(ModuleActionType.ViewSource, Localization.GlobalResourceFile),
                              ModuleActionType.ViewSource,
                              "",
                              "action_source.gif",
-                             NavigateUrl(TabId, "ViewSource", false, "ModuleId=" + ModuleId, "ctlid=" + Configuration.ModuleControlId, "ReturnURL=" + FilterUrl(request)),
+                        NavigateUrl(
+                            TabId,
+                            "ViewSource",
                              false,
+                            "ModuleId=" + ModuleId,
+                            "ctlid=" + Configuration.ModuleControlId,
+                            "ReturnURL=" + FilterUrl(request)),
+                        false,
                              SecurityAccessLevel.Host,
                              true,
                              false);
@@ -663,21 +720,33 @@ namespace DotNetNuke.UI.Modules
 
 
 
-            if (!Globals.IsAdminControl() && ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "DELETE,MANAGE", Configuration))
+                if (!Globals.IsAdminControl()
+                    && ModulePermissionController.HasModuleAccess(
+                        SecurityAccessLevel.Admin,
+                        "DELETE,MANAGE",
+                        Configuration))
             {
                 if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "DELETE", Configuration))
                 {
                     //Check if this is the owner instance of a shared module.
-                    string confirmText = "confirm('" + ClientAPI.GetSafeJSString(Localization.GetString("DeleteModule.Confirm")) + "')";
+                        string confirmText = "confirm('"
+                                             + ClientAPI.GetSafeJSString(Localization.GetString("DeleteModule.Confirm"))
+                                             + "')";
                     if (!Configuration.IsShared)
                     {
-                        if (ModuleController.Instance.GetTabModulesByModule(Configuration.ModuleID).Cast<ModuleInfo>().Any(instance => instance.IsShared))
+                            if (
+                                ModuleController.Instance.GetTabModulesByModule(Configuration.ModuleID)
+                                    .Cast<ModuleInfo>()
+                                    .Any(instance => instance.IsShared))
                         {
-                            confirmText = "confirm('" + ClientAPI.GetSafeJSString(Localization.GetString("DeleteSharedModule.Confirm")) + "')";
+                                confirmText = "confirm('"
+                                              + ClientAPI.GetSafeJSString(
+                                                  Localization.GetString("DeleteSharedModule.Confirm")) + "')";
                         }
                     }
 
-                    _moduleGenericActions.Actions.Add(GetNextActionID(),
+                        _moduleGenericActions.Actions.Add(
+                            GetNextActionID(),
                                  Localization.GetString(ModuleActionType.DeleteModule, Localization.GlobalResourceFile),
                                  ModuleActionType.DeleteModule,
                                  Configuration.ModuleID.ToString(),
@@ -691,7 +760,8 @@ namespace DotNetNuke.UI.Modules
                 }
                 if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "MANAGE", Configuration))
                 {
-                    _moduleGenericActions.Actions.Add(GetNextActionID(),
+                        _moduleGenericActions.Actions.Add(
+                            GetNextActionID(),
                                  Localization.GetString(ModuleActionType.ClearCache, Localization.GlobalResourceFile),
                                  ModuleActionType.ClearCache,
                                  Configuration.ModuleID.ToString(),
@@ -708,6 +778,7 @@ namespace DotNetNuke.UI.Modules
                     //module movement
                     AddMenuMoveActions();
                 }
+            }
             }
 
             if (_moduleGenericActions.Actions.Count > 0)

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -506,12 +506,12 @@ namespace DotNetNuke.UI.Modules
         /// -----------------------------------------------------------------------------
         private void LoadActions(HttpRequest request)
         {
+            _actions = new ModuleActionCollection();
             if (PortalSettings.IsLocked)
             {
                 return;
             }
 
-            _actions = new ModuleActionCollection();
             _moduleGenericActions = new ModuleAction(GetNextActionID(), Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
             int maxActionId = Null.NullInteger;
 

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -506,23 +506,20 @@ namespace DotNetNuke.UI.Modules
         /// -----------------------------------------------------------------------------
         private void LoadActions(HttpRequest request)
         {
+            if (PortalSettings.IsLocked)
+            {
+                return;
+            }
+
             _actions = new ModuleActionCollection();
             _moduleGenericActions = new ModuleAction(GetNextActionID(), Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
             int maxActionId = Null.NullInteger;
-
-            if (!PortalSettings.Current.IsLocked)
-            {
 
             //check if module Implements Entities.Modules.IActionable interface
             var actionable = _moduleControl as IActionable;
             if (actionable != null)
             {
-                    _moduleSpecificActions = new ModuleAction(
-                        GetNextActionID(),
-                        Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile),
-                        string.Empty,
-                        string.Empty,
-                        string.Empty);
+                _moduleSpecificActions = new ModuleAction(GetNextActionID(), Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
 
                 ModuleActionCollection moduleActions = actionable.ModuleActions;
 
@@ -540,15 +537,9 @@ namespace DotNetNuke.UI.Modules
                         }
                         _moduleSpecificActions.Actions.Add(action);
 
-                            if (!UIUtilities.IsLegacyUI(ModuleId, action.ControlKey, PortalId)
-                                && action.Url.Contains("ctl"))
+                        if (!UIUtilities.IsLegacyUI(ModuleId, action.ControlKey, PortalId) && action.Url.Contains("ctl"))
                         {
-                                action.ClientScript = UrlUtils.PopUpUrl(
-                                    action.Url,
-                                    _moduleControl as Control,
-                                    PortalSettings,
-                                    true,
-                                    false);
+                            action.ClientScript = UrlUtils.PopUpUrl(action.Url, _moduleControl as Control, PortalSettings, true, false);
                         }
                     }
                 }
@@ -573,49 +564,30 @@ namespace DotNetNuke.UI.Modules
             if (Configuration != null && (Configuration.IsShared && Configuration.IsShareableViewOnly)
                     && TabPermissionController.CanAddContentToPage())
             {
-                    _moduleGenericActions.Actions.Add(
-                        GetNextActionID(),
+                _moduleGenericActions.Actions.Add(GetNextActionID(),
                              Localization.GetString("ModulePermissions.Action", Localization.GlobalResourceFile),
                              "ModulePermissions",
                              "",
                              "action_settings.gif",
-                        NavigateUrl(
-                            TabId,
-                            "ModulePermissions",
+                             NavigateUrl(TabId, "ModulePermissions", false, "ModuleId=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
                              false,
-                            "ModuleId=" + ModuleId,
-                            "ReturnURL=" + FilterUrl(request)),
-                        false,
                              SecurityAccessLevel.ViewPermissions,
                              true,
                              false);
             }
             else
             {
-                    if (!Globals.IsAdminControl()
-                        && ModulePermissionController.HasModuleAccess(
-                            SecurityAccessLevel.Admin,
-                            "DELETE,MANAGE",
-                            Configuration))
+                if (!Globals.IsAdminControl() && ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "DELETE,MANAGE", Configuration))
                 {
-                        if (ModulePermissionController.HasModuleAccess(
-                            SecurityAccessLevel.Admin,
-                            "MANAGE",
-                            Configuration))
+                    if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "MANAGE", Configuration))
                     {
-                            _moduleGenericActions.Actions.Add(
-                                GetNextActionID(),
+                        _moduleGenericActions.Actions.Add(GetNextActionID(),
                                                           Localization.GetString(ModuleActionType.ModuleSettings, Localization.GlobalResourceFile),
                                                           ModuleActionType.ModuleSettings,
                                                           "",
                                                           "action_settings.gif",
-                                NavigateUrl(
-                                    TabId,
-                                    "Module",
+                                                          NavigateUrl(TabId, "Module", false, "ModuleId=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
                                                           false,
-                                    "ModuleId=" + ModuleId,
-                                    "ReturnURL=" + FilterUrl(request)),
-                                false,
                                                           SecurityAccessLevel.Edit,
                                                           true,
                                                           false);
@@ -628,46 +600,29 @@ namespace DotNetNuke.UI.Modules
                 //check if module implements IPortable interface, and user has Admin permissions
                 if (Configuration.DesktopModule.IsPortable)
                 {
-                        if (ModulePermissionController.HasModuleAccess(
-                            SecurityAccessLevel.Admin,
-                            "EXPORT",
-                            Configuration))
+                    if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "EXPORT", Configuration))
                     {
-                            _moduleGenericActions.Actions.Add(
-                                GetNextActionID(),
+                        _moduleGenericActions.Actions.Add(GetNextActionID(),
                                      Localization.GetString(ModuleActionType.ExportModule, Localization.GlobalResourceFile),
                                      ModuleActionType.ExportModule,
                                      "",
                                      "action_export.gif",
-                                NavigateUrl(
-                                    PortalSettings.ActiveTab.TabID,
-                                    "ExportModule",
-                                    false,
-                                    "moduleid=" + ModuleId,
-                                    "ReturnURL=" + FilterUrl(request)),
+                                     NavigateUrl(PortalSettings.ActiveTab.TabID, "ExportModule", false, "moduleid=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
+
                                      "",
                                      false,
                                      SecurityAccessLevel.View,
                                      true,
                                      false);
                     }
-                        if (ModulePermissionController.HasModuleAccess(
-                            SecurityAccessLevel.Admin,
-                            "IMPORT",
-                            Configuration))
+                    if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "IMPORT", Configuration))
                     {
-                            _moduleGenericActions.Actions.Add(
-                                GetNextActionID(),
+                        _moduleGenericActions.Actions.Add(GetNextActionID(),
                                      Localization.GetString(ModuleActionType.ImportModule, Localization.GlobalResourceFile),
                                      ModuleActionType.ImportModule,
                                      "",
                                      "action_import.gif",
-                                NavigateUrl(
-                                    PortalSettings.ActiveTab.TabID,
-                                    "ImportModule",
-                                    false,
-                                    "moduleid=" + ModuleId,
-                                    "ReturnURL=" + FilterUrl(request)),
+                                     NavigateUrl(PortalSettings.ActiveTab.TabID, "ImportModule", false, "moduleid=" + ModuleId, "ReturnURL=" + FilterUrl(request)),
                                      "",
                                      false,
                                      SecurityAccessLevel.View,
@@ -684,7 +639,8 @@ namespace DotNetNuke.UI.Modules
             //help module actions available to content editors and administrators
             const string permisisonList = "CONTENT,DELETE,EDIT,EXPORT,IMPORT,MANAGE";
             if (ModulePermissionController.HasModulePermission(Configuration.ModulePermissions, permisisonList) 
-                    && request.QueryString["ctl"] != "Help" && !Globals.IsAdminControl())
+                    && request.QueryString["ctl"] != "Help"
+                    && !Globals.IsAdminControl())
             {
                 AddHelpActions();
             }
@@ -696,23 +652,15 @@ namespace DotNetNuke.UI.Modules
                 AddPrintAction();
             }
 
-                if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Host, "MANAGE", Configuration)
-                    && !Globals.IsAdminControl())
+            if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Host, "MANAGE", Configuration) && !Globals.IsAdminControl())
             {
-                    _moduleGenericActions.Actions.Add(
-                        GetNextActionID(),
+                _moduleGenericActions.Actions.Add(GetNextActionID(),
                              Localization.GetString(ModuleActionType.ViewSource, Localization.GlobalResourceFile),
                              ModuleActionType.ViewSource,
                              "",
                              "action_source.gif",
-                        NavigateUrl(
-                            TabId,
-                            "ViewSource",
+                             NavigateUrl(TabId, "ViewSource", false, "ModuleId=" + ModuleId, "ctlid=" + Configuration.ModuleControlId, "ReturnURL=" + FilterUrl(request)),
                              false,
-                            "ModuleId=" + ModuleId,
-                            "ctlid=" + Configuration.ModuleControlId,
-                            "ReturnURL=" + FilterUrl(request)),
-                        false,
                              SecurityAccessLevel.Host,
                              true,
                              false);
@@ -720,33 +668,21 @@ namespace DotNetNuke.UI.Modules
 
 
 
-                if (!Globals.IsAdminControl()
-                    && ModulePermissionController.HasModuleAccess(
-                        SecurityAccessLevel.Admin,
-                        "DELETE,MANAGE",
-                        Configuration))
+            if (!Globals.IsAdminControl() && ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "DELETE,MANAGE", Configuration))
             {
                 if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "DELETE", Configuration))
                 {
                     //Check if this is the owner instance of a shared module.
-                        string confirmText = "confirm('"
-                                             + ClientAPI.GetSafeJSString(Localization.GetString("DeleteModule.Confirm"))
-                                             + "')";
+                    string confirmText = "confirm('" + ClientAPI.GetSafeJSString(Localization.GetString("DeleteModule.Confirm")) + "')";
                     if (!Configuration.IsShared)
                     {
-                            if (
-                                ModuleController.Instance.GetTabModulesByModule(Configuration.ModuleID)
-                                    .Cast<ModuleInfo>()
-                                    .Any(instance => instance.IsShared))
+                        if (ModuleController.Instance.GetTabModulesByModule(Configuration.ModuleID).Cast<ModuleInfo>().Any(instance => instance.IsShared))
                         {
-                                confirmText = "confirm('"
-                                              + ClientAPI.GetSafeJSString(
-                                                  Localization.GetString("DeleteSharedModule.Confirm")) + "')";
+                            confirmText = "confirm('" + ClientAPI.GetSafeJSString(Localization.GetString("DeleteSharedModule.Confirm")) + "')";
                         }
                     }
 
-                        _moduleGenericActions.Actions.Add(
-                            GetNextActionID(),
+                    _moduleGenericActions.Actions.Add(GetNextActionID(),
                                  Localization.GetString(ModuleActionType.DeleteModule, Localization.GlobalResourceFile),
                                  ModuleActionType.DeleteModule,
                                  Configuration.ModuleID.ToString(),
@@ -760,8 +696,7 @@ namespace DotNetNuke.UI.Modules
                 }
                 if (ModulePermissionController.HasModuleAccess(SecurityAccessLevel.Admin, "MANAGE", Configuration))
                 {
-                        _moduleGenericActions.Actions.Add(
-                            GetNextActionID(),
+                    _moduleGenericActions.Actions.Add(GetNextActionID(),
                                  Localization.GetString(ModuleActionType.ClearCache, Localization.GlobalResourceFile),
                                  ModuleActionType.ClearCache,
                                  Configuration.ModuleID.ToString(),
@@ -778,7 +713,6 @@ namespace DotNetNuke.UI.Modules
                     //module movement
                     AddMenuMoveActions();
                 }
-            }
             }
 
             if (_moduleGenericActions.Actions.Count > 0)

--- a/Website/Resources/Shared/scripts/dnn.controlBar.js
+++ b/Website/Resources/Shared/scripts/dnn.controlBar.js
@@ -539,6 +539,40 @@ dnn.controlBar.init = function (settings) {
         });
     };
 
+    dnn.controlBar.lockInstance = function (locking) {
+        var service = dnn.controlBar.getService();
+        var serviceUrl = dnn.controlBar.getServiceUrl(service);
+        $.ajax({
+            url: serviceUrl + 'LockInstance',
+            type: 'POST',
+            data: { Lock: locking },
+            beforeSend: service.setModuleHeaders,
+            success: function () {
+                window.location.href = window.location.href.split('#')[0];
+            },
+            error: function (xhr) {
+                dnn.controlBar.responseError(xhr);
+            }
+        });
+    };
+
+    dnn.controlBar.lockSite = function (locking) {
+        var service = dnn.controlBar.getService();
+        var serviceUrl = dnn.controlBar.getServiceUrl(service);
+        $.ajax({
+            url: serviceUrl + 'LockSite',
+            type: 'POST',
+            data: { Lock: locking },
+            beforeSend: service.setModuleHeaders,
+            success: function () {
+                window.location.href = window.location.href.split('#')[0];
+            },
+            error: function (xhr) {
+                dnn.controlBar.responseError(xhr);
+            }
+        });
+    };
+
     dnn.controlBar.switchSite = function (site) {
         if (site) {
             var dataVar = { Site: site };
@@ -1465,6 +1499,26 @@ dnn.controlBar.init = function (settings) {
 
     $('#controlBar_RecycleAppPool').click(function () {
         dnn.controlBar.recycleAppPool();
+        return false;
+    });
+
+    $('#controlBar_LockInstance').click(function () {
+        dnn.controlBar.lockInstance(true);
+        return false;
+    });
+
+    $('#controlBar_UnlockInstance').click(function () {
+        dnn.controlBar.lockInstance(false);
+        return false;
+    });
+
+    $('#controlBar_LockSite').click(function () {
+        dnn.controlBar.lockSite(true);
+        return false;
+    });
+
+    $('#controlBar_UnlockSite').click(function () {
+        dnn.controlBar.lockSite(false);
         return false;
     });
 

--- a/Website/admin/ControlPanel/App_LocalResources/ControlBar.ascx.resx
+++ b/Website/admin/ControlPanel/App_LocalResources/ControlBar.ascx.resx
@@ -351,4 +351,16 @@
   <data name="Tool.UnpublishPage.Text" xml:space="preserve">
     <value>Make Private</value>
   </data>
+  <data name="Tool.LockInstance.Text" xml:space="preserve">
+    <value>Lock Instance</value>
+  </data>
+  <data name="Tool.LockSite.Text" xml:space="preserve">
+    <value>Lock Site</value>
+  </data>
+  <data name="Tool.UnlockInstance.Text" xml:space="preserve">
+    <value>Unlock Instance</value>
+  </data>
+  <data name="Tool.UnlockSite.Text" xml:space="preserve">
+    <value>Unlock Site</value>
+  </data>
 </root>

--- a/Website/admin/ControlPanel/ControlBar.ascx
+++ b/Website/admin/ControlPanel/ControlBar.ascx
@@ -102,19 +102,12 @@
                                         <%= GetString("Tool.ClearCache.Text") %></a></li>
                                     <li><a href='javascript:void(0)' id="controlBar_RecycleAppPool">
                                         <%= GetString("Tool.RecycleApp.Text") %></a></li>
-                                    <li>
-                                        <div id="ControlBar_SiteSelector">
-                                            <p><%= GetString("Tool.SwitchSites.Text") %></p>
-                                            <dnn:DnnComboBox runat="server" ID="controlBar_SwitchSite" ClientIDMode="Static" Skin="DnnBlack" ViewStateMode="Disabled"/>
-                                            <input type="submit" value="<%= GetString("Tool.SwitchSites.Button") %>" id="controlBar_SwitchSiteButton" class="dnnPrimaryAction" />
-                                        </div>
-                                    </li>
-                                        <% if (DotNetNuke.Entities.Host.Host.IsLocked == false) { %>
-                                            <li><a href='javascript:void(0)' id="controlBar_LockInstance"><%= GetString("Tool.LockInstance.Text") %></a></li>
-                                        <% } else {%>
-                                            <li><a href='javascript:void(0)' id="controlBar_UnlockInstance"><%= GetString("Tool.UnlockInstance.Text") %></a></li>
-                                        <% } %>
+                                    <% if (DotNetNuke.Entities.Host.Host.IsLocked == false) { %>
+                                        <li><a href='javascript:void(0)' id="controlBar_LockInstance"><%= GetString("Tool.LockInstance.Text") %></a></li>
+                                    <% } else {%>
+                                        <li><a href='javascript:void(0)' id="controlBar_UnlockInstance"><%= GetString("Tool.UnlockInstance.Text") %></a></li>
                                     <% } %>
+                                   <% } %>
                                     <% if (UserController.Instance.GetCurrentUserInfo().IsInRole(PortalSettings.AdministratorRoleName) && DotNetNuke.Entities.Host.Host.IsLocked == false) { %>
                                         <% if (PortalSettings.IsThisPortalLocked == false) { %>
                                             <li><a href='javascript:void(0)' id="controlBar_LockSite"><%= GetString("Tool.LockSite.Text") %></a></li>
@@ -122,6 +115,13 @@
                                             <li><a href='javascript:void(0)' id="controlBar_UnlockSite"><%= GetString("Tool.UnlockSite.Text") %></a></li>
                                         <% } %>
                                     <% } %>
+                                    <li>
+                                        <div id="ControlBar_SiteSelector">
+                                            <p><%= GetString("Tool.SwitchSites.Text") %></p>
+                                            <dnn:DnnComboBox runat="server" ID="controlBar_SwitchSite" ClientIDMode="Static" Skin="DnnBlack" ViewStateMode="Disabled"/>
+                                            <input type="submit" value="<%= GetString("Tool.SwitchSites.Button") %>" id="controlBar_SwitchSiteButton" class="dnnPrimaryAction" />
+                                        </div>
+                                    </li>
                                     <% if (ShowSwitchLanguagesPanel()) { %>
                                     <li>
                                         <div id="ControlBar_LanguageSelector">

--- a/Website/admin/ControlPanel/ControlBar.ascx
+++ b/Website/admin/ControlPanel/ControlBar.ascx
@@ -97,28 +97,37 @@
                                     <li>
                                         <a href="javascript: openFileUploader();"><%= GetString("Tool.UploadFile.Text") %></a>
                                     </li>
-                                   <% if (UserController.Instance.GetCurrentUserInfo().IsSuperUser)
-                                      {%>
+                                   <% if (UserController.Instance.GetCurrentUserInfo().IsSuperUser) {%>
                                     <li><a href='javascript:void(0)' id="controlBar_ClearCache">
                                         <%= GetString("Tool.ClearCache.Text") %></a></li>
                                     <li><a href='javascript:void(0)' id="controlBar_RecycleAppPool">
                                         <%= GetString("Tool.RecycleApp.Text") %></a></li>
                                     <li>
                                         <div id="ControlBar_SiteSelector">
-                                            <p>
-                                                <%= GetString("Tool.SwitchSites.Text") %></p>
-											<dnn:DnnComboBox runat="server" ID="controlBar_SwitchSite" ClientIDMode="Static" Skin="DnnBlack" ViewStateMode="Disabled"/>
+                                            <p><%= GetString("Tool.SwitchSites.Text") %></p>
+                                            <dnn:DnnComboBox runat="server" ID="controlBar_SwitchSite" ClientIDMode="Static" Skin="DnnBlack" ViewStateMode="Disabled"/>
                                             <input type="submit" value="<%= GetString("Tool.SwitchSites.Button") %>" id="controlBar_SwitchSiteButton" class="dnnPrimaryAction" />
                                         </div>
                                     </li>
+                                        <% if (DotNetNuke.Entities.Host.Host.IsLocked == false) { %>
+                                            <li><a href='javascript:void(0)' id="controlBar_LockInstance"><%= GetString("Tool.LockInstance.Text") %></a></li>
+                                        <% } else {%>
+                                            <li><a href='javascript:void(0)' id="controlBar_UnlockInstance"><%= GetString("Tool.UnlockInstance.Text") %></a></li>
+                                        <% } %>
                                     <% } %>
-                                    <% if (ShowSwitchLanguagesPanel())
-                                       { %>
+                                    <% if (UserController.Instance.GetCurrentUserInfo().IsInRole(PortalSettings.AdministratorRoleName) && DotNetNuke.Entities.Host.Host.IsLocked == false) { %>
+                                        <% if (PortalSettings.IsThisPortalLocked == false) { %>
+                                            <li><a href='javascript:void(0)' id="controlBar_LockSite"><%= GetString("Tool.LockSite.Text") %></a></li>
+                                        <% } else { %>
+                                            <li><a href='javascript:void(0)' id="controlBar_UnlockSite"><%= GetString("Tool.UnlockSite.Text") %></a></li>
+                                        <% } %>
+                                    <% } %>
+                                    <% if (ShowSwitchLanguagesPanel()) { %>
                                     <li>
                                         <div id="ControlBar_LanguageSelector">
                                             <p>
                                                <%= GetString("Tool.SwitchLanguages.Text") %></p>
-											<dnn:DnnComboBox runat="server" ID="controlBar_SwitchLanguage" ClientIDMode="Static" Skin="DnnBlack" ViewStateMode="Disabled"/>
+                                            <dnn:DnnComboBox runat="server" ID="controlBar_SwitchLanguage" ClientIDMode="Static" Skin="DnnBlack" ViewStateMode="Disabled"/>
                                             <input type="submit" value="<%= GetString("Tool.SwitchSites.Button") %>" id="controlBar_SwitchLanguageButton" class="dnnPrimaryAction" />
                                         </div>
                                     </li>


### PR DESCRIPTION
[DNN-8374](https://dnntracker.atlassian.net/browse/DNN-8374)

> We've made some customizations for a client which we think would be a good fit for inclusion in the core. There's a "Lock Site" action added to the control bar, which allows a super-user to turn off modifications to the site (probably for entering some sort of maintenance mode). For our client, the "good enough" way this is implemented is to disable the module actions whenever the site is locked (in addition, custom modules are able to access the locked status via a property on `PortalSettings` and do any additional changes, if desired).
