### PR TITLE
Nuspec cleanup

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>DotNetNuke</id>
+    <id>DotNetNuke.Bundle</id>
     <version>9.0.1</version>
     <title>DNN Platform</title>
     <authors>DNN Corp</authors>

--- a/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Bundle</id>
     <version>9.0.1</version>
     <title>DotNetNuke Bundle</title>
-    <authors>DotNetNuke Corporation</authors>
-    <owners>DotNetNuke Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>DotNetNuke Bundle containing DotNetNuke.dll, .Instrumentation.dll, .Web.dll and .Web.Client.dll</description>
-    <copyright>DotNetNuke is copyright 2002-2017 by DotNetNuke Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.dll" target="lib\"/>

--- a/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Bundle</id>
     <version>9.0.1</version>
-    <title>DotNetNuke Bundle</title>
+    <title>DNN Platform</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>DotNetNuke Bundle containing DotNetNuke.dll, .Instrumentation.dll, .Web.dll and .Web.Client.dll</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components required for developing many different kinds of extensions for DNN Platform.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
@@ -10,31 +10,20 @@
     <description>
       DNN Platform is an open source web application framework.
       This package contains components required for developing many different kinds of extensions for DNN Platform.
+      Installing this package also installs DotNetNuke.Core, DotNetNuke.Instrumentation, DotNetNuke.Web, DotNetNuke.Web.Client, DotNetNuke.Web.Mvc, DotNetNuke.WebApi, and DotNetNuke.Web.Deprecated.
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
+    <dependencies>
+      <dependency id="DotNetNuke.Core" version="9.0.1" />
+      <dependency id="DotNetNuke.Instrumentation" version="9.0.1" />
+      <dependency id="DotNetNuke.Web" version="9.0.1" />
+      <dependency id="DotNetNuke.Web.Client" version="9.0.1" />
+      <dependency id="DotNetNuke.Web.Mvc" version="9.0.1" />
+      <dependency id="DotNetNuke.WebApi" version="9.0.1" />
+      <dependency id="DotNetNuke.Web.Deprecated" version="9.0.1" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.pdb" target="lib\"/>
-
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.pdb" target="lib\"/>
-
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.pdb" target="lib\"/>
-
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.pdb" target="lib\"/>
-
-    <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.pdb" target="lib\"/>
-
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.pdb" target="lib\"/>
-
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.dll" target="lib\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.pdb" target="lib\"/>
-
     <file src="DNN.Platform\DNN Platform\Components\ClientDependency\Source\Bin\ClientDependency.Core.dll" target="lib\"/>
     <file src="DNN.Platform\DNN Platform\Components\ClientDependency\Source\Bin\ClientDependency.Core.pdb" target="lib\"/>
 
@@ -53,7 +42,6 @@
     <file src="DNN.Platform\DNN Platform\Tests\DotNetNuke.Tests.Utilities\bin\DotNetNuke.Tests.Utilities.dll" target="lib\"/>
     <file src="DNN.Platform\DNN Platform\Tests\DotNetNuke.Tests.Utilities\bin\DotNetNuke.Tests.Utilities.pdb" target="lib\"/>
 
-    <file src="DNN.Platform\DNN Platform\Components\Telerik\bin\Telerik.Web.UI.dll" target="lib\net40\"/>
     <file src="DNN.Platform\DNN Platform\Components\51Degrees\bin\FiftyOne.Foundation.dll" target="lib\"/>
     <file src="DNN.Platform\DNN Platform\Controls\DotNetNuke.WebControls\bin\DotNetNuke.WebControls.dll" target="lib\"/>
   </files>

--- a/Build/Tools/NuGet/DotNetNuke.Core.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Core.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Core</id>
     <version>9.0.1</version>
-    <title>DNN Core</title>
+    <title>DNN Platform (Core)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains only the core DNN Platform library.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.Core.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Core.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Core</id>
     <version>9.0.1</version>
     <title>DNN Core</title>
-    <authors>DNN Corporation</authors>
-    <owners>DNN Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.dll" target="lib\net40" />

--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Instrumentation</id>
     <version>9.0.1</version>
-    <title>DNN Instrumentation</title>
+    <title>DNN Platform (Instrumentation)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components required for logging and instrumentation for DNN Platform.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Instrumentation</id>
     <version>9.0.1</version>
     <title>DNN Instrumentation</title>
-    <authors>DNN Corporation</authors>
-    <owners>DNN Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\net40\" />

--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -15,6 +15,7 @@
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\net40\" />
+    <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.pdb" target="lib\net40\" />
     <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.dll" target="lib\net40\"/>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.pdb" target="lib\net40\"/>
   </files>

--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -15,5 +15,7 @@
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\net40\" />
+    <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.dll" target="lib\net40\"/>
+    <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.pdb" target="lib\net40\"/>
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
@@ -15,5 +15,6 @@
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.dll" target="lib\net40\" />
+    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.pdb" target="lib\net40\" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Web.Client</id>
     <version>9.0.1</version>
