### PR TITLE
Refix the script injection issue on Search

### DIFF
--- a/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx
+++ b/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx
@@ -118,7 +118,7 @@
         if(typeof dnn != 'undefined' && dnn.searchResult){
             dnn.searchResult.moduleId = <%= ModuleId %>;
             dnn.searchResult.queryOptions = {
-                searchTerm: '<%= Localization.GetSafeJSString(SearchTerm) %>',
+                searchTerm: '<%= HttpUtility.JavaScriptStringEncode(SearchTerm) %>',
                 sortOption: <%= SortOption %>,
                 pageIndex: <%= PageIndex %>,
                 pageSize: <%= PageSize %>


### PR DESCRIPTION
As documented in the comment for commit 6216b09acc41b59ab9a4655a25737fe9ad5f0ab4 `Localization.GetSafeJSString` is not enough to prevent issues with XSS injection. We should really replace ALL calls with the safer `HttpUtility.JavaScriptStringEncode` method, but for now at least let's fix the reported site.