### PR TITLE
renewal token must be validate before renewing access token.

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
@@ -214,7 +214,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             if (ptoken == null)
             {
                 if (Logger.IsTraceEnabled) Logger.Trace("Token not found in DB");
-                return EmptyWithError("token-not-found");
+                return EmptyWithError("not-found");
             }
 
             if (ptoken.RenewalExpiry <= DateTime.UtcNow)
@@ -226,26 +226,26 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             if (ptoken.RenewalHash != GetHashedStr(renewalToken))
             {
                 if (Logger.IsTraceEnabled) Logger.Trace("Invalid renewal token");
-                return EmptyWithError("bad-renewal-token");
+                return EmptyWithError("bad-token");
             }
 
             if (ptoken.TokenHash != GetHashedStr(rawToken))
             {
                 if (Logger.IsTraceEnabled) Logger.Trace("Invalid access token");
-                return EmptyWithError("bad-access-token");
+                return EmptyWithError("bad-token");
             }
 
             var userInfo = TryGetUser(jwt, false);
             if (userInfo == null)
             {
                 if (Logger.IsTraceEnabled) Logger.Trace("User not found in DB");
-                return EmptyWithError("user-not-found");
+                return EmptyWithError("not-found");
             }
 
             if ((ptoken.UserId != userInfo.UserID))
             {
                 if (Logger.IsTraceEnabled) Logger.Trace("Mismatch token and user");
-                return EmptyWithError("bad-token-user");
+                return EmptyWithError("bad-token");
             }
 
             return UpdateToken(renewalToken, ptoken, userInfo);

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
@@ -164,7 +164,6 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
                 UserId = userInfo.UserID,
                 TokenExpiry = now.AddMinutes(SessionTokenTtl),
                 RenewalExpiry = now.AddDays(RenewalTokenTtl),
-                //TokenHash = GetHashedStr(accessToken), -- not computed yet
                 RenewalHash = GetHashedStr(renewalToken),
             };
 
@@ -215,7 +214,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             if (ptoken == null)
             {
                 if (Logger.IsTraceEnabled) Logger.Trace("Token not found in DB");
-                return EmptyWithError("not-found");
+                return EmptyWithError("token-not-found");
             }
 
             if (ptoken.RenewalExpiry <= DateTime.UtcNow)
@@ -224,17 +223,29 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
                 return EmptyWithError("not-more-renewal");
             }
 
+            if (ptoken.RenewalHash != GetHashedStr(renewalToken))
+            {
+                if (Logger.IsTraceEnabled) Logger.Trace("Invalid renewal token");
+                return EmptyWithError("bad-renewal-token");
+            }
+
+            if (ptoken.TokenHash != GetHashedStr(rawToken))
+            {
+                if (Logger.IsTraceEnabled) Logger.Trace("Invalid access token");
+                return EmptyWithError("bad-access-token");
+            }
+
             var userInfo = TryGetUser(jwt, false);
             if (userInfo == null)
             {
-                if (Logger.IsTraceEnabled) Logger.Trace("Token not found in DB");
-                return EmptyWithError("not-found");
+                if (Logger.IsTraceEnabled) Logger.Trace("User not found in DB");
+                return EmptyWithError("user-not-found");
             }
 
-            if ((ptoken.TokenHash != GetHashedStr(rawToken)) || (ptoken.UserId != userInfo.UserID))
+            if ((ptoken.UserId != userInfo.UserID))
             {
-                if (Logger.IsTraceEnabled) Logger.Trace("Mismatch in received token");
-                return EmptyWithError("bad-token");
+                if (Logger.IsTraceEnabled) Logger.Trace("Mismatch token and user");
+                return EmptyWithError("bad-token-user");
             }
 
             return UpdateToken(renewalToken, ptoken, userInfo);
@@ -254,7 +265,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             var secret = ObtainSecret(ptoken.TokenId, portalSettings.GUID, userInfo.Membership.LastPasswordChangeDate);
             var jwt = CreateJwtToken(secret, portalSettings.PortalAlias.HTTPAlias, ptoken, userInfo.Roles);
             var accessToken = jwt.RawData;
-            
+
             // save hash values in DB so no one with access can create JWT header from existing data
             ptoken.TokenHash = GetHashedStr(accessToken);
             DataProvider.UpdateToken(ptoken);


### PR DESCRIPTION
Fix issue #2133

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
1. renewal token must be validate before renewing access token.
2. making error messages clear