### PR TITLE
DNN-8532 - Messaging Fails for users with an Apostrophe in their name

### DIFF
--- a/DNN Platform/Modules/CoreMessaging/View.ascx
+++ b/DNN Platform/Modules/CoreMessaging/View.ascx
@@ -284,8 +284,8 @@
 		    notificationTitleText: '<%= ClientAPI.GetSafeJSString(LocalizeString("Notifications")) %>',
 		    archiveTitleText: '<%= ClientAPI.GetSafeJSString(LocalizeString("MarkArchive")) %>',
 		    sentTitleText: '<%= ClientAPI.GetSafeJSString(LocalizeString("Sent")) %>',
-		    currentUserText: '<%= UserController.Instance.GetCurrentUserInfo().DisplayName %>',
-            portalText: '<%= PortalSettings.PortalName %>'
+		    currentUserText: '<%= ClientAPI.GetSafeJSString(UserController.Instance.GetCurrentUserInfo().DisplayName) %>',
+            portalText: '<%= ClientAPI.GetSafeJSString(PortalSettings.PortalName) %>'
 	}, {
             openTriggerScope: '#<%= coreMessaging.ClientID %>',
             openTriggerSelector: '.ComposeMessage',


### PR DESCRIPTION
Fixed username encoding so now can contains apostrophe without errors on messaging tab. Also applied same fix in portal name variable.