### PR TITLE
Don't try to request empty JS library file DNN-8381

### DIFF
--- a/DNN Platform/Library/Framework/JavaScriptLibraries/JavaScript.cs
+++ b/DNN Platform/Library/Framework/JavaScriptLibraries/JavaScript.cs
@@ -399,9 +399,14 @@ namespace DotNetNuke.Framework.JavaScriptLibraries
 
         private static void RegisterScript(Page page, JavaScriptLibrary jsl)
         {
+            if (string.IsNullOrEmpty(jsl.FileName))
+            {
+                return;
+            }
+
             ClientResourceManager.RegisterScript(page, GetScriptPath(jsl), GetFileOrder(jsl), GetScriptLocation(jsl));
 
-            //workaround to support IE specific script unti we move to IE version that no longer requires this
+            //workaround to support IE specific script until we move to IE version that no longer requires this
             if (jsl.LibraryName == CommonJs.jQueryFileUpload)
             {
                 ClientResourceManager.RegisterScript(page,


### PR DESCRIPTION
[DNN-8381](https://dnntracker.atlassian.net/browse/DNN-8381)

>DNN should support JS library packages without their own script, but which just pull in dependencies.  This mostly works already, but causes a `script` tag to be included for the empty library, causing a 404 request.
>
>### Steps to Reproduce
>1. Download all packages from https://github.com/EngageSoftware/DNN-JavaScript-Libraries/releases/tag/jQuery.cycle_2.1.5 which have a numeric prefix
>2. Copy those packages to the `\Install\JavaScriptLibrary` folder of your DNN website
>3. Hit the `/Install/Install.aspx?mode=installresources` URL of your DNN website
>4. Ensure script combination is turned off
>5. Install attached module which requests the `jQuery.cycle2` JS library
>
>### Expected Results
>* All dependent libraries included on the page
>* No script requests that result in a 404
>
>### Actual Results
>* Request for the jQuery.cycle2 library folder (e.g. `/Resources/libraries/jQuery.cycle2/02_01_05/?cdv=91`), which results in a 404