### PR TITLE
DNN-8586: Make QuickSettings Control.ID unique

### DIFF
--- a/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -124,6 +124,7 @@ namespace DotNetNuke.Admin.Containers
                 {
                     SupportsQuickSettings = true;
                     var control  = ModuleControlFactory.LoadModuleControl(Page, ModuleContext.Configuration, "QuickSettings", quickSettingsControl.ControlSrc);
+                    control.ID += ModuleContext.ModuleId;
                     quickSettings.Controls.Add(control);
 
                     DisplayQuickSettings = ModuleContext.Configuration.ModuleSettings.GetValueOrDefault("QS_FirstLoad", true);


### PR DESCRIPTION
This prevents a collision with FindControl when deleting the module.