### PR TITLE
Bug/dnn 8939

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Routing/HttpRequestExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Routing/HttpRequestExtensions.cs
@@ -65,32 +65,6 @@ namespace DotNetNuke.Web.Mvc.Routing
         public static string GetIPAddress(HttpRequestBase request)
         {
             return UserRequestIPAddressController.Instance.GetUserRequestIPAddress(request);
-        }
-        
-        private static bool CheckMask(IPAddress address, IPAddress mask, IPAddress target)
-        {
-            if (mask == null)
-                return false;
-
-            var ba = address.GetAddressBytes();
-            var bm = mask.GetAddressBytes();
-            var bb = target.GetAddressBytes();
-
-            if (ba.Length != bm.Length || bm.Length != bb.Length)
-                return false;
-
-            for (var i = 0; i < ba.Length; i++)
-            {
-                var m = bm[i];
-
-                var a = ba[i] & m;
-                var b = bb[i] & m;
-
-                if (a != b)
-                    return false;
-            }
-
-            return true;
-        }
+        }        
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Routing/HttpRequestExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Routing/HttpRequestExtensions.cs
@@ -61,7 +61,6 @@ namespace DotNetNuke.Web.Mvc.Routing
             return fallback;
         }
 
-        [Obsolete("Deprecated in 9.2.0. Use UserRequestIPAddressController.Instance.GetUserRequestIPAddress")]
         public static string GetIPAddress(HttpRequestBase request)
         {
             return UserRequestIPAddressController.Instance.GetUserRequestIPAddress(request);

--- a/DNN Platform/DotNetNuke.Web.Mvc/Routing/HttpRequestExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Routing/HttpRequestExtensions.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Web;
 using System.Web.Http;
 using DotNetNuke.Entities.Modules;
+using DotNetNuke.Services.UserRequest;
 
 namespace DotNetNuke.Web.Mvc.Routing
 {
@@ -60,35 +61,12 @@ namespace DotNetNuke.Web.Mvc.Routing
             return fallback;
         }
 
+        [Obsolete("Deprecated in 9.2.0. Use UserRequestIPAddressController.Instance.GetUserRequestIPAddress")]
         public static string GetIPAddress(HttpRequestBase request)
         {
-            var szRemoteAddr = request.UserHostAddress;
-            var szXForwardedFor = request.ServerVariables["X_FORWARDED_FOR"];
-            var szIP = string.Empty;
-
-            if (szXForwardedFor == null)
-            {
-                szIP = szRemoteAddr;
-            }
-            else
-            {
-                szIP = szXForwardedFor;
-                if (szIP.IndexOf(",", StringComparison.Ordinal) <= 0) return szIP;
-                var arIPs = szIP.Split(',');
-                foreach (var item in arIPs.Where(item => !IsPrivateIP(item)))
-                {
-                    return item;
-                }
-            }
-            return szIP;
+            return UserRequestIPAddressController.Instance.GetUserRequestIPAddress(request);
         }
-        private static bool IsPrivateIP(string address)
-        {
-            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
-            var ipAddress = new IPAddress(Encoding.UTF8.GetBytes(address));
-            return interfaces.Select(iface => iface.GetIPProperties()).SelectMany(properties => properties.UnicastAddresses).Any(ifAddr => ifAddr.IPv4Mask != null && ifAddr.Address.AddressFamily == AddressFamily.InterNetwork && CheckMask(ifAddr.Address, ifAddr.IPv4Mask, ipAddress));
-        }
-
+        
         private static bool CheckMask(IPAddress address, IPAddress mask, IPAddress target)
         {
             if (mask == null)

--- a/DNN Platform/DotNetNuke.Web/Api/HttpRequestMessageExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/HttpRequestMessageExtensions.cs
@@ -19,11 +19,10 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
-using System;
 using System.Net.Http;
 using System.Web;
-using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
+using DotNetNuke.Services.UserRequest;
 
 namespace DotNetNuke.Web.Api
 {
@@ -87,7 +86,7 @@ namespace DotNetNuke.Web.Api
 
         public static string GetIPAddress(this HttpRequestMessage request)
         {
-            return GetHttpContext(request).Request.UserHostAddress;
+            return UserRequestIPAddressController.Instance.GetUserRequestIPAddress(GetHttpContext(request).Request);
         }
     }
 }

--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -41,6 +41,7 @@ using DotNetNuke.Services.Personalization;
 using DotNetNuke.UI.Skins.Controls;
 using DotNetNuke.UI.Skins.EventListeners;
 using DotNetNuke.Security.Roles.Internal;
+using DotNetNuke.Services.UserRequest;
 
 #endregion
 
@@ -217,7 +218,7 @@ namespace DotNetNuke.HttpModules.Membership
                 {
                     //update LastActivityDate and IP Address for user
                     user.Membership.LastActivityDate = DateTime.Now;
-                    user.LastIPAddress = request.UserHostAddress;
+                    user.LastIPAddress = UserRequestIPAddressController.Instance.GetUserRequestIPAddress(request);
                     UserController.UpdateUser(portalSettings.PortalId, user, false, false);
                 }
 

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1475,6 +1475,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Services\UserProfile\UserProfilePicHandler.cs" />
+    <Compile Include="Services\UserRequest\IUserRequestIPAddressController.cs" />
+    <Compile Include="Services\UserRequest\UserRequestIPAddressController.cs" />
     <Compile Include="UI\Containers\ActionBase.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>

--- a/DNN Platform/Library/Services/Authentication/AuthenticationLoginBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationLoginBase.cs
@@ -19,12 +19,11 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 #region Usings
-
 using System.Web;
-
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
-
+using DotNetNuke.Services.UserRequest;
+using System;
 #endregion
 
 namespace DotNetNuke.Services.Authentication
@@ -111,14 +110,10 @@ namespace DotNetNuke.Services.Authentication
             }
         }
 
