### PR TITLE
Improve user feedback for cleanup node in installer

### DIFF
--- a/DNN Platform/Library/Services/Installer/Installers/CleanupInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/CleanupInstaller.cs
@@ -75,7 +75,7 @@ namespace DotNetNuke.Services.Installer.Installers
             }
             catch (Exception ex)
             {
-                Log.AddWarning(string.Format(Util.CLEANUP_ProcessComplete, ex.Message));
+                Log.AddWarning(string.Format(Util.CLEANUP_ProcessError, ex.Message));
                 //DNN-9202: MUST NOT fail installation when cleanup files deletion fails
                 //return false;
             }

--- a/DNN Platform/Library/Services/Installer/Installers/CleanupInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/CleanupInstaller.cs
@@ -75,7 +75,7 @@ namespace DotNetNuke.Services.Installer.Installers
             }
             catch (Exception ex)
             {
-                Log.AddFailure(ex);
+                Log.AddWarning(string.Format(Util.CLEANUP_ProcessComplete, ex.Message));
                 //DNN-9202: MUST NOT fail installation when cleanup files deletion fails
                 //return false;
             }

--- a/DNN Platform/Library/Services/Installer/Util.cs
+++ b/DNN Platform/Library/Services/Installer/Util.cs
@@ -68,6 +68,7 @@ namespace DotNetNuke.Services.Installer
         public static string AUTHENTICATION_UnRegistered = GetLocalizedString("AUTHENTICATION_UnRegistered");
         public static string CLEANUP_Processing = GetLocalizedString("CLEANUP_Processing");
         public static string CLEANUP_ProcessComplete = GetLocalizedString("CLEANUP_ProcessComplete");
+        public static string CLEANUP_ProcessError = GetLocalizedString("CLEANUP_ProcessError");
         public static string COMPONENT_Installed = GetLocalizedString("COMPONENT_Installed");
         public static string COMPONENT_Skipped = GetLocalizedString("COMPONENT_Skipped");
         public static string COMPONENT_RolledBack = GetLocalizedString("COMPONENT_RolledBack");

--- a/Website/App_GlobalResources/SharedResources.resx
+++ b/Website/App_GlobalResources/SharedResources.resx
@@ -1329,6 +1329,9 @@
   <data name="CLEANUP_ProcessComplete.Text" xml:space="preserve">
     <value>Completed Processing of Cleanup File - {0}</value>
   </data>
+  <data name="CLEANUP_ProcessError.Text" xml:space="preserve">
+    <value>Non Fatal Error Cleaning Up Files: {0}</value>
+  </data>
   <data name="CLEANUP_Processing.Text" xml:space="preserve">
     <value>Processing Cleanup File - {0}</value>
   </data>


### PR DESCRIPTION
Instead of showing an install as having an error, failing to clean up a file/folder should show a warning as it is not fatal to the installation of an extension.

Fix #2206