### PR TITLE
DNN-8664 Update GetSafeJSString to use built-in encoder

### DIFF
--- a/DNN Platform/DotNetNuke.WebUtility/ClientAPI.vb
+++ b/DNN Platform/DotNetNuke.WebUtility/ClientAPI.vb
@@ -549,6 +549,10 @@ Namespace DotNetNuke.UI.Utilities
         ''' </history>
         ''' -----------------------------------------------------------------------------
         Public Shared Function GetSafeJSString(ByVal strString As String) As String
+            If String.IsNullOrEmpty(strString) Then
+                Return String.Empty
+            End If
+
             Return HttpUtility.JavaScriptStringEncode(strString)
         End Function
 

--- a/DNN Platform/DotNetNuke.WebUtility/ClientAPI.vb
+++ b/DNN Platform/DotNetNuke.WebUtility/ClientAPI.vb
@@ -46,8 +46,6 @@ Namespace DotNetNuke.UI.Utilities
     ''' -----------------------------------------------------------------------------
     Public Class ClientAPI
 
-        Dim Shared ReadOnly UnsafeJsRegex As Regex = new Regex("(['""\\])", RegexOptions.Compiled)
-
 #Region "Public Constants"
 
         Public Const SCRIPT_CALLBACKID As String = "__DNNCAPISCI"
@@ -551,11 +549,7 @@ Namespace DotNetNuke.UI.Utilities
         ''' </history>
         ''' -----------------------------------------------------------------------------
         Public Shared Function GetSafeJSString(ByVal strString As String) As String
-            If Len(strString) > 0 Then
-                Return UnsafeJsRegex.Replace(strString, "\$1")
-            Else
-                Return strString
-            End If
+            Return HttpUtility.JavaScriptStringEncode(strString)
         End Function
 
         Public Shared Function IsInCallback(ByVal objPage As Page) As Boolean

--- a/DNN Platform/Library/Services/Localization/Localization.cs
+++ b/DNN Platform/Library/Services/Localization/Localization.cs
@@ -122,8 +122,6 @@ namespace DotNetNuke.Services.Localization
         //private static readonly ILocaleController LocaleController.Instance = LocaleController.Instance;
         //private static readonly ILocalizationProvider _localizationProvider = LocalizationProvider.Instance;
         private static bool? _showMissingKeys;
-
-        private static readonly Regex UnsafeJsRegex = new Regex("(['\"\\\\])", RegexOptions.Compiled);
         #endregion
 
         #region Public Shared Properties
@@ -1245,13 +1243,7 @@ namespace DotNetNuke.Services.Localization
         /// <returns>the string that is safe to use in a javascript function</returns>
         public static string GetSafeJSString(string unsafeString)
         {
-            var safeString = string.IsNullOrEmpty(unsafeString) ? "" : UnsafeJsRegex.Replace(unsafeString, "\\$1");
-			if (safeString.Length > 0)
-	        {
-				safeString = safeString.Replace("\r", string.Empty).Replace("\n", string.Empty);
-	        }
-
-			return safeString;
+            return HttpUtility.JavaScriptStringEncode(unsafeString);
         }
 
         /// <summary>

--- a/DNN Platform/Library/Services/Localization/Localization.cs
+++ b/DNN Platform/Library/Services/Localization/Localization.cs
@@ -1243,6 +1243,11 @@ namespace DotNetNuke.Services.Localization
         /// <returns>the string that is safe to use in a javascript function</returns>
         public static string GetSafeJSString(string unsafeString)
         {
+            if (string.IsNullOrEmpty(unsafeString))
+            {
+                return string.Empty;
+            }
+
             return HttpUtility.JavaScriptStringEncode(unsafeString);
         }
 


### PR DESCRIPTION
The current implementations are woefully incomplete and can cause breakages and
security risks

This is an alternate implementation of #1488, thanks to @IDisposable for taking on the initial work for fixing this!  I'm suggesting this implementation so that :one: other users of the `GetSafeJSString` methods are protected, not just usages within DNN, :two: to simplify the change and not have to touch as many core files, and :three: to avoid having to distinguish between the two overloads of `Localization.GetSafeJSString`.

[DNN-8664](https://dnntracker.atlassian.net/browse/DNN-8664)
>Through testing and correction of an XSS vulnerability found in the SearchResults module, we've discovered that the library routine used to escape strings for inclusion as a javascript variable in a script block does NOT safely escape HTML tags. This means that submitting an input that contains `</script>` will end the surrounding `<script>` block early. This means that arbitrary HTML can be injected, including other `<script>` blocks by user input. Rather than piecemeal fix this, I'm suggesting a wholesale swap-out from the `Localization.GetSafeJSString` to the Microsoft provided `HttpUtility.JavaScriptStringEncode` which is provably much safer.