### PR TITLE
DNN-8411: Fixed culture insensitivity issue when retrieving role by name

### DIFF
--- a/DNN Platform/Library/Security/Roles/DNNRoleProvider.cs
+++ b/DNN Platform/Library/Security/Roles/DNNRoleProvider.cs
@@ -388,7 +388,7 @@ namespace DotNetNuke.Security.Roles
 
         public override RoleGroupInfo GetRoleGroupByName(int portalId, string roleGroupName)
         {
-            roleGroupName = roleGroupName.ToUpper().Trim();
+            roleGroupName = roleGroupName.Trim();
             return GetRoleGroupsInternal(portalId).SingleOrDefault(r => roleGroupName.Equals(r.RoleGroupName.Trim(), StringComparison.InvariantCultureIgnoreCase));
         }
 

--- a/DNN Platform/Library/Security/Roles/RoleController.cs
+++ b/DNN Platform/Library/Security/Roles/RoleController.cs
@@ -309,7 +309,7 @@ namespace DotNetNuke.Security.Roles
 
         public RoleInfo GetRoleByName(int portalId, string roleName)
         {
-            roleName = roleName.ToUpper().Trim();
+            roleName = roleName.Trim();
             return GetRoles(portalId).SingleOrDefault(r => roleName.Equals(r.RoleName.Trim(), StringComparison.InvariantCultureIgnoreCase) && r.PortalID == portalId);
         }
 

--- a/Website/DesktopModules/Admin/Security/EditRoles.ascx.cs
+++ b/Website/DesktopModules/Admin/Security/EditRoles.ascx.cs
@@ -385,7 +385,7 @@ namespace DotNetNuke.Modules.Admin.Security
 
                     if (_roleID == -1)
                     {
-                        var rolename = role.RoleName.ToUpper();
+                        var rolename = role.RoleName;
                         if (RoleController.Instance.GetRole(PortalId,
                             r => rolename.Equals(r.RoleName, StringComparison.InvariantCultureIgnoreCase)) == null)
                         {


### PR DESCRIPTION
Removing ToUpper on roleName/roleGroupName, since it is only used in an InvariantCultureIgnoreCase string comparison and causes issues in Turkish websites (i capitalizes to Turkish i using ToUpper)