### PR TITLE
DNN-9537: Fix for a Journal Module ImageURL Bug

### DIFF
--- a/DNN Platform/Modules/Journal/Scripts/journal.js
+++ b/DNN Platform/Modules/Journal/Scripts/journal.js
@@ -619,6 +619,7 @@ function pluginInit() {
                 $(opts.previewSelector + ' #imgCount').text(currImage + 1 + ' of ' + images.length);
                 $(opts.previewSelector + ' #imagePreviewer').show();
             } else {
+                journalItem.ItemData.ImageUrl = '';
                 $(opts.previewSelector + ' #imagePreviewer').hide();
             }
             if (link.Description == null) {


### PR DESCRIPTION
Fix for the Journal Module having problems with PreviewURL Links that do not have an Image in the page anywhere.