### PR TITLE
Fixes git clone error due to ClientDependency submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "DNN Platform/Components/ClientDependency"]
 	path = DNN Platform/Components/ClientDependency
-	url = git@github.com:dnnsoftware/ClientDependency.git
+	url = https://github.com/dnnsoftware/ClientDependency.git


### PR DESCRIPTION
Fixes a git clone error using git@github.com instead of https://github.com
closes #2051 