+        [Obsolete("Deprecated in 9.2.0. Use UserRequestIPAddressController.Instance.GetUserRequestIPAddress")]
         public static string GetIPAddress()
         {
-            string _IPAddress = Null.NullString;
-            if (HttpContext.Current.Request.UserHostAddress != null)
-            {
-                _IPAddress = HttpContext.Current.Request.UserHostAddress;
-            }
-            return _IPAddress;
+            return UserRequestIPAddressController.Instance.GetUserRequestIPAddress(new HttpRequestWrapper(HttpContext.Current.Request));                        
         }
     }
 }

--- a/DNN Platform/Library/Services/GeneratedImage/IPCount.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/IPCount.cs
@@ -1,4 +1,5 @@
 ﻿using DotNetNuke.Common.Utils;
+using DotNetNuke.Services.UserRequest;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -165,32 +166,10 @@ namespace DotNetNuke.Services.GeneratedImage
         /// method to get Client ip address
         /// </summary>
         /// <returns>IP Address of visitor</returns>
+        [Obsolete("Deprecated in 9.2.0. Use UserRequestIPAddressController.Instance.GetUserRequestIPAddress")]
         public static string GetVisitorIPAddress(HttpContextBase context)
         {
-            var visitorIPAddress = context.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-
-            if (string.IsNullOrEmpty(visitorIPAddress))
-            {
-                visitorIPAddress = context.Request.ServerVariables["REMOTE_ADDR"];
-            }
-
-            if (string.IsNullOrEmpty(visitorIPAddress))
-            {
-                visitorIPAddress = context.Request.UserHostAddress;
-            }
-
-            if (string.IsNullOrEmpty(visitorIPAddress) || visitorIPAddress.Trim() == "::1")
-            {
-                visitorIPAddress = string.Empty;
-            }
-
-            if (string.IsNullOrEmpty(visitorIPAddress))
-            {
-                //This is for Local(LAN) Connected ID Address
-                var stringHostName = Dns.GetHostName();
-                visitorIPAddress = NetworkUtils.GetAddress(stringHostName, AddressType.IPv4);
-            }
-            return visitorIPAddress;
+            return UserRequestIPAddressController.Instance.GetUserRequestIPAddress(context.Request);            
         }
     }
 }

--- a/DNN Platform/Library/Services/UserRequest/IUserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/IUserRequestIPAddressController.cs
@@ -1,0 +1,35 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System.Web;
+
+namespace DotNetNuke.Services.UserRequest
+{
+    public interface IUserRequestIPAddressController
+    {
+        /// <summary>
+        ///  To retrieve IP of user making request to application
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns>IP address</returns>
+        string GetUserRequestIPAddress(HttpRequestBase request);
+    }
+}

