### PR TITLE
Password history should have minimum timeframe for password retention (DNN-9759)

### DIFF
--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -3317,14 +3317,26 @@ namespace DotNetNuke.Data
 
         #region Password History
 
+        [Obsolete("Deprecated in Platform 9.2.0, please use the overload that takes passwordsRetained and daysRetained")]
         public virtual IDataReader GetPasswordHistory(int userId)
         {
-            return ExecuteReader("GetPasswordHistory", GetNull(userId));
+            return this.GetPasswordHistory(userId, int.MaxValue, int.MaxValue);
         }
 
+        public virtual IDataReader GetPasswordHistory(int userId, int passwordsRetained, int daysRetained)
+        {
+            return ExecuteReader("GetPasswordHistory", GetNull(userId), passwordsRetained, daysRetained);
+        }
+
+        [Obsolete("Deprecated in Platform 9.2.0, please use the overload that takes daysRetained")]
         public virtual void AddPasswordHistory(int userId, string password, string passwordHistory, int retained)
         {
-            ExecuteNonQuery("AddPasswordHistory", GetNull(userId), password, passwordHistory, retained, GetNull(userId));
+            this.AddPasswordHistory(userId, password, passwordHistory, retained, int.MaxValue);
+        }
+
+        public virtual void AddPasswordHistory(int userId, string password, string passwordHistory, int passwordsRetained, int daysRetained)
+        {
+            ExecuteNonQuery("AddPasswordHistory", GetNull(userId), password, passwordHistory, passwordsRetained, daysRetained, GetNull(userId));
         }
 
         #endregion

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -835,6 +835,17 @@ namespace DotNetNuke.Entities.Host
         }
 
         /// <summary>
+        /// Gets the number of days that must pass before a password can be reused - default is 0 (i.e. password reuse is only governed by <see cref="EnablePasswordHistory"/> and <see cref="MembershipNumberPasswords"/>)
+        /// </summary>
+        public static int MembershipDaysBeforePasswordReuse
+        {
+            get
+            {
+                return HostController.Instance.GetInteger("MembershipDaysBeforePasswordReuse", 0);
+            }
+        }
+
+        /// <summary>
         /// sets the HTTP Status code returned if IP address filtering is enabled on login
         /// and the users IP does not meet criteria -default is 403
         /// </summary>

--- a/DNN Platform/Library/Entities/Users/Membership/MembershipPasswordSettings.cs
+++ b/DNN Platform/Library/Entities/Users/Membership/MembershipPasswordSettings.cs
@@ -39,6 +39,7 @@ namespace DotNetNuke.Entities.Users.Membership
         public bool EnablePasswordHistory { get; set; }
 
         public int NumberOfPasswordsStored { get; set; }
+        public int NumberOfDaysBeforePasswordReuse { get; set; }
         public int ResetLinkValidity { get; set; }
 
         /// <summary>
@@ -111,6 +112,7 @@ namespace DotNetNuke.Entities.Users.Membership
 
                 ResetLinkValidity = Host.Host.MembershipResetLinkValidity;
                 NumberOfPasswordsStored = Host.Host.MembershipNumberPasswords;
+                NumberOfDaysBeforePasswordReuse = Host.Host.MembershipDaysBeforePasswordReuse;
             }
             else //setup default values during install process.
             {

--- a/Website/Providers/DataProviders/SqlDataProvider/09.02.00.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/09.02.00.SqlDataProvider
@@ -558,19 +558,10 @@ CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetPasswordHistory]
 	@PasswordsRetained  int,
 	@DaysRetained       int
 AS
-	DELETE FROM {databaseOwner}{objectQualifier}PasswordHistory
-	WHERE UserID=@UserId
-	  AND PasswordHistoryID NOT IN (
-		SELECT TOP (@PasswordsRetained) PasswordHistoryID
-		FROM {databaseOwner}{objectQualifier}PasswordHistory
-		WHERE UserID=@UserId
-		ORDER BY CreatedOnDate DESC
-		)
-	  AND DATEDIFF(day, CreatedOnDate, GETDATE()) > @DaysRetained;
-
-	SELECT *
+	SELECT TOP (@PasswordsRetained) *
 	FROM {databaseOwner}{objectQualifier}PasswordHistory
 	WHERE UserID=@UserID
