### PR TITLE
DNN-10462: Added support for DnnUrlHelper in DnnController for MVC

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using System.Web.Mvc;
+using System.Web.Routing;
 using System.Web.UI;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Modules.Actions;
@@ -14,6 +15,7 @@ using DotNetNuke.Services.Localization;
 using DotNetNuke.UI.Modules;
 using DotNetNuke.Web.Mvc.Framework.ActionResults;
 using DotNetNuke.Web.Mvc.Framework.Modules;
+using DotNetNuke.Web.Mvc.Helpers;
 
 namespace DotNetNuke.Web.Mvc.Framework.Controllers
 {
@@ -35,6 +37,8 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
         }
 
         public Page DnnPage { get; set; }
+
+        public new DnnUrlHelper Url { get; set; }
 
         public string LocalResourceFile { get; set; }
 
@@ -117,6 +121,12 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
                 TempData = TempData,
                 ViewEngineCollection = ViewEngineCollection
             };
+        }
+
+        protected override void Initialize(RequestContext requestContext)
+        {
+            base.Initialize(requestContext);
+            Url = new DnnUrlHelper(requestContext, this);
         }
 
         public ViewEngineCollection ViewEngineCollectionEx { get; set; }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/IDnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/IDnnController.cs
@@ -5,6 +5,7 @@ using System.Web.Mvc;
 using System.Web.UI;
 using DotNetNuke.Entities.Modules.Actions;
 using DotNetNuke.UI.Modules;
