### PR TITLE
DNN-8450 Allow override of prefixing the service name for OAuth providers

### DIFF
--- a/DNN Platform/Library/Security/Membership/MembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/MembershipProvider.cs
@@ -119,6 +119,11 @@ namespace DotNetNuke.Security.Membership
             return null;
         }
 
+        public virtual UserInfo GetUserByAuthToken(int portalId, string userToken, string authType)
+        {
+            throw new NotImplementedException();
+        }
+
         public virtual ArrayList GetUsers(int portalId, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {
             throw new NotImplementedException();
@@ -182,8 +187,7 @@ namespace DotNetNuke.Security.Membership
         {
             throw new NotImplementedException();
         }
-
-
+        
         #endregion
     }
 }

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -46,6 +46,7 @@ using System.Text;
 using System.Web;
 using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Data;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Security.Membership;
 using DotNetNuke.Instrumentation;
@@ -134,7 +135,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
 
         //oAuth 1 and 2
         protected Uri AuthorizationEndpoint { get; set; }
-        protected string AuthToken { get; private set; }
+        protected string AuthToken { get; set; }
         protected TimeSpan AuthTokenExpiry { get; set; }
         protected Uri MeGraphEndpoint { get; set; }
         protected Uri TokenEndpoint { get; set; }
@@ -158,6 +159,16 @@ namespace DotNetNuke.Services.Authentication.OAuth
 
         public Uri CallbackUri { get; set; }
         public string Service { get; set; }
+
+        public virtual bool PrefixServiceToUserName
+        {
+            get { return true; }
+        }
+
+        public virtual bool AutoMatchExistingUsers
+        {
+            get { return false; }
+        }
 
         #endregion
 
