### PR TITLE
add new sharpziplib assembly name to ignore list

### DIFF
--- a/DNN Platform/Library/Framework/Reflections/TypeLocator.cs
+++ b/DNN Platform/Library/Framework/Reflections/TypeLocator.cs
@@ -106,7 +106,7 @@ namespace DotNetNuke.Framework.Reflections
                 || assemblyName.StartsWith("icsharpcode") || assemblyName.StartsWith("fiftyone")
                 || assemblyName.StartsWith("lucene") || assemblyName.StartsWith("microsoft")
                 || assemblyName.StartsWith("newtonsoft") || assemblyName.StartsWith("petapoco")
-                || assemblyName.StartsWith("sharpziplib") || assemblyName.StartsWith("system")
+                || assemblyName.StartsWith("sharpziplib")  || assemblyName.StartsWith("icsharpcode.sharpziplib")|| assemblyName.StartsWith("system")
                 || assemblyName.StartsWith("telerik") || assemblyName.StartsWith("webformsmvp")
                 || assemblyName.StartsWith("webmatrix") || assemblyName.StartsWith("solpart")
                 );


### PR DESCRIPTION
## Summary
Added the updated `SharpZipLib` assembly name to the ignore list of assemblies to scan for Dnn features and extension points. 

## Details
In v9.2.0 the assembly was updated but the `CanScan` function wasn't. This pull request updates Dnn to be aware of both assemblies since in v9.2.1 we are attempting to solve the breaking change for any module developers who were directly referencing `SharpLibZip`