### PR TITLE
NOJIRA: Add back DotNetNuke.WebApi NuGet package

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>DotNetNuke.WebApi</id>
+    <version>9.0.1</version>
+    <title>DNN Platform (ASP.NET Web API)</title>
+    <authors>DNN Corp</authors>
+    <owners>DNN Corp</owners>
+    <licenseUrl>https://github.com/dnnsoftware/Dnn.Platform/blob/development/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      DNN Platform is an open source web application framework.
+      This package contains components required for developing web services for DNN Platform.
+    </description>
+    <copyright>DNN and DotNetNuke are copyright 2002-2017 by DNN Corp. All Rights Reserved.</copyright>
+    <dependencies>
+      <dependency id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" />
+      <dependency id="DotNetNuke.Web" version="9.0.1" />
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Web.Http" targetFramework="net40" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src=".\*" exclude="**\*" />
+  </files>
+</package>


### PR DESCRIPTION
This NuGet package was removed, because it was including all of the source.  This explicitly ignores all files (before, since this only had dependencies and no files, NuGet automatically added all files)

This reverts ff1258b829250728b8c0cc8f59c993da030983a1 (which was a breaking change, since it removed a previously-public website)
This is related to #1592