### PR TITLE
DNN-10141: Deprecating WebFormsMVP + DotNetNuke.Web.Mvp and all class…

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Mvp/AttributeBasedViewStateSerializer.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/AttributeBasedViewStateSerializer.cs
@@ -29,6 +29,7 @@ using System.Web.UI;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class AttributeBasedViewStateSerializer
     {
         private const BindingFlags MemberBindingFlags = BindingFlags.Instance | BindingFlags.Public;

--- a/DNN Platform/DotNetNuke.Web/Mvp/HttpHandlerPresenter.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/HttpHandlerPresenter.cs
@@ -24,6 +24,7 @@ using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class HttpHandlerPresenter<TView> : Presenter<TView> where TView : class, IHttpHandlerView
     {
         protected HttpHandlerPresenter(TView view) : base(view)

--- a/DNN Platform/DotNetNuke.Web/Mvp/HttpHandlerView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/HttpHandlerView.cs
@@ -18,13 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-using System;
-using System.Web;
 
+using System;
 using WebFormsMvp.Web;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class HttpHandlerView : MvpHttpHandler, IHttpHandlerView
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/IHttpHandlerView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IHttpHandlerView.cs
@@ -18,10 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
 using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IHttpHandlerView : IView
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/IModuleView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IModuleView.cs
@@ -20,12 +20,13 @@
 #endregion
 #region Usings
 
-using WebFormsMvp;
+using System;
 
 #endregion
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IModuleView : IModuleViewBase
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/IModuleViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IModuleViewBase.cs
@@ -30,6 +30,7 @@ using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IModuleViewBase : IView
     {
         bool AutoDataBind { get; set; }

--- a/DNN Platform/DotNetNuke.Web/Mvp/IModuleViewOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IModuleViewOfT.cs
@@ -20,12 +20,14 @@
 #endregion
 #region Usings
 
+using System;
 using WebFormsMvp;
 
 #endregion
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IModuleView<TModel> : IModuleViewBase, IView<TModel> where TModel : class, new()
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/ISettingsView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ISettingsView.cs
@@ -22,6 +22,7 @@ using System;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface ISettingsView : IModuleViewBase
     {
         event EventHandler OnLoadSettings;

--- a/DNN Platform/DotNetNuke.Web/Mvp/ISettingsViewOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ISettingsViewOfT.cs
@@ -18,12 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-using System;
 
+using System;
 using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface ISettingsView<TModel> : IModuleViewBase, IView<TModel> where TModel : class, new()
     {
         event EventHandler OnLoadSettings;

--- a/DNN Platform/DotNetNuke.Web/Mvp/IWebServiceView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IWebServiceView.cs
@@ -18,10 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-using WebFormsMvp;
+
+using System;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IWebServiceView : IWebServiceViewBase
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/IWebServiceViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IWebServiceViewBase.cs
@@ -18,10 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
 using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IWebServiceViewBase : IView
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/IWebServiceViewOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/IWebServiceViewOfT.cs
@@ -18,10 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
 using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IWebServiceView<TModel> : IWebServiceViewBase, IView<TModel> where TModel : class, new()
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModulePresenter.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModulePresenter.cs
@@ -18,8 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
+
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModulePresenter<TView> : ModulePresenterBase<TView> where TView : class, IModuleView
     {
         #region Constructors

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModulePresenterBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModulePresenterBase.cs
@@ -34,11 +34,11 @@ using DotNetNuke.Web.Validators;
 
 using WebFormsMvp;
 
-
 #endregion
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModulePresenterBase<TView> : Presenter<TView> where TView : class, IModuleViewBase
     {
         #region Constructors

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModulePresenterOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModulePresenterOfT.cs
@@ -18,8 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
+
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModulePresenter<TView, TModel> : ModulePresenterBase<TView> where TView : class, IModuleView<TModel> where TModel : class, new()
     {
         protected ModulePresenter(TView view) : base(view)

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModuleSettingsPresenter.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModuleSettingsPresenter.cs
@@ -18,11 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
 using System;
 using System.Collections.Generic;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class ModuleSettingsPresenterBase<TView> : ModulePresenterBase<TView> where TView : class, ISettingsView
     {
         #region Constructors

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModuleSettingsPresenterOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModuleSettingsPresenterOfT.cs
@@ -27,6 +27,7 @@ using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModuleSettingsPresenter<TView, TModel> : ModulePresenterBase<TView>
         where TView : class, ISettingsView<TModel>
         where TModel : SettingsModel, new()

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModuleView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModuleView.cs
@@ -18,8 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
+
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModuleView : ModuleViewBase
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModuleViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModuleViewBase.cs
@@ -34,6 +34,7 @@ using WebFormsMvp.Web;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModuleViewBase : ModuleUserControlBase, IModuleViewBase
     {
         #region Constructors

--- a/DNN Platform/DotNetNuke.Web/Mvp/ModuleViewOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ModuleViewOfT.cs
@@ -29,6 +29,7 @@ using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ModuleView<TModel> : ModuleViewBase, IView<TModel> where TModel : class, new()
     {
         private TModel _model;

--- a/DNN Platform/DotNetNuke.Web/Mvp/ProfileModuleViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ProfileModuleViewBase.cs
@@ -18,6 +18,7 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
 using System;
 using System.Globalization;
 
@@ -30,6 +31,7 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class ProfileModuleViewBase<TModel> : ModuleView<TModel>, IProfileModule where TModel : class, new()
     {
         #region IProfileModule Members

--- a/DNN Platform/DotNetNuke.Web/Mvp/SettingsModel.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/SettingsModel.cs
@@ -21,10 +21,12 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class SettingsModel
     {
         public Dictionary<string, string> ModuleSettings { get; set; }

--- a/DNN Platform/DotNetNuke.Web/Mvp/SettingsView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/SettingsView.cs
@@ -25,6 +25,7 @@ using System;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class SettingsView<TModel> : SettingsViewBase, ISettingsView<TModel> where TModel : SettingsModel, new() 
     {
         private TModel _model;

--- a/DNN Platform/DotNetNuke.Web/Mvp/SettingsViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/SettingsViewBase.cs
@@ -28,6 +28,7 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class SettingsViewBase : ModuleViewBase, ISettingsView, ISettingsControl
     {
         #region ISettingsControl Members

--- a/DNN Platform/DotNetNuke.Web/Mvp/ViewStateAttribute.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ViewStateAttribute.cs
@@ -26,6 +26,7 @@ using System;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class ViewStateAttribute : Attribute
     {

--- a/DNN Platform/DotNetNuke.Web/Mvp/WebServicePresenter.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/WebServicePresenter.cs
@@ -18,12 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-using System;
 
+using System;
 using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class WebServicePresenter<TView> : Presenter<TView> where TView : class, IWebServiceView
     {
         protected WebServicePresenter(TView view) : base(view)

--- a/DNN Platform/DotNetNuke.Web/Mvp/WebServiceView.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/WebServiceView.cs
@@ -18,8 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+
+using System;
+
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class WebServiceView : WebServiceViewBase
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/WebServiceViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/WebServiceViewBase.cs
@@ -18,13 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-using System;
-using System.Web;
 
+using System;
 using WebFormsMvp.Web;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class WebServiceViewBase : MvpWebService, IWebServiceViewBase
     {
     }

--- a/DNN Platform/DotNetNuke.Web/Mvp/WebServiceViewOfT.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/WebServiceViewOfT.cs
@@ -18,15 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
+using System;
 using WebFormsMvp;
 
 namespace DotNetNuke.Web.Mvp
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public abstract class WebServiceViewOfT<TModel> : ModuleViewBase, IView<TModel> where TModel : class, new()
     {
         private TModel _model;

--- a/DNN Platform/Modules/HtmlEditorManager/Presenters/ProviderConfigurationPresenter.cs
+++ b/DNN Platform/Modules/HtmlEditorManager/Presenters/ProviderConfigurationPresenter.cs
@@ -38,11 +38,10 @@ namespace DotNetNuke.Modules.HtmlEditorManager.Presenters
     using DotNetNuke.Web.UI;
     using DotNetNuke.Web.UI.WebControls;
 
-
-
     /// <summary>
     /// Presenter for Provider Configuration
     /// </summary>
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class ProviderConfigurationPresenter : ModulePresenter<IProviderConfigurationView, ProviderConfigurationViewModel>
     {
         /// <summary>The HTML editor node</summary>

--- a/DNN Platform/Modules/HtmlEditorManager/Views/IProviderConfigurationView.cs
+++ b/DNN Platform/Modules/HtmlEditorManager/Views/IProviderConfigurationView.cs
@@ -29,6 +29,7 @@ namespace DotNetNuke.Modules.HtmlEditorManager.Views
     /// <summary>
     /// Interface for the Provider Configuration View
     /// </summary>
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public interface IProviderConfigurationView : IModuleView<ProviderConfigurationViewModel>
     {
         /// <summary>Occurs when [save editor choice].</summary>

--- a/DNN Platform/Modules/HtmlEditorManager/Views/ProviderConfiguration.ascx.cs
+++ b/DNN Platform/Modules/HtmlEditorManager/Views/ProviderConfiguration.ascx.cs
@@ -32,6 +32,7 @@ namespace DotNetNuke.Modules.HtmlEditorManager.Views
     /// <summary>
     /// View control for selecting an HTML provider
     /// </summary>
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public partial class ProviderConfiguration : ModuleView<ProviderConfigurationViewModel>, IProviderConfigurationView
     {
         /// <summary>Occurs when the save button is clicked.</summary>

--- a/DNN Platform/Modules/MemberDirectory/Presenters/ModuleSettingsPresenter.cs
+++ b/DNN Platform/Modules/MemberDirectory/Presenters/ModuleSettingsPresenter.cs
@@ -23,6 +23,7 @@
 
 #region Usings
 
+using System;
 using System.Collections.Generic;
 
 using DotNetNuke.Common.Lists;
@@ -30,13 +31,13 @@ using DotNetNuke.Entities.Profile;
 using DotNetNuke.Entities.Users.Social;
 using DotNetNuke.Modules.MemberDirectory.ViewModels;
 using DotNetNuke.Security.Roles;
-using DotNetNuke.Security.Roles.Internal;
 using DotNetNuke.Web.Mvp;
 
 #endregion
 
 namespace DotNetNuke.Modules.MemberDirectory.Presenters
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class ModuleSettingsPresenter : ModuleSettingsPresenter<ISettingsView<MemberDirectorySettingsModel>, MemberDirectorySettingsModel>
     {
         public ModuleSettingsPresenter(ISettingsView<MemberDirectorySettingsModel> view)

--- a/DNN Platform/Modules/MemberDirectory/Settings.ascx.cs
+++ b/DNN Platform/Modules/MemberDirectory/Settings.ascx.cs
@@ -47,6 +47,7 @@ using WebFormsMvp;
 
 namespace DotNetNuke.Modules.MemberDirectory
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     [PresenterBinding(typeof(ModuleSettingsPresenter))]
     public partial class Settings : SettingsView<MemberDirectorySettingsModel>
     {

--- a/DNN Platform/Modules/MemberDirectory/ViewModels/MemberDirectorySettingsModel.cs
+++ b/DNN Platform/Modules/MemberDirectory/ViewModels/MemberDirectorySettingsModel.cs
@@ -20,6 +20,7 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 
 using DotNetNuke.Entities.Profile;
@@ -29,6 +30,7 @@ using DotNetNuke.Web.Mvp;
 
 namespace DotNetNuke.Modules.MemberDirectory.ViewModels
 {
+    [Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]
     public class MemberDirectorySettingsModel : SettingsModel
     {
         public IList<ProfilePropertyDefinition> ProfileProperties;

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">


### PR DESCRIPTION
…es referencing these.

All source code affected classes were decorated with:
[Obsolete("Deprecated in DNN 9.2.0. Replace WebFormsMvp and DotNetNuke.Web.Mvp with MVC or SPA patterns instead")]