### PR TITLE
DNN-8604 Avoid touching files when XmlMerge doesn't change anything

### DIFF
--- a/DNN Platform/Library/Services/Installer/Installers/ConfigInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/ConfigInstaller.cs
@@ -124,7 +124,7 @@ namespace DotNetNuke.Services.Installer.Installers
         {
             try
             {
-                if (string.IsNullOrEmpty(_FileName))
+                if (string.IsNullOrEmpty(_FileName) && _xmlMerge.ConfigUpdateChangedNodes)
                 {
                     //Save the XmlDocument
                     Config.Save(TargetConfig, TargetFile.FullName);
@@ -164,10 +164,10 @@ namespace DotNetNuke.Services.Installer.Installers
                     TargetConfig.Load(Path.Combine(PhysicalSitePath, TargetFile.FullName));
 
                     //Create XmlMerge instance from InstallConfig source
-                    var merge = new XmlMerge(new StringReader(InstallConfig), Package.Version.ToString(), Package.Name);
+                    _xmlMerge = new XmlMerge(new StringReader(InstallConfig), Package.Version.ToString(), Package.Name);
 
                     //Update the Config file - Note that this method does not save the file - we will save it in Commit
-                    merge.UpdateConfig(TargetConfig);
+                    _xmlMerge.UpdateConfig(TargetConfig);
                     Completed = true;
                     Log.AddInfo(Util.CONFIG_Updated + " - " + TargetFile.Name);
                 }

--- a/DNN Platform/Library/Services/Installer/XmlMerge.cs
+++ b/DNN Platform/Library/Services/Installer/XmlMerge.cs
@@ -544,8 +544,7 @@ namespace DotNetNuke.Services.Installer
                     {
                         case "overwrite":
                             var oldContent = rootNode.InnerXml;
-                            rootNode.RemoveChild(targetNode);
-                            rootNode.InnerXml = rootNode.InnerXml + child.OuterXml;
+                            rootNode.ReplaceChild(TargetConfig.ImportNode(child, true), targetNode);
                             var newContent = rootNode.InnerXml;
                             changedNode = !string.Equals(oldContent, newContent, StringComparison.Ordinal);
                             break;

--- a/DNN Platform/Library/Services/Installer/XmlMerge.cs
+++ b/DNN Platform/Library/Services/Installer/XmlMerge.cs
@@ -158,6 +158,14 @@ namespace DotNetNuke.Services.Installer
         /// -----------------------------------------------------------------------------
         public string Version { get; private set; }
 
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// Gets a value indicating whether the last update performed by this instance resulted in any changes
+        /// </summary>
+        /// <value><c>true</c> if there were changes, <c>false</c> if no changes were made to the target document</value>
+        /// -----------------------------------------------------------------------------
+        public bool ConfigUpdateChangedNodes { get; private set; }
+
         public IDictionary<string, XmlDocument> PendingDocuments
         {
             get
@@ -175,35 +183,44 @@ namespace DotNetNuke.Services.Installer
 
 		#region "Private Methods"
 
-        private void AddNode(XmlNode rootNode, XmlNode actionNode)
+        private bool AddNode(XmlNode rootNode, XmlNode actionNode)
         {
+            var changedNode = false;
             foreach (XmlNode child in actionNode.ChildNodes)
             {
                 if (child.NodeType == XmlNodeType.Element || child.NodeType == XmlNodeType.Comment)
                 {
                     rootNode.AppendChild(TargetConfig.ImportNode(child, true));
 					DnnInstallLogger.InstallLogInfo(Localization.Localization.GetString("LogStart", Localization.Localization.GlobalResourceFile) + "AddNode:" + child.InnerXml.ToString());
+                    changedNode = true;
                 }
             }
+
+            return changedNode;
         }
 
-        private void PrependNode(XmlNode rootNode, XmlNode actionNode)
+        private bool PrependNode(XmlNode rootNode, XmlNode actionNode)
         {
+            var changedNode = false;
             foreach (XmlNode child in actionNode.ChildNodes)
             {
                 if (child.NodeType == XmlNodeType.Element || child.NodeType == XmlNodeType.Comment)
                 {
                     rootNode.PrependChild(TargetConfig.ImportNode(child, true));
                     DnnInstallLogger.InstallLogInfo(Localization.Localization.GetString("LogStart", Localization.Localization.GlobalResourceFile) + "PrependNode:" + child.InnerXml.ToString());
+                    changedNode = true;
                 }
             }
+
+            return changedNode;
         }
 
-        private void InsertNode(XmlNode childRootNode, XmlNode actionNode, NodeInsertType mode)
+        private bool InsertNode(XmlNode childRootNode, XmlNode actionNode, NodeInsertType mode)
         {
             XmlNode rootNode = childRootNode.ParentNode;
             Debug.Assert(rootNode != null);
-            
+
+            var changedNode = false;
             foreach (XmlNode child in actionNode.ChildNodes)
             {
                 if (child.NodeType == XmlNodeType.Element || child.NodeType == XmlNodeType.Comment)
@@ -213,16 +230,20 @@ namespace DotNetNuke.Services.Installer
                     {
                         case NodeInsertType.Before:
                             rootNode.InsertBefore(TargetConfig.ImportNode(child, true), childRootNode);
+                            changedNode = true;
                             break;
                         case NodeInsertType.After:
                             rootNode.InsertAfter(TargetConfig.ImportNode(child, true), childRootNode);
+                            changedNode = true;
                             break;
                     }
                 }
             }
+
+            return changedNode;
         }
 
-        private void ProcessNode(XmlNode node, XmlNode targetRoot)
+        private bool ProcessNode(XmlNode node, XmlNode targetRoot)
         {
             Debug.Assert(node.Attributes != null, "node.Attributes != null");
 
@@ -232,35 +253,29 @@ namespace DotNetNuke.Services.Installer
 
 			if (rootNode == null)
 			{
-			    return; //not every TargetRoot will contain every target node
+			    return false; //not every TargetRoot will contain every target node
 			}
             
             switch (nodeAction)
             {
                 case "add":
-                    AddNode(rootNode, node);
-                    break;
+                    return AddNode(rootNode, node);
                 case "prepend":
-                    PrependNode(rootNode, node);
-                    break;
+                    return PrependNode(rootNode, node);
                 case "insertbefore":
-                    InsertNode(rootNode, node, NodeInsertType.Before);
-                    break;
+                    return InsertNode(rootNode, node, NodeInsertType.Before);
                 case "insertafter":
-                    InsertNode(rootNode, node, NodeInsertType.After);
-                    break;
+                    return InsertNode(rootNode, node, NodeInsertType.After);
                 case "remove":
-                    RemoveNode(rootNode);
-                    break;
+                    return RemoveNode(rootNode);
                 case "removeattribute":
-                    RemoveAttribute(rootNode, node);
-                    break;
+                    return RemoveAttribute(rootNode, node);
                 case "update":
-                    UpdateNode(rootNode, node);
-                    break;
+                    return UpdateNode(rootNode, node);
                 case "updateattribute":
-                    UpdateAttribute(rootNode, node);
-                    break;
+                    return UpdateAttribute(rootNode, node);
+                default:
+                    return false;
             }
         }
 
@@ -294,8 +309,10 @@ namespace DotNetNuke.Services.Installer
             return adjustedPath;
         }
 
-        private void ProcessNodes(XmlNodeList nodes, bool saveConfig)
+        private bool ProcessNodes(XmlNodeList nodes, bool saveConfig)
         {
+            var changedNodes = false;
+
             //The nodes definition is not correct so skip changes
             if (TargetConfig != null)
             {
@@ -309,7 +326,7 @@ namespace DotNetNuke.Services.Installer
                     var root = targetRoots[0];
                     foreach (XmlNode node in nodes)
                     {
-                        ProcessNode(node, root);
+                        changedNodes = ProcessNode(node, root) || changedNodes;
                     }
                 }
                 else
@@ -325,11 +342,11 @@ namespace DotNetNuke.Services.Installer
                         
                         if(hits.Count == 1)
                         {
-                            ProcessNode(node, hits[0]);
+                            changedNodes = ProcessNode(node, hits[0]) || changedNodes;
                         }
                         else if(hits.Count < targetRoots.Count)
                         {
-                            ProcessNode(node, hits[0]);
+                            changedNodes = ProcessNode(node, hits[0]) || changedNodes;
                         }
                         else
                         {
@@ -337,22 +354,24 @@ namespace DotNetNuke.Services.Installer
                             XmlNode hit = FindMatchingNodes(node, hits, "targetpath").FirstOrDefault();
                             if (hit != null)
                             {
-                                ProcessNode(node, hit);
+                                changedNodes = ProcessNode(node, hit) || changedNodes;
                             }
                             else
                             {
                                 //all paths match at root level but no targetpaths match below that so default to the initial root
-                                ProcessNode(node, hits[0]);
+                                changedNodes = ProcessNode(node, hits[0]) || changedNodes;
                             }
                         }
                     }
                 }
                 
-                if (saveConfig)
+                if (saveConfig && changedNodes)
                 {
                     Config.Save(TargetConfig, TargetFileName);
                 }
             }
