### PR TITLE
DNN-6696: avoid unnecessary db compatibility level upgrade 

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/07.04.00.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/07.04.00.SqlDataProvider
@@ -18,7 +18,7 @@ BEGIN
     SELECT @Name = DB_NAME()
     SELECT @CompatibilityLevel = compatibility_level FROM sys.databases WHERE name = @Name
 
-    IF @CompatibilityLevel <= 100
+    IF @CompatibilityLevel < 100 -- run only, if level is less than 100
     BEGIN
 	    DECLARE @sql NVARCHAR(max)
 	    SELECT @sql = N'ALTER DATABASE [' + @Name + '] SET COMPATIBILITY_LEVEL = 100'


### PR DESCRIPTION
level should only upgraded, if less than desired value (not equal).
There have been a number of users reporting errors due to missing permission - this change will not solve this problem, but at least reduce it.