--- a/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
@@ -1,0 +1,84 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using DotNetNuke.Entities.Controllers;
+using System;
+using System.Web;
+using System.Linq;
+using DotNetNuke.Framework;
+using System.Net;
+
+namespace DotNetNuke.Services.UserRequest
+{
+    public class UserRequestIPAddressController : ServiceLocator<IUserRequestIPAddressController,UserRequestIPAddressController>, IUserRequestIPAddressController
+    {
+        public string GetUserRequestIPAddress(HttpRequestBase request)
+        {            
+            var userRequestIPHeader = HostController.Instance.GetString("UserRequestIPHeader", "X-Forwarded-For");
+            var userIPAddress = string.Empty;
+
+            if (request.Headers.AllKeys.Contains(userRequestIPHeader))
+            {
+                userIPAddress = request.Headers[userRequestIPHeader];
+                userIPAddress = userIPAddress.Split(',')[0];                
+            }            
+
+            if (string.IsNullOrEmpty(userIPAddress))
+            {
+                var remoteAddrVariable = "REMOTE_ADDR";
+                if (request.ServerVariables.AllKeys.Contains(remoteAddrVariable))
+                {
+                    userIPAddress = request.ServerVariables[remoteAddrVariable];
+                }
+            }
+
+            if (string.IsNullOrEmpty(userIPAddress))
+            {
+                userIPAddress = request.UserHostAddress;
+            }
+
+            if (string.IsNullOrEmpty(userIPAddress) || userIPAddress.Trim() == "::1")
+            {
+                userIPAddress = string.Empty;
+            }
+            
+            if (!string.IsNullOrEmpty(userIPAddress) && !ValidateIPv4(userIPAddress))
+            {
+                userIPAddress = string.Empty;
+            }
+
+            return userIPAddress;
+        }
+
+        private bool ValidateIPv4(string ipString)
+        {
+            if (ipString.Split('.').Length != 4) return false;
+            IPAddress address;
+            return IPAddress.TryParse(ipString, out address);
+        }
+
+
+        protected override Func<IUserRequestIPAddressController> GetFactory()
+        {
+            return () => new UserRequestIPAddressController();
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Services\Mobile\RedirectionControllerTests.cs" />
     <Compile Include="Services\Tokens\PropertyAccessTests.cs" />
     <Compile Include="FileSystemUtilsTests.cs" />
+    <Compile Include="Services\UserRequest\UserRequestIPAddressControllerTest.cs" />
     <Compile Include="TabCollectionTest.cs" />
     <Compile Include="Services\HtmlUtilsTest.cs" />
     <Compile Include="Providers\Caching\DataCacheTests.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/UserRequest/UserRequestIPAddressControllerTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/UserRequest/UserRequestIPAddressControllerTest.cs
@@ -112,7 +112,6 @@ namespace DotNetNuke.Tests.Core.Services.UserRequest
         [TestCase("abc.111.eer")]
         [TestCase("somedomain.com")]
         [TestCase("244.275.111.111")]
-        [TestCase("0.0.0.0")]
         public void UserRequestIPAddress_ShouldReturnEmptyString_IfIPAddressIsNotValid(string requestIp)
         {
             //Arrange

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/UserRequest/UserRequestIPAddressControllerTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/UserRequest/UserRequestIPAddressControllerTest.cs
@@ -1,0 +1,135 @@
+﻿#region Copyright
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// All Rights Reserved
+#endregion
+
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Tests.Utilities.Mocks;
+using Moq;
+using NUnit.Framework;
+using DotNetNuke.Entities.Controllers;
+using System.Web;
+using DotNetNuke.Tests.Utilities;
+using System.Collections.Specialized;
+using DotNetNuke.Services.UserRequest;
+
+namespace DotNetNuke.Tests.Core.Services.UserRequest
+{
+    [TestFixture]
+    class UserRequestIPAddressControllerTest
+    {
+        private Mock<IPortalController> _mockPortalController;
+        private Mock<IHostController> _mockHostController;
+        private Mock<HttpContextBase> _mockhttpContext;
+        private Mock<HttpRequestBase> _mockRequest;
+        
+        private UserRequestIPAddressController _userRequestIPAddressController;
+
+        [SetUp]
+        public void Setup()
+        {
+            var requestIp = "111.111.111.111";
+            NameValueCollection serverVariables = new NameValueCollection();
+            
+            // Setup Mock
+            _mockhttpContext = HttpContextHelper.RegisterMockHttpContext();
+            _mockRequest = Mock.Get(_mockhttpContext.Object.Request);
+            _mockRequest.Setup(x => x.ServerVariables).Returns(serverVariables);
+            _mockRequest.Setup(x => x.UserHostAddress).Returns(requestIp);            
+            _mockHostController = MockComponentProvider.CreateNew<IHostController>();
+            _mockPortalController = MockComponentProvider.CreateNew<IPortalController>();
+            PortalController.SetTestableInstance(_mockPortalController.Object);
+
+            // System under test
+            _userRequestIPAddressController = new UserRequestIPAddressController();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            MockComponentProvider.ResetContainer();
+        }
+
+        [Test]
+        public void UserRequestIPAddress_ShouldReturnIP_IfXForwardedHeaderIsPresent()
+        {
+            //Arrange
+            var expectedIp = "111.111.111.111";
+            var headerName = "X-Forwarded-For";
+            var requestIp = "111.111.111.111";
+
+            _mockHostController.Setup(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns(headerName);
+
+            NameValueCollection headersWithXForwardedHeaders = new NameValueCollection();
+            headersWithXForwardedHeaders.Add(headerName, requestIp);
+            _mockRequest.Setup(x => x.Headers).Returns(headersWithXForwardedHeaders);
+
+            //Act
+            string userRequestIPAddress = _userRequestIPAddressController.GetUserRequestIPAddress(_mockhttpContext.Object.Request);
+
+            //Assert            
+            Assert.AreSame(expectedIp, userRequestIPAddress);
+        }
+
+        [Test]
+        public void UserRequestIPAddress_ShouldReturnIP_IfRemoteAddrServerVariablePresent()
+        {
+            //Arrange
+            var expectedIp = "111.111.111.111";
+            var remoteVariable = "REMOTE_ADDR";
+            var requestIp = "111.111.111.111";
+
+            NameValueCollection serverVariables = new NameValueCollection();
+            serverVariables.Add(remoteVariable, requestIp);
+            _mockRequest.Setup(x => x.ServerVariables).Returns(serverVariables);
+
+            //Act
+            var userRequestIPAddress = _userRequestIPAddressController.GetUserRequestIPAddress(_mockhttpContext.Object.Request);
+
+            //Assert            
+            Assert.AreSame(expectedIp, userRequestIPAddress);
+            _mockRequest.VerifyGet(r => r.ServerVariables);
+            _mockRequest.VerifyGet(r => r.Headers);
+            _mockHostController.Verify(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>()));
+        }
+
+        [Test]
+        public void UserRequestIPAddress_ShouldReturnIP_IfUserHostAddress()
+        {
+            //Arrange
+            var expectedIp = "111.111.111.111";
+
+            //Act
+            var userRequestIPAddress = _userRequestIPAddressController.GetUserRequestIPAddress(_mockhttpContext.Object.Request);
+
+            //Assert            
+            Assert.AreSame(expectedIp, userRequestIPAddress);
+            _mockRequest.VerifyGet(r => r.UserHostAddress);
+        }
+
+        [TestCase("abc.111.eer")]
+        [TestCase("somedomain.com")]
+        [TestCase("244.275.111.111")]
+        [TestCase("abc.111.eer")]
+        public void UserRequestIPAddress_ShouldReturnEmptyString_IfIPAddressIsNotValid(string requestIp)
+        {
+            //Arrange
+            var headerName = "X-Forwarded-For";
+
+            _mockHostController.Setup(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns(headerName);
+
+            NameValueCollection headersWithXForwardedHeaders = new NameValueCollection();
+            headersWithXForwardedHeaders.Add(headerName, requestIp);
+            _mockRequest.Setup(x => x.Headers).Returns(headersWithXForwardedHeaders);
+
+
+            //Act
+            var userRequestIPAddress = _userRequestIPAddressController.GetUserRequestIPAddress(_mockhttpContext.Object.Request);
+
+            //Assert            
+            Assert.AreSame(string.Empty, userRequestIPAddress);
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/UserRequest/UserRequestIPAddressControllerTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/UserRequest/UserRequestIPAddressControllerTest.cs
@@ -50,27 +50,27 @@ namespace DotNetNuke.Tests.Core.Services.UserRequest
         public void TearDown()
         {
             MockComponentProvider.ResetContainer();
-        }
+        }        
 
-        [Test]
-        public void UserRequestIPAddress_ShouldReturnIP_IfXForwardedHeaderIsPresent()
+        [TestCase("111.111.111.111","X-Forwarded-For")]
+        [TestCase("111.111.111.111,123.112.11.33", "X-Forwarded-For")]
+        [TestCase("111.111.111.111", "X-ProxyUser-Ip")]
+        [TestCase("111.111.111.111,23.112.11.33", "X-ProxyUser-Ip")]
+        public void UserRequestIPAddress_ShouldReturnIP_IfAnyHeaderIsPresent(string requestIp, string headerName)
         {
             //Arrange
-            var expectedIp = "111.111.111.111";
-            var headerName = "X-Forwarded-For";
-            var requestIp = "111.111.111.111";
-
-            _mockHostController.Setup(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns(headerName);
+            var expectedIp = "111.111.111.111";                    
 
             NameValueCollection headersWithXForwardedHeaders = new NameValueCollection();
             headersWithXForwardedHeaders.Add(headerName, requestIp);
+            _mockHostController.Setup(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns(headerName);
             _mockRequest.Setup(x => x.Headers).Returns(headersWithXForwardedHeaders);
 
             //Act
             string userRequestIPAddress = _userRequestIPAddressController.GetUserRequestIPAddress(_mockhttpContext.Object.Request);
 
             //Assert            
-            Assert.AreSame(expectedIp, userRequestIPAddress);
+            Assert.AreEqual(expectedIp, userRequestIPAddress);
         }
 
         [Test]
@@ -112,19 +112,17 @@ namespace DotNetNuke.Tests.Core.Services.UserRequest
         [TestCase("abc.111.eer")]
         [TestCase("somedomain.com")]
         [TestCase("244.275.111.111")]
-        [TestCase("abc.111.eer")]
+        [TestCase("0.0.0.0")]
         public void UserRequestIPAddress_ShouldReturnEmptyString_IfIPAddressIsNotValid(string requestIp)
         {
             //Arrange
-            var headerName = "X-Forwarded-For";
-
-            _mockHostController.Setup(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns(headerName);
+            var headerName = "X-Forwarded-For";           
 
             NameValueCollection headersWithXForwardedHeaders = new NameValueCollection();
             headersWithXForwardedHeaders.Add(headerName, requestIp);
             _mockRequest.Setup(x => x.Headers).Returns(headersWithXForwardedHeaders);
-
-
+            _mockHostController.Setup(hc => hc.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns(headerName);
+            
             //Act
             var userRequestIPAddress = _userRequestIPAddressController.GetUserRequestIPAddress(_mockhttpContext.Object.Request);
 

--- a/Website/admin/Security/PasswordReset.ascx.cs
+++ b/Website/admin/Security/PasswordReset.ascx.cs
@@ -39,6 +39,7 @@ using DotNetNuke.UI.Skins.Controls;
 using DotNetNuke.Web.Client;
 using DotNetNuke.Web.Client.ClientResourceManagement;
 using DotNetNuke.Web.UI.WebControls;
+using DotNetNuke.Services.UserRequest;
 
 #endregion
 
@@ -72,9 +73,9 @@ namespace DotNetNuke.Modules.Admin.Security
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            _ipAddress = Request.UserHostAddress;
+            _ipAddress = UserRequestIPAddressController.Instance.GetUserRequestIPAddress(new HttpRequestWrapper(Request));
 
-			JavaScript.RequestRegistration(CommonJs.DnnPlugins);
+            JavaScript.RequestRegistration(CommonJs.DnnPlugins);
 			ClientResourceManager.RegisterScript(Page, "~/Resources/Shared/scripts/dnn.jquery.extensions.js");
 			ClientResourceManager.RegisterScript(Page, "~/Resources/Shared/scripts/dnn.jquery.tooltip.js");
 			ClientResourceManager.RegisterScript(Page, "~/Resources/Shared/scripts/dnn.PasswordStrength.js");

--- a/Website/admin/Security/SendPassword.ascx.cs
+++ b/Website/admin/Security/SendPassword.ascx.cs
@@ -38,6 +38,7 @@ using DotNetNuke.Services.Localization;
 using DotNetNuke.Services.Log.EventLog;
 using DotNetNuke.Services.Mail;
 using DotNetNuke.UI.Skins.Controls;
+using DotNetNuke.Services.UserRequest;
 
 #endregion
 
@@ -224,11 +225,7 @@ namespace DotNetNuke.Modules.Admin.Security
             cmdSendPassword.Click += OnSendPasswordClick;
 			cancelButton.Click += cancelButton_Click;
 
-            if (Request.UserHostAddress != null)
-            {
-                _ipAddress = Request.UserHostAddress;
-            }
-
+            _ipAddress = UserRequestIPAddressController.Instance.GetUserRequestIPAddress(new HttpRequestWrapper(Request));            
 
 			divEmail.Visible = ShowEmailField;
 			divUsername.Visible = !UsernameDisabled;


### PR DESCRIPTION
DNN-8939: SI: IP Address Tracking when using a Load Balancer
- Did the change for getting IP against any Header from HostSetttings meanwhile Default is X-Forwarded-For
- Change the existing methods to use new controller and obselete them
- Not returning DNS name as security con mentioned in CONTENT-8523

Put this controller in 
dnn platform\library\services\userrequest

Unittest added in 
DNN Platform\Tests\DotNetNuke.Tests.Core\Services\UserRequest\
With test cases for 
- Valid IP address
- Header/ServerVariable present to obtain IP against

Can be extended per customer requirement




