### PR TITLE
Adds support for RedirectToAction from a DnnController

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnRedirecttoRouteResult.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnRedirecttoRouteResult.cs
@@ -22,6 +22,8 @@
 using System.Web.Mvc;
 using System.Web.Routing;
 using DotNetNuke.Common;
+using DotNetNuke.Web.Mvc.Framework.Controllers;
+using DotNetNuke.Web.Mvc.Helpers;
 
 namespace DotNetNuke.Web.Mvc.Framework.ActionResults
 {
@@ -34,6 +36,14 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionResults
             ControllerName = controllerName;
         }
 
+        public DnnRedirecttoRouteResult(string actionName, string controllerName, string routeName, RouteValueDictionary routeValues, bool permanent, DnnUrlHelper url)
+            : this(actionName, controllerName, routeName, routeValues, permanent)
+        {
+            Url = url;
+        }
+
+        public DnnUrlHelper Url { get; private set; }
+
         public string ActionName { get; private set; }
 
         public string ControllerName { get; private set; }
@@ -45,8 +55,15 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionResults
             Guard.Against(context.IsChildAction, "Cannot Redirect In Child Action");
 
             string url;
-            //TODO - match other actions
-            url = Globals.NavigateURL();
+            if (Url != null && context.Controller is IDnnController)
+            {
+                url = Url.Action(ActionName, ControllerName);
+            }
+            else
+            {
+                //TODO - match other actions
+                url = Globals.NavigateURL();
+            }
 
             if (Permanent)
             {
@@ -61,3 +78,4 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionResults
         }
     }
 }
+    

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
@@ -56,6 +56,11 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
             get { return (ModuleContext == null) ? null : ModuleContext.PortalSettings; }
         }
 
+        protected override RedirectToRouteResult RedirectToAction(string actionName, string controllerName, RouteValueDictionary routeValues)
+        {
+            return new DnnRedirecttoRouteResult(actionName, controllerName, string.Empty, routeValues, false, Url);
+        }
+
         protected internal RedirectToRouteResult RedirectToDefaultRoute()
         {
             return new DnnRedirecttoRouteResult(String.Empty, String.Empty, String.Empty, null, false);


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
Adds RedirectToAction support in the DnnController to support the additional API. This is a small change but will have a big impact on our MVC API. We updated the DnnController to override the virtual RedirectToAction to properly use our `DnnRedirectToRouteResult` object. All the non-virtual methods rely on this. 

AspNetWebStack Controller class
https://github.com/aspnet/AspNetWebStack/blob/master/src/System.Web.Mvc/Controller.cs
Lines: 478-517

Looking at the Microsoft Controller implementation referenced above the all the non-virtual RedirectToAction rely on the virtual one that we now override in this change.

We also update the `DnnRedirectToRouteResult` to handle the correct Url Mapping. Consider you have 2 DNN MVC Modules on the same page, routing is handled the same way it currently does by passing in the instance of the DnnUrlHelper. This forces the page to appropriately take into account multiple MVC Modules on the current page and apply the correct ModuleId to the Url when generating it.

<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->

Fixes #2170