### PR TITLE
DNN-8374 adding locking functionality to the instance and individual sites

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -30,6 +31,7 @@ using System.Net.Http.Headers;
 using System.Web.Http;
 using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Controllers;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Modules.Definitions;
@@ -488,6 +490,31 @@ namespace DotNetNuke.Web.InternalServices
             Controller.SaveBookMark(PortalSettings.PortalId, UserInfo.UserID, bookmark.Title, bookmark.Bookmark);
 
             return Request.CreateResponse(HttpStatusCode.OK, new { Success = true });
+        }
+
+        public class LockingDTO
+        {
+            public bool Lock { get; set; }
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [RequireHost]
+        public HttpResponseMessage LockInstance(LockingDTO lockingRequest)
+        {
+            HostController.Instance.Update("IsLocked", lockingRequest.Lock.ToString(), true);
+            HostController.Instance.Update("LockedByUserId", this.UserInfo.UserID.ToString(CultureInfo.InvariantCulture), true);
+            return Request.CreateResponse(HttpStatusCode.OK);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [RequireHost]
+        public HttpResponseMessage LockSite(LockingDTO lockingRequest)
+        {
+            PortalController.UpdatePortalSetting(PortalSettings.PortalId, "IsLocked", lockingRequest.Lock.ToString(), true);
+            PortalController.UpdatePortalSetting(PortalSettings.PortalId, "LockedByUserId", this.UserInfo.UserID.ToString(CultureInfo.InvariantCulture), true);
+            return Request.CreateResponse(HttpStatusCode.OK);
         }
 
         private void ToggleUserMode(string mode)

--- a/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ControlBarController.cs
@@ -503,7 +503,6 @@ namespace DotNetNuke.Web.InternalServices
         public HttpResponseMessage LockInstance(LockingDTO lockingRequest)
         {
             HostController.Instance.Update("IsLocked", lockingRequest.Lock.ToString(), true);
-            HostController.Instance.Update("LockedByUserId", this.UserInfo.UserID.ToString(CultureInfo.InvariantCulture), true);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
 
@@ -513,7 +512,6 @@ namespace DotNetNuke.Web.InternalServices
         public HttpResponseMessage LockSite(LockingDTO lockingRequest)
         {
             PortalController.UpdatePortalSetting(PortalSettings.PortalId, "IsLocked", lockingRequest.Lock.ToString(), true);
-            PortalController.UpdatePortalSetting(PortalSettings.PortalId, "LockedByUserId", this.UserInfo.UserID.ToString(CultureInfo.InvariantCulture), true);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
 

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -1674,6 +1674,23 @@ namespace DotNetNuke.Entities.Host
 			}
 		}
 
+        /// <summary>
+        /// Get a value indicating whether to put the entire instance into maintenance mode
+        /// </summary>
+        public static bool IsLocked
+        {
+            get { return HostController.Instance.GetBoolean("IsLocked", false); }
+        }
+
+        /// <summary>
+        /// Get the ID of the user that locked the entire instance
+        /// </summary>
+        public static int LockedByUserId
+        {
+            get { return HostController.Instance.GetInteger("LockedByUserId", Null.NullInteger); }
+        }
+
+
         #endregion
     }
 }

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -1682,15 +1682,6 @@ namespace DotNetNuke.Entities.Host
             get { return HostController.Instance.GetBoolean("IsLocked", false); }
         }
 
-        /// <summary>
-        /// Get the ID of the user that locked the entire instance
-        /// </summary>
-        public static int LockedByUserId
-        {
-            get { return HostController.Instance.GetInteger("LockedByUserId", Null.NullInteger); }
-        }
-
-
         #endregion
     }
 }

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -554,14 +554,6 @@ namespace DotNetNuke.Entities.Portals
             get { return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false); }
         }
 
-        /// <summary>
-        /// Get the ID of the user who locked this portal
-        /// </summary>
-        public int LockedByUserId
-        {
-            get { return PortalController.GetPortalSettingAsInteger("LockedByUserId", PortalId, Null.NullInteger); }
-        }
-
 		public TimeZoneInfo TimeZone
 		{
 			get { return _timeZone; }

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -538,6 +538,30 @@ namespace DotNetNuke.Entities.Portals
 			}
 		}
 
+        /// <summary>
+        /// Get a value indicating whether the current portal is in maintenance mode (if either this specific portal or the entire instance is locked). If locked, any actions which update the database should be disabled.
+        /// </summary>
+        public bool IsLocked
+        {
+            get { return IsThisPortalLocked || Host.Host.IsLocked; }
+        }
+
+        /// <summary>
+        /// Get a value indicating whether the current portal is in maintenance mode (note, the entire instance may still be locked, this only indicates whether this portal is specifically locked). If locked, any actions which update the database should be disabled.
+        /// </summary>
+        public bool IsThisPortalLocked
+        {
+            get { return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false); }
+        }
+
+        /// <summary>
+        /// Get the ID of the user who locked this portal
+        /// </summary>
+        public int LockedByUserId
+        {
+            get { return PortalController.GetPortalSettingAsInteger("LockedByUserId", PortalId, Null.NullInteger); }
+        }
+
 		public TimeZoneInfo TimeZone
 		{
 			get { return _timeZone; }

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -151,7 +151,7 @@ namespace DotNetNuke.UI.Modules
                 //role lookup on every property access (instead caching the result)
                 if (!_isEditable.HasValue)
                 {
-                    bool blnPreview = (PortalSettings.UserMode == PortalSettings.Mode.View);
+                    bool blnPreview = (PortalSettings.UserMode == PortalSettings.Mode.View) || PortalSettings.IsLocked;
                     if (Globals.IsHostTab(PortalSettings.ActiveTab.TabID))
                     {
                         blnPreview = false;
@@ -507,6 +507,11 @@ namespace DotNetNuke.UI.Modules
         private void LoadActions(HttpRequest request)
         {
             _actions = new ModuleActionCollection();
+            if (PortalSettings.IsLocked)
+            {
+                return;
+            }
+
             _moduleGenericActions = new ModuleAction(GetNextActionID(), Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
             int maxActionId = Null.NullInteger;
 


### PR DESCRIPTION
This is a continuation of #1272, after rebasing and fixing conflicts

[DNN-8374](https://dnntracker.atlassian.net/browse/DNN-8374)

> We've made some customizations for a client which we think would be a good fit for inclusion in the core. There's a "Lock Site" action added to the control bar, which allows a super-user to turn off modifications to the site (probably for entering some sort of maintenance mode). For our client, the "good enough" way this is implemented is to disable the module actions whenever the site is locked (in addition, custom modules are able to access the locked status via a property on `PortalSettings` and do any additional changes, if desired).
