### PR TITLE
DNN-8559 enhance UX for Usage Details report in Extensions module

### DIFF
--- a/Website/DesktopModules/Admin/Extensions/App_LocalResources/UsageDetails.ascx.resx
+++ b/Website/DesktopModules/Admin/Extensions/App_LocalResources/UsageDetails.ascx.resx
@@ -147,9 +147,6 @@
   <data name="grd.PagerSettings.PreviousPageText" xml:space="preserve">
     <value>&lt; Previous Page   </value>
   </data>
-  <data name="FilterOptionSelect.Text" xml:space="preserve">
-    <value>&lt;select&gt;</value>
-  </data>
   <data name="Msg.NotUsedBy" xml:space="preserve">
     <value>This module does not exist on any {0} pages.</value>
   </data>

--- a/Website/DesktopModules/Admin/Extensions/UsageDetails.ascx.cs
+++ b/Website/DesktopModules/Admin/Extensions/UsageDetails.ascx.cs
@@ -209,8 +209,7 @@ namespace DotNetNuke.Modules.Admin.Extensions
                     FilterUsageList.DataBind();
 
                     FilterUsageList.InsertItem(0, Localization.GetString("FilterOptionHost", LocalResourceFile), Null.NullInteger.ToString());
-                    FilterUsageList.InsertItem(0, Localization.GetString("FilterOptionSelect", LocalResourceFile), "-2");
-                    FilterUsageList.Items[0].Selected = true;
+                    FilterUsageList.SelectedValue = this.PortalId.ToString();
                 }
             }
         }
@@ -241,15 +240,8 @@ namespace DotNetNuke.Modules.Admin.Extensions
             {
                 if (IsSuperTab)
                 {
-                    if (selectedPortalID == -2)
-                    {
-                        portalName = string.Empty;
-                    }
-                    else
-                    {
-                        tabs = BuildData(selectedPortalID);
-                        portalName = selectedPortalName;
-                    }
+                    tabs = BuildData(selectedPortalID);
+                    portalName = selectedPortalName;
                 }
                 else
                 {

--- a/Website/DesktopModules/Admin/Extensions/UsageDetails.ascx.cs
+++ b/Website/DesktopModules/Admin/Extensions/UsageDetails.ascx.cs
@@ -163,32 +163,33 @@ namespace DotNetNuke.Modules.Admin.Extensions
         protected string GetFormattedLink(object dataItem)
         {
             var returnValue = new StringBuilder();
-            if ((dataItem is TabInfo))
+            var tab = dataItem as TabInfo;
+            if (tab != null)
             {
-                var tab = (TabInfo) dataItem;
-                if ((tab != null))
+                int index = 0;
+                TabController.Instance.PopulateBreadCrumbs(ref tab);
+                foreach (TabInfo t in tab.BreadCrumbs)
                 {
-                    int index = 0;
-                    TabController.Instance.PopulateBreadCrumbs(ref tab);
-                    foreach (TabInfo t in tab.BreadCrumbs)
+                    if (index > 0)
                     {
-                        if ((index > 0))
-                        {
-                            returnValue.Append(" > ");
-                        }
-                        if ((tab.BreadCrumbs.Count - 1 == index))
-                        {
-                            string url;
-                            //use the current portal alias for host tabs
-                            url = Globals.AddHTTP(t.PortalID == Null.NullInteger? PortalSettings.PortalAlias.HTTPAlias : PortalAliasController.Instance.GetPortalAliasesByPortalId(t.PortalID).ToList()[0].HTTPAlias) + "/Default.aspx?tabId=" + t.TabID;
-                            returnValue.AppendFormat("<a href=\"{0}\">{1}</a>", url, t.LocalizedTabName);
-                        }
-                        else
-                        {
-                            returnValue.AppendFormat("{0}", t.LocalizedTabName);
-                        }
-                        index = index + 1;
+                        returnValue.Append(" &gt; ");
                     }
+                    if (index < tab.BreadCrumbs.Count - 1)
+                    {
+                        returnValue.AppendFormat("{0}", t.LocalizedTabName);
+                    }
+                    else
+                    {
+                        //use the current portal alias for host tabs
+                        var alias = t.PortalID == Null.NullInteger || t.PortalID == this.PortalId
+                                        ? this.PortalSettings.PortalAlias
+                                        : PortalAliasController.Instance.GetPortalAliasesByPortalId(t.PortalID)
+                                                                .OrderBy(pa => pa.IsPrimary ? 0 : 1)
+                                                                .First();
+                        var url = Globals.NavigateURL(t.TabID, new PortalSettings(t.PortalID, alias), string.Empty);
+                        returnValue.AppendFormat("<a href=\"{0}\">{1}</a>", url, t.LocalizedTabName);
+                    }
+                    index = index + 1;
                 }
             }
             return returnValue.ToString();


### PR DESCRIPTION
[DNN-8559](https://dnntracker.atlassian.net/browse/DNN-8559)
>There are a couple of small changes that the Usage Details report in the extensions module could make to make its user experience smoother.

[DNN-8560](https://dnntracker.atlassian.net/browse/DNN-8560) (sub-task)
>The module generates URLs using the first portal alias for the site, instead of the primary alias. Also, it generates the URL as `/Default.aspx?tabId=123` instead of generating the canonical URL for the page.

[DNN-8561](https://dnntracker.atlassian.net/browse/DNN-8561) (sub-task)
>When accessing the usage details of a module from _Host -> Extensions_, it requires you to pick the portal/site, even if your installation only contains one site. It should default to the current site.