+	  AND DATEDIFF(day, CreatedOnDate, GETDATE()) <= @DaysRetained;
 GO
 
 /************************************************************/

--- a/Website/Providers/DataProviders/SqlDataProvider/09.02.00.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/09.02.00.SqlDataProvider
@@ -502,6 +502,77 @@ BEGIN
 END
 GO
 
+IF EXISTS (SELECT * FROM dbo.sysobjects WHERE id = object_id(N'{databaseOwner}[{objectQualifier}AddPasswordHistory]') AND OBJECTPROPERTY(id, N'IsPROCEDURE') = 1)
+	DROP PROCEDURE {databaseOwner}{objectQualifier}AddPasswordHistory
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}AddPasswordHistory]
+	@UserId             int,
+	@Password           nvarchar(128),
+	@PasswordSalt       nvarchar(128),
+	@PasswordsRetained  int,
+	@DaysRetained       int,
+	@CreatedByUserID    int
+AS
+
+	BEGIN
+
+	INSERT INTO {databaseOwner}{objectQualifier}PasswordHistory (
+		UserId,
+		[Password],
+		PasswordSalt,
+		CreatedByUserID,
+		CreatedOnDate,
+		LastModifiedByUserID,
+		LastModifiedOnDate
+	)
+	VALUES (
+		@UserId,
+		@Password,
+		@PasswordSalt,
+		@CreatedByUserID,
+		GETDATE(),
+		@CreatedByUserID,
+		GETDATE()
+	)
+
+	DELETE FROM {databaseOwner}{objectQualifier}PasswordHistory
+	WHERE UserID=@UserId
+	  AND PasswordHistoryID NOT IN (
+		SELECT TOP (@PasswordsRetained) PasswordHistoryID
+		FROM {databaseOwner}{objectQualifier}PasswordHistory
+		WHERE UserID=@UserId
+		ORDER BY CreatedOnDate DESC
+		)
+	  AND DATEDIFF(day, CreatedOnDate, GETDATE()) > @DaysRetained
+
+	END
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects WHERE id = object_id(N'{databaseOwner}[{objectQualifier}GetPasswordHistory]') AND OBJECTPROPERTY(id, N'IsPROCEDURE') = 1)
+	DROP PROCEDURE {databaseOwner}{objectQualifier}GetPasswordHistory
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetPasswordHistory]
+	@UserID             int,
+	@PasswordsRetained  int,
+	@DaysRetained       int
+AS
+	DELETE FROM {databaseOwner}{objectQualifier}PasswordHistory
+	WHERE UserID=@UserId
+	  AND PasswordHistoryID NOT IN (
+		SELECT TOP (@PasswordsRetained) PasswordHistoryID
+		FROM {databaseOwner}{objectQualifier}PasswordHistory
+		WHERE UserID=@UserId
+		ORDER BY CreatedOnDate DESC
+		)
+	  AND DATEDIFF(day, CreatedOnDate, GETDATE()) > @DaysRetained;
+
+	SELECT *
+	FROM {databaseOwner}{objectQualifier}PasswordHistory
+	WHERE UserID=@UserID
+GO
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/


### PR DESCRIPTION
[DNN-9759](https://dnntracker.atlassian.net/browse/DNN-9759)

>As part of a security audit, it came up that we couldn't set a minimum timeframe for which to retain passwords. So, while we can say that you can't reuse your last six (for example) passwords, there's nothing to stop you from changing you password six times in a row and reusing your original password.
>
>I'd like to propose adding a new setting with the minimum number of days to retain passwords (our client's requirements are six months, but I would plan to default to zero, for backwards compatibility, unless y'all think there should be a default).
