### PR TITLE
task/DNN-10662 fix breaking test on Team City

### DIFF
--- a/DNN Platform/Library/Entities/EventManager.cs
+++ b/DNN Platform/Library/Entities/EventManager.cs
@@ -193,8 +193,7 @@ namespace DotNetNuke.Entities
                 FileAdded(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_ADDED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_ADDED);
         }
 
         public virtual void OnFileChanged(FileChangedEventArgs args)
@@ -204,8 +203,7 @@ namespace DotNetNuke.Entities
                 FileChanged(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_CHANGED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_CHANGED);
         }
 
         public virtual void OnFileDeleted(FileDeletedEventArgs args)
@@ -215,8 +213,7 @@ namespace DotNetNuke.Entities
                 FileDeleted(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_DELETED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_DELETED);
         }
 
         public virtual void OnFileMetadataChanged(FileChangedEventArgs args)
@@ -226,8 +223,7 @@ namespace DotNetNuke.Entities
                 FileMetadataChanged(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_METADATACHANGED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_METADATACHANGED);
         }
 
         public virtual void OnFileDownloaded(FileDownloadedEventArgs args)
@@ -237,8 +233,7 @@ namespace DotNetNuke.Entities
                 FileDownloaded(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_DOWNLOADED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_DOWNLOADED);
         }
 
         public virtual void OnFileMoved(FileMovedEventArgs args)
@@ -248,8 +243,7 @@ namespace DotNetNuke.Entities
                 FileMoved(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_MOVED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_MOVED);
         }
 
         public virtual void OnFileOverwritten(FileChangedEventArgs args)
@@ -259,8 +253,7 @@ namespace DotNetNuke.Entities
                 FileOverwritten(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_OVERWRITTEN);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_OVERWRITTEN);
         }
 
         public virtual void OnFileRenamed(FileRenamedEventArgs args)
@@ -270,8 +263,7 @@ namespace DotNetNuke.Entities
                 FileRenamed(this, args);
             }
 
-            EventLogController.Instance.AddLog(args.FileInfo, PortalSettings.Current,
-                args.UserId, "", EventLogController.EventLogType.FILE_RENAMED);
+            AddLog(args.FileInfo, args.UserId, EventLogController.EventLogType.FILE_RENAMED);
         }
 
         public virtual void OnFolderAdded(FolderChangedEventArgs args)
@@ -553,6 +545,16 @@ namespace DotNetNuke.Entities
                 TabSerialize += handlers.Value.TabSerialize;
                 TabDeserialize += handlers.Value.TabDeserialize;
             }
+        }
+
+        private static void AddLog(IFileInfo fileInfo, int userId, EventLogController.EventLogType logType)
+        {
+            if (fileInfo == null)
+            {
+                return;
+            }
+
+            EventLogController.Instance.AddLog(fileInfo, PortalSettings.Current, userId, "", logType);
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FileManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FileManagerTests.cs
@@ -39,6 +39,7 @@ using DotNetNuke.Services.FileSystem.Internal;
 using DotNetNuke.Tests.Utilities;
 using DotNetNuke.Tests.Utilities.Mocks;
 using DotNetNuke.Security.Permissions;
+using DotNetNuke.Services.Log.EventLog;
 using Moq;
 
 using NUnit.Framework;
@@ -98,6 +99,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             _mockFileLockingController = new Mock<IFileLockingController>();
             _mockFileDeletionController = new Mock<IFileDeletionController>();
             
+            EventLogController.SetTestableInstance(Mock.Of<IEventLogController>());
             FolderManager.RegisterInstance(_folderManager.Object);
             FolderPermissionController.SetTestableInstance(_folderPermissionController.Object);
             PortalController.SetTestableInstance(_portalController.Object);


### PR DESCRIPTION
Logging in `FileManager` has been breaking unit tests recently.

1. I've made the logger call in `EventManager` more resilient to nulls and lil bit less repetitive
1. there was still one more test failing so I actually mocked the event log controller 