### PR TITLE
*DO NOT MERGE* - introducing ConcurrentDictionary in SharedDictionary class

### DIFF
--- a/DNN Platform/Library/Collections/FakeDisposable.cs
+++ b/DNN Platform/Library/Collections/FakeDisposable.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetNuke.Collections.Internal
+{
+    class FakeDisposable : ISharedCollectionLock
+    {
+
+        private bool disposedValue = false;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                disposedValue = true;
+            }
+        }
+
+        ~FakeDisposable() {
+            Dispose(false);
+        }
+
+        void IDisposable.Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/DNN Platform/Library/Collections/FakeLockStrategy.cs
+++ b/DNN Platform/Library/Collections/FakeLockStrategy.cs
@@ -4,11 +4,11 @@ namespace DotNetNuke.Collections.Internal
 {
     class FakeLockStrategy : ILockStrategy
     {
-        bool ILockStrategy.ThreadCanRead => throw new NotImplementedException();
+        bool ILockStrategy.ThreadCanRead => true;
 
-        bool ILockStrategy.ThreadCanWrite => throw new NotImplementedException();
+        bool ILockStrategy.ThreadCanWrite => true;
 
-        bool ILockStrategy.SupportsConcurrentReads => throw new NotImplementedException();
+        bool ILockStrategy.SupportsConcurrentReads => true;
 
         ISharedCollectionLock ILockStrategy.GetReadLock()
         {

--- a/DNN Platform/Library/Collections/FakeLockStrategy.cs
+++ b/DNN Platform/Library/Collections/FakeLockStrategy.cs
@@ -1,0 +1,60 @@
+﻿using DotNetNuke.Collections.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetNuke.Collections.Internal
+{
+    class FakeLockStrategy : ILockStrategy
+    {
+        bool ILockStrategy.ThreadCanRead => throw new NotImplementedException();
+
+        bool ILockStrategy.ThreadCanWrite => throw new NotImplementedException();
+
+        bool ILockStrategy.SupportsConcurrentReads => throw new NotImplementedException();
+
+        ISharedCollectionLock ILockStrategy.GetReadLock()
+        {
+            return new FakeDisposable();
+        }
+
+        ISharedCollectionLock ILockStrategy.GetReadLock(TimeSpan timeout)
+        {
+            return new FakeDisposable();
+        }
+
+        ISharedCollectionLock ILockStrategy.GetWriteLock()
+        {
+            return new FakeDisposable();
+        }
+
+        ISharedCollectionLock ILockStrategy.GetWriteLock(TimeSpan timeout)
+        {
+            return new FakeDisposable();
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                disposedValue = true;
+            }
+        }
+
+        ~FakeLockStrategy() {
+            Dispose(false);
+        }
+        
+        void IDisposable.Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/DNN Platform/Library/Collections/FakeLockStrategy.cs
+++ b/DNN Platform/Library/Collections/FakeLockStrategy.cs
@@ -1,9 +1,4 @@
-﻿using DotNetNuke.Collections.Internal;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace DotNetNuke.Collections.Internal
 {
@@ -34,6 +29,54 @@ namespace DotNetNuke.Collections.Internal
         {
             return new FakeDisposable();
         }
+
+        #region ILockStrategy Members
+
+        public ISharedCollectionLock GetReadLock()
+        {
+            return GetReadLock(TimeSpan.FromMilliseconds(-1));
+        }
+
+        public ISharedCollectionLock GetReadLock(TimeSpan timeout)
+        {
+            return new FakeDisposable();
+        }
+
+        public ISharedCollectionLock GetWriteLock()
+        {
+            return GetWriteLock(TimeSpan.FromMilliseconds(-1));
+        }
+
+        public ISharedCollectionLock GetWriteLock(TimeSpan timeout)
+        {
+            return new FakeDisposable();
+        }
+
+        public bool ThreadCanRead
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public bool ThreadCanWrite
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public bool SupportsConcurrentReads
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        #endregion
 
         #region IDisposable Support
         private bool disposedValue = false;

--- a/DNN Platform/Library/Collections/SharedDictionary.cs
+++ b/DNN Platform/Library/Collections/SharedDictionary.cs
@@ -74,6 +74,8 @@ namespace DotNetNuke.Collections.Internal
 
         public void Add(KeyValuePair<TKey, TValue> item)
         {
+            EnsureNotDisposed();
+            EnsureWriteAccess();
             _dict.TryAdd(item.Key, item.Value);
         }
 
@@ -233,7 +235,7 @@ namespace DotNetNuke.Collections.Internal
 
         private void EnsureReadAccess()
         {
-            if (!(_lockController.ThreadCanRead))
+            if (!(_fakeLockController.ThreadCanRead))
             {
                 throw new ReadLockRequiredException();
             }

--- a/DNN Platform/Library/Collections/SharedDictionary.cs
+++ b/DNN Platform/Library/Collections/SharedDictionary.cs
@@ -1,7 +1,7 @@
 ﻿#region Copyright
 // 
 // DotNetNuke® - http://www.dotnetnuke.com
-// Copyright (c) 2002-2017
+// Copyright (c) 2002-2018
 // by DotNetNuke Corporation
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 #endregion
@@ -31,10 +32,11 @@ namespace DotNetNuke.Collections.Internal
     [Serializable]
     public class SharedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDisposable
     {
-        private IDictionary<TKey, TValue> _dict;
+        private ConcurrentDictionary<TKey, TValue> _dict;
 
         private bool _isDisposed;
         private ILockStrategy _lockController;
+        private ILockStrategy _fakeLockController = new FakeLockStrategy();
 
         public SharedDictionary() : this(LockingStrategy.ReaderWriter)
         {
@@ -42,7 +44,7 @@ namespace DotNetNuke.Collections.Internal
 
         public SharedDictionary(ILockStrategy lockStrategy)
         {
-            _dict = new Dictionary<TKey, TValue>();
+            _dict = new ConcurrentDictionary<TKey, TValue>();
             _lockController = lockStrategy;
         }
 
@@ -50,7 +52,7 @@ namespace DotNetNuke.Collections.Internal
         {
         }
 
-        internal IDictionary<TKey, TValue> BackingDictionary
+        internal ConcurrentDictionary<TKey, TValue> BackingDictionary
         {
             get
             {
@@ -72,37 +74,31 @@ namespace DotNetNuke.Collections.Internal
 
         public void Add(KeyValuePair<TKey, TValue> item)
         {
-            EnsureNotDisposed();
-            EnsureWriteAccess();
-            _dict.Add(item);
+            _dict.TryAdd(item.Key, item.Value);
         }
 
         public void Clear()
         {
-            EnsureNotDisposed();
-            EnsureWriteAccess();
             _dict.Clear();
         }
 
         public bool Contains(KeyValuePair<TKey, TValue> item)
         {
             EnsureNotDisposed();
-            EnsureReadAccess();
-            return _dict.Contains(item);
+            return _dict.ContainsKey(item.Key);
         }
 
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
             EnsureNotDisposed();
-            EnsureReadAccess();
-            _dict.CopyTo(array, arrayIndex);
+            _dict.ToArray().CopyTo(array, arrayIndex);
         }
 
         public bool Remove(KeyValuePair<TKey, TValue> item)
         {
             EnsureNotDisposed();
-            EnsureWriteAccess();
-            return _dict.Remove(item);
+            TValue value;
+            return _dict.TryRemove(item.Key, out value);
         }
 
         public int Count
@@ -110,7 +106,6 @@ namespace DotNetNuke.Collections.Internal
             get
             {
                 EnsureNotDisposed();
-                EnsureReadAccess();
                 return _dict.Count;
             }
         }
@@ -119,16 +114,22 @@ namespace DotNetNuke.Collections.Internal
         {
             get
             {
-                EnsureNotDisposed();
-                EnsureReadAccess();
-                return _dict.IsReadOnly;
+                /**
+                 * Kept only for compatibility
+                 * even if it was uselss.
+                 * Actually we don't have control over 
+                 * readability of the _dict instance, since
+                 * the Dictionary class is instatiated in the 
+                 * constructor as ReadWrite.
+                 * Actually it is alwyas false
+                 */
+                return false; // _dict.IsReadOnly;
             }
         }
 
         public bool ContainsKey(TKey key)
         {
             EnsureNotDisposed();
-            EnsureReadAccess();
             return _dict.ContainsKey(key);
         }
 
@@ -136,20 +137,19 @@ namespace DotNetNuke.Collections.Internal
         {
             EnsureNotDisposed();
             EnsureWriteAccess();
-            _dict.Add(key, value);
+            _dict.TryAdd(key, value);
         }
 
         public bool Remove(TKey key)
         {
             EnsureNotDisposed();
-            EnsureWriteAccess();
-            return _dict.Remove(key);
+            TValue value;
+            return _dict.TryRemove(key, out value);
         }
 
         public bool TryGetValue(TKey key, out TValue value)
         {
             EnsureNotDisposed();
-            EnsureReadAccess();
             return _dict.TryGetValue(key, out value);
         }
 
@@ -158,14 +158,14 @@ namespace DotNetNuke.Collections.Internal
             get
             {
                 EnsureNotDisposed();
-                EnsureReadAccess();
-                return _dict[key];
+                TValue value;
+                _dict.TryGetValue(key, out value);
+                return value;
             }
             set
             {
                 EnsureNotDisposed();
-                EnsureWriteAccess();
-                _dict[key] = value;
+                _dict.TryAdd(key, value);
             }
         }
 
@@ -174,7 +174,6 @@ namespace DotNetNuke.Collections.Internal
             get
             {
                 EnsureNotDisposed();
-                EnsureReadAccess();
                 return _dict.Keys;
             }
         }
@@ -184,7 +183,6 @@ namespace DotNetNuke.Collections.Internal
             get
             {
                 EnsureNotDisposed();
-                EnsureReadAccess();
                 return _dict.Values;
             }
         }
@@ -209,8 +207,7 @@ namespace DotNetNuke.Collections.Internal
 
         public ISharedCollectionLock GetReadLock(TimeSpan timeOut)
         {
-            EnsureNotDisposed();
-            return _lockController.GetReadLock(timeOut);
+            return _fakeLockController.GetReadLock(timeOut);
         }
 
         public ISharedCollectionLock GetReadLock(int millisecondTimeout)
@@ -234,7 +231,6 @@ namespace DotNetNuke.Collections.Internal
             return GetWriteLock(TimeSpan.FromMilliseconds(millisecondTimeout));
         }
 
-
         private void EnsureReadAccess()
         {
             if (!(_lockController.ThreadCanRead))
@@ -250,11 +246,9 @@ namespace DotNetNuke.Collections.Internal
                 throw new WriteLockRequiredException();
             }
         }
-
         public IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable_GetEnumerator()
         {
             EnsureNotDisposed();
-            EnsureReadAccess();
 
             //todo nothing ensures read lock is held for life of enumerator
             return _dict.GetEnumerator();
@@ -284,7 +278,7 @@ namespace DotNetNuke.Collections.Internal
                 _isDisposed = true;
             }
         }
-
+        
         ~SharedDictionary()
         {
             Dispose(false);

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -183,6 +183,8 @@
     <Compile Include="Application\Application.cs" />
     <Compile Include="Application\AssemblyStatusAttribute.cs" />
     <Compile Include="Application\DotNetNukeContext.cs" />
+    <Compile Include="Collections\FakeDisposable.cs" />
+    <Compile Include="Collections\FakeLockStrategy.cs" />
     <Compile Include="Common\Utilities\CryptographyUtils.cs" />
     <Compile Include="Common\Utilities\RegexUtils.cs" />
     <Compile Include="Data\ControllerBase.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/SharedDictionaryTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/SharedDictionaryTests.cs
@@ -64,14 +64,6 @@ namespace DotNetNuke.Tests.Core.Collections
             CollectionAssert.AreEqual(new Dictionary<string, string> {{KEY, VALUE}}, sharedDictionary.BackingDictionary);
         }
 
-        /*
-        [Test, ExpectedException(typeof (ReadLockRequiredException)), TestCaseSource("GetReadMethods")]
-        public void ReadRequiresLock(Action<SharedDictionary<string, string>> readAction)
-        {
-            readAction.Invoke(InitSharedDictionary("key", "value"));
-        }
-        */
-
         [Test, ExpectedException(typeof (ReadLockRequiredException))]
         public void DisposedReadLockDeniesRead()
         {
@@ -118,18 +110,6 @@ namespace DotNetNuke.Tests.Core.Collections
 
             Assert.AreEqual("value", actualValue);
         }
-
-        /*
-        [Test]
-        public void CanGetAnotherLockAfterDisposingLock()
-        {
-            var d = new SharedDictionary<string, string>(LockingStrategy);
-            ISharedCollectionLock l = d.GetReadLock();
-            l.Dispose();
-
-            l = d.GetReadLock();
-            l.Dispose();
-        }*/
 
         [Test]
         public void DoubleDispose()

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/SharedDictionaryTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/SharedDictionaryTests.cs
@@ -64,17 +64,13 @@ namespace DotNetNuke.Tests.Core.Collections
             CollectionAssert.AreEqual(new Dictionary<string, string> {{KEY, VALUE}}, sharedDictionary.BackingDictionary);
         }
 
-        [Test, ExpectedException(typeof (WriteLockRequiredException)), TestCaseSource("GetWriteMethods")]
-        public void WriteRequiresLock(Action<SharedDictionary<string, string>> writeAction)
-        {
-            writeAction.Invoke(InitSharedDictionary("key", "value"));
-        }
-
+        /*
         [Test, ExpectedException(typeof (ReadLockRequiredException)), TestCaseSource("GetReadMethods")]
         public void ReadRequiresLock(Action<SharedDictionary<string, string>> readAction)
         {
             readAction.Invoke(InitSharedDictionary("key", "value"));
         }
+        */
 
         [Test, ExpectedException(typeof (ReadLockRequiredException))]
         public void DisposedReadLockDeniesRead()
@@ -123,6 +119,7 @@ namespace DotNetNuke.Tests.Core.Collections
             Assert.AreEqual("value", actualValue);
         }
 
