### PR TITLE
DNN-8456: Fixed parsing of forcedownload query parameter (do not throw exception if the parametr has not the correct format) and removed unused blnClientCache variable

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
@@ -98,7 +98,6 @@ namespace DotNetNuke.Services.FileSystem
 
             //get the URL
             string URL = "";
-            bool blnClientCache = true;
             if (context.Request.QueryString["fileticket"] != null)
             {
 

--- a/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
@@ -99,7 +99,6 @@ namespace DotNetNuke.Services.FileSystem
             //get the URL
             string URL = "";
             bool blnClientCache = true;
-            bool blnForceDownload = false;
             if (context.Request.QueryString["fileticket"] != null)
             {
 
@@ -152,6 +151,7 @@ namespace DotNetNuke.Services.FileSystem
                 }
 
                 //get optional parameters
+                bool blnForceDownload = false;
                 if ((context.Request.QueryString["forcedownload"] != null) || (context.Request.QueryString["contenttype"] != null))
                 {
                      bool.TryParse(context.Request.QueryString["forcedownload"], out blnForceDownload);

--- a/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
@@ -152,13 +152,9 @@ namespace DotNetNuke.Services.FileSystem
                 }
 
                 //get optional parameters
-                if (context.Request.QueryString["clientcache"] != null)
-                {
-                    blnClientCache = bool.Parse(context.Request.QueryString["clientcache"]);
-                }
                 if ((context.Request.QueryString["forcedownload"] != null) || (context.Request.QueryString["contenttype"] != null))
                 {
-                    blnForceDownload = bool.Parse(context.Request.QueryString["forcedownload"]);
+                     bool.TryParse(context.Request.QueryString["forcedownload"], out blnForceDownload);
                 }
                 var contentDisposition = blnForceDownload ? ContentDisposition.Attachment : ContentDisposition.Inline;
 


### PR DESCRIPTION
See https://dnntracker.atlassian.net/browse/DNN-8456
