### PR TITLE
DNN-8629: Fixed System.ArgumentException in IsStandardFileURLFormat

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FileUrlHelper.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileUrlHelper.cs
@@ -29,7 +29,7 @@ namespace DotNetNuke.Services.FileSystem
     public class FileUrlHelper
     {
         private static readonly Regex RegexStandardFile =
-            new Regex(@"^/portals/(?<portal>[0-9]+|_default)/(?<filePath>.*\.[a-z0-9]*)$".ToLower(), RegexOptions.Compiled);
+            new Regex(@"^/portals/(?<portal>[0-9]+|_default)/(?<filePath>.*\.[a-z0-9]*)$", RegexOptions.Compiled);
 
         public static bool IsStandardFileURLFormat(string requestPath, out IFileInfo fileRequested)
         {


### PR DESCRIPTION
See https://dnntracker.atlassian.net/browse/DNN-8629.

The line `var filePath = match.Groups["filePath"].Value;` does not work if the regex is converted to lower case.