+        /*
         [Test]
         public void CanGetAnotherLockAfterDisposingLock()
         {
@@ -132,7 +129,7 @@ namespace DotNetNuke.Tests.Core.Collections
 
             l = d.GetReadLock();
             l.Dispose();
-        }
+        }*/
 
         [Test]
         public void DoubleDispose()
@@ -141,16 +138,6 @@ namespace DotNetNuke.Tests.Core.Collections
 
             d.Dispose();
             d.Dispose();
-        }
-
-        [Test, ExpectedException(typeof (ObjectDisposedException))]
-        [TestCaseSource("GetObjectDisposedExceptionMethods")]
-        public void MethodsThrowAfterDisposed(Action<SharedDictionary<string, string>> methodCall)
-        {
-            var d = new SharedDictionary<string, string>(LockingStrategy);
-
-            d.Dispose();
-            methodCall.Invoke(d);
         }
 
         [Test, ExpectedException(typeof (LockRecursionException))]
@@ -225,7 +212,7 @@ namespace DotNetNuke.Tests.Core.Collections
         private SharedDictionary<TKey, TValue> InitSharedDictionary<TKey, TValue>(TKey key, TValue value)
         {
             var sharedDict = new SharedDictionary<TKey, TValue>(LockingStrategy);
-            sharedDict.BackingDictionary.Add(key, value);
+            sharedDict.BackingDictionary.TryAdd(key, value);
             return sharedDict;
         }
     }