-    <title>DNN Web Client</title>
+    <title>DNN Platform (Client Resources)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components which can be used for managing client-side resources (e.g. JavaScript and CSS) within DNN Platform.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Web.Client</id>
     <version>9.0.1</version>
     <title>DNN Web Client</title>
-    <authors>DNN Corporation</authors>
-    <owners>DNN Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.dll" target="lib\net40\" />

--- a/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
@@ -12,11 +12,13 @@
       This package contains components which are deprecated and expected to be removed from DNN Platform in a later version.
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
+    <dependencies>
+      <dependency id="DotNetNuke.Web" version="9.0.1" />
+    </dependencies>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.dll" target="lib\net40\" />
     <file src="DNN.Platform\Website\bin\Telerik.Web.UI.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.dll" target="lib\net40\" />
     <file src="DNN.Platform\Website\Licenses\Telerik RadControls for ASP.NET AJAX (Custom).pdf" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
@@ -18,6 +18,7 @@
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.dll" target="lib\net40\" />
+    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.pdb" target="lib\net40\" />
     <file src="DNN.Platform\Website\bin\Telerik.Web.UI.dll" target="lib\net40\" />
     <file src="DNN.Platform\Website\Licenses\Telerik RadControls for ASP.NET AJAX (Custom).pdf" />
   </files>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Web.Deprecated</id>
     <version>9.0.1</version>
-    <title>DNN Web Deprecated</title>
+    <title>DNN Platform (Deprecated Components)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components which are deprecated and expected to be removed from DNN Platform in a later version.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Web.Deprecated</id>
     <version>9.0.1</version>
     <title>DNN Web Deprecated</title>
-    <authors>DNN Corporation</authors>
-    <owners>DNN Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.dll" target="lib\net40\" />

--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -12,6 +12,9 @@
       This package contains components required for developing DNN Platform modules using ASP.NET MVC.
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
+    <dependencies>
+      <dependency id="DotNetNuke.Web" version="9.0.1" />
+    </dependencies>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Mvc.dll" target="lib\net45\"/>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Web.Mvc</id>
     <version>9.0.1</version>
     <title>DotNetNuke Web Mvc</title>
-    <authors>DotNetNuke Corporation</authors>
-    <owners>DotNetNuke Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DotNetNuke is copyright 2002-2017 by DotNetNuke Corporation. All Rights Reserved.</copyright>    
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Mvc.dll" target="lib\net45\"/>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Web.Mvc</id>
     <version>9.0.1</version>
-    <title>DotNetNuke Web Mvc</title>
+    <title>DNN Platform (ASP.NET MVC)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components required for developing DNN Platform modules using ASP.NET MVC.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -15,6 +15,8 @@
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.dll" target="lib\net40\" />
+    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.pdb" target="lib\net40\" />
     <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.dll" target="lib\net40\" />
+    <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.pdb" target="lib\net40\" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.Web</id>
     <version>9.0.1</version>
     <title>DNN Web</title>
-    <authors>DNN Corporation</authors>
-    <owners>DNN Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
     <file src="DNN.Platform\Website\bin\DotNetNuke.Web.dll" target="lib\net40\" />

--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.Web</id>
     <version>9.0.1</version>
-    <title>DNN Web</title>
+    <title>DNN Platform (Web)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components required for developing extensions for DNN Platform.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -3,11 +3,14 @@
   <metadata>
     <id>DotNetNuke.WebApi</id>
     <version>9.0.1</version>
-    <title>DNN WebApi</title>
+    <title>DNN Platform (ASP.NET Web API)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Open Source Web Application Framework</description>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components required for developing web services for DNN Platform.
+    </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" />

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -4,11 +4,11 @@
     <id>DotNetNuke.WebApi</id>
     <version>9.0.1</version>
     <title>DNN WebApi</title>
-    <authors>DNN Corporation</authors>
-    <owners>DNN Corporation</owners>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Open Source Web Application Framework</description>
-    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corporation. All Rights Reserved.</copyright>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" />
     </dependencies>

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -14,13 +14,10 @@
     <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" />
+      <dependency id="DotNetNuke.Web" version="9.0.1" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Web.Http" targetFramework="net40" />
     </frameworkAssemblies>
   </metadata>
-  <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.pdb" target="lib\net40\" />
-  </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>DotNetNuke.Bundle</id>
+    <id>DotNetNuke</id>
     <version>9.0.1</version>
     <title>DNN Platform</title>
     <authors>DNN Corp</authors>


### PR DESCRIPTION
This PR improves the NuGet packages by using consistent terminology and naming, and expanding descriptive text.  

It also uses dependencies between packages instead of duplicating files in each package (though I believe this can be improved on more than is in place via this PR).

Finally, the new DotNetNuke.Bundle package is renamed to just DotNetNuke, to indicate its place as the standard "meta" package.

Any feedback is welcome!  Thanks!