### PR TITLE
DNN-10082 Fix issue with JSON when sending message

### DIFF
--- a/DNN Platform/Library/Services/Social/Messaging/MessagingController.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/MessagingController.cs
@@ -1,21 +1,21 @@
 ﻿#region Copyright
-// 
+//
 // DotNetNuke® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2017
 // by DotNetNuke Corporation
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
 // to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
 // of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
-// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 #endregion
 #region Usings
@@ -47,7 +47,7 @@ namespace DotNetNuke.Services.Social.Messaging
     /// </summary>
     /// <remarks>
     /// </remarks>
-    public class MessagingController 
+    public class MessagingController
                                 : ServiceLocator<IMessagingController, MessagingController>
                                 , IMessagingController
     {
@@ -158,7 +158,7 @@ namespace DotNetNuke.Services.Social.Messaging
             {
                 throw new ArgumentException(Localization.Localization.GetString("MsgEmptyToListFoundError", Localization.Localization.ExceptionsResourceFile));
             }
-            
+
             if (sbTo.Length > ConstMaxTo)
             {
                 throw new ArgumentException(string.Format(Localization.Localization.GetString("MsgToListTooBigError", Localization.Localization.ExceptionsResourceFile), ConstMaxTo, sbTo.Length));
@@ -173,7 +173,7 @@ namespace DotNetNuke.Services.Social.Messaging
             }
 
             //Cannot have attachments if it's not enabled
-            if (fileIDs != null && !InternalMessagingController.Instance.AttachmentsAllowed(sender.PortalID))
+            if (fileIDs != null && fileIDs.Count > 0 && !InternalMessagingController.Instance.AttachmentsAllowed(sender.PortalID))
             {
                 throw new AttachmentsNotAllowed(Localization.Localization.GetString("MsgAttachmentsNotAllowed", Localization.Localization.ExceptionsResourceFile));
             }
@@ -240,7 +240,7 @@ namespace DotNetNuke.Services.Social.Messaging
                 var recipient = InternalMessagingController.Instance.GetMessageRecipient(message.MessageID, sender.UserID);
 
                 if(recipient == null)
-                { 
+                {
                     //add sender as a recipient of the message
                     recipient = new MessageRecipient { MessageID = message.MessageID, UserID = sender.UserID, Read = false, RecipientID = Null.NullInteger };
                     recipient.RecipientID = _dataService.SaveMessageRecipient(recipient, UserController.Instance.GetCurrentUserInfo().UserID);

--- a/Website/Resources/Shared/components/ComposeMessage/ComposeMessage.js
+++ b/Website/Resources/Shared/components/ComposeMessage/ComposeMessage.js
@@ -98,10 +98,10 @@
                 // we only need to initialize this plugin once, doing so more than once will lead to multiple dialogs.
                 // this is because the #userFileManager element is never destroyed when the compose message dialog is closed.
 	        	composeMessageDialog.find('#userFileManager').userFileManager(opts.userFileManagerOptions);
-		        
+
                 $wrap.data('fileManagerInitialized', true);
             }
-	        
+
 	        if ($.fn.dnnUserFileUpload && typeof $.fn.dnnUserFileUpload === "function") {
 				composeMessageDialog.find('.fileUploadArea').dnnUserFileUpload({
 					maxFileSize: opts.maxFileSize,
@@ -114,7 +114,7 @@
 					}
 				});
 	        }
-	        
+
 	        composeMessageDialog.find('#to').tokenInput(opts.serviceurlbase + "Search", {
 				// We can set the tokenLimit here
 				theme: "facebook",
@@ -211,7 +211,7 @@
                     if (prePopulatedRecipients != null) {
                         composeMessageDialog.find('#subject').focus();
                     }
-	                
+
 					composeMessageDialog.find('.fileUploadArea input').dnnFileInput();
                 },
                 close: function(event, ui) {
@@ -224,16 +224,16 @@
                             var params = {
                                 subject: encodeURIComponent(composeMessageDialog.find('#subject').val()),
                                 body: encodeURIComponent(composeMessageDialog.find('#bodytext').val()),
-                                roleIds: (roles.length > 0 ? JSON.stringify(roles) : {}),
-                                userIds: (users.length > 0 ? JSON.stringify(users) : {}),
-                                fileIds: (attachments.length > 0 ? JSON.stringify(attachments) : {})
+                                roleIds: JSON.stringify(roles),
+                                userIds: JSON.stringify(users),
+                                fileIds: JSON.stringify(attachments)
                             };
                             $.ajax(
-                                {   
+                                {
                                     url: opts.serviceurlbase + "Create",
-                                    type: "POST", 
+                                    type: "POST",
                                     data: JSON.stringify(params),
-                                    contentType: "application/json", 
+                                    contentType: "application/json",
                                     dataType: "json",
                                     beforeSend: opts.servicesFramework.setModuleHeaders
                                 }).done(function (data) {


### PR DESCRIPTION
The JSON sent to MessagingServiceController from ComposeMessage.js is invalid,
but fails in an acceptable way with Newtonsoft.Json v7. However, in v8 (through
the current version, v10), this causes a larger failure, which breaks the API
(resulting in a null reference exception at the start of the call).  This
change adjusts the JSON to always send an array (serialized as a string),
rather than sending an empty object when the array would be empty.  This also
requires the calling code to expect empty lists, rather than null lists.

[DNN-10082](https://dnntracker.atlassian.net/browse/DNN-10082)
>If the Newtonsoft.Json dependency is updated (you could install [newtonsoft.json.8.0.3.zip](https://dnntracker.atlassian.net/secure/attachment/55312/55312_newtonsoft.json.8.0.3.zip) or [newtonsoft.json.10.0.3.zip]()https://dnntracker.atlassian.net/secure/attachment/55311/55311_newtonsoft.json.10.0.3.zip, or a 3rd party module which requires a newer version), there's an error when trying to send a message:
>
><a href="https://dnntracker.atlassian.net/secure/attachment/55310/55310_2017-07-18_15-37-29.png"><img src="https://dnntracker.atlassian.net/secure/thumbnail/55310/2017-07-18_15-37-29.png?default=false" alt="An error occurred while creating the message:Object reference not set to an instance of an object." /></a>
>
>This issue stems from the JavaScript for the Compose Message component sending an unexpected JSON structure to the MessagingController web API (specifically, the API is expecting strings, the component sends empty objects).  In Newtonsoft.Json v7, this results in those fields being `null`, while after version 7 (versions 8-10), this results in a failure to complete the model binding, so the whole DTO is `null`.