### PR TITLE
(DNN-8129) Adjust default setting for SMTP client for idletime and connectionlimit

### DIFF
--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -1388,9 +1388,9 @@ namespace DotNetNuke.Entities.Host
             {
                 if (SMTPPortalEnabled)
                 {
-                    return PortalController.GetPortalSettingAsInteger("SMTPConnectionLimit", PortalSettings.Current.PortalId, 1);
+                    return PortalController.GetPortalSettingAsInteger("SMTPConnectionLimit", PortalSettings.Current.PortalId, 2);
                 }
-                return HostController.Instance.GetInteger("SMTPConnectionLimit", 1);
+                return HostController.Instance.GetInteger("SMTPConnectionLimit", 2);
             }
         }
         /// -----------------------------------------------------------------------------
@@ -1404,9 +1404,9 @@ namespace DotNetNuke.Entities.Host
             {
                 if (SMTPPortalEnabled)
                 {
-                    return PortalController.GetPortalSettingAsInteger("SMTPMaxIdleTime", PortalSettings.Current.PortalId, 0);
+                    return PortalController.GetPortalSettingAsInteger("SMTPMaxIdleTime", PortalSettings.Current.PortalId, 100000);
                 }
-                return HostController.Instance.GetInteger("SMTPMaxIdleTime", 0);
+                return HostController.Instance.GetInteger("SMTPMaxIdleTime", 100000);
             }
         }
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -259,8 +259,8 @@ namespace DotNetNuke.Entities.Portals
             portalSettings.STDURL = settings.GetValueOrDefault("STDURL", Null.NullString);
             portalSettings.EnableRegisterNotification = settings.GetValueOrDefault("EnableRegisterNotification", true);
             portalSettings.DefaultAuthProvider = settings.GetValueOrDefault("DefaultAuthProvider", "DNN");
-            portalSettings.SMTPConnectionLimit = settings.GetValueOrDefault("SMTPConnectionLimit", 1);
-            portalSettings.SMTPMaxIdleTime = settings.GetValueOrDefault("SMTPMaxIdleTime", 0);
+            portalSettings.SMTPConnectionLimit = settings.GetValueOrDefault("SMTPConnectionLimit", 2);
+            portalSettings.SMTPMaxIdleTime = settings.GetValueOrDefault("SMTPMaxIdleTime", 100000);
 
             portalSettings.ControlPanelSecurity = PortalSettings.ControlPanelPermission.ModuleEditor;
             string setting = settings.GetValueOrDefault("ControlPanelSecurity", "");

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/TestFiles/DefaultValues.csv
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/TestFiles/DefaultValues.csv
@@ -26,8 +26,8 @@ SSLURL,							SSLURL,							SSLURL,							false,
 STDURL,							STDURL,							STDURL,							false,
 EnableRegisterNotification,		EnableRegisterNotification,		EnableRegisterNotification,		false,				true
 DefaultAuthProvider,			DefaultAuthProvider,			DefaultAuthProvider,			false,				DNN
-SMTPConnectionLimit,			SMTPConnectionLimit,			SMTPConnectionLimit,			false,				1
-SMTPMaxIdleTime,				SMTPMaxIdleTime,				SMTPMaxIdleTime,				false,				0
+SMTPConnectionLimit,			SMTPConnectionLimit,			SMTPConnectionLimit,			false,				2
+SMTPMaxIdleTime,				SMTPMaxIdleTime,				SMTPMaxIdleTime,				false,				100000
 ControlPanelSecurity,			ControlPanelSecurity,			ControlPanelSecurity,			false,				ModuleEditor
 DefaultControlPanelMode,		DefaultControlPanelMode,		ControlPanelMode,				false,				View
 DefaultControlPanelVisibility,	DefaultControlPanelVisibility,	ControlPanelVisibility,			false,				true


### PR DESCRIPTION
Changed `MaxIdleTime` from `0` to `100000` (100 seconds). This is the [default in .NET Framework](https://msdn.microsoft.com/en-us/library/system.net.servicepointmanager.maxservicepointidletime(v=vs.110).aspx). The old default of 0 may cause .NET to reuses a closed socket/connection and fail with error "Unable to write data to the transport connection: An established connection was aborted by the software in your host machine." This is because most SMPT-Servers close an open SMTP-connection after 5 minutes.

Also changed `ConnectionLimit` from `1` to `2`. This is the [default in .NET Framework](https://msdn.microsoft.com/en-us/library/system.net.servicepointmanager.defaultconnectionlimit(v=vs.110).aspx). Note: The [default in .NET Framework depends whether a loopback address is used or not](https://stackoverflow.com/q/22930486/4049371).