+
+            return changedNodes;
         }
 
         private IEnumerable<XmlNode> FindMatchingNodes(XmlNode mergeNode, IEnumerable<XmlNode> rootNodes, string pathAttributeName)
@@ -407,11 +426,12 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        private void RemoveAttribute(XmlNode rootNode, XmlNode actionNode)
+        private bool RemoveAttribute(XmlNode rootNode, XmlNode actionNode)
         {
             Debug.Assert(actionNode.Attributes != null, "actionNode.Attributes != null");
             Debug.Assert(rootNode.Attributes != null, "rootNode.Attributes != null");
-            
+
+            var changedNode = false;
             if (actionNode.Attributes["name"] != null)
             {
                 string attributeName = actionNode.Attributes["name"].Value;
@@ -421,16 +441,19 @@ namespace DotNetNuke.Services.Installer
                     {
                         rootNode.Attributes.Remove(rootNode.Attributes[attributeName]);
 						DnnInstallLogger.InstallLogInfo(Localization.Localization.GetString("LogStart", Localization.Localization.GlobalResourceFile) + "RemoveAttribute:attributeName=" + attributeName.ToString());
+                        changedNode = true;
                     }
                 }
             }
+
+            return changedNode;
         }
 
-        private void RemoveNode(XmlNode node)
+        private bool RemoveNode(XmlNode node)
         {
+            var changedNode = false;
             if (node != null)
             {
-                
                 //Get Parent
                 XmlNode parentNode = node.ParentNode;
 
@@ -439,15 +462,19 @@ namespace DotNetNuke.Services.Installer
                 {
                     parentNode.RemoveChild(node);
 					DnnInstallLogger.InstallLogInfo(Localization.Localization.GetString("LogStart", Localization.Localization.GlobalResourceFile) + "RemoveNode:" + node.InnerXml.ToString());
+                    changedNode = true;
                 }
             }
+
+            return changedNode;
         }
 