+using DotNetNuke.Web.Mvc.Helpers;
 
 namespace DotNetNuke.Web.Mvc.Framework.Controllers
 {
@@ -27,6 +28,8 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
         bool ValidateRequest { get; set; }
 
         ViewEngineCollection ViewEngineCollectionEx { get; set; }
+
+        DnnUrlHelper Url { get; set; }
 
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
@@ -24,6 +24,7 @@ namespace DotNetNuke.Web.Mvc.Helpers
 
         public DnnUrlHelper(RequestContext requestContext, IDnnController controller)
         {
+            Requires.NotNull("requestContext", requestContext);
             Requires.NotNull("controller", controller);
 
             UrlHelper = new UrlHelper(requestContext);
@@ -92,7 +93,7 @@ namespace DotNetNuke.Web.Mvc.Helpers
 
         public virtual string Action()
         {
-            return _viewContext.RequestContext.HttpContext.Request.RawUrl;
+            return UrlHelper.RequestContext.HttpContext.Request.RawUrl;
         }
 
         public virtual string Action(string actionName)

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
@@ -22,6 +22,21 @@ namespace DotNetNuke.Web.Mvc.Helpers
         {
         }
 
+        public DnnUrlHelper(RequestContext requestContext, IDnnController controller)
+        {
+            Requires.NotNull("controller", controller);
+
+            UrlHelper = new UrlHelper(requestContext);
+            _controller = controller;
+
+            if (_controller == null)
+            {
+                throw new InvalidOperationException("The DnnUrlHelper class can only be used in Views that inherit from DnnWebViewPage");
+            }
+
+            ModuleContext = _controller.ModuleContext;
+        }
+
         public DnnUrlHelper(ViewContext viewContext, RouteCollection routeCollection)
         {
             Requires.NotNull("viewContext", viewContext);

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnUrlHelper.cs
@@ -29,12 +29,6 @@ namespace DotNetNuke.Web.Mvc.Helpers
 
             UrlHelper = new UrlHelper(requestContext);
             _controller = controller;
-
-            if (_controller == null)
-            {
-                throw new InvalidOperationException("The DnnUrlHelper class can only be used in Views that inherit from DnnWebViewPage");
-            }
-
             ModuleContext = _controller.ModuleContext;
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Fakes/FakeDnnController.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Fakes/FakeDnnController.cs
@@ -22,8 +22,8 @@
 #endregion
 
 using System.Web.Mvc;
-using System.Web.UI.WebControls;
 using DotNetNuke.Web.Mvc.Framework.Controllers;
+using System.Web.Routing;
 
 namespace DotNetNuke.Tests.Web.Mvc.Fakes
 {
@@ -43,5 +43,13 @@ namespace DotNetNuke.Tests.Web.Mvc.Fakes
         {
             return View("Action3", "Master3", dog);
         }
+
+        public void MockInitialize(RequestContext requestContext)
+        {
+            // Mocking out the entire MvcHandler and Controller lifecycle proved to be difficult
+            // This method executes the initialization logic that occurs on every request which is
+            // executed from the Execute method.
+            Initialize(requestContext);
+        }    
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Controllers/DnnControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Controllers/DnnControllerTests.cs
@@ -164,6 +164,20 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Controllers
             Assert.AreEqual(controller.ViewEngineCollection, dnnViewResult.ViewEngineCollection);
         }
 
+        [Test]
+        public void Initialize_CreatesInstance_Of_DnnUrlHelper()
+        {
+            //Arrange
+            HttpContextBase httpContextBase = MockHelper.CreateMockHttpContext();
+
+            //Act
+            var controller = SetupController(httpContextBase);
+            controller.MockInitialize(httpContextBase.Request.RequestContext);
+
+            //Assert
+            Assert.NotNull(controller.Url);
+        }
+
         private FakeDnnController SetupController(HttpContextBase context)
         {
             var controller = new FakeDnnController();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/MockHelper.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/MockHelper.cs
@@ -47,6 +47,8 @@ namespace DotNetNuke.Tests.Web.Mvc
             var mockRequest = new Mock<HttpRequestBase>();
             mockRequest.Setup(r => r.QueryString)
                        .Returns(new NameValueCollection());
+            mockRequest.Setup(r => r.RequestContext)
+                       .Returns(new RequestContext());
 
             var mockResponse = new Mock<HttpResponseBase>();
 
@@ -54,7 +56,7 @@ namespace DotNetNuke.Tests.Web.Mvc
                        .Returns(mockRequest.Object);
             mockContext.SetupGet(c => c.Response)
                        .Returns(mockResponse.Object);
-
+            
             return mockContext.Object;
         }
 


### PR DESCRIPTION
Added support in the `DnnController` for `DnnUrlHelper`. 

* I added the `DnnUrlHelper` inside of the `IDnnController` and `DnnController`. Since the ASP.NET MVC object isn't really useful in DNN Routing I created our `DNNUrlHelper` as a new property which hides the base Url implementation. In the `DnnController` 
* The `DnnController` now overrides the ASP.NET MVC `Controller` method `Initialize(RequestContext requestContext)` and sets our `DnnUrlHelper`. This is the **exact** same way that the `Controller` works from ASP.NET MVC. This method will get called on every request and be able to appropriately set the `DnnUrlHelper`

**Our code**
```c#
protected override void Initialize(RequestContext requestContext)
{
    base.Initialize(requestContext);
    Url = new DnnUrlHelper(requestContext, this);
}
```

**ASP.NET MVC Code**
Code Snippet from [ASP.NET MVC repo](https://github.com/aspnet/AspNetWebStack/)
```c#
protected override void Initialize(RequestContext requestContext)
{
    base.Initialize(requestContext);
    Url = new UrlHelper(requestContext);
}
```

**Usage**
Now in a DNN MVC Module we can handle routing inside of the controller. Suppose you are in a scenario where you are handling a form submission with a `HttpPost` and you want to redirect to a new controller route. Now you can just specify `Url.Action("NewRoute")`, see snippet below:

```c#
public class FooController : DnnController
{
    public ActionResult Index()
    {
        return View();
    }

    [HttpPost]
    public ActionResult Index(object data)
    {
        // do something with form data
        
        return Redirect(Url.Action("NewAction"));
    }

    public ActionResult NewAction()
    {
        return View();
    }
}
```