@@ -618,18 +629,38 @@ namespace DotNetNuke.Services.Authentication.OAuth
         {
             var loginStatus = UserLoginStatus.LOGIN_FAILURE;
 
-            string userName = Service + "-" + user.Id;
+            string userName = PrefixServiceToUserName ? Service + "-" + user.Email : user.Email;
+            string token = Service + "-" + user.Email + "-" + user.Id;
 
-            var objUserInfo = UserController.ValidateUser(settings.PortalId, userName, "",
-                                                                Service, "",
+            UserInfo objUserInfo;
+
+            if (AutoMatchExistingUsers)
+            {
+                objUserInfo = MembershipProvider.Instance().GetUserByUserName(settings.PortalId, userName);
+
+                if (objUserInfo != null)
+                {
+                    //user already exists... lets check for a token next... 
+                    var dnnAuthToken = MembershipProvider.Instance().GetUserByAuthToken(settings.PortalId, token, Service);
+
+                    if (dnnAuthToken == null)
+                    {
+                        DataProvider.Instance().AddUserAuthentication(objUserInfo.UserID, Service, token, objUserInfo.UserID);
+                    }
+                }
+            }
+
+            objUserInfo = UserController.ValidateUser(settings.PortalId, userName, "",
+                                                                Service, token,
                                                                 settings.PortalName, IPAddress,
                                                                 ref loginStatus);
 
 
             //Raise UserAuthenticated Event
-            var eventArgs = new UserAuthenticatedEventArgs(objUserInfo, userName, loginStatus, Service)
+            var eventArgs = new UserAuthenticatedEventArgs(objUserInfo, token, loginStatus, Service)
                                             {
-                                                AutoRegister = true
+                                                AutoRegister = true,
+                                                UserName = userName,
                                             };
 
             var profileProperties = new NameValueCollection();

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -629,20 +629,18 @@ namespace DotNetNuke.Services.Authentication.OAuth
         {
             var loginStatus = UserLoginStatus.LOGIN_FAILURE;
 
-            string userName = PrefixServiceToUserName ? Service + "-" + user.Email : user.Email;
-            string token = Service + "-" + user.Email + "-" + user.Id;
+            string userName = PrefixServiceToUserName ? Service + "-" + user.Id : user.Id;
+            string token = Service + "-" + user.Id;
 
             UserInfo objUserInfo;
 
             if (AutoMatchExistingUsers)
             {
                 objUserInfo = MembershipProvider.Instance().GetUserByUserName(settings.PortalId, userName);
-
                 if (objUserInfo != null)
                 {
                     //user already exists... lets check for a token next... 
                     var dnnAuthToken = MembershipProvider.Instance().GetUserByAuthToken(settings.PortalId, token, Service);
-
                     if (dnnAuthToken == null)
                     {
                         DataProvider.Instance().AddUserAuthentication(objUserInfo.UserID, Service, token, objUserInfo.UserID);

--- a/DNN Platform/Library/Services/Authentication/UserAuthenticatedEventArgs.cs
+++ b/DNN Platform/Library/Services/Authentication/UserAuthenticatedEventArgs.cs
@@ -123,5 +123,12 @@ namespace DotNetNuke.Services.Authentication
         /// </summary>
         /// -----------------------------------------------------------------------------
         public string UserToken { get; set; }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// Gets and sets the Username
+        /// </summary>
+        /// -----------------------------------------------------------------------------
+        public string UserName { get; set; }
     }
 }

--- a/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -60,104 +60,104 @@ namespace DotNetNuke.Modules.Admin.Authentication
 {
     using Host = DotNetNuke.Entities.Host.Host;
 
-	/// <summary>
-	/// The Signin UserModuleBase is used to provide a login for a registered user
-	/// </summary>
-	/// <remarks>
-	/// </remarks>
-	public partial class Login : UserModuleBase
-	{
-		private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (Login));
+    /// <summary>
+    /// The Signin UserModuleBase is used to provide a login for a registered user
+    /// </summary>
+    /// <remarks>
+    /// </remarks>
+    public partial class Login : UserModuleBase
+    {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(Login));
 
         private static readonly Regex UserLanguageRegex = new Regex("(.*)(&|\\?)(language=)([^&\\?]+)(.*)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         #region Private Members
 
-		private readonly List<AuthenticationLoginBase> _loginControls = new List<AuthenticationLoginBase>();
-        private readonly  List<AuthenticationLoginBase> _defaultauthLogin = new List<AuthenticationLoginBase>();
+        private readonly List<AuthenticationLoginBase> _loginControls = new List<AuthenticationLoginBase>();
+        private readonly List<AuthenticationLoginBase> _defaultauthLogin = new List<AuthenticationLoginBase>();
         private readonly List<OAuthLoginBase> _oAuthControls = new List<OAuthLoginBase>();
 
-		#endregion
+        #endregion
 
-		#region Protected Properties
+        #region Protected Properties
 
-		/// <summary>
-		/// Gets and sets the current AuthenticationType
-		/// </summary>
-		protected string AuthenticationType
-		{
-			get
-			{
-				var authenticationType = Null.NullString;
-				if (ViewState["AuthenticationType"] != null)
-				{
-					authenticationType = Convert.ToString(ViewState["AuthenticationType"]);
-				}
-				return authenticationType;
-			}
-			set
-			{
-				ViewState["AuthenticationType"] = value;
-			}
-		}
+        /// <summary>
+        /// Gets and sets the current AuthenticationType
+        /// </summary>
+        protected string AuthenticationType
+        {
+            get
+            {
+                var authenticationType = Null.NullString;
+                if (ViewState["AuthenticationType"] != null)
+                {
+                    authenticationType = Convert.ToString(ViewState["AuthenticationType"]);
+                }
+                return authenticationType;
+            }
+            set
+            {
+                ViewState["AuthenticationType"] = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets and sets a flag that determines whether the user should be automatically registered
-		/// </summary>
-		protected bool AutoRegister
-		{
-			get
-			{
-				var autoRegister = Null.NullBoolean;
-				if (ViewState["AutoRegister"] != null)
-				{
-					autoRegister = Convert.ToBoolean(ViewState["AutoRegister"]);
-				}
-				return autoRegister;
-			}
-			set
-			{
-				ViewState["AutoRegister"] = value;
-			}
-		}
+        /// <summary>
+        /// Gets and sets a flag that determines whether the user should be automatically registered
+        /// </summary>
+        protected bool AutoRegister
+        {
+            get
+            {
+                var autoRegister = Null.NullBoolean;
+                if (ViewState["AutoRegister"] != null)
+                {
+                    autoRegister = Convert.ToBoolean(ViewState["AutoRegister"]);
+                }
+                return autoRegister;
+            }
+            set
+            {
+                ViewState["AutoRegister"] = value;
+            }
+        }
 
-		protected NameValueCollection ProfileProperties
-		{
-			get
-			{
-				var profile = new NameValueCollection();
-				if (ViewState["ProfileProperties"] != null)
-				{
-					profile = (NameValueCollection) ViewState["ProfileProperties"];
-				}
-				return profile;
-			}
-			set
-			{
-				ViewState["ProfileProperties"] = value;
-			}
-		}
+        protected NameValueCollection ProfileProperties
+        {
+            get
+            {
+                var profile = new NameValueCollection();
+                if (ViewState["ProfileProperties"] != null)
+                {
+                    profile = (NameValueCollection)ViewState["ProfileProperties"];
+                }
+                return profile;
+            }
+            set
+            {
+                ViewState["ProfileProperties"] = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets and sets the current Page No
-		/// </summary>
-		protected int PageNo
-		{
-			get
-			{
-				var pageNo = 0;
-				if (ViewState["PageNo"] != null)
-				{
-					pageNo = Convert.ToInt32(ViewState["PageNo"]);
-				}
-				return pageNo;
-			}
-			set
-			{
-				ViewState["PageNo"] = value;
-			}
-		}
+        /// <summary>
+        /// Gets and sets the current Page No
+        /// </summary>
+        protected int PageNo
+        {
+            get
+            {
+                var pageNo = 0;
+                if (ViewState["PageNo"] != null)
+                {
+                    pageNo = Convert.ToInt32(ViewState["PageNo"]);
+                }
+                return pageNo;
+            }
+            set
+            {
+                ViewState["PageNo"] = value;
+            }
+        }
 
         /// <summary>
         /// Gets the Redirect URL (after successful login)
@@ -288,54 +288,54 @@ namespace DotNetNuke.Modules.Admin.Authentication
             }
         }
 
-		/// <summary>
-		/// Gets whether the Captcha control is used to validate the login
-		/// </summary>
-		protected bool UseCaptcha
-		{
-			get
-			{
-				object setting = GetSetting(PortalId, "Security_CaptchaLogin");
-				return Convert.ToBoolean(setting);
-			}
-		}
+        /// <summary>
+        /// Gets whether the Captcha control is used to validate the login
+        /// </summary>
+        protected bool UseCaptcha
+        {
+            get
+            {
+                object setting = GetSetting(PortalId, "Security_CaptchaLogin");
+                return Convert.ToBoolean(setting);
+            }
+        }
 
-		protected UserLoginStatus LoginStatus
-		{
-			get
-			{
-				UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
-				if (ViewState["LoginStatus"] != null)
-				{
-					loginStatus = (UserLoginStatus) ViewState["LoginStatus"];
-				}
-				return loginStatus;
-			}
-			set
-			{
-				ViewState["LoginStatus"] = value;
-			}
-		}
+        protected UserLoginStatus LoginStatus
+        {
+            get
+            {
+                UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
+                if (ViewState["LoginStatus"] != null)
+                {
+                    loginStatus = (UserLoginStatus)ViewState["LoginStatus"];
+                }
+                return loginStatus;
+            }
+            set
+            {
+                ViewState["LoginStatus"] = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets and sets the current UserToken
-		/// </summary>
-		protected string UserToken
-		{
-			get
-			{
-				var userToken = "";
-				if (ViewState["UserToken"] != null)
-				{
-					userToken = Convert.ToString(ViewState["UserToken"]);
-				}
-				return userToken;
-			}
-			set
-			{
-				ViewState["UserToken"] = value;
-			}
-		}
+        /// <summary>
+        /// Gets and sets the current UserToken
+        /// </summary>
+        protected string UserToken
+        {
+            get
+            {
+                var userToken = "";
+                if (ViewState["UserToken"] != null)
+                {
+                    userToken = Convert.ToString(ViewState["UserToken"]);
+                }
+                return userToken;
+            }
+            set
+            {
+                ViewState["UserToken"] = value;
+            }
+        }
 
 		/// <summary>
 		/// Gets and sets the current UserName
@@ -357,25 +357,25 @@ namespace DotNetNuke.Modules.Admin.Authentication
 			}
 		}
 
-		#endregion
+        #endregion
 
-		#region Private Methods
+        #region Private Methods
 
-		private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)
-		{
-			//search selected authentication control for username and password fields
-			//and inject autocomplete=off so browsers do not remember sensitive details
-			var username = loginControl.FindControl("txtUsername") as WebControl;
-			if (username != null)
-			{
-				username.Attributes.Add("AUTOCOMPLETE", "off");
-			}
-			var password = loginControl.FindControl("txtPassword") as WebControl;
-			if (password != null)
-			{
-				password.Attributes.Add("AUTOCOMPLETE", "off");
-			}
-		}
+        private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)
+        {
+            //search selected authentication control for username and password fields
+            //and inject autocomplete=off so browsers do not remember sensitive details
+            var username = loginControl.FindControl("txtUsername") as WebControl;
+            if (username != null)
+            {
+                username.Attributes.Add("AUTOCOMPLETE", "off");
+            }
+            var password = loginControl.FindControl("txtPassword") as WebControl;
+            if (password != null)
+            {
+                password.Attributes.Add("AUTOCOMPLETE", "off");
+            }
+        }
 
         private void BindLogin()
         {
@@ -450,23 +450,23 @@ namespace DotNetNuke.Modules.Admin.Authentication
                     {
                         //if there are social authprovider only
                         if (_oAuthControls.Count == 0)
-                        //Portal has no login controls enabled so load default DNN control
-                        DisplayLoginControl(defaultLoginControl, false, false);
+                            //Portal has no login controls enabled so load default DNN control
+                            DisplayLoginControl(defaultLoginControl, false, false);
                     }
                     break;
                 case 1:
                     //We don't want the control to render with tabbed interface
-                    DisplayLoginControl(_defaultauthLogin.Count == 1 
-                                            ? _defaultauthLogin[0] 
-                                            : _loginControls.Count == 1 
-                                                ? _loginControls[0] 
-                                                : _oAuthControls[0], 
+                    DisplayLoginControl(_defaultauthLogin.Count == 1
+                                            ? _defaultauthLogin[0]
+                                            : _loginControls.Count == 1
+                                                ? _loginControls[0]
+                                                : _oAuthControls[0],
                                         false,
                                         false);
                     break;
                 default:
                     //make sure defaultAuth provider control is diplayed first
-                    if (_defaultauthLogin.Count>0) DisplayTabbedLoginControl(_defaultauthLogin[0], tsLogin.Tabs);
+                    if (_defaultauthLogin.Count > 0) DisplayTabbedLoginControl(_defaultauthLogin[0], tsLogin.Tabs);
                     foreach (AuthenticationLoginBase authLoginControl in _loginControls)
                     {
                         DisplayTabbedLoginControl(authLoginControl, tsLogin.Tabs);
@@ -506,59 +506,59 @@ namespace DotNetNuke.Modules.Admin.Authentication
         }
 
         private void BindRegister()
-		{
-			lblType.Text = AuthenticationType;
-			lblToken.Text = UserToken;
+        {
+            lblType.Text = AuthenticationType;
+            lblToken.Text = UserToken;
 
-			//Verify that the current user has access to this page
-			if (PortalSettings.UserRegistration == (int) Globals.PortalRegistrationType.NoRegistration && Request.IsAuthenticated == false)
-			{
-				Response.Redirect(Globals.NavigateURL("Access Denied"), true);
-			}
-			lblRegisterHelp.Text = Localization.GetSystemMessage(PortalSettings, "MESSAGE_REGISTRATION_INSTRUCTIONS");
-			switch (PortalSettings.UserRegistration)
-			{
-				case (int) Globals.PortalRegistrationType.PrivateRegistration:
-					lblRegisterHelp.Text += Localization.GetString("PrivateMembership", Localization.SharedResourceFile);
-					break;
-				case (int) Globals.PortalRegistrationType.PublicRegistration:
-					lblRegisterHelp.Text += Localization.GetString("PublicMembership", Localization.SharedResourceFile);
-					break;
-				case (int) Globals.PortalRegistrationType.VerifiedRegistration:
-					lblRegisterHelp.Text += Localization.GetString("VerifiedMembership", Localization.SharedResourceFile);
-					break;
-			}
-			if (AutoRegister)
-			{
-				InitialiseUser();
-			}
-			bool UserValid = true;
-			if (string.IsNullOrEmpty(User.Username) || string.IsNullOrEmpty(User.Email) || string.IsNullOrEmpty(User.FirstName) || string.IsNullOrEmpty(User.LastName))
-			{
-				UserValid = Null.NullBoolean;
-			}
-			if (AutoRegister && UserValid)
-			{
-				ctlUser.Visible = false;
-				lblRegisterTitle.Text = Localization.GetString("CreateTitle", LocalResourceFile);
-				cmdCreateUser.Text = Localization.GetString("cmdCreate", LocalResourceFile);
-			}
-			else
-			{
-				lblRegisterHelp.Text += Localization.GetString("Required", Localization.SharedResourceFile);
-				lblRegisterTitle.Text = Localization.GetString("RegisterTitle", LocalResourceFile);
-				cmdCreateUser.Text = Localization.GetString("cmdRegister", LocalResourceFile);
-				ctlUser.ShowPassword = false;
-				ctlUser.ShowUpdate = false;
-				ctlUser.User = User;
-				ctlUser.DataBind();
-			}
-		}
+            //Verify that the current user has access to this page
+            if (PortalSettings.UserRegistration == (int)Globals.PortalRegistrationType.NoRegistration && Request.IsAuthenticated == false)
+            {
+                Response.Redirect(Globals.NavigateURL("Access Denied"), true);
+            }
+            lblRegisterHelp.Text = Localization.GetSystemMessage(PortalSettings, "MESSAGE_REGISTRATION_INSTRUCTIONS");
+            switch (PortalSettings.UserRegistration)
+            {
+                case (int)Globals.PortalRegistrationType.PrivateRegistration:
+                    lblRegisterHelp.Text += Localization.GetString("PrivateMembership", Localization.SharedResourceFile);
+                    break;
+                case (int)Globals.PortalRegistrationType.PublicRegistration:
+                    lblRegisterHelp.Text += Localization.GetString("PublicMembership", Localization.SharedResourceFile);
+                    break;
+                case (int)Globals.PortalRegistrationType.VerifiedRegistration:
+                    lblRegisterHelp.Text += Localization.GetString("VerifiedMembership", Localization.SharedResourceFile);
+                    break;
+            }
+            if (AutoRegister)
+            {
+                InitialiseUser();
+            }
+            bool UserValid = true;
+            if (string.IsNullOrEmpty(User.Username) || string.IsNullOrEmpty(User.Email) || string.IsNullOrEmpty(User.FirstName) || string.IsNullOrEmpty(User.LastName))
+            {
+                UserValid = Null.NullBoolean;
+            }
+            if (AutoRegister && UserValid)
+            {
+                ctlUser.Visible = false;
+                lblRegisterTitle.Text = Localization.GetString("CreateTitle", LocalResourceFile);
+                cmdCreateUser.Text = Localization.GetString("cmdCreate", LocalResourceFile);
+            }
+            else
+            {
+                lblRegisterHelp.Text += Localization.GetString("Required", Localization.SharedResourceFile);
+                lblRegisterTitle.Text = Localization.GetString("RegisterTitle", LocalResourceFile);
+                cmdCreateUser.Text = Localization.GetString("cmdRegister", LocalResourceFile);
+                ctlUser.ShowPassword = false;
+                ctlUser.ShowUpdate = false;
+                ctlUser.User = User;
+                ctlUser.DataBind();
+            }
+        }
 
         private void DisplayLoginControl(AuthenticationLoginBase authLoginControl, bool addHeader, bool addFooter)
         {
             //Create a <div> to hold the control
-            var container = new HtmlGenericControl { TagName = "div", ID = authLoginControl.AuthenticationType, ViewStateMode = ViewStateMode.Disabled};
+            var container = new HtmlGenericControl { TagName = "div", ID = authLoginControl.AuthenticationType, ViewStateMode = ViewStateMode.Disabled };
 
             //Add Settings Control to Container
             container.Controls.Add(authLoginControl);
@@ -592,69 +592,57 @@ namespace DotNetNuke.Modules.Admin.Authentication
         private void DisplayTabbedLoginControl(AuthenticationLoginBase authLoginControl, TabStripTabCollection Tabs)
         {
             var tab = new DNNTab(Localization.GetString("Title", authLoginControl.LocalResourceFile)) { ID = authLoginControl.AuthenticationType };
-            
+
             tab.Controls.Add(authLoginControl);
             Tabs.Add(tab);
-            
+
             tsLogin.Visible = true;
         }
 
         private void InitialiseUser()
-		{
-			//Load any Profile properties that may have been returned
-			UpdateProfile(User, false);
+        {
+            //Load any Profile properties that may have been returned
+            UpdateProfile(User, false);
 
             //Set UserName to authentication Token            
             User.Username = GenerateUserName();
 
-			//Set DisplayName to UserToken if null
-			if (string.IsNullOrEmpty(User.DisplayName))
-			{
-				User.DisplayName = UserToken.Replace("http://", "").TrimEnd('/');
-			}
-			
-			//Parse DisplayName into FirstName/LastName
-			if (User.DisplayName.IndexOf(' ') > 0)
-			{
-				User.FirstName = User.DisplayName.Substring(0, User.DisplayName.IndexOf(' '));
-				User.LastName = User.DisplayName.Substring(User.DisplayName.IndexOf(' ') + 1);
-			}
-			
-			//Set FirstName to Authentication Type (if null)
-			if (string.IsNullOrEmpty(User.FirstName))
-			{
-				User.FirstName = AuthenticationType;
-			}
-			//Set FirstName to "User" (if null)
-			if (string.IsNullOrEmpty(User.LastName))
-			{
-				User.LastName = "User";
-			}
-		}
+            //Set DisplayName to UserToken if null
+            if (string.IsNullOrEmpty(User.DisplayName))
+            {
+                User.DisplayName = UserToken.Replace("http://", "").TrimEnd('/');
+            }
+
+            //Parse DisplayName into FirstName/LastName
+            if (User.DisplayName.IndexOf(' ') > 0)
+            {
+                User.FirstName = User.DisplayName.Substring(0, User.DisplayName.IndexOf(' '));
+                User.LastName = User.DisplayName.Substring(User.DisplayName.IndexOf(' ') + 1);
+            }
+
+            //Set FirstName to Authentication Type (if null)
+            if (string.IsNullOrEmpty(User.FirstName))
+            {
+                User.FirstName = AuthenticationType;
+            }
+            //Set FirstName to "User" (if null)
+            if (string.IsNullOrEmpty(User.LastName))
+            {
+                User.LastName = "User";
+            }
+        }
 
         private string GenerateUserName()
         {
-            //Try the best username. Default it to UserName
-            var userName = UserName;
-
-            if (!string.IsNullOrEmpty(userName))
+            if (!string.IsNullOrEmpty(UserName))
             {
-                return userName;
-            }
-            else
-            {
-                userName = UserToken.Replace("http://", "").TrimEnd('/');
-
-                if (!string.IsNullOrEmpty(userName))
-                {
-                    return userName;
-                }
+                return UserName;
             }
 
             //Try Email prefix
             var emailPrefix = string.Empty;
             if (!string.IsNullOrEmpty(User.Email))
-            {                
+            {
                 if (User.Email.IndexOf("@", StringComparison.Ordinal) != -1)
                 {
                     emailPrefix = User.Email.Substring(0, User.Email.IndexOf("@", StringComparison.Ordinal));
@@ -689,7 +677,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
             //Try First Name + space + First letter last name            
             if (!string.IsNullOrEmpty(User.LastName) && !string.IsNullOrEmpty(User.FirstName))
             {
-                var newUserName = User.FirstName + " " + User.LastName.Substring(0,1);
+                var newUserName = User.FirstName + " " + User.LastName.Substring(0, 1);
                 var user = UserController.GetUserByName(PortalId, newUserName);
                 if (user == null)
                 {
@@ -722,101 +710,101 @@ namespace DotNetNuke.Modules.Admin.Authentication
                 }
             }
 
-            return userName;
+            return UserToken.Replace("http://", "").TrimEnd('/');
         }
 
-		/// -----------------------------------------------------------------------------
-		/// <summary>
-		/// ShowPanel controls what "panel" is to be displayed
-		/// </summary>
-		/// -----------------------------------------------------------------------------
-		private void ShowPanel()
-		{
-			bool showLogin = (PageNo == 0);
-			bool showRegister = (PageNo == 1);
-			bool showPassword = (PageNo == 2);
-			bool showProfile = (PageNo == 3);
-			pnlProfile.Visible = showProfile;
-			pnlPassword.Visible = showPassword;
-			pnlLogin.Visible = showLogin;
-			pnlRegister.Visible = showRegister;
-			pnlAssociate.Visible = showRegister;
-			switch (PageNo)
-			{
-				case 0:
-					BindLogin();
-					break;
-				case 1:
-					BindRegister();
-					break;
-				case 2:
-					ctlPassword.UserId = UserId;
-					ctlPassword.DataBind();
-					break;
-				case 3:
-					ctlProfile.UserId = UserId;
-					ctlProfile.DataBind();
-					break;
-			}
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// ShowPanel controls what "panel" is to be displayed
+        /// </summary>
+        /// -----------------------------------------------------------------------------
+        private void ShowPanel()
+        {
+            bool showLogin = (PageNo == 0);
+            bool showRegister = (PageNo == 1);
+            bool showPassword = (PageNo == 2);
+            bool showProfile = (PageNo == 3);
+            pnlProfile.Visible = showProfile;
+            pnlPassword.Visible = showPassword;
+            pnlLogin.Visible = showLogin;
+            pnlRegister.Visible = showRegister;
+            pnlAssociate.Visible = showRegister;
+            switch (PageNo)
+            {
+                case 0:
+                    BindLogin();
+                    break;
+                case 1:
+                    BindRegister();
+                    break;
+                case 2:
+                    ctlPassword.UserId = UserId;
+                    ctlPassword.DataBind();
+                    break;
+                case 3:
+                    ctlProfile.UserId = UserId;
+                    ctlProfile.DataBind();
+                    break;
+            }
 
             if (showProfile && UrlUtils.InPopUp())
-			{
-				ScriptManager.RegisterClientScriptBlock(this, GetType(), "ResizePopup", "if(parent.$('#iPopUp').length > 0 && parent.$('#iPopUp').dialog('isOpen')){parent.$('#iPopUp').dialog({width: 950, height: 550}).dialog({position: 'center'});};", true);
-			}
-		}
+            {
+                ScriptManager.RegisterClientScriptBlock(this, GetType(), "ResizePopup", "if(parent.$('#iPopUp').length > 0 && parent.$('#iPopUp').dialog('isOpen')){parent.$('#iPopUp').dialog({width: 950, height: 550}).dialog({position: 'center'});};", true);
+            }
+        }
 
-		private void UpdateProfile(UserInfo objUser, bool update)
-		{
-			bool bUpdateUser = false;
-			if (ProfileProperties.Count > 0)
-			{
-				foreach (string key in ProfileProperties)
-				{
-					switch (key)
-					{
-						case "FirstName":
-							if (objUser.FirstName != ProfileProperties[key])
-							{
-								objUser.FirstName = ProfileProperties[key];
-								bUpdateUser = true;
-							}
-							break;
-						case "LastName":
-							if (objUser.LastName != ProfileProperties[key])
-							{
-								objUser.LastName = ProfileProperties[key];
-								bUpdateUser = true;
-							}
-							break;
-						case "Email":
-							if (objUser.Email != ProfileProperties[key])
-							{
-								objUser.Email = ProfileProperties[key];
-								bUpdateUser = true;
-							}
-							break;
-						case "DisplayName":
-							if (objUser.DisplayName != ProfileProperties[key])
-							{
-								objUser.DisplayName = ProfileProperties[key];
-								bUpdateUser = true;
-							}
-							break;
-						default:
-							objUser.Profile.SetProfileProperty(key, ProfileProperties[key]);
-							break;
-					}
-				}
-				if (update)
-				{
-					if (bUpdateUser)
-					{
-						UserController.UpdateUser(PortalId, objUser);
-					}
-					ProfileController.UpdateUserProfile(objUser);
-				}
-			}
-		}
+        private void UpdateProfile(UserInfo objUser, bool update)
+        {
+            bool bUpdateUser = false;
+            if (ProfileProperties.Count > 0)
+            {
+                foreach (string key in ProfileProperties)
+                {
+                    switch (key)
+                    {
+                        case "FirstName":
+                            if (objUser.FirstName != ProfileProperties[key])
+                            {
+                                objUser.FirstName = ProfileProperties[key];
+                                bUpdateUser = true;
+                            }
+                            break;
+                        case "LastName":
+                            if (objUser.LastName != ProfileProperties[key])
+                            {
+                                objUser.LastName = ProfileProperties[key];
+                                bUpdateUser = true;
+                            }
+                            break;
+                        case "Email":
+                            if (objUser.Email != ProfileProperties[key])
+                            {
+                                objUser.Email = ProfileProperties[key];
+                                bUpdateUser = true;
+                            }
+                            break;
+                        case "DisplayName":
+                            if (objUser.DisplayName != ProfileProperties[key])
+                            {
+                                objUser.DisplayName = ProfileProperties[key];
+                                bUpdateUser = true;
+                            }
+                            break;
+                        default:
+                            objUser.Profile.SetProfileProperty(key, ProfileProperties[key]);
+                            break;
+                    }
+                }
+                if (update)
+                {
+                    if (bUpdateUser)
+                    {
+                        UserController.UpdateUser(PortalId, objUser);
+                    }
+                    ProfileController.UpdateUserProfile(objUser);
+                }
+            }
+        }
 
         /// -----------------------------------------------------------------------------
         /// <summary>
@@ -935,50 +923,50 @@ namespace DotNetNuke.Modules.Admin.Authentication
                 !string.IsNullOrEmpty(Request.QueryString["verificationcode"]);
         }
 
-		private bool LocaleEnabled(string locale)
-		{
-			return LocaleController.Instance.GetLocales(PortalSettings.PortalId).ContainsKey(locale);
-		}
+        private bool LocaleEnabled(string locale)
+        {
+            return LocaleController.Instance.GetLocales(PortalSettings.PortalId).ContainsKey(locale);
+        }
 
         #endregion
 
         #region Event Handlers
 
-		/// <summary>
-		/// Page_Init runs when the control is initialised
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		protected override void OnInit(EventArgs e)
-		{
-			base.OnInit(e);
+        /// <summary>
+        /// Page_Init runs when the control is initialised
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        protected override void OnInit(EventArgs e)
+        {
+            base.OnInit(e);
 
-			ctlPassword.PasswordUpdated += PasswordUpdated;
-			ctlProfile.ProfileUpdated += ProfileUpdated;
-			ctlUser.UserCreateCompleted += UserCreateCompleted;
+            ctlPassword.PasswordUpdated += PasswordUpdated;
+            ctlProfile.ProfileUpdated += ProfileUpdated;
+            ctlUser.UserCreateCompleted += UserCreateCompleted;
 
-			//Set the User Control Properties
-			ctlUser.ID = "User";
+            //Set the User Control Properties
+            ctlUser.ID = "User";
 
-			//Set the Profile Control Properties
-			ctlPassword.ID = "Password";
+            //Set the Profile Control Properties
+            ctlPassword.ID = "Password";
 
-			//Set the Profile Control Properties
-			ctlProfile.ID = "Profile";
+            //Set the Profile Control Properties
+            ctlProfile.ID = "Profile";
 
-			//Override the redirected page title if page has loaded with ctl=Login
-			if (Request.QueryString["ctl"] != null)
-			{
-				if (Request.QueryString["ctl"].ToLower() == "login")
-				{
-					var myPage = (CDefault) Page;
-					if (myPage.PortalSettings.LoginTabId == TabId || myPage.PortalSettings.LoginTabId == -1)
-					{
-						myPage.Title = Localization.GetString("ControlTitle_login", LocalResourceFile);
-					}
-				}
-			}
-		}
+            //Override the redirected page title if page has loaded with ctl=Login
+            if (Request.QueryString["ctl"] != null)
+            {
+                if (Request.QueryString["ctl"].ToLower() == "login")
+                {
+                    var myPage = (CDefault)Page;
+                    if (myPage.PortalSettings.LoginTabId == TabId || myPage.PortalSettings.LoginTabId == -1)
+                    {
+                        myPage.Title = Localization.GetString("ControlTitle_login", LocalResourceFile);
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Page_Load runs when the control is loaded
@@ -1067,129 +1055,129 @@ namespace DotNetNuke.Modules.Admin.Authentication
 
         }
 
-	    /// <summary>
-		/// cmdAssociate_Click runs when the associate button is clicked
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		protected void cmdAssociate_Click(object sender, EventArgs e)
-		{
-			if ((UseCaptcha && ctlCaptcha.IsValid) || (!UseCaptcha))
-			{
-				UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
-				UserInfo objUser = UserController.ValidateUser(PortalId,
-															   txtUsername.Text,
-															   txtPassword.Text,
-															   "DNN",
-															   "",
-															   PortalSettings.PortalName,
-															   AuthenticationLoginBase.GetIPAddress(),
-															   ref loginStatus);
-				if (loginStatus == UserLoginStatus.LOGIN_SUCCESS)
-				{
-					//Assocate alternate Login with User and proceed with Login
-					AuthenticationController.AddUserAuthentication(objUser.UserID, AuthenticationType, UserToken);
-					if (objUser != null)
-					{
-						UpdateProfile(objUser, true);
-					}
-					ValidateUser(objUser, true);
-				}
-				else
-				{
-					AddModuleMessage("AssociationFailed", ModuleMessage.ModuleMessageType.RedError, true);
-				}
-			}
-		}
+        /// <summary>
+        /// cmdAssociate_Click runs when the associate button is clicked
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        protected void cmdAssociate_Click(object sender, EventArgs e)
+        {
+            if ((UseCaptcha && ctlCaptcha.IsValid) || (!UseCaptcha))
+            {
+                UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
+                UserInfo objUser = UserController.ValidateUser(PortalId,
+                                                               txtUsername.Text,
+                                                               txtPassword.Text,
+                                                               "DNN",
+                                                               "",
+                                                               PortalSettings.PortalName,
+                                                               AuthenticationLoginBase.GetIPAddress(),
+                                                               ref loginStatus);
+                if (loginStatus == UserLoginStatus.LOGIN_SUCCESS)
+                {
+                    //Assocate alternate Login with User and proceed with Login
+                    AuthenticationController.AddUserAuthentication(objUser.UserID, AuthenticationType, UserToken);
+                    if (objUser != null)
+                    {
+                        UpdateProfile(objUser, true);
+                    }
+                    ValidateUser(objUser, true);
+                }
+                else
+                {
+                    AddModuleMessage("AssociationFailed", ModuleMessage.ModuleMessageType.RedError, true);
+                }
+            }
+        }
 
-		/// <summary>
-		/// cmdCreateUser runs when the register (as new user) button is clicked
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		protected void cmdCreateUser_Click(object sender, EventArgs e)
-		{
-			User.Membership.Password = UserController.GeneratePassword();
+        /// <summary>
+        /// cmdCreateUser runs when the register (as new user) button is clicked
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        protected void cmdCreateUser_Click(object sender, EventArgs e)
+        {
+            User.Membership.Password = UserController.GeneratePassword();
 
-			if (AutoRegister)
-			{
-				ctlUser.User = User;
+            if (AutoRegister)
+            {
+                ctlUser.User = User;
 
-				//Call the Create User method of the User control so that it can create
-				//the user and raise the appropriate event(s)
-				ctlUser.CreateUser();
-			}
-			else
-			{
-				if (ctlUser.IsValid)
-				{
-					//Call the Create User method of the User control so that it can create
-					//the user and raise the appropriate event(s)
-					ctlUser.CreateUser();
-				}
-			}
-		}
+                //Call the Create User method of the User control so that it can create
+                //the user and raise the appropriate event(s)
+                ctlUser.CreateUser();
+            }
+            else
+            {
+                if (ctlUser.IsValid)
+                {
+                    //Call the Create User method of the User control so that it can create
+                    //the user and raise the appropriate event(s)
+                    ctlUser.CreateUser();
+                }
+            }
+        }
 
-		/// <summary>
-		/// cmdProceed_Click runs when the Proceed Anyway button is clicked
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		protected void cmdProceed_Click(object sender, EventArgs e)
-		{
-			var user = ctlPassword.User;
-			ValidateUser(user, true);
-		}
+        /// <summary>
+        /// cmdProceed_Click runs when the Proceed Anyway button is clicked
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        protected void cmdProceed_Click(object sender, EventArgs e)
+        {
+            var user = ctlPassword.User;
+            ValidateUser(user, true);
+        }
 
-		/// <summary>
-		/// PasswordUpdated runs when the password is updated
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		protected void PasswordUpdated(object sender, Password.PasswordUpdatedEventArgs e)
-		{
-			PasswordUpdateStatus status = e.UpdateStatus;
-			if (status == PasswordUpdateStatus.Success)
-			{
-				AddModuleMessage("PasswordChanged", ModuleMessage.ModuleMessageType.GreenSuccess, true);
-				var user = ctlPassword.User;
-				user.Membership.LastPasswordChangeDate = DateTime.Now;
-				user.Membership.UpdatePassword = false;
-				LoginStatus = user.IsSuperUser ? UserLoginStatus.LOGIN_SUPERUSER : UserLoginStatus.LOGIN_SUCCESS;
-				UserLoginStatus userstatus = UserLoginStatus.LOGIN_FAILURE;
-				UserController.CheckInsecurePassword(user.Username, user.Membership.Password, ref userstatus);
-				LoginStatus = userstatus;
-				ValidateUser(user, true);
-			}
-			else
-			{
-				AddModuleMessage(status.ToString(), ModuleMessage.ModuleMessageType.RedError, true);
-			}
-		}
+        /// <summary>
+        /// PasswordUpdated runs when the password is updated
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        protected void PasswordUpdated(object sender, Password.PasswordUpdatedEventArgs e)
+        {
+            PasswordUpdateStatus status = e.UpdateStatus;
+            if (status == PasswordUpdateStatus.Success)
+            {
+                AddModuleMessage("PasswordChanged", ModuleMessage.ModuleMessageType.GreenSuccess, true);
+                var user = ctlPassword.User;
+                user.Membership.LastPasswordChangeDate = DateTime.Now;
+                user.Membership.UpdatePassword = false;
+                LoginStatus = user.IsSuperUser ? UserLoginStatus.LOGIN_SUPERUSER : UserLoginStatus.LOGIN_SUCCESS;
+                UserLoginStatus userstatus = UserLoginStatus.LOGIN_FAILURE;
+                UserController.CheckInsecurePassword(user.Username, user.Membership.Password, ref userstatus);
+                LoginStatus = userstatus;
+                ValidateUser(user, true);
+            }
+            else
+            {
+                AddModuleMessage(status.ToString(), ModuleMessage.ModuleMessageType.RedError, true);
+            }
+        }
 
-		/// <summary>
-		/// ProfileUpdated runs when the profile is updated
-		/// </summary>
-		protected void ProfileUpdated(object sender, EventArgs e)
-		{
-			//Authorize User
-			ValidateUser(ctlProfile.User, true);
-		}
+        /// <summary>
+        /// ProfileUpdated runs when the profile is updated
+        /// </summary>
+        protected void ProfileUpdated(object sender, EventArgs e)
+        {
+            //Authorize User
+            ValidateUser(ctlProfile.User, true);
+        }
 
-		/// <summary>
-		/// UserAuthenticated runs when the user is authenticated by one of the child
-		/// Authentication controls
-		/// </summary>
-		protected void UserAuthenticated(object sender, UserAuthenticatedEventArgs e)
-		{
-			LoginStatus = e.LoginStatus;
+        /// <summary>
+        /// UserAuthenticated runs when the user is authenticated by one of the child
+        /// Authentication controls
+        /// </summary>
+        protected void UserAuthenticated(object sender, UserAuthenticatedEventArgs e)
+        {
+            LoginStatus = e.LoginStatus;
 
-			//Check the Login Status
-			switch (LoginStatus)
-			{
-				case UserLoginStatus.LOGIN_USERNOTAPPROVED:
-					switch (e.Message)
-					{
+            //Check the Login Status
+            switch (LoginStatus)
+            {
+                case UserLoginStatus.LOGIN_USERNOTAPPROVED:
+                    switch (e.Message)
+                    {
                         case "UnverifiedUser":
                             if (e.User != null)
                             {
@@ -1200,20 +1188,20 @@ namespace DotNetNuke.Modules.Admin.Authentication
                                 UpdateProfile(e.User, true);
                                 ValidateUser(e.User, false);
                             }
-					        break;
-						case "EnterCode":
-							AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.YellowWarning, true);
-							break;
-						case "InvalidCode":
-						case "UserNotAuthorized":
-							AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
-							break;
-						default:
-							AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
-							break;
-					}
-					break;
-				case UserLoginStatus.LOGIN_USERLOCKEDOUT:
+                            break;
+                        case "EnterCode":
+                            AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.YellowWarning, true);
+                            break;
+                        case "InvalidCode":
+                        case "UserNotAuthorized":
+                            AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
+                            break;
+                        default:
+                            AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
+                            break;
+                    }
+                    break;
+                case UserLoginStatus.LOGIN_USERLOCKEDOUT:
                     if (Host.AutoAccountUnlockDuration > 0)
                     {
                         AddLocalizedModuleMessage(string.Format(Localization.GetString("UserLockedOut", LocalResourceFile), Host.AutoAccountUnlockDuration), ModuleMessage.ModuleMessageType.RedError, true);
@@ -1222,27 +1210,27 @@ namespace DotNetNuke.Modules.Admin.Authentication
                     {
                         AddLocalizedModuleMessage(Localization.GetString("UserLockedOut_ContactAdmin", LocalResourceFile), ModuleMessage.ModuleMessageType.RedError, true);
                     }
-					//notify administrator about account lockout ( possible hack attempt )
-					var Custom = new ArrayList {e.UserToken};
+                    //notify administrator about account lockout ( possible hack attempt )
+                    var Custom = new ArrayList { e.UserToken };
 
-					var message = new Message
-									  {
-										  FromUserID = PortalSettings.AdministratorId,
-										  ToUserID = PortalSettings.AdministratorId,
-										  Subject = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_SUBJECT", Localization.GlobalResourceFile, Custom),
-										  Body = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_BODY", Localization.GlobalResourceFile, Custom),
-										  Status = MessageStatusType.Unread
-									  };
-					//_messagingController.SaveMessage(_message);
+                    var message = new Message
+                    {
+                        FromUserID = PortalSettings.AdministratorId,
+                        ToUserID = PortalSettings.AdministratorId,
+                        Subject = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_SUBJECT", Localization.GlobalResourceFile, Custom),
+                        Body = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_BODY", Localization.GlobalResourceFile, Custom),
+                        Status = MessageStatusType.Unread
+                    };
+                    //_messagingController.SaveMessage(_message);
 
-					Mail.SendEmail(PortalSettings.Email, PortalSettings.Email, message.Subject, message.Body);
-					break;
-				case UserLoginStatus.LOGIN_FAILURE:
-					//A Login Failure can mean one of two things:
-					//  1 - User was authenticated by the Authentication System but is not "affiliated" with a DNN Account
-					//  2 - User was not authenticated
-					if (e.Authenticated)
-					{
+                    Mail.SendEmail(PortalSettings.Email, PortalSettings.Email, message.Subject, message.Body);
+                    break;
+                case UserLoginStatus.LOGIN_FAILURE:
+                    //A Login Failure can mean one of two things:
+                    //  1 - User was authenticated by the Authentication System but is not "affiliated" with a DNN Account
+                    //  2 - User was not authenticated
+                    if (e.Authenticated)
+                    {
                         AutoRegister = e.AutoRegister;
                         AuthenticationType = e.AuthenticationType;
                         ProfileProperties = e.Profile;
@@ -1264,69 +1252,69 @@ namespace DotNetNuke.Modules.Admin.Authentication
                             PageNo = 1;
                             ShowPanel();
                         }
-					}
-					else
-					{
-						if (string.IsNullOrEmpty(e.Message))
-						{
-							AddModuleMessage("LoginFailed", ModuleMessage.ModuleMessageType.RedError, true);
-						}
-						else
-						{
-							AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
-						}
-					}
-					break;
-				default:
-					if (e.User != null)
-					{
-						//First update the profile (if any properties have been passed)
-						AuthenticationType = e.AuthenticationType;
-						ProfileProperties = e.Profile;
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(e.Message))
+                        {
+                            AddModuleMessage("LoginFailed", ModuleMessage.ModuleMessageType.RedError, true);
+                        }
+                        else
+                        {
+                            AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
+                        }
+                    }
+                    break;
+                default:
+                    if (e.User != null)
+                    {
+                        //First update the profile (if any properties have been passed)
+                        AuthenticationType = e.AuthenticationType;
+                        ProfileProperties = e.Profile;
                         RememberMe = e.RememberMe;
-						UpdateProfile(e.User, true);
-						ValidateUser(e.User, (e.AuthenticationType != "DNN"));
-					}
-					break;
-			}
-		}
+                        UpdateProfile(e.User, true);
+                        ValidateUser(e.User, (e.AuthenticationType != "DNN"));
+                    }
+                    break;
+            }
+        }
 
-		/// <summary>
-		/// UserCreateCompleted runs when a new user has been Created
-		/// </summary>
-		/// <remarks>
-		/// </remarks>
-		protected void UserCreateCompleted(object sender, UserUserControlBase.UserCreatedEventArgs e)
-		{
-			var strMessage = "";
-			try
-			{
-				if (e.CreateStatus == UserCreateStatus.Success)
-				{
-					//Assocate alternate Login with User and proceed with Login
-					AuthenticationController.AddUserAuthentication(e.NewUser.UserID, AuthenticationType, UserToken);
+        /// <summary>
+        /// UserCreateCompleted runs when a new user has been Created
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        protected void UserCreateCompleted(object sender, UserUserControlBase.UserCreatedEventArgs e)
+        {
+            var strMessage = "";
+            try
+            {
+                if (e.CreateStatus == UserCreateStatus.Success)
+                {
+                    //Assocate alternate Login with User and proceed with Login
+                    AuthenticationController.AddUserAuthentication(e.NewUser.UserID, AuthenticationType, UserToken);
 
-					strMessage = CompleteUserCreation(e.CreateStatus, e.NewUser, e.Notify, true);
-					if ((string.IsNullOrEmpty(strMessage)))
-					{
-						//First update the profile (if any properties have been passed)
-						UpdateProfile(e.NewUser, true);
+                    strMessage = CompleteUserCreation(e.CreateStatus, e.NewUser, e.Notify, true);
+                    if ((string.IsNullOrEmpty(strMessage)))
+                    {
+                        //First update the profile (if any properties have been passed)
+                        UpdateProfile(e.NewUser, true);
 
-						ValidateUser(e.NewUser, true);
-					}
-				}
-				else
-				{
-					AddLocalizedModuleMessage(UserController.GetUserCreateStatus(e.CreateStatus), ModuleMessage.ModuleMessageType.RedError, true);
-				}
-			}
-			catch (Exception exc) //Module failed to load
-			{
-				Exceptions.ProcessModuleLoadException(this, exc);
-			}
-		}
-		
-		#endregion
+                        ValidateUser(e.NewUser, true);
+                    }
+                }
+                else
+                {
+                    AddLocalizedModuleMessage(UserController.GetUserCreateStatus(e.CreateStatus), ModuleMessage.ModuleMessageType.RedError, true);
+                }
+            }
+            catch (Exception exc) //Module failed to load
+            {
+                Exceptions.ProcessModuleLoadException(this, exc);
+            }
+        }
 
-	}
+        #endregion
+
+    }
 }

--- a/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -60,104 +60,104 @@ namespace DotNetNuke.Modules.Admin.Authentication
 {
     using Host = DotNetNuke.Entities.Host.Host;
 
-    /// <summary>
-    /// The Signin UserModuleBase is used to provide a login for a registered user
-    /// </summary>
-    /// <remarks>
-    /// </remarks>
-    public partial class Login : UserModuleBase
-    {
-        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(Login));
+	/// <summary>
+	/// The Signin UserModuleBase is used to provide a login for a registered user
+	/// </summary>
+	/// <remarks>
+	/// </remarks>
+	public partial class Login : UserModuleBase
+	{
+		private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (Login));
 
         private static readonly Regex UserLanguageRegex = new Regex("(.*)(&|\\?)(language=)([^&\\?]+)(.*)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         #region Private Members
 
-        private readonly List<AuthenticationLoginBase> _loginControls = new List<AuthenticationLoginBase>();
-        private readonly List<AuthenticationLoginBase> _defaultauthLogin = new List<AuthenticationLoginBase>();
+		private readonly List<AuthenticationLoginBase> _loginControls = new List<AuthenticationLoginBase>();
+        private readonly  List<AuthenticationLoginBase> _defaultauthLogin = new List<AuthenticationLoginBase>();
         private readonly List<OAuthLoginBase> _oAuthControls = new List<OAuthLoginBase>();
 
-        #endregion
+		#endregion
 
-        #region Protected Properties
+		#region Protected Properties
 
-        /// <summary>
-        /// Gets and sets the current AuthenticationType
-        /// </summary>
-        protected string AuthenticationType
-        {
-            get
-            {
-                var authenticationType = Null.NullString;
-                if (ViewState["AuthenticationType"] != null)
-                {
-                    authenticationType = Convert.ToString(ViewState["AuthenticationType"]);
-                }
-                return authenticationType;
-            }
-            set
-            {
-                ViewState["AuthenticationType"] = value;
-            }
-        }
+		/// <summary>
+		/// Gets and sets the current AuthenticationType
+		/// </summary>
+		protected string AuthenticationType
+		{
+			get
+			{
+				var authenticationType = Null.NullString;
+				if (ViewState["AuthenticationType"] != null)
+				{
+					authenticationType = Convert.ToString(ViewState["AuthenticationType"]);
+				}
+				return authenticationType;
+			}
+			set
+			{
+				ViewState["AuthenticationType"] = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets and sets a flag that determines whether the user should be automatically registered
-        /// </summary>
-        protected bool AutoRegister
-        {
-            get
-            {
-                var autoRegister = Null.NullBoolean;
-                if (ViewState["AutoRegister"] != null)
-                {
-                    autoRegister = Convert.ToBoolean(ViewState["AutoRegister"]);
-                }
-                return autoRegister;
-            }
-            set
-            {
-                ViewState["AutoRegister"] = value;
-            }
-        }
+		/// <summary>
+		/// Gets and sets a flag that determines whether the user should be automatically registered
+		/// </summary>
+		protected bool AutoRegister
+		{
+			get
+			{
+				var autoRegister = Null.NullBoolean;
+				if (ViewState["AutoRegister"] != null)
+				{
+					autoRegister = Convert.ToBoolean(ViewState["AutoRegister"]);
+				}
+				return autoRegister;
+			}
+			set
+			{
+				ViewState["AutoRegister"] = value;
+			}
+		}
 
-        protected NameValueCollection ProfileProperties
-        {
-            get
-            {
-                var profile = new NameValueCollection();
-                if (ViewState["ProfileProperties"] != null)
-                {
-                    profile = (NameValueCollection)ViewState["ProfileProperties"];
-                }
-                return profile;
-            }
-            set
-            {
-                ViewState["ProfileProperties"] = value;
-            }
-        }
+		protected NameValueCollection ProfileProperties
+		{
+			get
+			{
+				var profile = new NameValueCollection();
+				if (ViewState["ProfileProperties"] != null)
+				{
+					profile = (NameValueCollection) ViewState["ProfileProperties"];
+				}
+				return profile;
+			}
+			set
+			{
+				ViewState["ProfileProperties"] = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets and sets the current Page No
-        /// </summary>
-        protected int PageNo
-        {
-            get
-            {
-                var pageNo = 0;
-                if (ViewState["PageNo"] != null)
-                {
-                    pageNo = Convert.ToInt32(ViewState["PageNo"]);
-                }
-                return pageNo;
-            }
-            set
-            {
-                ViewState["PageNo"] = value;
-            }
-        }
+		/// <summary>
+		/// Gets and sets the current Page No
+		/// </summary>
+		protected int PageNo
+		{
+			get
+			{
+				var pageNo = 0;
+				if (ViewState["PageNo"] != null)
+				{
+					pageNo = Convert.ToInt32(ViewState["PageNo"]);
+				}
+				return pageNo;
+			}
+			set
+			{
+				ViewState["PageNo"] = value;
+			}
+		}
 
         /// <summary>
         /// Gets the Redirect URL (after successful login)
@@ -288,74 +288,94 @@ namespace DotNetNuke.Modules.Admin.Authentication
             }
         }
 
-        /// <summary>
-        /// Gets whether the Captcha control is used to validate the login
-        /// </summary>
-        protected bool UseCaptcha
-        {
-            get
-            {
-                object setting = GetSetting(PortalId, "Security_CaptchaLogin");
-                return Convert.ToBoolean(setting);
-            }
-        }
+		/// <summary>
+		/// Gets whether the Captcha control is used to validate the login
+		/// </summary>
+		protected bool UseCaptcha
+		{
+			get
+			{
+				object setting = GetSetting(PortalId, "Security_CaptchaLogin");
+				return Convert.ToBoolean(setting);
+			}
+		}
 
-        protected UserLoginStatus LoginStatus
-        {
-            get
-            {
-                UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
-                if (ViewState["LoginStatus"] != null)
-                {
-                    loginStatus = (UserLoginStatus)ViewState["LoginStatus"];
-                }
-                return loginStatus;
-            }
-            set
-            {
-                ViewState["LoginStatus"] = value;
-            }
-        }
+		protected UserLoginStatus LoginStatus
+		{
+			get
+			{
+				UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
+				if (ViewState["LoginStatus"] != null)
+				{
+					loginStatus = (UserLoginStatus) ViewState["LoginStatus"];
+				}
+				return loginStatus;
+			}
+			set
+			{
+				ViewState["LoginStatus"] = value;
+			}
+		}
 
-        /// <summary>
-        /// Gets and sets the current UserToken
-        /// </summary>
-        protected string UserToken
-        {
-            get
-            {
-                var userToken = "";
-                if (ViewState["UserToken"] != null)
-                {
-                    userToken = Convert.ToString(ViewState["UserToken"]);
-                }
-                return userToken;
-            }
-            set
-            {
-                ViewState["UserToken"] = value;
-            }
-        }
+		/// <summary>
+		/// Gets and sets the current UserToken
+		/// </summary>
+		protected string UserToken
+		{
+			get
+			{
+				var userToken = "";
+				if (ViewState["UserToken"] != null)
+				{
+					userToken = Convert.ToString(ViewState["UserToken"]);
+				}
+				return userToken;
+			}
+			set
+			{
+				ViewState["UserToken"] = value;
+			}
+		}
 
-        #endregion
+		/// <summary>
+		/// Gets and sets the current UserName
+		/// </summary>
+		protected string UserName
+		{
+			get
+			{
+				var userName = "";
+				if (ViewState["UserName"] != null)
+				{
+                    userName = Convert.ToString(ViewState["UserName"]);
+				}
+				return userName;
+			}
+			set
+			{
+				ViewState["UserName"] = value;
+			}
+		}
 
-        #region Private Methods
+		#endregion
 
-        private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)
-        {
-            //search selected authentication control for username and password fields
-            //and inject autocomplete=off so browsers do not remember sensitive details
-            var username = loginControl.FindControl("txtUsername") as WebControl;
-            if (username != null)
-            {
-                username.Attributes.Add("AUTOCOMPLETE", "off");
-            }
-            var password = loginControl.FindControl("txtPassword") as WebControl;
-            if (password != null)
-            {
-                password.Attributes.Add("AUTOCOMPLETE", "off");
-            }
-        }
+		#region Private Methods
+
+		private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)
+		{
+			//search selected authentication control for username and password fields
+			//and inject autocomplete=off so browsers do not remember sensitive details
+			var username = loginControl.FindControl("txtUsername") as WebControl;
+			if (username != null)
+			{
+				username.Attributes.Add("AUTOCOMPLETE", "off");
+			}
+			var password = loginControl.FindControl("txtPassword") as WebControl;
+			if (password != null)
+			{
+				password.Attributes.Add("AUTOCOMPLETE", "off");
+			}
+		}
 
         private void BindLogin()
         {
@@ -381,6 +401,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
                         if (authSystem.AuthenticationType == "DNN")
                         {
                             defaultLoginControl = authLoginControl;
+                            pnlLoginContainer.Visible = true;
                         }
 
                         //Check if AuthSystem is Enabled
@@ -429,23 +450,23 @@ namespace DotNetNuke.Modules.Admin.Authentication
                     {
                         //if there are social authprovider only
                         if (_oAuthControls.Count == 0)
-                            //Portal has no login controls enabled so load default DNN control
-                            DisplayLoginControl(defaultLoginControl, false, false);
+                        //Portal has no login controls enabled so load default DNN control
+                        DisplayLoginControl(defaultLoginControl, false, false);
                     }
                     break;
                 case 1:
                     //We don't want the control to render with tabbed interface
-                    DisplayLoginControl(_defaultauthLogin.Count == 1
-                                            ? _defaultauthLogin[0]
-                                            : _loginControls.Count == 1
-                                                ? _loginControls[0]
-                                                : _oAuthControls[0],
+                    DisplayLoginControl(_defaultauthLogin.Count == 1 
+                                            ? _defaultauthLogin[0] 
+                                            : _loginControls.Count == 1 
+                                                ? _loginControls[0] 
+                                                : _oAuthControls[0], 
                                         false,
                                         false);
                     break;
                 default:
                     //make sure defaultAuth provider control is diplayed first
-                    if (_defaultauthLogin.Count > 0) DisplayTabbedLoginControl(_defaultauthLogin[0], tsLogin.Tabs);
+                    if (_defaultauthLogin.Count>0) DisplayTabbedLoginControl(_defaultauthLogin[0], tsLogin.Tabs);
                     foreach (AuthenticationLoginBase authLoginControl in _loginControls)
                     {
                         DisplayTabbedLoginControl(authLoginControl, tsLogin.Tabs);
@@ -485,59 +506,59 @@ namespace DotNetNuke.Modules.Admin.Authentication
         }
 
         private void BindRegister()
-        {
-            lblType.Text = AuthenticationType;
-            lblToken.Text = UserToken;
+		{
+			lblType.Text = AuthenticationType;
+			lblToken.Text = UserToken;
 
-            //Verify that the current user has access to this page
-            if (PortalSettings.UserRegistration == (int)Globals.PortalRegistrationType.NoRegistration && Request.IsAuthenticated == false)
-            {
-                Response.Redirect(Globals.NavigateURL("Access Denied"), true);
-            }
-            lblRegisterHelp.Text = Localization.GetSystemMessage(PortalSettings, "MESSAGE_REGISTRATION_INSTRUCTIONS");
-            switch (PortalSettings.UserRegistration)
-            {
-                case (int)Globals.PortalRegistrationType.PrivateRegistration:
-                    lblRegisterHelp.Text += Localization.GetString("PrivateMembership", Localization.SharedResourceFile);
-                    break;
-                case (int)Globals.PortalRegistrationType.PublicRegistration:
-                    lblRegisterHelp.Text += Localization.GetString("PublicMembership", Localization.SharedResourceFile);
-                    break;
-                case (int)Globals.PortalRegistrationType.VerifiedRegistration:
-                    lblRegisterHelp.Text += Localization.GetString("VerifiedMembership", Localization.SharedResourceFile);
-                    break;
-            }
-            if (AutoRegister)
-            {
-                InitialiseUser();
-            }
-            bool UserValid = true;
-            if (string.IsNullOrEmpty(User.Username) || string.IsNullOrEmpty(User.Email) || string.IsNullOrEmpty(User.FirstName) || string.IsNullOrEmpty(User.LastName))
-            {
-                UserValid = Null.NullBoolean;
-            }
-            if (AutoRegister && UserValid)
-            {
-                ctlUser.Visible = false;
-                lblRegisterTitle.Text = Localization.GetString("CreateTitle", LocalResourceFile);
-                cmdCreateUser.Text = Localization.GetString("cmdCreate", LocalResourceFile);
-            }
-            else
-            {
-                lblRegisterHelp.Text += Localization.GetString("Required", Localization.SharedResourceFile);
-                lblRegisterTitle.Text = Localization.GetString("RegisterTitle", LocalResourceFile);
-                cmdCreateUser.Text = Localization.GetString("cmdRegister", LocalResourceFile);
-                ctlUser.ShowPassword = false;
-                ctlUser.ShowUpdate = false;
-                ctlUser.User = User;
-                ctlUser.DataBind();
-            }
-        }
+			//Verify that the current user has access to this page
+			if (PortalSettings.UserRegistration == (int) Globals.PortalRegistrationType.NoRegistration && Request.IsAuthenticated == false)
+			{
+				Response.Redirect(Globals.NavigateURL("Access Denied"), true);
+			}
+			lblRegisterHelp.Text = Localization.GetSystemMessage(PortalSettings, "MESSAGE_REGISTRATION_INSTRUCTIONS");
+			switch (PortalSettings.UserRegistration)
+			{
+				case (int) Globals.PortalRegistrationType.PrivateRegistration:
+					lblRegisterHelp.Text += Localization.GetString("PrivateMembership", Localization.SharedResourceFile);
+					break;
+				case (int) Globals.PortalRegistrationType.PublicRegistration:
+					lblRegisterHelp.Text += Localization.GetString("PublicMembership", Localization.SharedResourceFile);
+					break;
+				case (int) Globals.PortalRegistrationType.VerifiedRegistration:
+					lblRegisterHelp.Text += Localization.GetString("VerifiedMembership", Localization.SharedResourceFile);
+					break;
+			}
+			if (AutoRegister)
+			{
+				InitialiseUser();
+			}
+			bool UserValid = true;
+			if (string.IsNullOrEmpty(User.Username) || string.IsNullOrEmpty(User.Email) || string.IsNullOrEmpty(User.FirstName) || string.IsNullOrEmpty(User.LastName))
+			{
+				UserValid = Null.NullBoolean;
+			}
+			if (AutoRegister && UserValid)
+			{
+				ctlUser.Visible = false;
+				lblRegisterTitle.Text = Localization.GetString("CreateTitle", LocalResourceFile);
+				cmdCreateUser.Text = Localization.GetString("cmdCreate", LocalResourceFile);
+			}
+			else
+			{
+				lblRegisterHelp.Text += Localization.GetString("Required", Localization.SharedResourceFile);
+				lblRegisterTitle.Text = Localization.GetString("RegisterTitle", LocalResourceFile);
+				cmdCreateUser.Text = Localization.GetString("cmdRegister", LocalResourceFile);
+				ctlUser.ShowPassword = false;
+				ctlUser.ShowUpdate = false;
+				ctlUser.User = User;
+				ctlUser.DataBind();
+			}
+		}
 
         private void DisplayLoginControl(AuthenticationLoginBase authLoginControl, bool addHeader, bool addFooter)
         {
             //Create a <div> to hold the control
-            var container = new HtmlGenericControl { TagName = "div", ID = authLoginControl.AuthenticationType, ViewStateMode = ViewStateMode.Disabled };
+            var container = new HtmlGenericControl { TagName = "div", ID = authLoginControl.AuthenticationType, ViewStateMode = ViewStateMode.Disabled};
 
             //Add Settings Control to Container
             container.Controls.Add(authLoginControl);
@@ -566,61 +587,74 @@ namespace DotNetNuke.Modules.Admin.Authentication
             {
                 pnlLoginContainer.Controls.Add(new LiteralControl("<br />"));
             }
-            pnlLoginContainer.Visible = true;
         }
 
         private void DisplayTabbedLoginControl(AuthenticationLoginBase authLoginControl, TabStripTabCollection Tabs)
         {
             var tab = new DNNTab(Localization.GetString("Title", authLoginControl.LocalResourceFile)) { ID = authLoginControl.AuthenticationType };
-
+            
             tab.Controls.Add(authLoginControl);
             Tabs.Add(tab);
-
+            
             tsLogin.Visible = true;
         }
 
         private void InitialiseUser()
-        {
-            //Load any Profile properties that may have been returned
-            UpdateProfile(User, false);
+		{
+			//Load any Profile properties that may have been returned
+			UpdateProfile(User, false);
 
             //Set UserName to authentication Token            
             User.Username = GenerateUserName();
 
-            //Set DisplayName to UserToken if null
-            if (string.IsNullOrEmpty(User.DisplayName))
-            {
-                User.DisplayName = UserToken.Replace("http://", "").TrimEnd('/');
-            }
-
-            //Parse DisplayName into FirstName/LastName
-            if (User.DisplayName.IndexOf(' ') > 0)
-            {
-                User.FirstName = User.DisplayName.Substring(0, User.DisplayName.IndexOf(' '));
-                User.LastName = User.DisplayName.Substring(User.DisplayName.IndexOf(' ') + 1);
-            }
-
-            //Set FirstName to Authentication Type (if null)
-            if (string.IsNullOrEmpty(User.FirstName))
-            {
-                User.FirstName = AuthenticationType;
-            }
-            //Set FirstName to "User" (if null)
-            if (string.IsNullOrEmpty(User.LastName))
-            {
-                User.LastName = "User";
-            }
-        }
+			//Set DisplayName to UserToken if null
+			if (string.IsNullOrEmpty(User.DisplayName))
+			{
+				User.DisplayName = UserToken.Replace("http://", "").TrimEnd('/');
+			}
+			
+			//Parse DisplayName into FirstName/LastName
+			if (User.DisplayName.IndexOf(' ') > 0)
+			{
+				User.FirstName = User.DisplayName.Substring(0, User.DisplayName.IndexOf(' '));
+				User.LastName = User.DisplayName.Substring(User.DisplayName.IndexOf(' ') + 1);
+			}
+			
+			//Set FirstName to Authentication Type (if null)
+			if (string.IsNullOrEmpty(User.FirstName))
+			{
+				User.FirstName = AuthenticationType;
+			}
+			//Set FirstName to "User" (if null)
+			if (string.IsNullOrEmpty(User.LastName))
+			{
+				User.LastName = "User";
+			}
+		}
 
         private string GenerateUserName()
         {
-            //Try the best username. Default it to UserToken
-            var userName = UserToken.Replace("http://", "").TrimEnd('/');
+            //Try the best username. Default it to UserName
+            var userName = UserName;
+
+            if (!string.IsNullOrEmpty(userName))
+            {
+                return userName;
+            }
+            else
+            {
+                userName = UserToken.Replace("http://", "").TrimEnd('/');
+
+                if (!string.IsNullOrEmpty(userName))
+                {
+                    return userName;
+                }
+            }
 
             //Try Email prefix
             var emailPrefix = string.Empty;
             if (!string.IsNullOrEmpty(User.Email))
-            {
+            {                
                 if (User.Email.IndexOf("@", StringComparison.Ordinal) != -1)
                 {
                     emailPrefix = User.Email.Substring(0, User.Email.IndexOf("@", StringComparison.Ordinal));
@@ -655,7 +689,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
             //Try First Name + space + First letter last name            
             if (!string.IsNullOrEmpty(User.LastName) && !string.IsNullOrEmpty(User.FirstName))
             {
-                var newUserName = User.FirstName + " " + User.LastName.Substring(0, 1);
+                var newUserName = User.FirstName + " " + User.LastName.Substring(0,1);
                 var user = UserController.GetUserByName(PortalId, newUserName);
                 if (user == null)
                 {
@@ -691,98 +725,98 @@ namespace DotNetNuke.Modules.Admin.Authentication
             return userName;
         }
 
-        /// -----------------------------------------------------------------------------
-        /// <summary>
-        /// ShowPanel controls what "panel" is to be displayed
-        /// </summary>
-        /// -----------------------------------------------------------------------------
-        private void ShowPanel()
-        {
-            bool showLogin = (PageNo == 0);
-            bool showRegister = (PageNo == 1);
-            bool showPassword = (PageNo == 2);
-            bool showProfile = (PageNo == 3);
-            pnlProfile.Visible = showProfile;
-            pnlPassword.Visible = showPassword;
-            pnlLogin.Visible = showLogin;
-            pnlRegister.Visible = showRegister;
-            pnlAssociate.Visible = showRegister;
-            switch (PageNo)
-            {
-                case 0:
-                    BindLogin();
-                    break;
-                case 1:
-                    BindRegister();
-                    break;
-                case 2:
-                    ctlPassword.UserId = UserId;
-                    ctlPassword.DataBind();
-                    break;
-                case 3:
-                    ctlProfile.UserId = UserId;
-                    ctlProfile.DataBind();
-                    break;
-            }
+		/// -----------------------------------------------------------------------------
+		/// <summary>
+		/// ShowPanel controls what "panel" is to be displayed
+		/// </summary>
+		/// -----------------------------------------------------------------------------
+		private void ShowPanel()
+		{
+			bool showLogin = (PageNo == 0);
+			bool showRegister = (PageNo == 1);
+			bool showPassword = (PageNo == 2);
+			bool showProfile = (PageNo == 3);
+			pnlProfile.Visible = showProfile;
+			pnlPassword.Visible = showPassword;
+			pnlLogin.Visible = showLogin;
+			pnlRegister.Visible = showRegister;
+			pnlAssociate.Visible = showRegister;
+			switch (PageNo)
+			{
+				case 0:
+					BindLogin();
+					break;
+				case 1:
+					BindRegister();
+					break;
+				case 2:
+					ctlPassword.UserId = UserId;
+					ctlPassword.DataBind();
+					break;
+				case 3:
+					ctlProfile.UserId = UserId;
+					ctlProfile.DataBind();
+					break;
+			}
 
             if (showProfile && UrlUtils.InPopUp())
-            {
-                ScriptManager.RegisterClientScriptBlock(this, GetType(), "ResizePopup", "if(parent.$('#iPopUp').length > 0 && parent.$('#iPopUp').dialog('isOpen')){parent.$('#iPopUp').dialog({width: 950, height: 550}).dialog({position: 'center'});};", true);
-            }
-        }
+			{
+				ScriptManager.RegisterClientScriptBlock(this, GetType(), "ResizePopup", "if(parent.$('#iPopUp').length > 0 && parent.$('#iPopUp').dialog('isOpen')){parent.$('#iPopUp').dialog({width: 950, height: 550}).dialog({position: 'center'});};", true);
+			}
+		}
 
-        private void UpdateProfile(UserInfo objUser, bool update)
-        {
-            bool bUpdateUser = false;
-            if (ProfileProperties.Count > 0)
-            {
-                foreach (string key in ProfileProperties)
-                {
-                    switch (key)
-                    {
-                        case "FirstName":
-                            if (objUser.FirstName != ProfileProperties[key])
-                            {
-                                objUser.FirstName = ProfileProperties[key];
-                                bUpdateUser = true;
-                            }
-                            break;
-                        case "LastName":
-                            if (objUser.LastName != ProfileProperties[key])
-                            {
-                                objUser.LastName = ProfileProperties[key];
-                                bUpdateUser = true;
-                            }
-                            break;
-                        case "Email":
-                            if (objUser.Email != ProfileProperties[key])
-                            {
-                                objUser.Email = ProfileProperties[key];
-                                bUpdateUser = true;
-                            }
-                            break;
-                        case "DisplayName":
-                            if (objUser.DisplayName != ProfileProperties[key])
-                            {
-                                objUser.DisplayName = ProfileProperties[key];
-                                bUpdateUser = true;
-                            }
-                            break;
-                        default:
-                            objUser.Profile.SetProfileProperty(key, ProfileProperties[key]);
-                            break;
-                    }
-                }
-                if (update)
-                {
-                    if (bUpdateUser)
-                    {
-                        UserController.UpdateUser(PortalId, objUser);
-                    }
-                    ProfileController.UpdateUserProfile(objUser);
-                }
-            }
-        }
+		private void UpdateProfile(UserInfo objUser, bool update)
+		{
+			bool bUpdateUser = false;
+			if (ProfileProperties.Count > 0)
+			{
+				foreach (string key in ProfileProperties)
+				{
+					switch (key)
+					{
+						case "FirstName":
+							if (objUser.FirstName != ProfileProperties[key])
+							{
+								objUser.FirstName = ProfileProperties[key];
+								bUpdateUser = true;
+							}
+							break;
+						case "LastName":
+							if (objUser.LastName != ProfileProperties[key])
+							{
+								objUser.LastName = ProfileProperties[key];
+								bUpdateUser = true;
+							}
+							break;
+						case "Email":
+							if (objUser.Email != ProfileProperties[key])
+							{
+								objUser.Email = ProfileProperties[key];
+								bUpdateUser = true;
+							}
+							break;
+						case "DisplayName":
+							if (objUser.DisplayName != ProfileProperties[key])
+							{
+								objUser.DisplayName = ProfileProperties[key];
+								bUpdateUser = true;
+							}
+							break;
+						default:
+							objUser.Profile.SetProfileProperty(key, ProfileProperties[key]);
+							break;
+					}
+				}
+				if (update)
+				{
+					if (bUpdateUser)
+					{
+						UserController.UpdateUser(PortalId, objUser);
+					}
+					ProfileController.UpdateUserProfile(objUser);
+				}
+			}
+		}
 
         /// -----------------------------------------------------------------------------
         /// <summary>
@@ -901,50 +935,50 @@ namespace DotNetNuke.Modules.Admin.Authentication
                 !string.IsNullOrEmpty(Request.QueryString["verificationcode"]);
         }
 
-        private bool LocaleEnabled(string locale)
-        {
-            return LocaleController.Instance.GetLocales(PortalSettings.PortalId).ContainsKey(locale);
-        }
+		private bool LocaleEnabled(string locale)
+		{
+			return LocaleController.Instance.GetLocales(PortalSettings.PortalId).ContainsKey(locale);
+		}
 
         #endregion
 
         #region Event Handlers
 
-        /// <summary>
-        /// Page_Init runs when the control is initialised
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        protected override void OnInit(EventArgs e)
-        {
-            base.OnInit(e);
+		/// <summary>
+		/// Page_Init runs when the control is initialised
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		protected override void OnInit(EventArgs e)
+		{
+			base.OnInit(e);
 
-            ctlPassword.PasswordUpdated += PasswordUpdated;
-            ctlProfile.ProfileUpdated += ProfileUpdated;
-            ctlUser.UserCreateCompleted += UserCreateCompleted;
+			ctlPassword.PasswordUpdated += PasswordUpdated;
+			ctlProfile.ProfileUpdated += ProfileUpdated;
+			ctlUser.UserCreateCompleted += UserCreateCompleted;
 
-            //Set the User Control Properties
-            ctlUser.ID = "User";
+			//Set the User Control Properties
+			ctlUser.ID = "User";
 
-            //Set the Profile Control Properties
-            ctlPassword.ID = "Password";
+			//Set the Profile Control Properties
+			ctlPassword.ID = "Password";
 
-            //Set the Profile Control Properties
-            ctlProfile.ID = "Profile";
+			//Set the Profile Control Properties
+			ctlProfile.ID = "Profile";
 
-            //Override the redirected page title if page has loaded with ctl=Login
-            if (Request.QueryString["ctl"] != null)
-            {
-                if (Request.QueryString["ctl"].ToLower() == "login")
-                {
-                    var myPage = (CDefault)Page;
-                    if (myPage.PortalSettings.LoginTabId == TabId || myPage.PortalSettings.LoginTabId == -1)
-                    {
-                        myPage.Title = Localization.GetString("ControlTitle_login", LocalResourceFile);
-                    }
-                }
-            }
-        }
+			//Override the redirected page title if page has loaded with ctl=Login
+			if (Request.QueryString["ctl"] != null)
+			{
+				if (Request.QueryString["ctl"].ToLower() == "login")
+				{
+					var myPage = (CDefault) Page;
+					if (myPage.PortalSettings.LoginTabId == TabId || myPage.PortalSettings.LoginTabId == -1)
+					{
+						myPage.Title = Localization.GetString("ControlTitle_login", LocalResourceFile);
+					}
+				}
+			}
+		}
 
         /// <summary>
         /// Page_Load runs when the control is loaded
@@ -1033,129 +1067,129 @@ namespace DotNetNuke.Modules.Admin.Authentication
 
         }
 
-        /// <summary>
-        /// cmdAssociate_Click runs when the associate button is clicked
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        protected void cmdAssociate_Click(object sender, EventArgs e)
-        {
-            if ((UseCaptcha && ctlCaptcha.IsValid) || (!UseCaptcha))
-            {
-                UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
-                UserInfo objUser = UserController.ValidateUser(PortalId,
-                                                               txtUsername.Text,
-                                                               txtPassword.Text,
-                                                               "DNN",
-                                                               "",
-                                                               PortalSettings.PortalName,
-                                                               AuthenticationLoginBase.GetIPAddress(),
-                                                               ref loginStatus);
-                if (loginStatus == UserLoginStatus.LOGIN_SUCCESS)
-                {
-                    //Assocate alternate Login with User and proceed with Login
-                    AuthenticationController.AddUserAuthentication(objUser.UserID, AuthenticationType, UserToken);
-                    if (objUser != null)
-                    {
-                        UpdateProfile(objUser, true);
-                    }
-                    ValidateUser(objUser, true);
-                }
-                else
-                {
-                    AddModuleMessage("AssociationFailed", ModuleMessage.ModuleMessageType.RedError, true);
-                }
-            }
-        }
+	    /// <summary>
+		/// cmdAssociate_Click runs when the associate button is clicked
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		protected void cmdAssociate_Click(object sender, EventArgs e)
+		{
+			if ((UseCaptcha && ctlCaptcha.IsValid) || (!UseCaptcha))
+			{
+				UserLoginStatus loginStatus = UserLoginStatus.LOGIN_FAILURE;
+				UserInfo objUser = UserController.ValidateUser(PortalId,
+															   txtUsername.Text,
+															   txtPassword.Text,
+															   "DNN",
+															   "",
+															   PortalSettings.PortalName,
+															   AuthenticationLoginBase.GetIPAddress(),
+															   ref loginStatus);
+				if (loginStatus == UserLoginStatus.LOGIN_SUCCESS)
+				{
+					//Assocate alternate Login with User and proceed with Login
+					AuthenticationController.AddUserAuthentication(objUser.UserID, AuthenticationType, UserToken);
+					if (objUser != null)
+					{
+						UpdateProfile(objUser, true);
+					}
+					ValidateUser(objUser, true);
+				}
+				else
+				{
+					AddModuleMessage("AssociationFailed", ModuleMessage.ModuleMessageType.RedError, true);
+				}
+			}
+		}
 
-        /// <summary>
-        /// cmdCreateUser runs when the register (as new user) button is clicked
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        protected void cmdCreateUser_Click(object sender, EventArgs e)
-        {
-            User.Membership.Password = UserController.GeneratePassword();
+		/// <summary>
+		/// cmdCreateUser runs when the register (as new user) button is clicked
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		protected void cmdCreateUser_Click(object sender, EventArgs e)
+		{
+			User.Membership.Password = UserController.GeneratePassword();
 
-            if (AutoRegister)
-            {
-                ctlUser.User = User;
+			if (AutoRegister)
+			{
+				ctlUser.User = User;
 
-                //Call the Create User method of the User control so that it can create
-                //the user and raise the appropriate event(s)
-                ctlUser.CreateUser();
-            }
-            else
-            {
-                if (ctlUser.IsValid)
-                {
-                    //Call the Create User method of the User control so that it can create
-                    //the user and raise the appropriate event(s)
-                    ctlUser.CreateUser();
-                }
-            }
-        }
+				//Call the Create User method of the User control so that it can create
+				//the user and raise the appropriate event(s)
+				ctlUser.CreateUser();
+			}
+			else
+			{
+				if (ctlUser.IsValid)
+				{
+					//Call the Create User method of the User control so that it can create
+					//the user and raise the appropriate event(s)
+					ctlUser.CreateUser();
+				}
+			}
+		}
 
-        /// <summary>
-        /// cmdProceed_Click runs when the Proceed Anyway button is clicked
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        protected void cmdProceed_Click(object sender, EventArgs e)
-        {
-            var user = ctlPassword.User;
-            ValidateUser(user, true);
-        }
+		/// <summary>
+		/// cmdProceed_Click runs when the Proceed Anyway button is clicked
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		protected void cmdProceed_Click(object sender, EventArgs e)
+		{
+			var user = ctlPassword.User;
+			ValidateUser(user, true);
+		}
 
-        /// <summary>
-        /// PasswordUpdated runs when the password is updated
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        protected void PasswordUpdated(object sender, Password.PasswordUpdatedEventArgs e)
-        {
-            PasswordUpdateStatus status = e.UpdateStatus;
-            if (status == PasswordUpdateStatus.Success)
-            {
-                AddModuleMessage("PasswordChanged", ModuleMessage.ModuleMessageType.GreenSuccess, true);
-                var user = ctlPassword.User;
-                user.Membership.LastPasswordChangeDate = DateTime.Now;
-                user.Membership.UpdatePassword = false;
-                LoginStatus = user.IsSuperUser ? UserLoginStatus.LOGIN_SUPERUSER : UserLoginStatus.LOGIN_SUCCESS;
-                UserLoginStatus userstatus = UserLoginStatus.LOGIN_FAILURE;
-                UserController.CheckInsecurePassword(user.Username, user.Membership.Password, ref userstatus);
-                LoginStatus = userstatus;
-                ValidateUser(user, true);
-            }
-            else
-            {
-                AddModuleMessage(status.ToString(), ModuleMessage.ModuleMessageType.RedError, true);
-            }
-        }
+		/// <summary>
+		/// PasswordUpdated runs when the password is updated
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		protected void PasswordUpdated(object sender, Password.PasswordUpdatedEventArgs e)
+		{
+			PasswordUpdateStatus status = e.UpdateStatus;
+			if (status == PasswordUpdateStatus.Success)
+			{
+				AddModuleMessage("PasswordChanged", ModuleMessage.ModuleMessageType.GreenSuccess, true);
+				var user = ctlPassword.User;
+				user.Membership.LastPasswordChangeDate = DateTime.Now;
+				user.Membership.UpdatePassword = false;
+				LoginStatus = user.IsSuperUser ? UserLoginStatus.LOGIN_SUPERUSER : UserLoginStatus.LOGIN_SUCCESS;
+				UserLoginStatus userstatus = UserLoginStatus.LOGIN_FAILURE;
+				UserController.CheckInsecurePassword(user.Username, user.Membership.Password, ref userstatus);
+				LoginStatus = userstatus;
+				ValidateUser(user, true);
+			}
+			else
+			{
+				AddModuleMessage(status.ToString(), ModuleMessage.ModuleMessageType.RedError, true);
+			}
+		}
 
-        /// <summary>
-        /// ProfileUpdated runs when the profile is updated
-        /// </summary>
-        protected void ProfileUpdated(object sender, EventArgs e)
-        {
-            //Authorize User
-            ValidateUser(ctlProfile.User, true);
-        }
+		/// <summary>
+		/// ProfileUpdated runs when the profile is updated
+		/// </summary>
+		protected void ProfileUpdated(object sender, EventArgs e)
+		{
+			//Authorize User
+			ValidateUser(ctlProfile.User, true);
+		}
 
-        /// <summary>
-        /// UserAuthenticated runs when the user is authenticated by one of the child
-        /// Authentication controls
-        /// </summary>
-        protected void UserAuthenticated(object sender, UserAuthenticatedEventArgs e)
-        {
-            LoginStatus = e.LoginStatus;
+		/// <summary>
+		/// UserAuthenticated runs when the user is authenticated by one of the child
+		/// Authentication controls
+		/// </summary>
+		protected void UserAuthenticated(object sender, UserAuthenticatedEventArgs e)
+		{
+			LoginStatus = e.LoginStatus;
 
-            //Check the Login Status
-            switch (LoginStatus)
-            {
-                case UserLoginStatus.LOGIN_USERNOTAPPROVED:
-                    switch (e.Message)
-                    {
+			//Check the Login Status
+			switch (LoginStatus)
+			{
+				case UserLoginStatus.LOGIN_USERNOTAPPROVED:
+					switch (e.Message)
+					{
                         case "UnverifiedUser":
                             if (e.User != null)
                             {
@@ -1166,20 +1200,20 @@ namespace DotNetNuke.Modules.Admin.Authentication
                                 UpdateProfile(e.User, true);
                                 ValidateUser(e.User, false);
                             }
-                            break;
-                        case "EnterCode":
-                            AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.YellowWarning, true);
-                            break;
-                        case "InvalidCode":
-                        case "UserNotAuthorized":
-                            AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
-                            break;
-                        default:
-                            AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
-                            break;
-                    }
-                    break;
-                case UserLoginStatus.LOGIN_USERLOCKEDOUT:
+					        break;
+						case "EnterCode":
+							AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.YellowWarning, true);
+							break;
+						case "InvalidCode":
+						case "UserNotAuthorized":
+							AddModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
+							break;
+						default:
+							AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
+							break;
+					}
+					break;
+				case UserLoginStatus.LOGIN_USERLOCKEDOUT:
                     if (Host.AutoAccountUnlockDuration > 0)
                     {
                         AddLocalizedModuleMessage(string.Format(Localization.GetString("UserLockedOut", LocalResourceFile), Host.AutoAccountUnlockDuration), ModuleMessage.ModuleMessageType.RedError, true);
@@ -1188,31 +1222,32 @@ namespace DotNetNuke.Modules.Admin.Authentication
                     {
                         AddLocalizedModuleMessage(Localization.GetString("UserLockedOut_ContactAdmin", LocalResourceFile), ModuleMessage.ModuleMessageType.RedError, true);
                     }
-                    //notify administrator about account lockout ( possible hack attempt )
-                    var Custom = new ArrayList { e.UserToken };
+					//notify administrator about account lockout ( possible hack attempt )
+					var Custom = new ArrayList {e.UserToken};
 
-                    var message = new Message
-                    {
-                        FromUserID = PortalSettings.AdministratorId,
-                        ToUserID = PortalSettings.AdministratorId,
-                        Subject = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_SUBJECT", Localization.GlobalResourceFile, Custom),
-                        Body = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_BODY", Localization.GlobalResourceFile, Custom),
-                        Status = MessageStatusType.Unread
-                    };
-                    //_messagingController.SaveMessage(_message);
+					var message = new Message
+									  {
+										  FromUserID = PortalSettings.AdministratorId,
+										  ToUserID = PortalSettings.AdministratorId,
+										  Subject = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_SUBJECT", Localization.GlobalResourceFile, Custom),
+										  Body = Localization.GetSystemMessage(PortalSettings, "EMAIL_USER_LOCKOUT_BODY", Localization.GlobalResourceFile, Custom),
+										  Status = MessageStatusType.Unread
+									  };
+					//_messagingController.SaveMessage(_message);
 
-                    Mail.SendEmail(PortalSettings.Email, PortalSettings.Email, message.Subject, message.Body);
-                    break;
-                case UserLoginStatus.LOGIN_FAILURE:
-                    //A Login Failure can mean one of two things:
-                    //  1 - User was authenticated by the Authentication System but is not "affiliated" with a DNN Account
-                    //  2 - User was not authenticated
-                    if (e.Authenticated)
-                    {
+					Mail.SendEmail(PortalSettings.Email, PortalSettings.Email, message.Subject, message.Body);
+					break;
+				case UserLoginStatus.LOGIN_FAILURE:
+					//A Login Failure can mean one of two things:
+					//  1 - User was authenticated by the Authentication System but is not "affiliated" with a DNN Account
+					//  2 - User was not authenticated
+					if (e.Authenticated)
+					{
                         AutoRegister = e.AutoRegister;
                         AuthenticationType = e.AuthenticationType;
                         ProfileProperties = e.Profile;
                         UserToken = e.UserToken;
+                        UserName = e.UserName;
                         if (AutoRegister)
                         {
                             InitialiseUser();
@@ -1229,69 +1264,69 @@ namespace DotNetNuke.Modules.Admin.Authentication
                             PageNo = 1;
                             ShowPanel();
                         }
-                    }
-                    else
-                    {
-                        if (string.IsNullOrEmpty(e.Message))
-                        {
-                            AddModuleMessage("LoginFailed", ModuleMessage.ModuleMessageType.RedError, true);
-                        }
-                        else
-                        {
-                            AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
-                        }
-                    }
-                    break;
-                default:
-                    if (e.User != null)
-                    {
-                        //First update the profile (if any properties have been passed)
-                        AuthenticationType = e.AuthenticationType;
-                        ProfileProperties = e.Profile;
+					}
+					else
+					{
+						if (string.IsNullOrEmpty(e.Message))
+						{
+							AddModuleMessage("LoginFailed", ModuleMessage.ModuleMessageType.RedError, true);
+						}
+						else
+						{
+							AddLocalizedModuleMessage(e.Message, ModuleMessage.ModuleMessageType.RedError, true);
+						}
+					}
+					break;
+				default:
+					if (e.User != null)
+					{
+						//First update the profile (if any properties have been passed)
+						AuthenticationType = e.AuthenticationType;
+						ProfileProperties = e.Profile;
                         RememberMe = e.RememberMe;
-                        UpdateProfile(e.User, true);
-                        ValidateUser(e.User, (e.AuthenticationType != "DNN"));
-                    }
-                    break;
-            }
-        }
+						UpdateProfile(e.User, true);
+						ValidateUser(e.User, (e.AuthenticationType != "DNN"));
+					}
+					break;
+			}
+		}
 
-        /// <summary>
-        /// UserCreateCompleted runs when a new user has been Created
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        protected void UserCreateCompleted(object sender, UserUserControlBase.UserCreatedEventArgs e)
-        {
-            var strMessage = "";
-            try
-            {
-                if (e.CreateStatus == UserCreateStatus.Success)
-                {
-                    //Assocate alternate Login with User and proceed with Login
-                    AuthenticationController.AddUserAuthentication(e.NewUser.UserID, AuthenticationType, UserToken);
+		/// <summary>
+		/// UserCreateCompleted runs when a new user has been Created
+		/// </summary>
+		/// <remarks>
+		/// </remarks>
+		protected void UserCreateCompleted(object sender, UserUserControlBase.UserCreatedEventArgs e)
+		{
+			var strMessage = "";
+			try
+			{
+				if (e.CreateStatus == UserCreateStatus.Success)
+				{
+					//Assocate alternate Login with User and proceed with Login
+					AuthenticationController.AddUserAuthentication(e.NewUser.UserID, AuthenticationType, UserToken);
 
-                    strMessage = CompleteUserCreation(e.CreateStatus, e.NewUser, e.Notify, true);
-                    if ((string.IsNullOrEmpty(strMessage)))
-                    {
-                        //First update the profile (if any properties have been passed)
-                        UpdateProfile(e.NewUser, true);
+					strMessage = CompleteUserCreation(e.CreateStatus, e.NewUser, e.Notify, true);
+					if ((string.IsNullOrEmpty(strMessage)))
+					{
+						//First update the profile (if any properties have been passed)
+						UpdateProfile(e.NewUser, true);
 
-                        ValidateUser(e.NewUser, true);
-                    }
-                }
-                else
-                {
-                    AddLocalizedModuleMessage(UserController.GetUserCreateStatus(e.CreateStatus), ModuleMessage.ModuleMessageType.RedError, true);
-                }
-            }
-            catch (Exception exc) //Module failed to load
-            {
-                Exceptions.ProcessModuleLoadException(this, exc);
-            }
-        }
+						ValidateUser(e.NewUser, true);
+					}
+				}
+				else
+				{
+					AddLocalizedModuleMessage(UserController.GetUserCreateStatus(e.CreateStatus), ModuleMessage.ModuleMessageType.RedError, true);
+				}
+			}
+			catch (Exception exc) //Module failed to load
+			{
+				Exceptions.ProcessModuleLoadException(this, exc);
+			}
+		}
+		
+		#endregion
 
-        #endregion
-
-    }
+	}
 }


### PR DESCRIPTION
This is a continuation of #1346 (after rebasing and fixing conflicts)

[DNN-8450](https://dnntracker.atlassian.net/browse/DNN-8450)

> The fix for [DNN-4133](https://dnntracker.atlassian.net/browse/DNN-4133) was to add a prefix for the service to the beginning of the username. This broke our custom OAuth provider and I believe that we should have the ability to override whether we want to prefix the service to the Username in OAuth providers. In addition to allowing that overriding, this also implements the option to automatically associate logins to existing users, based on email.
> Testing of this API change will require a custom OAuth provider implementation which sets the new `PrefixServiceToUserName` and `AutoMatchExistingUsers` properties in that provider's implementation of `OAuthClientBase` to `false` and `true`, respectively. That custom provider may be an existing provider (e.g. Facebook), tweaked to override those two properties.
> When configured as mentioned above, the username of users who log in via that provider should be the user's email (as provided by the OAuth provider). Additionally, if a user with that email address as their username already exists, that OAuth login would be associated with the existing account, rather than trying to create a new account.
