### PR TITLE
DNN-18327: Fix the search for field definitions with spaces

### DIFF
--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/ProfileEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/ProfileEditorControl.cs
@@ -26,7 +26,6 @@ using System.Web.UI;
 using DotNetNuke.Common.Lists;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Profile;
-using DotNetNuke.Entities.Users;
 using DotNetNuke.Security;
 
 #endregion
@@ -35,6 +34,7 @@ using DotNetNuke.Security;
 namespace DotNetNuke.UI.WebControls
 // ReSharper restore CheckNamespace
 {
+    
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
     /// Namespace:  DotNetNuke.UI.WebControls
@@ -50,7 +50,9 @@ namespace DotNetNuke.UI.WebControls
     [ToolboxData("<{0}:ProfileEditorControl runat=server></{0}:ProfileEditorControl>")]
     public class ProfileEditorControl : CollectionEditorControl
     {
-		#region Protected Methods
+
+        
+        #region Protected Methods
 
         /// -----------------------------------------------------------------------------
         /// <summary>
@@ -73,8 +75,9 @@ namespace DotNetNuke.UI.WebControls
 
             foreach (FieldEditorControl editor in Fields)
             {
-                //Check whether Field is readonly
-                string fieldName = editor.Editor.Name;
+                //Check whether Field is readonly. Replace "_" with " " (Spaces) to find the correct definitions.
+                string fieldName = editor.Editor.Name.Replace("_", " ");
+
                 ProfilePropertyDefinitionCollection definitions = editor.DataSource as ProfilePropertyDefinitionCollection;
                 ProfilePropertyDefinition definition = definitions[fieldName];
 

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/ProfileEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/ProfileEditorControl.cs
@@ -50,8 +50,6 @@ namespace DotNetNuke.UI.WebControls
     [ToolboxData("<{0}:ProfileEditorControl runat=server></{0}:ProfileEditorControl>")]
     public class ProfileEditorControl : CollectionEditorControl
     {
-
-        
         #region Protected Methods
 
         /// -----------------------------------------------------------------------------

--- a/Website/Providers/DataProviders/SqlDataProvider/09.02.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/09.02.01.SqlDataProvider
@@ -102,6 +102,111 @@ ELSE
 		AND    ModuleId = @ModuleId
 GO
 
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}AddPropertyDefinition]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}AddPropertyDefinition]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}AddPropertyDefinition]
+	@PortalId int,
+	@ModuleDefId int,
+	@DataType int,
+	@DefaultValue nvarchar(max),
+	@PropertyCategory nvarchar(50),
+	@PropertyName nvarchar(50),
+	@ReadOnly bit,
+	@Required bit,
+	@ValidationExpression nvarchar(2000),
+	@ViewOrder int,
+	@Visible bit,
+    @Length int,
+    @DefaultVisibility int,
+	@CreatedByUserID int
+
+AS
+	DECLARE @PropertyDefinitionId int
+
+	SELECT @PropertyDefinitionId = PropertyDefinitionId
+		FROM   {databaseOwner}{objectQualifier}ProfilePropertyDefinition
+		WHERE  (PortalId = @PortalId OR (PortalId IS NULL AND @PortalId IS NULL))
+			AND (PropertyName = @PropertyName OR PropertyName = REPLACE(@PropertyName,' ','_') OR PropertyName = REPLACE(@PropertyName,'_',' '))
+			
+	IF @vieworder=-1
+		BEGIN
+			SELECT	@vieworder = MAX(ViewOrder) + 1 
+			FROM	{databaseOwner}{objectQualifier}ProfilePropertyDefinition
+		END
+
+	IF @PropertyDefinitionId IS NULL
+		BEGIN
+			INSERT {databaseOwner}{objectQualifier}ProfilePropertyDefinition	(
+					PortalId,
+					ModuleDefId,
+					Deleted,
+					DataType,
+					DefaultValue,
+					PropertyCategory,
+					PropertyName,
+					ReadOnly,
+					Required,
+					ValidationExpression,
+					ViewOrder,
+					Visible,
+					Length,
+                    DefaultVisibility,
+					[CreatedByUserID],
+					[CreatedOnDate],
+					[LastModifiedByUserID],
+					[LastModifiedOnDate]
+
+				)
+				VALUES	(
+					@PortalId,
+					@ModuleDefId,
+					0,
+					@DataType,
+					@DefaultValue,
+					@PropertyCategory,
+					@PropertyName,
+					@ReadOnly,
+					@Required,
+					@ValidationExpression,
+					@ViewOrder,
+					@Visible,
+					@Length,
+                    @DefaultVisibility,
+					@CreatedByUserID,
+  					getdate(),
+  					@CreatedByUserID,
+  					getdate()
+				)
+
+			SELECT @PropertyDefinitionId = SCOPE_IDENTITY()
+		END
+	ELSE
+		BEGIN
+			UPDATE {databaseOwner}{objectQualifier}ProfilePropertyDefinition 
+				SET PropertyName = @PropertyName,
+					DataType = @DataType,
+					ModuleDefId = @ModuleDefId,
+					DefaultValue = @DefaultValue,
+					PropertyCategory = @PropertyCategory,
+					ReadOnly = @ReadOnly,
+					Required = @Required,
+					ValidationExpression = @ValidationExpression,
+					ViewOrder = @ViewOrder,
+					Deleted = 0,
+					Visible = @Visible,
+					Length = @Length,
+                    DefaultVisibility = @DefaultVisibility,
+					[LastModifiedByUserID] = @CreatedByUserID,	
+					[LastModifiedOnDate] = getdate()
+				WHERE PropertyDefinitionId = @PropertyDefinitionId
+		END
+		
+	SELECT @PropertyDefinitionId
+GO
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/

--- a/Website/Providers/DataProviders/SqlDataProvider/09.02.01.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/09.02.01.SqlDataProvider
@@ -103,6 +103,7 @@ ELSE
 GO
 
 
+/*** [DNN-18327]:[ISSUE-2096] Replace underscores with spaces. ***/
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}AddPropertyDefinition]') AND type in (N'P', N'PC'))
 	DROP PROCEDURE {databaseOwner}[{objectQualifier}AddPropertyDefinition]
 GO
@@ -126,10 +127,13 @@ CREATE PROCEDURE {databaseOwner}[{objectQualifier}AddPropertyDefinition]
 AS
 	DECLARE @PropertyDefinitionId int
 
+	SET @PropertyName = Replace(LTrim(RTrim(Replace(@PropertyName,'_',' '))), '_', ' ')
+
+
 	SELECT @PropertyDefinitionId = PropertyDefinitionId
 		FROM   {databaseOwner}{objectQualifier}ProfilePropertyDefinition
 		WHERE  (PortalId = @PortalId OR (PortalId IS NULL AND @PortalId IS NULL))
-			AND (PropertyName = @PropertyName OR PropertyName = REPLACE(@PropertyName,' ','_') OR PropertyName = REPLACE(@PropertyName,'_',' '))
+			AND PropertyName = @PropertyName
 			
 	IF @vieworder=-1
 		BEGIN


### PR DESCRIPTION
When adding new fields to user profile, if the new field has spaces, it will not identify the read-only properties correctly.

fixes #2096