-        private void UpdateAttribute(XmlNode rootNode, XmlNode actionNode)
+        private bool UpdateAttribute(XmlNode rootNode, XmlNode actionNode)
         {
             Debug.Assert(actionNode.Attributes != null, "actionNode.Attributes != null");
             Debug.Assert(rootNode.Attributes != null, "rootNode.Attributes != null");
-            
+
+            var changedNode = false;
             if (actionNode.Attributes["name"] != null && actionNode.Attributes["value"] != null)
             {
                 string attributeName = actionNode.Attributes["name"].Value;
@@ -458,16 +485,26 @@ namespace DotNetNuke.Services.Installer
                     if (rootNode.Attributes[attributeName] == null)
                     {
                         rootNode.Attributes.Append(TargetConfig.CreateAttribute(attributeName));
+                        changedNode = true;
                     }
+
+                    var oldAttributeValue = rootNode.Attributes[attributeName].Value;
                     rootNode.Attributes[attributeName].Value = attributeValue;
+                    if (!string.Equals(oldAttributeValue, attributeValue, StringComparison.Ordinal))
+                    {
+                        changedNode = true;
+                    }
                 }
             }
+
+            return changedNode;
         }
 
-        private void UpdateNode(XmlNode rootNode, XmlNode actionNode)
+        private bool UpdateNode(XmlNode rootNode, XmlNode actionNode)
         {
             Debug.Assert(actionNode.Attributes != null, "actionNode.Attributes != null");
-            
+
+            var changedNode = false;
             string keyAttribute = "";
             if (actionNode.Attributes["key"] != null)
             {
@@ -497,6 +534,7 @@ namespace DotNetNuke.Services.Installer
                     {
                         //Since there is no collision we can just add the node
                         rootNode.AppendChild(TargetConfig.ImportNode(child, true));
+                        changedNode = true;
                         continue;
                     }
 
@@ -505,8 +543,11 @@ namespace DotNetNuke.Services.Installer
                     switch (collisionAction.ToLowerInvariant())
                     {
                         case "overwrite":
+                            var oldContent = rootNode.InnerXml;
                             rootNode.RemoveChild(targetNode);
                             rootNode.InnerXml = rootNode.InnerXml + child.OuterXml;
+                            var newContent = rootNode.InnerXml;
+                            changedNode = !string.Equals(oldContent, newContent, StringComparison.Ordinal);
                             break;
                         case "save":
                             string commentHeaderText = string.Format(Localization.Localization.GetString("XMLMERGE_Upgrade", Localization.Localization.SharedResourceFile),
@@ -520,12 +561,15 @@ namespace DotNetNuke.Services.Installer
 							XmlComment commentNode = TargetConfig.CreateComment(targetNodeContent);
                             rootNode.RemoveChild(targetNode);
                             rootNode.InnerXml = rootNode.InnerXml + commentHeader.OuterXml + commentNode.OuterXml + child.OuterXml;
+                            changedNode = true;
                             break;
                         case "ignore":
                             break;
                     }
                 }
             }
+
+            return changedNode;
         }
 
 	    private string GetNodeContentWithoutComment(XmlNode node)
