### PR TITLE
Properly handle SearchResult XSS issues.

### DIFF
--- a/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx
+++ b/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx
@@ -5,7 +5,7 @@
 
 <div class="dnnSearchBoxPanel">
     <a href="javascript:void(0)" class="dnnSearchResultAdvancedTip"><%= LinkAdvancedTipText %></a>
-    <input type="text" id="dnnSearchResult_dnnSearchBox" value="<%= SearchDisplayTerm %>" />
+    <input type="text" id="dnnSearchResult_dnnSearchBox" value="<%= HttpUtility.HtmlAttributeEncode(SearchTerm) %>" />
     <div id="dnnSearchResult-advancedTipContainer">
         <%= AdvancedSearchHintText %>
     </div>
@@ -37,7 +37,7 @@
     <div class="dnnLeft">
         <span></span>
     </div>
-    <div class="dnnRight">       
+    <div class="dnnRight">
     </div>
     <div class="dnnClear"></div>
 </div>
@@ -49,14 +49,14 @@
     <div class="dnnLeft">
         <span></span>
     </div>
-    <div class="dnnRight">       
+    <div class="dnnRight">
     </div>
 </div>
 
 <div id="dnnSearchResultAdvancedForm" class="dnnForm">
     <div class="dnnFormItem">
         <dnn:Label ID="lblAdvancedTags" runat="server" ResourceKey="lblAdvancedTags" />
-        <input type="text" id="advancedTagsCtrl" value="<%=TagsQuery %>" />
+        <input type="text" id="advancedTagsCtrl" value="<%= HttpUtility.HtmlAttributeEncode(TagsQuery) %>" />
     </div>
     <div class="dnnFormItem">
         <dnn:Label ID="lblAdvancedDates" runat="server" ResourceKey="lblAdvancedDates" />
@@ -98,13 +98,13 @@
             var checked = items.getItem(i).get_checked();
             if (checked) countOfChecked++;
         }
-        
+
         if (countOfChecked == 1) {
             var item = e.get_item();
             if (item.get_checked()) e.set_cancel(true);
         }
     }
-    
+
     function dnnSearchResultPageSizeChanged(sender, e) {
         var combo = $find('<%= ResultsPerPageList.ClientID %>');
         var pageSize = combo.get_value();
@@ -118,7 +118,7 @@
         if(typeof dnn != 'undefined' && dnn.searchResult){
             dnn.searchResult.moduleId = <%= ModuleId %>;
             dnn.searchResult.queryOptions = {
-                searchTerm: '<%= SearchTerm %>',
+                searchTerm: '<%= HttpUtility.JavaScriptStringEncode(SearchTerm) %>',
                 sortOption: <%= SortOption %>,
                 pageIndex: <%= PageIndex %>,
                 pageSize: <%= PageSize %>
@@ -142,7 +142,7 @@
                 currentPageIndexText: '<%= CurrentPageIndexText %>',
                 linkTarget: '<%= LinkTarget %>',
                 cultureCode: '<%= CultureCode %>'
-                
+
             });
         }
     });

--- a/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
+++ b/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
@@ -1,22 +1,22 @@
 #region Copyright
 
-// 
-// DotNetNuke® - http://www.dotnetnuke.com
+//
+// DotNetNukeï¿½ - http://www.dotnetnuke.com
 // Copyright (c) 2002-2016
 // by DotNetNuke Corporation
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
 // of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 #endregion
@@ -50,24 +50,19 @@ namespace DotNetNuke.Modules.SearchResults
         private IList<string> _searchContentSources;
         private IList<int> _searchPortalIds;
 
-        protected string SearchDisplayTerm
-        {
-            get { return Request.QueryString["Search"] != null ? HttpUtility.HtmlEncode(Request.QueryString["Search"].Replace("\"", "")) : string.Empty; }
-        }
-
         protected string SearchTerm
         {
-            get { return Request.QueryString["Search"] != null ? HttpUtility.HtmlEncode(Request.QueryString["Search"]) : string.Empty; }
+            get { return Request.QueryString["Search"] ?? string.Empty; }
         }
 
         protected string TagsQuery
         {
-            get { return Request.QueryString["Tag"] != null ? HttpUtility.HtmlEncode(Request.QueryString["Tag"].Replace("\"", "")) : string.Empty; }
+            get { return Request.QueryString["Tag"] ?? string.Empty; }
         }
 
         protected string SearchScopeParam
         {
-            get { return Request.QueryString["Scope"] != null ? HttpUtility.HtmlEncode(Request.QueryString["Scope"]) : string.Empty; }
+            get { return Request.QueryString["Scope"] ?? string.Empty; }
         }
 
         protected string [] SearchScope
@@ -81,7 +76,7 @@ namespace DotNetNuke.Modules.SearchResults
 
         protected string LastModifiedParam
         {
-            get { return Request.QueryString["LastModified"] != null ? HttpUtility.HtmlEncode(Request.QueryString["LastModified"]) : string.Empty; }
+            get { return Request.QueryString["LastModified"] ?? string.Empty; }
         }
 
         protected int PageIndex
@@ -98,7 +93,7 @@ namespace DotNetNuke.Modules.SearchResults
                 {
                     return pageIndex;
                 }
-                
+
                 return DefaultPageIndex;
             }
         }

--- a/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
+++ b/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
@@ -1,7 +1,7 @@
 #region Copyright
 
 //
-// DotNetNuke� - http://www.dotnetnuke.com
+// DotNetNuke® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2016
 // by DotNetNuke Corporation
 //

--- a/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
+++ b/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
@@ -1,11 +1,7 @@
 #region Copyright
 
 //
-<<<<<<< 2a837028d4fafdc2a75bd41ce5249dcf4401fe1e
 // DotNetNuke® - http://www.dotnetnuke.com
-=======
-// DotNetNuke� - http://www.dotnetnuke.com
->>>>>>> NOJIRA: update copyright.
 // Copyright (c) 2002-2016
 // by DotNetNuke Corporation
 //

--- a/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
+++ b/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
@@ -1,7 +1,11 @@
 #region Copyright
 
 //
+<<<<<<< 2a837028d4fafdc2a75bd41ce5249dcf4401fe1e
 // DotNetNuke® - http://www.dotnetnuke.com
+=======
+// DotNetNuke� - http://www.dotnetnuke.com
+>>>>>>> NOJIRA: update copyright.
 // Copyright (c) 2002-2016
 // by DotNetNuke Corporation
 //


### PR DESCRIPTION
The `SearchResult.ascx` page is susceptible to XSS when the search string has single-quotes (breaks JSON at page bottom). This patch fixes the issues the right way; using `HtmlAttributeEncode` when emitting user-supplied values (when echoing back the `SearchTerm` or `TagsQuery` values in the input fields) and `JavaScriptStringEncode` when emitting the `SeachTerm` in the `dnn.searchResult.queryOptions` script.

This also simplifies the code behind to null-coalesce the query parameters and not do the encoding on the input values (instead encoding them on the rendering out, as it should be)