### PR TITLE
DNN-9323 Mobile friendly CSS/JS for Digital Asset Manager

### DIFF
--- a/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
+++ b/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
@@ -340,11 +340,12 @@ dnnModule.digitalAssets = function ($, $find, $telerik, dnnModal) {
         var toggleButton = $("#DigitalAssetsToggleLeftPaneBtnId span", "#" + controls.scopeWrapperId);
         var loadingPanel = $(".dnnModuleDigitalAssetsMainLoading", "#" + controls.scopeWrapperId);
         var left;
+        var windowWidth = $(window).width();
 
         if (!leftPane.is(":visible")) {
             toggleButton.css("background-image", "url(" + settings.toggleLeftPaneHideImageUrl + ")");
             leftPane.animate({ width: 'toggle' }, 500, treeViewRefreshScrollbars);
-            left = 220;
+            left = windowWidth > 573 ? 220 : 0;
         } else {
             toggleButton.css("background-image", "url(" + settings.toggleLeftPaneShowImageUrl + ")");
             leftPane.animate({ width: 'toggle' }, 500);

--- a/DNN Platform/Modules/DigitalAssets/module.css
+++ b/DNN Platform/Modules/DigitalAssets/module.css
@@ -1211,7 +1211,6 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
     margin: 5px 0 5px 0;
 }
 
-/*DNN Digital Asset Management(DNN-9323)*/
 #dnnModuleDigitalAssetsSelectionToolbar {
     min-height:25px;
     padding: .2em .2em;
@@ -1225,7 +1224,6 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
     padding:.2em .2em;
 }
 
-/*DNN Digital Asset Management(DNN-9323)*/
 #dnnModuleDigitalAssetsSelectionToolbar {
     min-height:25px;
     padding: .2em .2em;

--- a/DNN Platform/Modules/DigitalAssets/module.css
+++ b/DNN Platform/Modules/DigitalAssets/module.css
@@ -1230,7 +1230,7 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
          width:100%;
          position:relative;
          min-height:25px;
-         height:150px;
+         height:120px;
     }
     
     .dnnModuleDigitalAssetsLeftPaneContents {
@@ -1238,8 +1238,21 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
          top:0;
          height:150px;
     }
+
     #dnnModuleDigitalAssetsContentPane {
         margin-left:0;
-        width:100%
+        width:100%;
+        padding-top:0;
+    }
+
+    #dnnModuleDigitalAssetsSearchBox {
+        min-width:inherit;
+        float:none;
+        margin:1em .5em;
+    }
+
+    .dnnModuleDigitalAssetsMainLoading, dnnModuleDigitalAssetsLoading {
+        /*TODO: apply background loading image*/
+        display:none;
     }
 }

--- a/DNN Platform/Modules/DigitalAssets/module.css
+++ b/DNN Platform/Modules/DigitalAssets/module.css
@@ -1210,3 +1210,36 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
 .dialogNote {
     margin: 5px 0 5px 0;
 }
+
+/*DNN Digital Asset Management(DNN-9323)*/
+#dnnModuleDigitalAssetsSelectionToolbar {
+    min-height:25px;
+    padding: .2em .2em;
+}
+#dnnModuleDigitalAssetsMainToolbar {
+    min-height:40px;
+    padding: 0 .2em;
+}
+#dnnModuleDigitalAssetsListViewToolbar {
+    height:auto;
+    padding:.2em .2em;
+}
+
+@media only screen and (max-width: 573px) {
+    #dnnModuleDigitalAssetsLeftPane {
+         width:100%;
+         position:relative;
+         min-height:25px;
+         height:150px;
+    }
+    
+    .dnnModuleDigitalAssetsLeftPaneContents {
+         position:relative;
+         top:0;
+         height:150px;
+    }
+    #dnnModuleDigitalAssetsContentPane {
+        margin-left:0;
+        width:100%
+    }
+}

--- a/DNN Platform/Modules/DigitalAssets/module.css
+++ b/DNN Platform/Modules/DigitalAssets/module.css
@@ -1225,6 +1225,20 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
     padding:.2em .2em;
 }
 
+/*DNN Digital Asset Management(DNN-9323)*/
+#dnnModuleDigitalAssetsSelectionToolbar {
+    min-height:25px;
+    padding: .2em .2em;
+}
+#dnnModuleDigitalAssetsMainToolbar {
+    min-height:40px;
+    padding: 0 .2em;
+}
+#dnnModuleDigitalAssetsListViewToolbar {
+    height:auto;
+    padding:.2em .2em;
+}
+
 @media only screen and (max-width: 573px) {
     #dnnModuleDigitalAssetsLeftPane {
          width:100%;
@@ -1236,7 +1250,7 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
     .dnnModuleDigitalAssetsLeftPaneContents {
          position:relative;
          top:0;
-         height:150px;
+         height:120px;
     }
 
     #dnnModuleDigitalAssetsContentPane {
@@ -1251,8 +1265,7 @@ div.EditFolderMappingContent .dnnFormItem .dnnLeft {
         margin:1em .5em;
     }
 
-    .dnnModuleDigitalAssetsMainLoading, dnnModuleDigitalAssetsLoading {
-        /*TODO: apply background loading image*/
-        display:none;
+    .dnnModuleDigitalAssetsMainLoading {
+        display:none !important;
     }
 }


### PR DESCRIPTION
Should make the Digital Asset Manager mobile friendly to about 350px.  It does not address all the necessary js to make it entirely responsive for window resize events.