@@ -571,11 +615,14 @@ namespace DotNetNuke.Services.Installer
         /// -----------------------------------------------------------------------------
         public void UpdateConfig(XmlDocument target)
         {
+            var changedAnyNodes = false;
             TargetConfig = target;
             if (TargetConfig != null)
             {
-                ProcessNodes(SourceConfig.SelectNodes("/configuration/nodes/node"), false);
+                changedAnyNodes = ProcessNodes(SourceConfig.SelectNodes("/configuration/nodes/node"), false);
             }
+
+            ConfigUpdateChangedNodes = changedAnyNodes;
         }
 
         /// -----------------------------------------------------------------------------
@@ -588,12 +635,15 @@ namespace DotNetNuke.Services.Installer
         /// -----------------------------------------------------------------------------
         public void UpdateConfig(XmlDocument target, string fileName)
         {
+            var changedAnyNodes = false;
             TargetFileName = fileName;
             TargetConfig = target;
             if (TargetConfig != null)
             {
-                ProcessNodes(SourceConfig.SelectNodes("/configuration/nodes/node"), true);
+                changedAnyNodes = ProcessNodes(SourceConfig.SelectNodes("/configuration/nodes/node"), true);
             }
+
+            ConfigUpdateChangedNodes = changedAnyNodes;
         }
 
         /// -----------------------------------------------------------------------------
@@ -610,6 +660,7 @@ namespace DotNetNuke.Services.Installer
 
         public void UpdateConfigs(bool autoSave)
         {
+            var changedAnyNodes = false;
             var nodes = SourceConfig.SelectNodes("/configuration/nodes");
             if (nodes != null)
             {
@@ -644,15 +695,17 @@ namespace DotNetNuke.Services.Installer
                     //The nodes definition is not correct so skip changes
                     if (TargetConfig != null && isAppliedToProduct)
                     {
-                        ProcessNodes(configNode.SelectNodes("node"), autoSave);
-
-                        if (!autoSave)
+                        var changedNodes = ProcessNodes(configNode.SelectNodes("node"), autoSave);
+                        changedAnyNodes = changedAnyNodes || changedNodes;
+                        if (!autoSave && changedNodes)
                         {
                             PendingDocuments.Add(TargetFileName, TargetConfig);
                         }
                     }
                 }
             }
+
+            ConfigUpdateChangedNodes = changedAnyNodes;
         }
 
         public void SavePendingConfigs()

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/DotNetNuke.Tests.Integration.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/DotNetNuke.Tests.Integration.csproj
@@ -237,6 +237,10 @@
     <Content Include="Files\Test.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Services\Installer\MergeFiles\ShouldChangeOnOverwriteMerge.xml" />
