### PR TITLE
Dnn 8503: Fixed vw_Modules  casting code

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/08.00.01.02.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/08.00.01.02.SqlDataProvider
@@ -10,8 +10,7 @@ SELECT M.PortalID AS OwnerPortalID, T.PortalID, TM.TabID, TM.TabModuleID, M.Modu
              WHERE CAST(fileid AS nchar(10)) = SUBSTRING(tm.IconFile, 8, 10)) 
 	   ELSE COALESCE (tm.IconFile, '') 
 	   END AS IconFile, 
-	   M.AllTabs, TM.Visibility, TM.IsDeleted, 
-       TM.Header, TM.Footer, M.StartDate, M.EndDate, TM.ContainerSrc, TM.DisplayTitle, TM.DisplayPrint, TM.DisplaySyndicate, TM.IsWebSlice, TM.WebSliceTitle, 
+	   M.AllTabs, TM.Visibility, TM.IsDeleted, TM.Header, TM.Footer, M.StartDate, M.EndDate, TM.ContainerSrc, TM.DisplayTitle, TM.DisplayPrint, TM.DisplaySyndicate, TM.IsWebSlice, TM.WebSliceTitle, 
        TM.WebSliceExpiryDate, TM.WebSliceTTL, M.InheritViewPermissions, M.IsShareable, M.IsShareableViewOnly, MD.DesktopModuleID, MD.DefaultCacheTime, 
        MC.ModuleControlID, DM.BusinessControllerClass, DM.IsAdmin, DM.SupportedFeatures, CI.ContentItemID, CI.[Content], CI.ContentTypeID, CI.ContentKey, CI.Indexed, 
        CI.StateID, M.CreatedByUserID, M.CreatedOnDate, M.LastModifiedByUserID, M.LastModifiedOnDate, M.LastContentModifiedOnDate, TM.UniqueId, TM.VersionGuid, 

--- a/Website/Providers/DataProviders/SqlDataProvider/08.00.01.02.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/08.00.01.02.SqlDataProvider
@@ -1,0 +1,28 @@
+/* DNN-8503 */
+
+ALTER VIEW {databaseOwner}[{objectQualifier}vw_Modules]
+AS
+SELECT M.PortalID AS OwnerPortalID, T.PortalID, TM.TabID, TM.TabModuleID, M.ModuleID, M.ModuleDefID, TM.ModuleOrder, TM.PaneName, TM.ModuleTitle, TM.CacheTime, 
+       TM.CacheMethod, TM.Alignment, TM.Color, TM.Border, 
+	   CASE WHEN tm.IconFile LIKE 'fileid=%' THEN
+			(SELECT IsNull(Folder, '') + [FileName]
+             FROM dbo.[vw_Files]
+             WHERE CAST(fileid AS nchar(10)) = SUBSTRING(tm.IconFile, 8, 10)) 
+	   ELSE COALESCE (tm.IconFile, '') 
+	   END AS IconFile, 
+	   M.AllTabs, TM.Visibility, TM.IsDeleted, 
+       TM.Header, TM.Footer, M.StartDate, M.EndDate, TM.ContainerSrc, TM.DisplayTitle, TM.DisplayPrint, TM.DisplaySyndicate, TM.IsWebSlice, TM.WebSliceTitle, 
+       TM.WebSliceExpiryDate, TM.WebSliceTTL, M.InheritViewPermissions, M.IsShareable, M.IsShareableViewOnly, MD.DesktopModuleID, MD.DefaultCacheTime, 
+       MC.ModuleControlID, DM.BusinessControllerClass, DM.IsAdmin, DM.SupportedFeatures, CI.ContentItemID, CI.[Content], CI.ContentTypeID, CI.ContentKey, CI.Indexed, 
+       CI.StateID, M.CreatedByUserID, M.CreatedOnDate, M.LastModifiedByUserID, M.LastModifiedOnDate, M.LastContentModifiedOnDate, TM.UniqueId, TM.VersionGuid, 
+       TM.DefaultLanguageGuid, TM.LocalizedVersionGuid, TM.CultureCode
+FROM dbo.ModuleDefinitions AS MD INNER JOIN
+     dbo.Modules AS M ON MD.ModuleDefID = M.ModuleDefID INNER JOIN
+     dbo.ModuleControls AS MC ON MD.ModuleDefID = MC.ModuleDefID INNER JOIN
+     dbo.DesktopModules AS DM ON MD.DesktopModuleID = DM.DesktopModuleID LEFT OUTER JOIN
+     dbo.ContentItems AS CI ON M.ContentItemID = CI.ContentItemID LEFT OUTER JOIN
+     dbo.TabModules AS TM ON M.ModuleID = TM.ModuleID LEFT OUTER JOIN
+     dbo.Tabs AS T ON TM.TabID = T.TabID
+WHERE (MC.ControlKey IS NULL)
+
+	


### PR DESCRIPTION
[DNN-8503](https://dnntracker.atlassian.net/browse/DNN-8503)
The VW_MODULES view has the below CASE statement causing an error:

CASE WHEN tm.IconFile LIKE 'fileid=%' THEN
 (SELECT IsNull(Folder, '') + [FileName]
 FROM dbo.[vw_Files]
 WHERE fileid = CAST(SUBSTRING(tm.IconFile, 8, 10) AS int)) ELSE COALESCE (tm.IconFile, '') END AS IconFile

When this view is joined to another table as in the stored procedure 'getModulebyDefinition', the subquery in the above codes is fired for some unknown reason. The substring returns a partial string of a file path for iconfile. It cannot be cast to integer and, therefore, causes a pagebase error stated in the issue tracker.

This contribution changes the code to the following:

CASE WHEN tm.IconFile LIKE 'fileid=%' THEN
 (SELECT IsNull(Folder, '') + [FileName]
 FROM dbo.[vw_Files]
 WHERE CAST(fileid AS nchar(10)) = SUBSTRING(tm.IconFile, 8, 10)) ELSE COALESCE (tm.IconFile, '') END AS IconFile

The result is the same but no accidental casting of strings to integers will happen. 

There are 2 commits with this pull request.  Github some how attached me with the wrong account on my first commit so I committed again with the correct account.
