### PR TITLE
Revert "DNN-4864: when class have AllowAnonymous attribute, then need check the action doesn't contains any authorize attribute."

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Api/AuthorizeAttributeBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/AuthorizeAttributeBase.cs
@@ -70,8 +70,7 @@ namespace DotNetNuke.Web.Api
         public static bool IsAnonymousAttributePresent(HttpActionContext actionContext)
         {
             return actionContext.ActionDescriptor.GetCustomAttributes<AllowAnonymousAttribute>().Any()
-                   || (actionContext.ControllerContext.ControllerDescriptor.GetCustomAttributes<AllowAnonymousAttribute>().Any()
-                        && !actionContext.ActionDescriptor.GetCustomAttributes<AuthorizeAttributeBase>().Any());
+                   || actionContext.ControllerContext.ControllerDescriptor.GetCustomAttributes<AllowAnonymousAttribute>().Any();
         }
     }
 }


### PR DESCRIPTION
Reverts dnnsoftware/Dnn.Platform#1314

This will cause the WebAPI to throw Unauthorized error even if there is AllowAnonymous attribute present at the controller level. (See JIRA SOCIAL-4458)

This issue will need different solution.