+    <EmbeddedResource Include="Services\Installer\MergeFiles\ShouldChangeOnOverwriteTarget.xml" />
+    <EmbeddedResource Include="Services\Installer\MergeFiles\NoChangeOnOverwriteTarget.xml" />
+    <EmbeddedResource Include="Services\Installer\MergeFiles\NoChangeOnOverwriteMerge.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/NoChangeOnOverwriteMerge.xml
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/NoChangeOnOverwriteMerge.xml
@@ -1,0 +1,13 @@
+﻿<configuration>
+  <nodes configfile="Web.config">
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="DNN-8604.key1" value="value1" />
+    </node>
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="DNN-8604.key2" value="value2" />
+    </node>
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="DNN-8604.key3" value="value3" />
+    </node>
+  </nodes>
+</configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/NoChangeOnOverwriteTarget.xml
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/NoChangeOnOverwriteTarget.xml
@@ -1,0 +1,7 @@
+﻿<configuration>
+    <appSettings>
+      <add key="DNN-8604.key1" value="value1" />
+      <add key="DNN-8604.key2" value="value2" />
+      <add key="DNN-8604.key3" value="value3" />
+    </appSettings>
+</configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldChangeOnOverwriteMerge.xml
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldChangeOnOverwriteMerge.xml
@@ -1,0 +1,13 @@
+﻿<configuration>
+  <nodes configfile="Web.config">
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="DNN-8604.key1" value="value1" />
+    </node>
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="DNN-8604.key2" value="value2" />
+    </node>
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="DNN-8604.key3" value="value3" />
+    </node>
+  </nodes>
+</configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldChangeOnOverwriteTarget.xml
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldChangeOnOverwriteTarget.xml
@@ -1,0 +1,7 @@
+﻿<configuration>
+    <appSettings>
+      <add key="DNN-8604.key1" value="value0" />
+      <add key="DNN-8604.key2" value="value2" />
+      <add key="DNN-8604.key3" value="value3" />
+    </appSettings>
+</configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/XmlMergeTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/XmlMergeTests.cs
@@ -454,6 +454,38 @@ namespace DotNetNuke.Tests.Integration.Services.Installer
 
         }
 
+        [Test]
+        public void NoChangeOnOverwrite()
+        {
+            XmlMerge merge = GetXmlMerge(nameof(NoChangeOnOverwrite));
+            XmlDocument targetDoc = LoadTargetDoc(nameof(NoChangeOnOverwrite));
+
+            merge.UpdateConfig(targetDoc);
+
+            WriteToDebug(targetDoc);
+
+            var nodes = targetDoc.SelectNodes("/configuration/appSettings/add");
+            Assert.AreEqual(3, nodes.Count);
+            
+            Assert.False(merge.ConfigUpdateChangedNodes);
+        }
+
+        [Test]
+        public void ShouldChangeOnOverwrite()
+        {
+            XmlMerge merge = GetXmlMerge(nameof(ShouldChangeOnOverwrite));
+            XmlDocument targetDoc = LoadTargetDoc(nameof(ShouldChangeOnOverwrite));
+
+            merge.UpdateConfig(targetDoc);
+
+            WriteToDebug(targetDoc);
+
+            var nodes = targetDoc.SelectNodes("/configuration/appSettings/add");
+            Assert.AreEqual(3, nodes.Count);
+            
+            Assert.True(merge.ConfigUpdateChangedNodes);
+        }
+
 // ReSharper restore PossibleNullReferenceException
     }
 


### PR DESCRIPTION
[DNN-8604](https://dnntracker.atlassian.net/browse/DNN-8604)

> It is common for packages to include a [config component](http://www.dnnsoftware.com/wiki/manifest-config-component) in their manifest if they require any adjustments to the `web.config` file.  On initial install, this change will be made correctly.  However, this component will also run on upgrades (ensuring that the config is correctly in place), and the vast majority of the time, won't do anything, since it was done on install.  The problem is that the config component still updates the `web.config` file, even if no changes are being made, which causes the website to be restarted unnecessarily.
> 
> I've attached a modified version of the Xcillion theme package which adds support for the `woff` and `woff2` font file formats.  When installing this a second time, it should not require restarting the site, but currently DNN will restart the site anyway.
