### PR TITLE
Fix CDF settings tests

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -243,7 +243,7 @@ namespace DotNetNuke.Entities.Portals
             }
             else
             {
-                crmVersion = HostController.Instance.GetInteger("CrmVersion");
+                crmVersion = settings.GetValueOrDefault("CrmVersion", HostController.Instance.GetInteger("CrmVersion"));
             }
             
             portalSettings.AllowUserUICulture = settings.GetValueOrDefault("AllowUserUICulture", false);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
@@ -97,6 +97,8 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
                             .Returns((string s, bool b) => Boolean.Parse(hostSettings[s]));
             mockHostController.Setup(c => c.GetInteger(It.IsAny<string>(), It.IsAny<int>()))
                             .Returns((string s, int i) => Int32.Parse(hostSettings[s]));
+            mockHostController.Setup(c => c.GetInteger(It.IsAny<string>()))
+                            .Returns((string s) => Int32.Parse(hostSettings[s]));
             HostController.RegisterInstance(mockHostController.Object);
 
             if (isHostDefault)

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/TestFiles/HostSettings.csv
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/TestFiles/HostSettings.csv
@@ -10,3 +10,4 @@ SearchIncludeNumeric,					true
 SearchIncludedTagInfoFilter,			a
 MaxSearchWordLength,					25
 MinSearchWordLength,					3
+CrmVersion, -1

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/TestFiles/SettingValues.csv
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/TestFiles/SettingValues.csv
@@ -1,5 +1,5 @@
 ﻿Test,							PropertyName,					SettingName,					SettingValue,			PropertyValue
-Cdf Version,					CdfVersion,						CdfVersion,						-1
+Cdf Version,					CdfVersion,						CrmVersion,						-1
 DefaultAdminContainer,			DefaultAdminContainer,			DefaultAdminContainer,			AdminContainer
 DefaultAdminSkin,				DefaultAdminSkin,				DefaultAdminSkin,				AdminSkin
 DefaultIconLocation,			DefaultIconLocation,			DefaultIconLocation,			icons/sigma


### PR DESCRIPTION
This fixes two failing tests which were caused by #2018 (see [here](https://github.com/dnnsoftware/Dnn.Platform/blob/development/DNN%20Platform/Library/Entities/Portals/PortalSettingsController.cs#L238-L250))

In short, the `CdfVersion` was previously only taken from portal settings and now it will be taken from host settings as fallback.