### PR TITLE
DNN-8539: Removing Redirect References when a tab is deleted

### DIFF
--- a/DNN Platform/Admin Modules/Dnn.Modules.Tabs/App_LocalResources/Tabs.ascx.resx
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Tabs/App_LocalResources/Tabs.ascx.resx
@@ -130,7 +130,7 @@
     <value>Collapse all Nodes</value>
   </data>
   <data name="ConfirmDelete.Text" xml:space="preserve">
-    <value>This will delete the selected page and all its child pages. Are you sure?</value>
+    <value>This will delete the selected page, all of its child pages, and all redirect references. Are you sure?</value>
   </data>
   <data name="DeletePage.Text" xml:space="preserve">
     <value>Delete Page</value>


### PR DESCRIPTION
Removing Redirect References when a tab is deleted and adding checking when serializing a tab in case it has a redirect to a page that no longer exists.