### PR TITLE
Added CultureInfo.InvariantCulture Date parsing

### DIFF
--- a/DNN Platform/Library/Services/Search/Controllers/SearchControllerImpl.cs
+++ b/DNN Platform/Library/Services/Search/Controllers/SearchControllerImpl.cs
@@ -353,7 +353,7 @@ namespace DotNetNuke.Services.Search.Controllers
                         break;
                     case Constants.ModifiedTimeTag:
                         DateTime modifiedTimeUtc;
-                        DateTime.TryParseExact(field.StringValue, Constants.DateTimeFormat, null, DateTimeStyles.None, out modifiedTimeUtc);
+                        DateTime.TryParseExact(field.StringValue, Constants.DateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out modifiedTimeUtc);
                         result.ModifiedTimeUtc = modifiedTimeUtc;
                         break;
                     default:


### PR DESCRIPTION
Added CultureInfo.InvariantCulture to DateTime.TryParseExact as the string is saved in specific culture, when the site is running in ar-sa culture the parse fails, and no results are returned as the calling functions try to format the date 0001/1/1 and fail, I tried this change in ar-sa and it is returning results again
