### PR TITLE
Dnn 8556: Check for Null Redirect Reference on tab when Exporting template.

### DIFF
--- a/DNN Platform/Admin Modules/Dnn.Modules.Tabs/App_LocalResources/Tabs.ascx.resx
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Tabs/App_LocalResources/Tabs.ascx.resx
@@ -130,7 +130,7 @@
     <value>Collapse all Nodes</value>
   </data>
   <data name="ConfirmDelete.Text" xml:space="preserve">
-    <value>This will delete the selected page, all of its child pages, and all redirect references. Are you sure?</value>
+    <value>This will delete the selected page and all its child pages. Are you sure?</value>
   </data>
   <data name="DeletePage.Text" xml:space="preserve">
     <value>Delete Page</value>

--- a/DNN Platform/Admin Modules/Dnn.Modules.Tabs/App_LocalResources/Tabs.ascx.resx
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Tabs/App_LocalResources/Tabs.ascx.resx
@@ -130,7 +130,7 @@
     <value>Collapse all Nodes</value>
   </data>
   <data name="ConfirmDelete.Text" xml:space="preserve">
-    <value>This will delete the selected page and all its child pages. Are you sure?</value>
+    <value>This will delete the selected page, all of its child pages, and all redirect references. Are you sure?</value>
   </data>
   <data name="DeletePage.Text" xml:space="preserve">
     <value>Delete Page</value>

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -2736,7 +2736,7 @@ namespace DotNetNuke.Entities.Tabs
                     break;
                 case TabType.Tab:
                     int tabId;
-                    if (Int32.TryParse(tab.Url, out tabId))
+                    if (int.TryParse(tab.Url, out tabId))
                     {
                         //Get the tab being linked to
                         TabInfo tempTab = TabController.Instance.GetTab(tabId, tab.PortalID, false);
@@ -2749,7 +2749,7 @@ namespace DotNetNuke.Entities.Tabs
                     break;
                 case TabType.File:
                     int fileId;
-                    if (Int32.TryParse(tab.Url.Substring(7), out fileId))
+                    if (int.TryParse(tab.Url.Substring(7), out fileId))
                     {
                         IFileInfo file = FileManager.Instance.GetFile(fileId);
                         if (file?.RelativePath != null)

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -773,9 +773,6 @@ namespace DotNetNuke.Entities.Tabs
                     tabToDelete.IsDeleted = true;
                     UpdateTab(tabToDelete);
 
-                    // Remove all tab redirect references.
-                    RemoveRedirectReferences(tabToDelete.TabID, tabToDelete.PortalID);
-
                     foreach (ModuleInfo m in ModuleController.Instance.GetTabModules(tabToDelete.TabID).Values)
                     {
                         ModuleController.Instance.DeleteTabModule(m.TabID, m.ModuleID, true);
@@ -796,18 +793,6 @@ namespace DotNetNuke.Entities.Tabs
             }
 
             return deleted;
-        }
-
-        /// <summary>Removes the redirect references.</summary>
-        /// <param name="tabId">The tab identifier.</param>
-        /// <param name="portalId">The portal identifier.</param>
-        private void RemoveRedirectReferences(int tabId, int portalId)
-        {
-            foreach (var tab in GetTabsByPortal(portalId).Values.Where(t => t.Url.Equals(tabId.ToString(CultureInfo.InvariantCulture))))
-            {
-                tab.Url = string.Empty;
-                UpdateTab(tab);
-            }
         }
 
         private void UpdateTabSettingInternal(int tabId, string settingName, string settingValue, bool clearCache)


### PR DESCRIPTION
This will prevent exporting from throwing Null Reference Exception if a page is redirecting to deleted tabs or files.