### PR TITLE
Fixes DNN-10071

### DIFF
--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -76,7 +76,12 @@ namespace DotNetNuke.Modules.Journal
 
         private static bool IsImageFile(string relativePath)
         {
-	        if (relativePath.Contains("?"))
+            if (relativePath == null)
+            {
+                return false;
+            }
+
+            if (relativePath.Contains("?"))
 	        {
 		        relativePath = relativePath.Substring(0,
 			        relativePath.IndexOf("?", StringComparison.InvariantCultureIgnoreCase));


### PR DESCRIPTION
Fixes DNN-10071 issue by adding check for null.
When _relativePath_ paramter was null, it was throwing an exception.