### PR TITLE
DNN-8530: Using Globals.DeleteFolderRecursive instead of Directory.De…

### DIFF
--- a/Website/DesktopModules/Admin/Extensions/Install.ascx.cs
+++ b/Website/DesktopModules/Admin/Extensions/Install.ascx.cs
@@ -612,8 +612,8 @@ namespace DotNetNuke.Modules.Admin.Extensions
 			{
 				if (!String.IsNullOrEmpty(TempInstallFolder) && Directory.Exists(TempInstallFolder))
 				{
-					Directory.Delete(TempInstallFolder, true);
-				}
+                    Globals.DeleteFolderRecursive(TempInstallFolder);
+                }
 
 				if (DeleteFile && File.Exists(FileName))
 				{


### PR DESCRIPTION
…lete to avoid IO exception when deleting temp extension install folder