### PR TITLE
DNN-9408 Upgrade ClientDependency.Core to 1.9.3

### DIFF
--- a/DNN Platform/Components/ClientDependency/Source/CompositeFiles/CompositeDependencyHandler.cs
+++ b/DNN Platform/Components/ClientDependency/Source/CompositeFiles/CompositeDependencyHandler.cs
@@ -56,7 +56,8 @@ namespace ClientDependency.Core.CompositeFiles
 
                 // querystring format
                 fileKey = queryStrings["s"];
-                if (!string.IsNullOrEmpty(queryStrings["cdv"]) && !Int32.TryParse(queryStrings["cdv"], out version))
+                var clientDepdendencyVersion = queryStrings["cdv"].TrimEnd('/');
+                if (!string.IsNullOrEmpty(clientDepdendencyVersion) && !Int32.TryParse(clientDepdendencyVersion, out version))
                     throw new ArgumentException("Could not parse the version in the request");
                 try
                 {

--- a/DNN Platform/Components/ClientDependency/Source/Config/ClientDependencySettings.cs
+++ b/DNN Platform/Components/ClientDependency/Source/Config/ClientDependencySettings.cs
@@ -164,9 +164,6 @@ namespace ClientDependency.Core.Config
 
         private bool? _allowOnlyFipsAlgorithms;
 
-        /// <summary>
-        /// Indicates whether CDF should enforce the policy to create only Federal Information Processing Standard (FIPS) certified algorithms.
-        /// </summary>
         [Obsolete("Use the built in .Net CryptoConfig.AllowOnlyFipsAlgorithms")]
         public bool AllowOnlyFipsAlgorithms
         {

--- a/DNN Platform/Components/ClientDependency/Source/HtmlAttributesStringParser.cs
+++ b/DNN Platform/Components/ClientDependency/Source/HtmlAttributesStringParser.cs
@@ -61,6 +61,8 @@ namespace ClientDependency.Core
 
                         //now we can add/replace the current value to the dictionary
                         destination[key] = val;
+                        key = "";
+                        val = "";
                         continue;
                     }
                     


### PR DESCRIPTION
This brings the change from #1854 up to date with the [1.9.3 release](https://github.com/Shazwazza/ClientDependency/releases/tag/v1.9.3) from a couple of days ago.

This includes a couple of changes from 1.9.2 to 1.9.3, importantly
Shazwazza/ClientDependency#108, which fixes a bug when adding multiple HTML
attributes to a script tag