### PR TITLE
DNN-8941 Package names should be case insensitive

### DIFF
--- a/DNN Platform/Library/Services/Installer/Dependencies/ManagedPackageDependency.cs
+++ b/DNN Platform/Library/Services/Installer/Dependencies/ManagedPackageDependency.cs
@@ -46,7 +46,7 @@ namespace DotNetNuke.Services.Installer.Dependencies
 
                 //Get Package from DataStore
                 PackageInfo package = PackageController.Instance.GetExtensionPackage(Null.NullInteger, 
-                                                (p) => p.Name == PackageDependency.PackageName 
+                                                (p) => p.Name.Equals(PackageDependency.PackageName, StringComparison.OrdinalIgnoreCase)
                                                                 && p.Version >= PackageDependency.Version);
                 if (package == null)
                 {

--- a/DNN Platform/Library/Services/Installer/Dependencies/PackageDependency.cs
+++ b/DNN Platform/Library/Services/Installer/Dependencies/PackageDependency.cs
@@ -30,6 +30,8 @@ using DotNetNuke.Services.Installer.Packages;
 
 namespace DotNetNuke.Services.Installer.Dependencies
 {
+    using System;
+
     /// -----------------------------------------------------------------------------
     /// <summary>
     /// The PackageDependency determines whether the dependent package is installed
@@ -56,7 +58,7 @@ namespace DotNetNuke.Services.Installer.Dependencies
                 bool _IsValid = true;
 
                 //Get Package from DataStore
-                PackageInfo package = PackageController.Instance.GetExtensionPackage(Null.NullInteger, (p) => p.Name == PackageName);
+                PackageInfo package = PackageController.Instance.GetExtensionPackage(Null.NullInteger, (p) => p.Name.Equals(PackageName, StringComparison.OrdinalIgnoreCase));
                 if (package == null)
                 {
                     _IsValid = false;

--- a/DNN Platform/Library/Services/Installer/Installers/LanguageInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/LanguageInstaller.cs
@@ -163,7 +163,7 @@ namespace DotNetNuke.Services.Installer.Installers
             else
             {
                 string packageName = Util.ReadElement(nav, "package");
-                PackageInfo package = PackageController.Instance.GetExtensionPackage(Null.NullInteger, p => p.Name == packageName);
+                PackageInfo package = PackageController.Instance.GetExtensionPackage(Null.NullInteger, p => p.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase));
                 if (package != null)
                 {
                     LanguagePack.DependentPackageID = package.PackageID;

--- a/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
@@ -360,17 +360,18 @@ namespace DotNetNuke.Services.Installer.Installers
             }
 
             //Attempt to get the Package from the Data Store (see if its installed)
-            var packageType = PackageController.Instance.GetExtensionPackageType(t => t.PackageType == Package.PackageType);
+            var packageType = PackageController.Instance.GetExtensionPackageType(t => t.PackageType.Equals(Package.PackageType, StringComparison.OrdinalIgnoreCase));
 
             if (packageType.SupportsSideBySideInstallation)
             {
-                _installedPackage = PackageController.Instance.GetExtensionPackage(Package.PortalID, p => p.Name == Package.Name
-                                                                                                            && p.PackageType == Package.PackageType
+                _installedPackage = PackageController.Instance.GetExtensionPackage(Package.PortalID, p => p.Name.Equals(Package.Name, StringComparison.OrdinalIgnoreCase)
+                                                                                                            && p.PackageType.Equals(Package.PackageType, StringComparison.OrdinalIgnoreCase)
                                                                                                             && p.Version == Package.Version);                
             }
             else
             {
-                _installedPackage = PackageController.Instance.GetExtensionPackage(Package.PortalID, p => p.Name == Package.Name && p.PackageType == Package.PackageType);
+                _installedPackage = PackageController.Instance.GetExtensionPackage(Package.PortalID, p => p.Name.Equals(Package.Name, StringComparison.OrdinalIgnoreCase) 
+                                                                                                            && p.PackageType.Equals(Package.PackageType, StringComparison.OrdinalIgnoreCase));
             }
 
             if (_installedPackage != null)

--- a/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
@@ -140,7 +140,7 @@ namespace DotNetNuke.Services.Installer.Installers
         /// -----------------------------------------------------------------------------
         private void CheckSecurity()
         {
-            PackageType type = PackageController.Instance.GetExtensionPackageType(t => t.PackageType == Package.PackageType);
+            PackageType type = PackageController.Instance.GetExtensionPackageType(t => t.PackageType.Equals(Package.PackageType, StringComparison.OrdinalIgnoreCase));
             if (type == null)
             {
                 //This package type not registered

--- a/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/PackageInstaller.cs
@@ -331,7 +331,7 @@ namespace DotNetNuke.Services.Installer.Installers
             Package.PackageType = Util.ReadAttribute(manifestNav, "type", Log, Util.EXCEPTION_TypeMissing);
 
             //If Skin or Container then set PortalID
-            if (Package.PackageType == "Skin" || Package.PackageType == "Container")
+            if (Package.PackageType.Equals("Skin", StringComparison.OrdinalIgnoreCase) || Package.PackageType.Equals("Container", StringComparison.OrdinalIgnoreCase))
             {
                 Package.PortalID = Package.InstallerInfo.PortalID;
             }

--- a/DNN Platform/Library/Services/Installer/LegacyUtil.cs
+++ b/DNN Platform/Library/Services/Installer/LegacyUtil.cs
@@ -214,9 +214,7 @@ namespace DotNetNuke.Services.Installer
             {
                 ParsePackageName(package, "_");
             }
-            if (package.PackageType == "Module" && AdminModules.Contains(package.Name + ",") || package.PackageType == "Module" && CoreModules.Contains(package.Name + ",") ||
-                (package.PackageType == "Container" || package.PackageType == "Skin") && KnownSkins.Contains(package.Name + ",") ||
-                package.PackageType == "SkinObject" && KnownSkinObjects.Contains(package.Name + ","))
+            if (package.PackageType.Equals("Module", StringComparison.OrdinalIgnoreCase) && AdminModules.Contains(package.Name + ",") || package.PackageType.Equals("Module", StringComparison.OrdinalIgnoreCase) && CoreModules.Contains(package.Name + ",") || (package.PackageType.Equals("Container", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Skin", StringComparison.OrdinalIgnoreCase)) && KnownSkins.Contains(package.Name + ",") || package.PackageType.Equals("SkinObject", StringComparison.OrdinalIgnoreCase) && KnownSkinObjects.Contains(package.Name + ","))
             {
                 if (string.IsNullOrEmpty(package.Owner))
                 {

--- a/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
@@ -318,19 +318,17 @@ namespace DotNetNuke.Services.Installer.Packages
                     case "Skin":
                     case "Container":
                         //Need to get path of skin being deleted so we can call the public CanDeleteSkin function in the SkinController
-                        string strRootSkin = package.PackageType == "Skin" ? SkinController.RootSkin : SkinController.RootContainer;
+                        string strRootSkin = package.PackageType.Equals("Skin", StringComparison.OrdinalIgnoreCase) ? SkinController.RootSkin : SkinController.RootContainer;
                         SkinPackageInfo _SkinPackageInfo = SkinController.GetSkinByPackageID(package.PackageID);
-                        string strFolderPath = Path.Combine(_SkinPackageInfo.PortalID == Null.NullInteger
-                                                                ? Path.Combine(Globals.HostMapPath, strRootSkin)
-                                                                : Path.Combine(portalSettings.HomeSystemDirectoryMapPath, strRootSkin), _SkinPackageInfo.SkinName);
+                        string strFolderPath = Path.Combine(_SkinPackageInfo.PortalID == Null.NullInteger ? Path.Combine(Globals.HostMapPath, strRootSkin) : Path.Combine(portalSettings.HomeSystemDirectoryMapPath, strRootSkin), _SkinPackageInfo.SkinName);
 
                         bCanDelete = SkinController.CanDeleteSkin(strFolderPath, portalSettings.HomeSystemDirectoryMapPath);
                         if (_SkinPackageInfo.PortalID != Null.NullInteger)
                         {
                             //To be compliant with all versions
                             strFolderPath = Path.Combine(Path.Combine(portalSettings.HomeDirectoryMapPath, strRootSkin), _SkinPackageInfo.SkinName);
-                            bCanDelete = bCanDelete && SkinController.CanDeleteSkin(strFolderPath, portalSettings.HomeDirectoryMapPath);    
-                        }                        
+                            bCanDelete = bCanDelete && SkinController.CanDeleteSkin(strFolderPath, portalSettings.HomeDirectoryMapPath);
+                        }
                         break;
                     case "Provider":
                         //Check if the provider is the default provider
@@ -454,8 +452,7 @@ namespace DotNetNuke.Services.Installer.Packages
                                     XPathNavigator iconFileNav = nav.SelectSingleNode("iconFile");
                                     if (package.FolderName != string.Empty && iconFileNav != null)
                                     {
-
-                                        if ((iconFileNav.Value != string.Empty) && (package.PackageType == "Module" || package.PackageType == "Auth_System" || package.PackageType == "Container" || package.PackageType == "Skin"))
+                                        if ((iconFileNav.Value != string.Empty) && (package.PackageType.Equals("Module", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Auth_System", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Container", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Skin", StringComparison.OrdinalIgnoreCase)))
                                         {
                                             if (iconFileNav.Value.StartsWith("~/"))
                                             {
@@ -553,7 +550,7 @@ namespace DotNetNuke.Services.Installer.Packages
         [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate)")]
         public static PackageInfo GetPackage(int packageID)
         {
-	        return Instance.GetExtensionPackage(Null.NullInteger, p => p.PackageID == packageID);
+            return Instance.GetExtensionPackage(Null.NullInteger, p => p.PackageID == packageID);
         }
 
         [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate)")]
@@ -589,13 +586,13 @@ namespace DotNetNuke.Services.Installer.Packages
         [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate)")]
         public static List<PackageInfo> GetPackagesByType(string type)
         {
-            return Instance.GetExtensionPackages(Null.NullInteger, p => p.PackageType == type).ToList();
+            return Instance.GetExtensionPackages(Null.NullInteger, p => p.PackageType.Equals(type, StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
         [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate)")]
         public static List<PackageInfo> GetPackagesByType(int portalId, string type)
         {
-            return Instance.GetExtensionPackages(portalId, p => p.PackageType == type).ToList();
+            return Instance.GetExtensionPackages(portalId, p => p.PackageType.Equals(type, StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
         [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackageType(Func<PackageType, bool> predicate)")]

--- a/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
@@ -291,7 +291,7 @@ namespace DotNetNuke.Services.Installer.Packages
         {
             bool bCanDelete = true;
 
-            var dependencies = Instance.GetPackageDependencies(d => d.PackageName == package.Name && d.Version <= package.Version);
+            var dependencies = Instance.GetPackageDependencies(d => d.PackageName.Equals(package.Name, StringComparison.OrdinalIgnoreCase) && d.Version <= package.Version);
             if (dependencies.Count > 0)
             {
                 //There is at least one package dependent on this package.
@@ -301,7 +301,7 @@ namespace DotNetNuke.Services.Installer.Packages
 
                     //Check if there is an alternative package
                     var packages = Instance.GetExtensionPackages(package.PortalID,
-                                                                 p => p.Name == dep.PackageName
+                                                                 p => p.Name.Equals(dep.PackageName, StringComparison.OrdinalIgnoreCase)
                                                                         && p.Version >= dep.Version
                                                                         && p.PackageID != package.PackageID);
                     if (packages.Count == 0)

--- a/DNN Platform/Library/Services/Installer/Util.cs
+++ b/DNN Platform/Library/Services/Installer/Util.cs
@@ -445,7 +445,7 @@ namespace DotNetNuke.Services.Installer
         public static string ParsePackageIconFileName(PackageInfo package)
         {
             var filename = string.Empty;
-            if ((package.IconFile != null) && (package.PackageType == "Module" || package.PackageType == "Auth_System" || package.PackageType == "Container" || package.PackageType == "Skin"))
+            if ((package.IconFile != null) && (package.PackageType.Equals("Module", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Auth_System", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Container", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Skin", StringComparison.OrdinalIgnoreCase)))
             {
                 filename = package.IconFile.StartsWith("~/" + package.FolderName) ? package.IconFile.Remove(0, ("~/" + package.FolderName).Length).TrimStart('/') : package.IconFile;
             }
@@ -455,7 +455,7 @@ namespace DotNetNuke.Services.Installer
         public static string ParsePackageIconFile(PackageInfo package)
         {
             var iconFile = string.Empty;
-            if ((package.IconFile != null) && (package.PackageType == "Module" || package.PackageType == "Auth_System" || package.PackageType == "Container" || package.PackageType == "Skin"))
+            if ((package.IconFile != null) && (package.PackageType.Equals("Module", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Auth_System", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Container", StringComparison.OrdinalIgnoreCase) || package.PackageType.Equals("Skin", StringComparison.OrdinalIgnoreCase)))
             {
                 iconFile = !package.IconFile.StartsWith("~/") ? "~/" + package.FolderName + "/" + package.IconFile : package.IconFile;
             }

--- a/DNN Platform/Library/Services/Localization/LocaleController.cs
+++ b/DNN Platform/Library/Services/Localization/LocaleController.cs
@@ -75,7 +75,7 @@ namespace DotNetNuke.Services.Localization
         /// </returns>
         public bool CanDeleteLanguage(int languageId)
         {
-            return PackageController.Instance.GetExtensionPackages(Null.NullInteger, p => p.PackageType == "CoreLanguagePack")
+            return PackageController.Instance.GetExtensionPackages(Null.NullInteger, p => p.PackageType.Equals("CoreLanguagePack", StringComparison.OrdinalIgnoreCase))
                         .Select(package => LanguagePackController.GetLanguagePackByPackage(package.PackageID))
                         .All(languagePack => languagePack.LanguageID != languageId);
         }

--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -3205,7 +3205,7 @@ namespace DotNetNuke.Services.Upgrade
 
         private static void UninstallPackage(string packageName, string packageType, bool deleteFiles = true)
         {
-            var searchInput = PackageController.Instance.GetExtensionPackage(Null.NullInteger, p => p.Name == packageName && p.PackageType == packageType);
+            var searchInput = PackageController.Instance.GetExtensionPackage(Null.NullInteger, p => p.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase) && p.PackageType.Equals(packageType, StringComparison.OrdinalIgnoreCase));
             if (searchInput != null)
             {
                 var searchInputInstaller = new Installer.Installer(searchInput, Globals.ApplicationMapPath);
@@ -4917,7 +4917,7 @@ namespace DotNetNuke.Services.Upgrade
                 foreach (var package in dependentPackages)
                 {
                     if ( package.Value.Dependencies.All(
-                            d => sortedPackages.Any(p => p.Value.Name == d.PackageName && p.Value.Version >= d.Version) ) )
+                            d => sortedPackages.Any(p => p.Value.Name.Equals(d.PackageName, StringComparison.OrdinalIgnoreCase) && p.Value.Version >= d.Version) ) )
                     {
                         sortedPackages.Add(package.Key, package.Value);
                         addedPackages.Add(package.Key);

--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -4965,18 +4965,18 @@ namespace DotNetNuke.Services.Upgrade
 		                var package = packages[file];
 
                         var installedPackage = PackageController.Instance.GetExtensionPackage(Null.NullInteger, 
-                            p => p.Name.Equals(package.Name, StringComparison.InvariantCultureIgnoreCase) 
-                                    && p.PackageType.Equals(package.PackageType, StringComparison.InvariantCultureIgnoreCase));
+                            p => p.Name.Equals(package.Name, StringComparison.OrdinalIgnoreCase) 
+                                    && p.PackageType.Equals(package.PackageType, StringComparison.OrdinalIgnoreCase));
 
-                        if (packages.Values.Count(p => p.FriendlyName.Equals(package.FriendlyName, StringComparison.InvariantCultureIgnoreCase)) > 1 
+                        if (packages.Values.Count(p => p.FriendlyName.Equals(package.FriendlyName, StringComparison.OrdinalIgnoreCase)) > 1 
                                 || installedPackage != null)
 		                {
-			                var oldPackages = packages.Where(kvp => kvp.Value.FriendlyName.Equals(package.FriendlyName, StringComparison.InvariantCultureIgnoreCase)
+			                var oldPackages = packages.Where(kvp => kvp.Value.FriendlyName.Equals(package.FriendlyName, StringComparison.OrdinalIgnoreCase)
                                                                         && kvp.Value.Version < package.Version).ToList();
 
                             //if there already have higher version installed, remove current one from list.
 		                    if (installedPackage != null && package.Version <= installedPackage.Version)
-		                    {
+		                {
 		                        oldPackages.Add(new KeyValuePair<string, PackageInfo>(file, package));
 		                    }
 

--- a/Website/DesktopModules/Admin/EditExtension/EditExtension.ascx.cs
+++ b/Website/DesktopModules/Admin/EditExtension/EditExtension.ascx.cs
@@ -96,7 +96,7 @@ namespace DotNetNuke.Modules.Admin.EditExtension
                 {
                     if (Package != null)
                     {
-                        var pkgType = PackageController.Instance.GetExtensionPackageType(t => t.PackageType == Package.PackageType);
+                        var pkgType = PackageController.Instance.GetExtensionPackageType(t => t.PackageType.Equals(Package.PackageType, StringComparison.OrdinalIgnoreCase));
                         if ((pkgType != null) && (!string.IsNullOrEmpty(pkgType.EditorControlSrc)))
                         {
                             _control = ControlUtilities.LoadControl<Control>(this, pkgType.EditorControlSrc);


### PR DESCRIPTION
[DNN-8941](https://dnntracker.atlassian.net/browse/DNN-8941)

> When a package has a dependency on another package, that dependency is currently case sensitive. Likewise, when installing a package, the search for duplicate packages (to determine if this is an upgrade, repair, etc.) is case sensitive. This behavior should not be case sensitive.
> # Scenario
> 
> The attached package [knockout-postbox_0.5.2_mismatch-dependency.zip](https://dnntracker.atlassian.net/secure/attachment/40755/knockout-postbox_0.5.2_mismatch-dependency.zip) has a dependency on "knockout," whereas the package that comes with DNN has the name "Knockout" with a capital _K_
> 
> ```
> <dependencies>
>   <dependency type="managedPackage" version="2.0.0">knockout</dependency>
> </dependencies>
> ```
> ## Steps to reproduce
> - Install the attached [knockout-postbox_0.5.2_mismatch-dependency.zip](https://dnntracker.atlassian.net/secure/attachment/40755/knockout-postbox_0.5.2_mismatch-dependency.zip) into your DNN site
> ## Expected
> - Package installs correctly
> ## Actual
> - Package fails because of an unmet dependency
> # Scenario
> 
> The attached package [Knockout-PostBox_0.5.2_mismatch-package.zip](https://dnntracker.atlassian.net/secure/attachment/40754/Knockout-PostBox_0.5.2_mismatch-package.zip) has the package name "Knockout-PostBox," whereas the package [knockout-postbox_0.5.2.zip](https://dnntracker.atlassian.net/secure/attachment/40753/knockout-postbox_0.5.2.zip) has the lowercase package name "knockout-postbox"
> ## Steps to reproduce
> - Install the attached [knockout-postbox_0.5.2.zip](https://dnntracker.atlassian.net/secure/attachment/40753/knockout-postbox_0.5.2.zip) into your DNN 
> - Install the attached [Knockout-PostBox_0.5.2_mismatch-package.zip](https://dnntracker.atlassian.net/secure/attachment/40754/Knockout-PostBox_0.5.2_mismatch-package.zip) into your DNN site
> ## Expected
> - Second package install indicates package is already installed, asks to do repair install
> ## Actual
> - Second package installs without indicating any issue