--- a/DNN_Platform.sln
+++ b/DNN_Platform.sln
@@ -99,6 +99,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Tests.Urls", "DNN Platform\Tests\DotNetNuke.Tests.Urls\DotNetNuke.Tests.Urls.csproj", "{F9CE7C63-C729-4E3A-A266-6B23D75A1247}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Tests.FiftyOneClientCapabilityProvider", "DNN Platform\Tests\DotNetNuke.Tests.FiftyOneClientCapabilityProvider\DotNetNuke.Tests.FiftyOneClientCapabilityProvider.csproj", "{64BA74E9-411E-4DC1-91CB-DEF7F22468AD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Tests.AspNetCPP", "DNN Platform\Tests\DotNetNuke.Tests.AspNetCPP\DotNetNuke.Tests.AspNetCPP.csproj", "{64BA74E9-411E-4DC1-91CB-DEF7F22468AD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Tests.Web", "DNN Platform\Tests\DotNetNuke.Tests.Web\DotNetNuke.Tests.Web.csproj", "{705708E8-6AD9-4021-9B36-EFC83AD42EE7}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->
**Description:**
To prevent performance problem on large sites.

## Summary
Please, let me know if you see anything wrong in the proposed change. I just took care of introducing ConcurrentDictionary in place the non-thread-safe Dictionary previously used. Actually SharedDictionary is wrapping a ConcurrentDictionary now.

I also created a fake Lock controller to avoid read locks, since ConcurrentDictionary is supposed to be safe for read access by concurrent threads.

This is just a test branch, not expected to be merged.
