### PR TITLE
Limit menu action ul selector to first ul

### DIFF
--- a/Website/admin/Menus/ModuleActions/ModuleActions.js
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.js
@@ -394,11 +394,11 @@
 
         $("#moduleActions-" + moduleId + " .dnn_mact > li").hoverIntent({
             over: function () {
-                showMenu($(this).find("ul"));
+                showMenu($(this).find("ul").first());
             },
             out: function () {
                 if (!($(this).hasClass("actionQuickSettings") && $(this).data('displayQuickSettings'))) {
-                    closeMenu($(this).find("ul"));
+                    closeMenu($(this).find("ul").first());
                 }
             },
             timeout: 400,


### PR DESCRIPTION
DNN-8678: When using a <ul> element in a quick settings view, the jquery
ul selector would apply to all ul elements.  Since showMenu() applied
styles by calling .css(), the menu placement adjustments being performed
would incorrectly be applied to <ul> elements internal to the quick
settings view. This limits the jquery object to the first <ul>.