### PR TITLE
Thread Safe URL Portals (IndexOutOfRangeException)

### DIFF
--- a/DNN Platform/Library/Entities/Urls/CacheController.cs
+++ b/DNN Platform/Library/Entities/Urls/CacheController.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Configuration;
@@ -249,7 +250,7 @@ namespace DotNetNuke.Entities.Urls
         /// <remarks>
         /// </remarks>
         internal void GetFriendlyUrlIndexFromCache(out SharedDictionary<int, SharedDictionary<string, string>> urlDict,
-                                                   out List<int> urlPortals,
+                                                   out ConcurrentBag<int> urlPortals,
                                                    out SharedDictionary<string, string> customAliasTabs)
         {
             urlDict = null;
@@ -257,7 +258,7 @@ namespace DotNetNuke.Entities.Urls
             customAliasTabs = null;
             object rawDict = DataCache.GetCache(UrlDictKey); //contains a dictionary of tabs for all portals
             object rawPortals = DataCache.GetCache(UrlPortalsKey);
-            //contas a list of portals for which we have retrieved the tabs
+            //contains a list of portals for which we have retrieved the tabs
             object rawCustomAliasTabs = DataCache.GetCache(CustomAliasTabsKey);
             //contains a dictionary of tabs with custom aliases, for all portals
             if (rawDict != null)
@@ -266,7 +267,7 @@ namespace DotNetNuke.Entities.Urls
             }
             if (rawPortals != null)
             {
-                urlPortals = (List<int>)rawPortals;
+                urlPortals = (ConcurrentBag<int>)rawPortals;
             }
             if (rawCustomAliasTabs != null)
             {
@@ -526,7 +527,7 @@ namespace DotNetNuke.Entities.Urls
         /// <remarks>
         /// </remarks>
         internal void StoreFriendlyUrlIndexInCache(SharedDictionary<int, SharedDictionary<string, string>> urlDict,
-                                                List<int> urlPortals,
+                                                ConcurrentBag<int> urlPortals,
                                                 SharedDictionary<string, string> customAliasTabs,
                                                 FriendlyUrlSettings settings,
                                                 string reason)
@@ -543,7 +544,6 @@ namespace DotNetNuke.Entities.Urls
             LogRemovedReason = settings.LogCacheMessages;
 
             SetPageCache(UrlDictKey, urlDict, new DNNCacheDependency(GetTabsCacheDependency(urlPortals)), settings, onRemovePageIndex);
-
             SetPageCache(UrlPortalsKey, urlPortals, settings);
             SetPageCache(CustomAliasTabsKey, customAliasTabs, settings);
 

--- a/DNN Platform/Library/Entities/Urls/CustomUrlDictController.cs
+++ b/DNN Platform/Library/Entities/Urls/CustomUrlDictController.cs
@@ -24,8 +24,9 @@
 #region Usings
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-
+using System.Linq;
 using DotNetNuke.Collections.Internal;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
@@ -181,7 +182,7 @@ namespace DotNetNuke.Entities.Urls
         {
             SharedDictionary<int, SharedDictionary<string, string>> urlDict;
             //this contains a list of all tabs for all the portals that have been retrieved
-            List<int> urlPortals; //this contains a list of the portals that have been retrieved
+            ConcurrentBag<int> urlPortals; //this contains a list of the portals that have been retrieved
             //get the objects from the cache
             var cc = new CacheController();
             cc.GetFriendlyUrlIndexFromCache(out urlDict, out urlPortals, out customAliasForTabs);
@@ -191,7 +192,7 @@ namespace DotNetNuke.Entities.Urls
                 if (urlPortals == null)
                 //no portals retrieved from cache, but was a dictionary.  Bit weird, but we'll run with it
                 {
-                    urlPortals = new List<int>();
+                    urlPortals = new ConcurrentBag<int>();
                 }
 
                 //check to see if this portal has been included in the dict
@@ -213,7 +214,7 @@ namespace DotNetNuke.Entities.Urls
             {
                 //rebuild the dictionary for this portal
                 urlDict = BuildUrlDictionary(urlDict, portalId, settings, ref customAliasForTabs);
-                urlPortals = new List<int> { portalId }; //always rebuild the portal list
+                urlPortals = new ConcurrentBag<int> { portalId }; //always rebuild the portal list
                 if (bypassCache == false) //if we are to cache this item (byPassCache = false)
                 {
                     //cache these items

--- a/DNN Platform/Library/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Library/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using DotNetNuke.Application;
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
 [assembly: CLSCompliant(true)]
 
-[assembly: AssemblyStatus(ReleaseMode.Alpha)]
+[assembly: AssemblyStatus(ReleaseMode.Stable)]
 
 // Allow internal variables to be visible to testing projects
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Core")]

--- a/Website/admin/Skins/UserAndLogin.ascx
+++ b/Website/admin/Skins/UserAndLogin.ascx
@@ -3,8 +3,11 @@
     <ul>
         <%  if (!IsAuthenticated)
             {
+                if (CanRegister)
+                {
         %> 
                 <li class="userRegister"><asp:HyperLink ID="registerLink" runat="server"><% =LocalizeString("Register") %></asp:HyperLink>
+        <%      } %>
                 <li class="userLogin"><asp:HyperLink ID="loginLink" runat="server"><% =LocalizeString("Login") %></asp:HyperLink>
         <%  }
             else


### PR DESCRIPTION
I've been unable to link my JIRA account, it seems like something is wrong with the dnntracker self-login process. 

Background:
* We have a fairly large DNN system with thousands of portals, running in a web farm setup
* nBrane is used as a caching provider to distribute the memory cache across servers

We've run into an issue where periodically our websites will start serving 500 errors on a server, because what appears to be invalid cache objects.

Attached is a stack trace of what we would typically see. Note: The originating source of this stack trace has many different variations.
``
[FATAL] DotNetNuke.Framework.PageBase - An error has occurred while loading page.
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.Collections.Generic.List`1.Contains(T item)
   at DotNetNuke.Entities.Urls.CustomUrlDictController.FetchCustomUrlDictionary(Int32 portalId, Boolean forceRebuild, Boolean bypassCache, FriendlyUrlSettings settings, SharedDictionary`2& customAliasForTabs, Guid parentTraceId)
   at DotNetNuke.Entities.Urls.TabPathHelper.GetTabPath(TabInfo tab, FriendlyUrlSettings settings, FriendlyUrlOptions options, Boolean ignoreCustomRedirects, Boolean homePageSiteRoot, Boolean isHomeTab, String cultureCode, Boolean isDefaultCultureCode, Boolean hasPath, Boolean& dropLangParms, String& customHttpAlias, Boolean& isCustomPath, Guid parentTraceId)
   at DotNetNuke.Entities.Urls.AdvancedFriendlyUrlProvider.ImproveFriendlyUrlWithMessages(TabInfo tab, String friendlyPath, String pageName, PortalSettings portalSettings, Boolean ignoreCustomRedirects, FriendlyUrlSettings settings, List`1& messages, Boolean cultureSpecificAlias, Guid parentTraceId)
   at DotNetNuke.Entities.Urls.AdvancedFriendlyUrlProvider.ImproveFriendlyUrl(TabInfo tab, String friendlyPath, String pageName, PortalSettings portalSettings, Boolean ignoreCustomRedirects, Boolean cultureSpecificAlias, FriendlyUrlSettings settings, Guid parentTraceId)
   at DotNetNuke.Entities.Urls.AdvancedFriendlyUrlProvider.FriendlyUrlInternal(TabInfo tab, String path, String pageName, String portalAlias, PortalSettings portalSettings)
   at DotNetNuke.Entities.Urls.AdvancedFriendlyUrlProvider.FriendlyUrl(TabInfo tab, String path, String pageName, PortalSettings portalSettings)
   at DotNetNuke.Common.Globals.NavigateURL(Int32 tabID, Boolean isSuperTab, PortalSettings settings, String controlKey, String language, String pageName, String[] additionalParameters)
   at DotNetNuke.UI.Modules.ModuleInstanceContext.NavigateUrl(Int32 tabID, String controlKey, String pageName, Boolean pageRedirect, String[] additionalParameters)
   at DotNetNuke.UI.Modules.ModuleInstanceContext.NavigateUrl(Int32 tabID, String controlKey, Boolean pageRedirect, String[] additionalParameters)
   at SiPlay.Cms.News.NewsList.<>c__DisplayClass14_0.<BuildNewsListItems>b__4(NewsArticle article)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at SiPlay.Cms.News.NewsList.BuildNewsListItems(NewsSettings settings, Int32 managerTabId, Int32 targetTabId)
   at SiPlay.Cms.News.NewsList.BuildViewModel()
   at SiPlay.Cms.News.NewsList.Page_Load(Object sender, EventArgs e)
   at System.Web.UI.Control.OnLoad(EventArgs e)
   at DotNetNuke.Entities.Modules.PortalModuleBase.OnLoad(EventArgs e)
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Control.LoadRecursive()
   at System.Web.UI.Page.ProcessRequestMain(Boolean includeStagesBeforeAsyncPoint, Boolean includeStagesAfterAsyncPoint)
``

In short, it appears like the cache for UrlPortals is getting into an invalid state due to the fact that List<int> is not thread safe, and you have multiple threads/processes dealing with this single controller instance. It seems like other objects stored in cache use the SharedDictionary generic class to get around this problem. This pull request is to simply change it to a .NET framework thread safe collection.

There seem to be a few StackOverflow threads about this problem. The following one seems to express it the best: https://stackoverflow.com/questions/43915717/index-out-of-bounds-on-list-contains

I'll continue to attempt to get a proper JIRA ticket filed for this issue, as well as working on testing it on a larger scale.

This change was forked and tested off of 8.0.1, but is valid for all versions.



