### PR TITLE
bug fix: lockout user throws error

### DIFF
--- a/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -284,7 +284,7 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
 					authenticated = (loginStatus != UserLoginStatus.LOGIN_FAILURE);
 				}
 
-                if (loginStatus != UserLoginStatus.LOGIN_FAILURE && PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false) && loginStatus != UserLoginStatus.LOGIN_USERLOCKEDOUT)
+                if (loginStatus != UserLoginStatus.LOGIN_FAILURE && PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false) && loginStatus != UserLoginStatus.LOGIN_USERLOCKEDOUT && loginStatus != UserLoginStatus.LOGIN_USERNOTAPPROVED)
                 {
                     //make sure internal username matches current e-mail address
                     if (objUser.Username.ToLower() != objUser.Email.ToLower())

--- a/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2016
 // by DotNetNuke Corporation
 // 
@@ -284,7 +284,7 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
 					authenticated = (loginStatus != UserLoginStatus.LOGIN_FAILURE);
 				}
 
-                if (loginStatus != UserLoginStatus.LOGIN_FAILURE && PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false))
+                if (loginStatus != UserLoginStatus.LOGIN_FAILURE && PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false) && loginStatus != UserLoginStatus.LOGIN_USERLOCKEDOUT)
                 {
                     //make sure internal username matches current e-mail address
                     if (objUser.Username.ToLower() != objUser.Email.ToLower())


### PR DESCRIPTION
When using Email address as username:
Login blocked after several failed login attempts. So the user is locked out for some minutes, but the problem is we did not receive a proper message indicating the locked out state, we see an error instead!