### PR TITLE
DNN-9835 URL pages incorrectly excluded from Add Existing Module picker

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/ItemListServiceController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ItemListServiceController.cs
@@ -1,7 +1,7 @@
 #region Copyright
 
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2017
 // by DotNetNuke Corporation
 // 
@@ -434,7 +434,7 @@ namespace DotNetNuke.Web.InternalServices
 
             if (portalId > -1)
             {
-                tabs = TabController.GetPortalTabs(portalId, (includeActive) ? Null.NullInteger : PortalSettings.ActiveTab.TabID, false, null, true, false, false, true, false)
+                tabs = TabController.GetPortalTabs(portalId, (includeActive) ? Null.NullInteger : PortalSettings.ActiveTab.TabID, false, null, true, false, includeAllTypes, true, false)
                                  .Where(tab => searchFunc(tab) 
                                             && tab.ParentId == parentId 
                                             && (includeDisabled || !tab.DisableLink) 


### PR DESCRIPTION
[DNN-9835](https://dnntracker.atlassian.net/browse/DNN-9835)

>If you have a page which redirects (i.e. its type is _Tab_ or _URL_), but it also has children, that page does not show up in the page picker for selecting an existing module, which means that its children cannot be selected, either (though the children are available by searching).
>
>As an example:
>
> -   _Advocacy_ (redirect to `/Advocacy/Overview`)
>     -  _Overview_
>     - _Details_
>
>None of these three pages would show, and modules on _Overview_ would not be available to be copied to _Details_ (or anywhere else).
>
>This manifests itself in a couple of different ways. The `DnnPortalPageDropDownList` is a control available to 3rd party developers to use, and it uses the web service `ItemListService/GetPageDescendantsInPortalGroup` to retrieve pages. If you setup a site with the above page structure in portal 0, you can go to `/DesktopModules/InternalServices/API/ItemListService/GetPageDescendantsInPortalGroup?parentId=P-0&sortOrder=0&searchText=&includeDisabled=true&includeAllTypes=true&includeActive=false&includeHostPages=false&roles=` in a browser to see the JSON returned from that call, and see that it does not include those pages. The issue is that `includeAllTypes=true` is ignored in the code path that gets hit. [This PR fixes that issue].
>
>In DNN 9, a different web service is used, `ItemListService/GetPages`, and that call just needs to have `includeAllTypes=true` added as a query-string parameter. I wasn't able to quickly find where in the persona bar that call was happening, so that fix is not included in the related PR.