### PR TITLE
DNN-8450: Allow Override of prefixing Service to Username for OAuth providers.

### DIFF
--- a/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
@@ -617,7 +617,7 @@ namespace DotNetNuke.Security.Membership
         }
 
        
-        private UserInfo GetUserByAuthToken(int portalId, string userToken, string authType)
+        public override UserInfo GetUserByAuthToken(int portalId, string userToken, string authType)
         {
             IDataReader dr = _dataProvider.GetUserByAuthToken(portalId, userToken, authType);
             UserInfo objUserInfo = FillUserInfo(portalId, dr, true);
@@ -856,43 +856,6 @@ namespace DotNetNuke.Security.Membership
             UserCreateStatus createStatus = ValidateForProfanity(user);
             string service = HttpContext.Current != null ? HttpContext.Current.Request.Params["state"] : string.Empty;
 
-            //DNN-4016
-            //the username exists, first we check to see if this is an OAUTH user
-            bool isOAuthUser = false;
-
-            if (String.IsNullOrEmpty(service) || service.Equals("DNN"))
-            {
-                isOAuthUser = false;
-            }
-            else
-            {
-                try
-                {
-                    UserAuthenticationInfo authUser = AuthenticationController.GetUserAuthentication(user.UserID);
-
-                    // Check that the OAuth service currently being used for login is the same as was previously used (this should always be true if user authenticated to userid)
-                    if (authUser == null || authUser.AuthenticationType.Equals(service, StringComparison.OrdinalIgnoreCase))
-                    {
-                        isOAuthUser = true;
-                        //DNN-4133 Change username to email address to ensure multiple users with the same email prefix, but different email domains can authenticate
-	                    if (!string.IsNullOrEmpty(user.Email))
-	                    {
-		                    user.Username = service + "-" + user.Email;
-	                    }
-                    }
-                    else
-                    {
-                        createStatus = UserCreateStatus.DuplicateEmail;
-                    }
-
-                }
-                catch (Exception ex)
-                {
-                    createStatus = UserCreateStatus.UnexpectedError;
-                    EventLogController.Instance.AddLog("CreateUser", "Exception checking oauth authentication in CreateUser for userid : " + user.UserID + " " + ex.InnerException.Message, EventLogController.EventLogType.ADMIN_ALERT);
-                }
-            }
-
             if (createStatus == UserCreateStatus.AddUser)
             {
                 ValidateForDuplicateDisplayName(user, ref createStatus);
@@ -908,7 +871,7 @@ namespace DotNetNuke.Security.Membership
                     {
                         //DNN-4016
                         //the username exists so we should now verify the password, DNN-4016 or check for oauth user authentication.
-                        if (isOAuthUser || ValidateUser(user.Username, user.Membership.Password))
+                        if (ValidateUser(user.Username, user.Membership.Password))
                         {
                             //check if user exists for the portal specified
                             objVerifyUser = GetUserByUserName(user.PortalID, user.Username);
@@ -1729,7 +1692,7 @@ namespace DotNetNuke.Security.Membership
             //Get a light-weight (unhydrated) DNN User from the Database, we will hydrate it later if neccessary
             UserInfo user = (authType == "DNN")
                                 ? GetUserByUserName(portalId, username)
-                                : GetUserByAuthToken(portalId, username, authType);
+                                : GetUserByAuthToken(portalId, verificationCode, authType);
             if (user != null && !user.IsDeleted)
             {
                 //Get AspNet MembershipUser

--- a/DNN Platform/Library/Security/Membership/MembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/MembershipProvider.cs
@@ -114,6 +114,11 @@ namespace DotNetNuke.Security.Membership
             return null;
         }
 
+        public virtual UserInfo GetUserByAuthToken(int portalId, string userToken, string authType)
+        {
+            throw new NotImplementedException();
+        }
+
         public virtual ArrayList GetUsers(int portalId, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {
             throw new NotImplementedException();

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -629,7 +629,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
         {
             var loginStatus = UserLoginStatus.LOGIN_FAILURE;
 
-            string userName = Service + "-" + user.Id;
+            string userName = PrefixServiceToUserName ? Service + "-" + user.Email : user.Email;
             string token = Service + "-" + user.Email + "-" + user.Id;
 
             UserInfo objUserInfo;

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -46,6 +46,7 @@ using System.Text;
 using System.Web;
 using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Data;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Security.Membership;
 using DotNetNuke.Instrumentation;
@@ -134,7 +135,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
 
         //oAuth 1 and 2
         protected Uri AuthorizationEndpoint { get; set; }
-        protected string AuthToken { get; private set; }
+        protected string AuthToken { get; set; }
         protected TimeSpan AuthTokenExpiry { get; set; }
         protected Uri MeGraphEndpoint { get; set; }
         protected Uri TokenEndpoint { get; set; }
@@ -158,6 +159,16 @@ namespace DotNetNuke.Services.Authentication.OAuth
 
         public Uri CallbackUri { get; set; }
         public string Service { get; set; }
+
+        public virtual bool PrefixServiceToUserName
+        {
+            get { return true; }
+        }
+
+        public virtual bool AutoMatchExistingUsers
+        {
+            get { return false; }
+        }
 
         #endregion
 
@@ -619,17 +630,37 @@ namespace DotNetNuke.Services.Authentication.OAuth
             var loginStatus = UserLoginStatus.LOGIN_FAILURE;
 
             string userName = Service + "-" + user.Id;
+            string token = Service + "-" + user.Email + "-" + user.Id;
 
-            var objUserInfo = UserController.ValidateUser(settings.PortalId, userName, "",
-                                                                Service, "",
+            UserInfo objUserInfo;
+
+            if (AutoMatchExistingUsers)
+            {
+                objUserInfo = MembershipProvider.Instance().GetUserByUserName(settings.PortalId, userName);
+
+                if (objUserInfo != null)
+                {
+                    //user already exists... lets check for a token next... 
+                    var dnnAuthToken = MembershipProvider.Instance().GetUserByAuthToken(settings.PortalId, token, Service);
+
+                    if (dnnAuthToken == null)
+                    {
+                        DataProvider.Instance().AddUserAuthentication(objUserInfo.UserID, Service, token, objUserInfo.UserID);
+                    }
+                }
+            }
+
+            objUserInfo = UserController.ValidateUser(settings.PortalId, userName, "",
+                                                                Service, token,
                                                                 settings.PortalName, IPAddress,
                                                                 ref loginStatus);
 
 
             //Raise UserAuthenticated Event
-            var eventArgs = new UserAuthenticatedEventArgs(objUserInfo, userName, loginStatus, Service)
+            var eventArgs = new UserAuthenticatedEventArgs(objUserInfo, token, loginStatus, Service)
                                             {
-                                                AutoRegister = true
+                                                AutoRegister = true,
+                                                UserName = userName,
                                             };
 
             var profileProperties = new NameValueCollection();

--- a/DNN Platform/Library/Services/Authentication/UserAuthenticatedEventArgs.cs
+++ b/DNN Platform/Library/Services/Authentication/UserAuthenticatedEventArgs.cs
@@ -123,5 +123,12 @@ namespace DotNetNuke.Services.Authentication
         /// </summary>
         /// -----------------------------------------------------------------------------
         public string UserToken { get; set; }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// Gets and sets the Username
+        /// </summary>
+        /// -----------------------------------------------------------------------------
+        public string UserName { get; set; }
     }
 }

--- a/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -332,6 +332,26 @@ namespace DotNetNuke.Modules.Admin.Authentication
 			}
 		}
 
+		/// <summary>
+		/// Gets and sets the current UserName
+		/// </summary>
+		protected string UserName
+		{
+			get
+			{
+				var userName = "";
+				if (ViewState["UserName"] != null)
+				{
+                    userName = Convert.ToString(ViewState["UserName"]);
+				}
+				return userName;
+			}
+			set
+			{
+				ViewState["UserName"] = value;
+			}
+		}
+
 		#endregion
 
 		#region Private Methods
@@ -376,6 +396,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
                         if (authSystem.AuthenticationType == "DNN")
                         {
                             defaultLoginControl = authLoginControl;
+                            pnlLoginContainer.Visible = true;
                         }
 
                         //Check if AuthSystem is Enabled
@@ -561,7 +582,6 @@ namespace DotNetNuke.Modules.Admin.Authentication
             {
                 pnlLoginContainer.Controls.Add(new LiteralControl("<br />"));
             }
-            pnlLoginContainer.Visible = true;
         }
 
         private void DisplayTabbedLoginControl(AuthenticationLoginBase authLoginControl, TabStripTabCollection Tabs)
@@ -609,8 +629,22 @@ namespace DotNetNuke.Modules.Admin.Authentication
 
         private string GenerateUserName()
         {
-            //Try the best username. Default it to UserToken
-            var userName = UserToken.Replace("http://", "").TrimEnd('/');
+            //Try the best username. Default it to UserName
+            var userName = UserName;
+
+            if (!string.IsNullOrEmpty(userName))
+            {
+                return userName;
+            }
+            else
+            {
+                userName = UserToken.Replace("http://", "").TrimEnd('/');
+
+                if (!string.IsNullOrEmpty(userName))
+                {
+                    return userName;
+                }
+            }
 
             //Try Email prefix
             var emailPrefix = string.Empty;
@@ -1203,6 +1237,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
                         AuthenticationType = e.AuthenticationType;
                         ProfileProperties = e.Profile;
                         UserToken = e.UserToken;
+                        UserName = e.UserName;
                         if (AutoRegister)
                         {
                             InitialiseUser();


### PR DESCRIPTION
[DNN-8450](https://dnntracker.atlassian.net/browse/DNN-8450)

> The fix for [DNN-4133](https://dnntracker.atlassian.net/browse/DNN-4133) was to add a prefix for the service to the beginning of the username. This broke our custom OAuth provider and I believe that we should have the ability to override whether we want to prefix the service to the Username in OAuth providers. In addition to allowing that overriding, this also implements the option to automatically associate logins to existing users, based on email.
> Testing of this API change will require a custom OAuth provider implementation which sets the new `PrefixServiceToUserName` and `AutoMatchExistingUsers` properties in that provider's implementation of `OAuthClientBase` to `false` and `true`, respectively. That custom provider may be an existing provider (e.g. Facebook), tweaked to override those two properties.
> When configured as mentioned above, the username of users who log in via that provider should be the user's email (as provided by the OAuth provider). Additionally, if a user with that email address as their username already exists, that OAuth login would be associated with the existing account, rather than trying to create a new account.
