### PR TITLE
String performance implementation improvements

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Deprecated/UI/WebControls/DnnFormToggleButtonItem.cs
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/UI/WebControls/DnnFormToggleButtonItem.cs
@@ -90,7 +90,7 @@ namespace DotNetNuke.Web.UI.WebControls
                     var stringValue = Value as string;
                     if (stringValue != null)
                     {
-                        _checkBox.Checked = stringValue.ToUpperInvariant().StartsWith("Y");
+                        _checkBox.Checked = stringValue.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase);
                     }
                     break;
                 default:

--- a/DNN Platform/DotNetNuke.Web.Deprecated/UI/WebControls/DnnLanguageComboBox.cs
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/UI/WebControls/DnnLanguageComboBox.cs
@@ -117,7 +117,7 @@ namespace DotNetNuke.Web.UI.WebControls
         {
             get
             {
-                string selectedValue = DisplayMode.ToUpperInvariant() == "NATIVE" ? _nativeCombo.SelectedValue : _englishCombo.SelectedValue;
+                string selectedValue = DisplayMode.Equals("NATIVE", StringComparison.InvariantCultureIgnoreCase) ? _nativeCombo.SelectedValue : _englishCombo.SelectedValue;
                 if (selectedValue == "None")
                 {
                     selectedValue = Null.NullString;
@@ -240,7 +240,7 @@ namespace DotNetNuke.Web.UI.WebControls
 
         protected override void OnPreRender(EventArgs e)
         {
-            if (DisplayMode.ToUpperInvariant() == "ENGLISH")
+            if (DisplayMode.Equals("ENGLISH", StringComparison.InvariantCultureIgnoreCase))
             {
                 if (_englishCombo.Items.FindItemByValue(_originalValue) != null)
                 {
@@ -268,11 +268,11 @@ namespace DotNetNuke.Web.UI.WebControls
 
             _englishCombo.AutoPostBack = AutoPostBack;
             _englishCombo.CausesValidation = CausesValidation;
-            _englishCombo.Visible = (DisplayMode.ToUpperInvariant() == "ENGLISH");
+            _englishCombo.Visible = (DisplayMode.Equals("ENGLISH", StringComparison.InvariantCultureIgnoreCase));
 
             _nativeCombo.AutoPostBack = AutoPostBack;
             _nativeCombo.CausesValidation = CausesValidation;
-            _nativeCombo.Visible = (DisplayMode.ToUpperInvariant() == "NATIVE");
+            _nativeCombo.Visible = (DisplayMode.Equals("NATIVE", StringComparison.InvariantCultureIgnoreCase));
 
             _modeRadioButtonList.Visible = ShowModeButtons;
 

--- a/DNN Platform/DotNetNuke.Web/Common/DotNetNukeShutdownOverload.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/DotNetNukeShutdownOverload.cs
@@ -153,7 +153,7 @@ namespace DotNetNuke.Web.Common.Internal
             if (Logger.IsInfoEnabled && !e.FullPath.EndsWith(".log.resources"))
                 Logger.Info($"Watcher Activity: {e.ChangeType}. Path: {e.FullPath}");
 
-            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").ToLowerInvariant().StartsWith(_binFolder))
+            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").StartsWith(_binFolder, StringComparison.InvariantCultureIgnoreCase))
             {
                 ShceduleShutdown();
             }
@@ -164,7 +164,7 @@ namespace DotNetNuke.Web.Common.Internal
             if (Logger.IsInfoEnabled && !e.FullPath.EndsWith(".log.resources"))
                 Logger.Info($"Watcher Activity: {e.ChangeType}. Path: {e.FullPath}");
 
-            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").ToLowerInvariant().StartsWith(_binFolder))
+            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").StartsWith(_binFolder, StringComparison.InvariantCultureIgnoreCase))
                 ShceduleShutdown();
         }
 
@@ -173,7 +173,7 @@ namespace DotNetNuke.Web.Common.Internal
             if (Logger.IsInfoEnabled && !e.FullPath.EndsWith(".log.resources"))
                 Logger.Info($"Watcher Activity: {e.ChangeType}. New Path: {e.FullPath}. Old Path: {e.OldFullPath}");
 
-            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").ToLowerInvariant().StartsWith(_binFolder))
+            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").StartsWith(_binFolder, StringComparison.InvariantCultureIgnoreCase))
                 ShceduleShutdown();
         }
 
@@ -182,7 +182,7 @@ namespace DotNetNuke.Web.Common.Internal
             if (Logger.IsInfoEnabled && !e.FullPath.EndsWith(".log.resources"))
                 Logger.Info($"Watcher Activity: {e.ChangeType}. Path: {e.FullPath}");
 
-            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").ToLowerInvariant().StartsWith(_binFolder))
+            if (_handleShutdowns && !_shutdownInprogress && (e.FullPath ?? "").StartsWith(_binFolder, StringComparison.InvariantCultureIgnoreCase))
                 ShceduleShutdown();
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFilePicker.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFilePicker.cs
@@ -528,7 +528,7 @@ namespace DotNetNuke.Web.UI.WebControls
 		private bool IsUserFolder(string folderPath)
 		{
             UserInfo user = User ?? UserController.Instance.GetCurrentUserInfo();
-            return (folderPath.ToLowerInvariant().StartsWith("users/") && folderPath.EndsWith(string.Format("/{0}/", user.UserID)));
+            return (folderPath.StartsWith("users/", StringComparison.InvariantCultureIgnoreCase) && folderPath.EndsWith(string.Format("/{0}/", user.UserID)));
 		}
 
 		private void LoadFiles()

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnUrlControl.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnUrlControl.cs
@@ -458,7 +458,7 @@ namespace DotNetNuke.Web.UI.WebControls
                         else
                         {
                             string mCustomUrl = txtUrl.Text;
-                            if (mCustomUrl.ToLowerInvariant() == "http://")
+                            if (mCustomUrl.Equals("http://", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 r = "";
                             }
@@ -589,7 +589,7 @@ namespace DotNetNuke.Web.UI.WebControls
                 ViewState["UrlType"] = _Urltype;
                 if (_Urltype == "F")
                 {
-                    if (_Url.ToLowerInvariant().StartsWith("fileid="))
+                    if (_Url.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase))
                     {
                         TrackingUrl = _Url;
                         var objFile = FileManager.Instance.GetFile(int.Parse(_Url.Substring(7)));
@@ -618,7 +618,7 @@ namespace DotNetNuke.Web.UI.WebControls
                 }
                 if (_Urltype == "M")
                 {
-                    if (_Url.ToLowerInvariant().StartsWith("userid="))
+                    if (_Url.StartsWith("userid=", StringComparison.InvariantCultureIgnoreCase))
                     {
                         UserInfo objUser = UserController.GetUserById(_objPortal.PortalID, int.Parse(_Url.Substring(7)));
                         if (objUser != null)

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/Internal/DnnFormToggleButtonItem.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/Internal/DnnFormToggleButtonItem.cs
@@ -92,7 +92,7 @@ namespace DotNetNuke.Web.UI.WebControls.Internal
                     var stringValue = Value as string;
                     if (stringValue != null)
                     {
-                        _checkBox.Checked = stringValue.ToUpperInvariant().StartsWith("Y");
+                        _checkBox.Checked = stringValue.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase);
                     }
                     break;
                 default:

--- a/DNN Platform/DotNetNuke.WebUtility/ClientAPI.vb
+++ b/DNN Platform/DotNetNuke.WebUtility/ClientAPI.vb
@@ -557,7 +557,7 @@ Namespace DotNetNuke.UI.Utilities
         End Function
 
         Public Shared Function IsInCallback(ByVal objPage As Page) As Boolean
-            Return Len(objPage.Request(SCRIPT_CALLBACKID)) > 0 AndAlso objPage.Request.HttpMethod.ToUpper() = "POST"
+            Return Len(objPage.Request(SCRIPT_CALLBACKID)) > 0 AndAlso objPage.Request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase)
         End Function
 
         Public Shared Sub HandleClientAPICallbackEvent(ByVal objPage As Page)

--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -186,7 +186,7 @@ namespace DotNetNuke.HttpModules.Membership
                 //authenticate user and set last login ( this is necessary for users who have a permanent Auth cookie set ) 
                 if (user == null || user.IsDeleted || user.Membership.LockedOut
                     || (!user.Membership.Approved && !user.IsInRole("Unverified Users"))
-                    || user.Username.ToLower() != context.User.Identity.Name.ToLower())
+                    || !user.Username.Equals(context.User.Identity.Name, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var portalSecurity = PortalSecurity.Instance;
                     portalSecurity.SignOut();

--- a/DNN Platform/HttpModules/OutputCaching/OutputCacheModule.cs
+++ b/DNN Platform/HttpModules/OutputCaching/OutputCacheModule.cs
@@ -69,7 +69,7 @@ namespace DotNetNuke.HttpModules.OutputCaching
         private void OnResolveRequestCache(object sender, EventArgs e)
         {
             bool cached = false;
-            if (_app == null || _app.Context == null || _app.Response.ContentType.ToLowerInvariant() != "text/html" || _app.Context.Request.IsAuthenticated || _app.Context.Request.Browser.Crawler)
+            if (_app == null || _app.Context == null || !_app.Response.ContentType.Equals("text/html", StringComparison.InvariantCultureIgnoreCase) || _app.Context.Request.IsAuthenticated || _app.Context.Request.Browser.Crawler)
             {
                 return;
             }
@@ -79,7 +79,7 @@ namespace DotNetNuke.HttpModules.OutputCaching
                 return;
             }
 
-            if (_app.Context.Request.RequestType == "POST" || ! (_app.Context.Request.Url.LocalPath.ToLowerInvariant().EndsWith(Globals.glbDefaultPage.ToLowerInvariant())))
+            if (_app.Context.Request.RequestType == "POST" || ! (_app.Context.Request.Url.LocalPath.EndsWith(Globals.glbDefaultPage, StringComparison.InvariantCultureIgnoreCase)))
             {
                 return;
             }

--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -3374,7 +3374,7 @@ namespace DotNetNuke.Common
             else if (TrackClicks || ForceDownload || UrlType == TabType.File)
             {
                 //format LinkClick wrapper
-                if (Link.ToLowerInvariant().StartsWith("fileid="))
+                if (Link.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase))
                 {
                     strLink = ApplicationPath + "/LinkClick.aspx?fileticket=" + UrlUtils.EncryptParameter(UrlUtils.GetParameterValue(Link), portalGuid);
                     if (PortalId == Null.NullInteger) //To track Host files
@@ -3889,7 +3889,7 @@ namespace DotNetNuke.Common
                     strExtension = File.Substring(File.LastIndexOf(".") + 1);
                 }
                 string FileName = File.Substring(CurrentDirectory.FullName.Length);
-                if (strExtensions.ToUpper().IndexOf(strExtension.ToUpper()) != -1 || string.IsNullOrEmpty(strExtensions))
+                if (strExtensions.IndexOf(strExtension, StringComparison.InvariantCultureIgnoreCase) != -1 || string.IsNullOrEmpty(strExtensions))
                 {
                     arrFileList.Add(new FileItem(FileName, FileName));
                 }

--- a/DNN Platform/Library/Common/Internal/GlobalsImpl.cs
+++ b/DNN Platform/Library/Common/Internal/GlobalsImpl.cs
@@ -124,9 +124,9 @@ namespace DotNetNuke.Common.Internal
                         //   - and to do that, we need to ensure the string we test against is long enough;
                         if ((url[queryIndex].Length >= ".aspx".Length))
                         {
-                            if (url[queryIndex].ToLowerInvariant().LastIndexOf(".aspx", StringComparison.Ordinal) == (url[queryIndex].Length - (".aspx".Length)) ||
-                                url[queryIndex].ToLowerInvariant().LastIndexOf(".axd", StringComparison.Ordinal) == (url[queryIndex].Length - (".axd".Length)) ||
-                                url[queryIndex].ToLowerInvariant().LastIndexOf(".ashx", StringComparison.Ordinal) == (url[queryIndex].Length - (".ashx".Length)))
+                            if (url[queryIndex].LastIndexOf(".aspx", StringComparison.OrdinalIgnoreCase) == (url[queryIndex].Length - (".aspx".Length)) ||
+                                url[queryIndex].LastIndexOf(".axd", StringComparison.OrdinalIgnoreCase) == (url[queryIndex].Length - (".axd".Length)) ||
+                                url[queryIndex].LastIndexOf(".ashx", StringComparison.OrdinalIgnoreCase) == (url[queryIndex].Length - (".ashx".Length)))
                             {
                                 break;
                             }

--- a/DNN Platform/Library/Common/Utilities/CBO.cs
+++ b/DNN Platform/Library/Common/Utilities/CBO.cs
@@ -147,8 +147,8 @@ namespace DotNetNuke.Common.Utilities
                         {
                             keyValue = (TKey) Convert.ChangeType(Null.SetNull(dr[keyField], keyValue), typeof (TKey));
                         }
-                        else if (typeof (TKey).Name.ToLowerInvariant() == "string" &&
-                                 dr[keyField].GetType().Name.ToLowerInvariant() == "dbnull")
+                        else if (typeof (TKey).Name.Equals("string", StringComparison.OrdinalIgnoreCase) &&
+                                 dr[keyField].GetType().Name.Equals("dbnull", StringComparison.OrdinalIgnoreCase))
                         {
                             keyValue = (TKey) Convert.ChangeType(Null.SetNull(dr[keyField], ""), typeof (TKey));
                         }

--- a/DNN Platform/Library/Common/Utilities/ImageUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/ImageUtils.cs
@@ -212,7 +212,7 @@ namespace DotNetNuke.Common.Utilities
                         canvas.InterpolationMode = InterpolationMode.HighQualityBicubic;
                         canvas.PixelOffsetMode = PixelOffsetMode.HighQuality;
 
-                        if (extension.ToLowerInvariant() != ".png")
+                        if (!extension.Equals(".png", StringComparison.InvariantCultureIgnoreCase))
                         {
                             canvas.Clear(Color.White);
                             canvas.FillRectangle(Brushes.White, 0, 0, imgSize.Width, imgSize.Height);
@@ -222,15 +222,15 @@ namespace DotNetNuke.Common.Utilities
 
                         //newImg.Save
                         ImageFormat imgFormat = ImageFormat.Bmp;
-                        if (extension.ToLowerInvariant() == ".png")
+                        if (extension.Equals(".png", StringComparison.InvariantCultureIgnoreCase))
                         {
                             imgFormat = ImageFormat.Png;
                         }
-                        else if (extension.ToLowerInvariant() == ".gif")
+                        else if (extension.Equals(".gif", StringComparison.InvariantCultureIgnoreCase))
                         {
                             imgFormat = ImageFormat.Gif;
                         }
-                        else if (extension.ToLowerInvariant() == ".jpg")
+                        else if (extension.Equals(".jpg", StringComparison.InvariantCultureIgnoreCase))
                         {
                             imgFormat = ImageFormat.Jpeg;
                         }

--- a/DNN Platform/Library/Common/Utilities/PathUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/PathUtils.cs
@@ -205,10 +205,10 @@ namespace DotNetNuke.Common.Utilities
         public virtual bool IsDefaultProtectedPath(string folderPath)
         {
             return String.IsNullOrEmpty(folderPath) ||
-                   folderPath.ToLowerInvariant() == "skins" ||
-                   folderPath.ToLowerInvariant() == "containers" ||
-                   folderPath.ToLowerInvariant().StartsWith("skins/") ||
-                   folderPath.ToLowerInvariant().StartsWith("containers/");
+                   folderPath.Equals("skins", StringComparison.InvariantCultureIgnoreCase) ||
+                   folderPath.Equals("containers", StringComparison.InvariantCultureIgnoreCase) ||
+                   folderPath.StartsWith("skins/", StringComparison.InvariantCultureIgnoreCase) ||
+                   folderPath.StartsWith("containers/", StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>

--- a/DNN Platform/Library/Common/Utilities/UrlController.cs
+++ b/DNN Platform/Library/Common/Utilities/UrlController.cs
@@ -88,7 +88,7 @@ namespace DotNetNuke.Common.Utilities
         public void UpdateUrlTracking(int PortalID, string Url, int ModuleId, int UserID)
         {
             TabType UrlType = Globals.GetURLType(Url);
-            if (UrlType == TabType.File && Url.ToLowerInvariant().StartsWith("fileid=") == false)
+            if (UrlType == TabType.File && Url.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase) == false)
             {
 				//to handle legacy scenarios before the introduction of the FileServerHandler
                 var fileName = Path.GetFileName(Url);

--- a/DNN Platform/Library/Common/Utilities/UrlUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/UrlUtils.cs
@@ -139,7 +139,7 @@ namespace DotNetNuke.Common.Utilities
                             //skip parameter
                             break;
                         default:
-                            if ((keys[i].ToLowerInvariant() == "portalid") && Globals.GetPortalSettings().ActiveTab.IsSuperTab)
+                            if ((keys[i].Equals("portalid", StringComparison.InvariantCultureIgnoreCase)) && Globals.GetPortalSettings().ActiveTab.IsSuperTab)
                             {
                                 //skip parameter
                                 //navigateURL adds portalid to querystring if tab is superTab

--- a/DNN Platform/Library/Data/SqlDataProvider.cs
+++ b/DNN Platform/Library/Data/SqlDataProvider.cs
@@ -1,6 +1,6 @@
 #region Copyright
 // 
-// DotNetNuke® - http://www.dotnetnuke.com
+// DotNetNukeÂ® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2018
 // by DotNetNuke Corporation
 // 
@@ -199,7 +199,7 @@ namespace DotNetNuke.Data
             string DBUser = "public";
 
             //If connection string does not use integrated security, then get user id.
-            //Normalize to uppervase before all of the comparisons
+            //Normalize to uppercase before all of the comparisons
             var connectionStringUppercase = ConnectionString.ToUpper();
             if (connectionStringUppercase.Contains("USER ID") || connectionStringUppercase.Contains("UID") || connectionStringUppercase.Contains("USER"))
             {

--- a/DNN Platform/Library/Data/SqlDataProvider.cs
+++ b/DNN Platform/Library/Data/SqlDataProvider.cs
@@ -199,16 +199,18 @@ namespace DotNetNuke.Data
             string DBUser = "public";
 
             //If connection string does not use integrated security, then get user id.
-            if (ConnectionString.ToUpper().Contains("USER ID") || ConnectionString.ToUpper().Contains("UID") || ConnectionString.ToUpper().Contains("USER"))
+            //Normalize to uppervase before all of the comparisons
+            var connectionStringUppercase = ConnectionString.ToUpper();
+            if (connectionStringUppercase.Contains("USER ID") || connectionStringUppercase.Contains("UID") || connectionStringUppercase.Contains("USER"))
             {
-                string[] ConnSettings = ConnectionString.Split(';');
+                string[] ConnSettings = connectionStringUppercase.Split(';');
 
                 foreach (string s in ConnSettings)
                 {
                     if (s != string.Empty)
                     {
                         string[] ConnSetting = s.Split('=');
-                        if ("USER ID|UID|USER".Contains(ConnSetting[0].Trim().ToUpper()))
+                        if ("USER ID|UID|USER".Contains(ConnSetting[0].Trim()))
                         {
                             DBUser = ConnSetting[1].Trim();
                         }
@@ -387,7 +389,7 @@ namespace DotNetNuke.Data
             string exceptions = ExecuteScriptInternal(UpgradeConnectionString, script, timeoutSec);
 
             //if the upgrade connection string is specified or or db_owner setting is not set to dbo
-            if (UpgradeConnectionString != ConnectionString || DatabaseOwner.Trim().ToLowerInvariant() != "dbo.")
+            if (UpgradeConnectionString != ConnectionString || !DatabaseOwner.Trim().Equals("dbo.", StringComparison.InvariantCultureIgnoreCase))
             {
                 try
                 {

--- a/DNN Platform/Library/Entities/Controllers/HostController.cs
+++ b/DNN Platform/Library/Entities/Controllers/HostController.cs
@@ -102,7 +102,7 @@ namespace DotNetNuke.Entities.Controllers
                 }
                 else
                 {
-                    retValue = (setting.ToUpperInvariant().StartsWith("Y") || setting.ToUpperInvariant() == "TRUE");
+                    retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.Equals("TRUE", StringComparison.InvariantCultureIgnoreCase));
                 }
             }
             catch (Exception exc)

--- a/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
@@ -121,7 +121,7 @@ namespace DotNetNuke.Entities.Modules
                             var commonValue = reader.GetAttribute("common");
                             if (!string.IsNullOrEmpty(commonValue))
                             {
-                                IsCommon = commonValue.ToLowerInvariant() == "true";
+                                IsCommon = commonValue.Equals("true", StringComparison.InvariantCultureIgnoreCase);
                             }
 
                             reader.Read();

--- a/DNN Platform/Library/Entities/Modules/ModuleControlController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleControlController.cs
@@ -134,7 +134,7 @@ namespace DotNetNuke.Entities.Modules
         public static ModuleControlInfo GetModuleControlByControlKey(string controlKey, int moduleDefID)
         {
             return (from kvp in GetModuleControls()
-                    where kvp.Value.ControlKey.ToLowerInvariant() == controlKey.ToLowerInvariant() 
+                    where kvp.Value.ControlKey.Equals(controlKey, StringComparison.InvariantCultureIgnoreCase)
                                 && kvp.Value.ModuleDefID == moduleDefID
                     select kvp.Value)
                    .FirstOrDefault();

--- a/DNN Platform/Library/Entities/Modules/UserModuleBase.cs
+++ b/DNN Platform/Library/Entities/Modules/UserModuleBase.cs
@@ -128,7 +128,7 @@ namespace DotNetNuke.Entities.Modules
                 if (Request.QueryString["ctl"] != null)
                 {
                     string ctl = Request.QueryString["ctl"];
-                    if (ctl.ToLowerInvariant() == "edit")
+                    if (ctl.Equals("edit", StringComparison.InvariantCultureIgnoreCase))
                     {
                         _IsEdit = true;
                     }
@@ -161,7 +161,7 @@ namespace DotNetNuke.Entities.Modules
                         if (Request.QueryString["ctl"] != null)
                         {
                             string ctl = Request.QueryString["ctl"];
-                            if (ctl.ToLowerInvariant() == "profile")
+                            if (ctl.Equals("profile", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 _IsProfile = true;
                             }

--- a/DNN Platform/Library/Entities/Portals/PortalAliasController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasController.cs
@@ -89,7 +89,7 @@ namespace DotNetNuke.Entities.Portals
             //domain.com and www.domain.com should be synonymous
             if (portalAlias == null)
             {
-                if (httpAlias.ToLowerInvariant().StartsWith("www."))
+                if (httpAlias.StartsWith("www.", StringComparison.InvariantCultureIgnoreCase))
                 {
                     //try alias without the "www." prefix
                     strPortalAlias = httpAlias.Replace("www.", "");

--- a/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
@@ -83,7 +83,7 @@ namespace DotNetNuke.Entities.Portals
             HTTPAlias = Null.SetNullString(dr["HTTPAlias"]);
             IsPrimary = Null.SetNullBoolean(dr["IsPrimary"]);
             var browserType = Null.SetNullString(dr["BrowserType"]);
-            BrowserType = String.IsNullOrEmpty(browserType) || browserType.ToLowerInvariant() == "normal"
+            BrowserType = String.IsNullOrEmpty(browserType) || browserType.Equals("normal", StringComparison.OrdinalIgnoreCase)
                               ? BrowserTypes.Normal
                               : BrowserTypes.Mobile;
             CultureCode = Null.SetNullString(dr["CultureCode"]);
@@ -132,7 +132,7 @@ namespace DotNetNuke.Entities.Portals
                         break;
                     case "browserType":
                         string type = reader.ReadElementContentAsString();
-                        BrowserType = type.ToLowerInvariant() == "mobile" ? BrowserTypes.Mobile : BrowserTypes.Normal;
+                        BrowserType = type.Equals("mobile", StringComparison.InvariantCultureIgnoreCase) ? BrowserTypes.Mobile : BrowserTypes.Normal;
                         break;
                     case "primary":
                         IsPrimary = reader.ReadElementContentAsBoolean();

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1012,7 +1012,7 @@ namespace DotNetNuke.Entities.Portals
                 }
                 else
                 {
-                    retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.ToUpperInvariant() == "TRUE");
+                    retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.Equals("TRUE", StringComparison.InvariantCultureIgnoreCase));
                 }
             }
             catch (Exception exc)
@@ -3104,7 +3104,7 @@ namespace DotNetNuke.Entities.Portals
                 }
                 else
                 {
-                    retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.ToUpperInvariant() == "TRUE");
+                    retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.Equals("TRUE", StringComparison.InvariantCultureIgnoreCase));
                 }
             }
             catch (Exception exc)
@@ -3135,7 +3135,7 @@ namespace DotNetNuke.Entities.Portals
 				}
 				else
 				{
-					retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.ToUpperInvariant() == "TRUE");
+					retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.Equals("TRUE", StringComparison.InvariantCultureIgnoreCase));
 				}
 			}
 			catch (Exception exc)

--- a/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettingsController.cs
@@ -280,20 +280,20 @@ namespace DotNetNuke.Entities.Portals
 
             portalSettings.ControlPanelSecurity = PortalSettings.ControlPanelPermission.ModuleEditor;
             string setting = settings.GetValueOrDefault("ControlPanelSecurity", "");
-            if (setting.ToUpperInvariant() == "TAB")
+            if (setting.Equals("TAB", StringComparison.InvariantCultureIgnoreCase))
             {
                 portalSettings.ControlPanelSecurity = PortalSettings.ControlPanelPermission.TabEditor;
             }
 
             portalSettings.DefaultControlPanelMode = PortalSettings.Mode.View;
             setting = settings.GetValueOrDefault("ControlPanelMode", "");
-            if (setting.ToUpperInvariant() == "EDIT")
+            if (setting.Equals("EDIT", StringComparison.InvariantCultureIgnoreCase))
             {
                 portalSettings.DefaultControlPanelMode = PortalSettings.Mode.Edit;
             }
 
             setting = settings.GetValueOrDefault("ControlPanelVisibility", "");
-            portalSettings.DefaultControlPanelVisibility = setting.ToUpperInvariant() != "MIN";
+            portalSettings.DefaultControlPanelVisibility = !setting.Equals("MIN", StringComparison.InvariantCultureIgnoreCase);
 
             setting = settings.GetValueOrDefault("TimeZone", "");
             if (!string.IsNullOrEmpty(setting))

--- a/DNN Platform/Library/Entities/Tabs/TabCollection.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabCollection.cs
@@ -142,10 +142,11 @@ namespace DotNetNuke.Entities.Tabs
         {
             List<TabInfo> localizedTabCollection;
 
-            if (!_localizedTabs.TryGetValue(cultureCode.ToLowerInvariant(), out localizedTabCollection))
+            var key = cultureCode.ToLowerInvariant();
+            if (!_localizedTabs.TryGetValue(key, out localizedTabCollection))
             {
                 localizedTabCollection = new List<TabInfo>();
-                _localizedTabs.Add(cultureCode.ToLowerInvariant(), localizedTabCollection);
+                _localizedTabs.Add(key, localizedTabCollection);
             }
 
             //Add tab to end of localized tabs

--- a/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
@@ -229,11 +229,11 @@ namespace DotNetNuke.Entities.Urls
         private static string CheckForDebug(HttpRequest request)
         {
             string debugValue = "";
-            const string debugToken = "_fugdebug";
+            const string debugToken = "_FUGDEBUG";
             //798 : change reference to debug parameters
             if (request != null)
             {
-                debugValue = (request.Params.Get("HTTP_" + debugToken.ToUpper()));
+                debugValue = (request.Params.Get("HTTP_" + debugToken));
             }
             if (debugValue == null)
             {
@@ -717,7 +717,7 @@ namespace DotNetNuke.Entities.Urls
                         //Add name part of name/value pair 
                         if (friendlyPath.EndsWith("/"))
                         {
-                            if (pair[0].ToLowerInvariant() == "tabid") //always lowercase the tabid part of the path
+                            if (pair[0].Equals("tabid", StringComparison.InvariantCultureIgnoreCase)) //always lowercase the tabid part of the path
                             {
                                 pathToAppend = pathToAppend + pair[0].ToLowerInvariant();
                             }
@@ -902,10 +902,10 @@ namespace DotNetNuke.Entities.Urls
             string result = friendlyPath;
             //821 : new 'CustomOnly' setting which allows keeping base Urls but also using Custom Urls.  Basically keeps search friendly 
             //but allows for customised urls and redirects
-            bool customOnly = settings.UrlFormat.ToLowerInvariant() == "customonly";
+            bool customOnly = settings.UrlFormat.Equals("customonly", StringComparison.InvariantCultureIgnoreCase);
             FriendlyUrlOptions options = UrlRewriterUtils.GetOptionsFromSettings(settings);
             //determine if an improved friendly Url is wanted at all
-            if ((settings.UrlFormat.ToLowerInvariant() == "advanced" || customOnly) && !RewriteController.IsExcludedFromFriendlyUrls(tab, settings, false))
+            if ((settings.UrlFormat.Equals("advanced", StringComparison.InvariantCultureIgnoreCase) || customOnly) && !RewriteController.IsExcludedFromFriendlyUrls(tab, settings, false))
             {
                 string newTabPath;
                 string customHttpAlias;

--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -316,7 +316,7 @@ namespace DotNetNuke.Entities.Urls
 
                         //Check if we have a standard url
                         var uri = new Uri(fullUrl);
-                        if (uri.PathAndQuery.ToLowerInvariant().StartsWith("/" + Globals.glbDefaultPage.ToLowerInvariant()))
+                        if (uri.PathAndQuery.StartsWith("/" + Globals.glbDefaultPage, StringComparison.InvariantCultureIgnoreCase))
                         {
                             result.DoRewrite = true;
                             result.Action = ActionType.CheckFor301;
@@ -1701,7 +1701,7 @@ namespace DotNetNuke.Entities.Urls
                                 if (!triedWWW)
                                 {
                                     triedWWW = true; //now tried adding/removing www
-                                    if (checkAlias.ToLowerInvariant().StartsWith("www."))
+                                    if (checkAlias.StartsWith("www.", StringComparison.InvariantCultureIgnoreCase))
                                     {
                                         checkAlias = checkAlias.Substring(4);
                                     }
@@ -2087,7 +2087,7 @@ namespace DotNetNuke.Entities.Urls
 
             if (result.PortalId == -1)
             {
-                if (!requestUri.LocalPath.ToLowerInvariant().EndsWith(Globals.glbDefaultPage.ToLowerInvariant()))
+                if (!requestUri.LocalPath.EndsWith(Globals.glbDefaultPage, StringComparison.InvariantCultureIgnoreCase))
                 {
                     // allows requests for aspx pages in custom folder locations to be processed 
                     return;
@@ -2288,7 +2288,7 @@ namespace DotNetNuke.Entities.Urls
 
         private static string MakeUrlWithAlias(Uri requestUri, string httpAlias)
         {
-            return requestUri.AbsoluteUri.ToLowerInvariant().StartsWith("https://")
+            return requestUri.AbsoluteUri.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase)
                              ? "https://" + httpAlias.Replace("*.", "") + "/"
                              : "http://" + httpAlias.Replace("*.", "") + "/";
         }
@@ -2338,8 +2338,9 @@ namespace DotNetNuke.Entities.Urls
 
         private static bool IgnoreRequestForWebServer(string requestedPath)
         {
-            if (requestedPath.ToLowerInvariant().IndexOf("synchronizecache.aspx", StringComparison.Ordinal) > 1
-                || requestedPath.EndsWith("keepalive.aspx", true, CultureInfo.InvariantCulture))
+            //Should standardize comparison methods
+            if (requestedPath.IndexOf("synchronizecache.aspx", StringComparison.OrdinalIgnoreCase) > 1
+                || requestedPath.EndsWith("keepalive.aspx", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -2404,7 +2405,7 @@ namespace DotNetNuke.Entities.Urls
                 //ignore all install requests
                 retVal = true;
             }
-            else if (request != null && request.Path.ToLowerInvariant().EndsWith("imagechallenge.captcha.aspx"))
+            else if (request != null && request.Path.EndsWith("imagechallenge.captcha.aspx", StringComparison.InvariantCultureIgnoreCase))
             {
                 retVal = true;
             }
@@ -2661,7 +2662,7 @@ namespace DotNetNuke.Entities.Urls
                             if (requestedUrlAliasEnd > Null.NullInteger)
                             {
                                 //818 : when a site root is used for a custom page Url, then check for max length within bounds
-                                if ((requestedUrl.Length - requestedUrlAliasEnd) >= 12 && requestedUrl.Substring(requestedUrlAliasEnd).ToLowerInvariant() == "default.aspx")
+                                if ((requestedUrl.Length - requestedUrlAliasEnd) >= 12 && requestedUrl.Substring(requestedUrlAliasEnd).Equals("default.aspx", StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     requestedUrl = requestedUrl.Substring(0, requestedUrl.Length - 12);
                                     //12 = default.aspx length

--- a/DNN Platform/Library/Entities/Urls/RedirectController.cs
+++ b/DNN Platform/Library/Entities/Urls/RedirectController.cs
@@ -239,7 +239,7 @@ namespace DotNetNuke.Entities.Urls
                                             //remove the tabid/xx from the path
                                             break; //that's it, we're finished
                                         }
-                                        if (parmPart.ToLowerInvariant() == "tabid")
+                                        if (parmPart.Equals("tabid", StringComparison.InvariantCultureIgnoreCase))
                                         {
                                             tabIdNext = true;
                                         }

--- a/DNN Platform/Library/Entities/Urls/RewriteController.cs
+++ b/DNN Platform/Library/Entities/Urls/RewriteController.cs
@@ -149,7 +149,7 @@ namespace DotNetNuke.Entities.Urls
                 }
 
                 if (settings.RedirectDefaultPage
-                    && url.ToLowerInvariant().EndsWith("/" + defaultPage)
+                    && url.EndsWith("/" + defaultPage, StringComparison.InvariantCultureIgnoreCase)
                     && result.RedirectAllowed)
                 {
                     result.Reason = RedirectReason.Site_Root_Home;
@@ -325,7 +325,7 @@ namespace DotNetNuke.Entities.Urls
             }
             if (lastPath >= 0)
             {
-                int defaultStart = tabKeyVal.ToLowerInvariant().IndexOf("default", lastPath, StringComparison.Ordinal);
+                int defaultStart = tabKeyVal.IndexOf("default", lastPath, StringComparison.OrdinalIgnoreCase);
                 //no .aspx on the end anymore
                 if (defaultStart > 0 && defaultStart > lastPath)
                 //there is a default in the path, and it's not the entire path (ie pagnamedefault and not default)
@@ -719,14 +719,14 @@ namespace DotNetNuke.Entities.Urls
             string result = value;
             string ext = extension.ToLowerInvariant();
             replaced = false;
-            if (result.ToLowerInvariant().EndsWith(ext) && ext != "")
+            if (result.EndsWith(ext, StringComparison.InvariantCultureIgnoreCase) && ext != "")
             {
                 result = result.Substring(0, result.Length - ext.Length);
                 replaced = true;
             }
             else
             {
-                if (result.ToLowerInvariant().EndsWith(".aspx"))
+                if (result.EndsWith(".aspx", StringComparison.InvariantCultureIgnoreCase))
                 {
                     result = result.Substring(0, result.Length - 5);
                     replaced = true;
@@ -738,7 +738,7 @@ namespace DotNetNuke.Entities.Urls
                     {
                         //safely remove .aspx from the language path without doing a full .aspx -> "" replace on the entire path
                         if (string.IsNullOrEmpty(result) == false &&
-                            result.ToLowerInvariant().EndsWith(".aspx" + langParms.ToLowerInvariant()))
+                            result.EndsWith(".aspx" + langParms, StringComparison.InvariantCultureIgnoreCase))
                         {
                             result = result.Substring(0, result.Length - (5 + langParms.Length)) + langParms;
                             replaced = true;
@@ -1333,7 +1333,7 @@ namespace DotNetNuke.Entities.Urls
                             for (var x = 1; x <= urlParams.Length - 1; x++)
                             {
                                 if (urlParams[x].Trim().Length > 0 &&
-                                    urlParams[x].ToLowerInvariant() != Globals.glbDefaultPage.ToLowerInvariant())
+                                    !urlParams[x].Equals(Globals.glbDefaultPage, StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     rewritePath = rewritePath + "&" + urlParams[x].Replace(".aspx", "").Trim() + "=";
                                     if ((x < (urlParams.Length - 1)))
@@ -1382,7 +1382,7 @@ namespace DotNetNuke.Entities.Urls
                                                     Guid parentTraceId)
         {
             string scheme = result.Scheme;
-            if (absoluteUri.ToLowerInvariant().StartsWith(scheme))
+            if (absoluteUri.StartsWith(scheme, StringComparison.InvariantCultureIgnoreCase))
             {
                 absoluteUri = absoluteUri.Substring(scheme.Length);
             }
@@ -1603,9 +1603,9 @@ namespace DotNetNuke.Entities.Urls
                 {
                     string thisParm = urlParms[i];
                     //here's the thing - we either take the last one and put it at the start, or just go two-by-two 
-                    if (thisParm.ToLowerInvariant() != Globals.glbDefaultPage.ToLowerInvariant())
+                    if (!thisParm.Equals(Globals.glbDefaultPage, StringComparison.InvariantCultureIgnoreCase))
                     {
-                        if (thisParm.ToLowerInvariant() == "tabid")
+                        if (thisParm.Equals("tabid", StringComparison.InvariantCultureIgnoreCase))
                         {
                             skip = true;
                             //discovering the tabid in the list of parameters means that 

--- a/DNN Platform/Library/Entities/Urls/TabIndexController.cs
+++ b/DNN Platform/Library/Entities/Urls/TabIndexController.cs
@@ -957,7 +957,7 @@ namespace DotNetNuke.Entities.Urls
                 string escapedAlias = Regex.Escape(plainAlias);
                 var aliasesToAdd = new List<string> { escapedAlias };
                 //check for existence of www. version of domain, if it doesn't have a www.
-                if (plainAlias.ToLowerInvariant().StartsWith("www."))
+                if (plainAlias.StartsWith("www.", StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (plainAlias.Length > 4)
                     {

--- a/DNN Platform/Library/Entities/Users/Membership/MembershipPropertyAccess.cs
+++ b/DNN Platform/Library/Entities/Users/Membership/MembershipPropertyAccess.cs
@@ -46,7 +46,7 @@ namespace DotNetNuke.Entities.Users
             bool UserQueriesHimself = (objUser.UserID == AccessingUser.UserID && objUser.UserID != -1);
             if (CurrentScope < Scope.DefaultSettings || (CurrentScope == Scope.DefaultSettings && !UserQueriesHimself) ||
                 ((CurrentScope != Scope.SystemMessages || objUser.IsSuperUser) 
-                    && (propertyName.ToLowerInvariant() == "password" || propertyName.ToLowerInvariant() == "passwordanswer" || propertyName.ToLowerInvariant() == "passwordquestion")
+                    && (propertyName.Equals("password", StringComparison.InvariantCultureIgnoreCase) || propertyName.Equals("passwordanswer", StringComparison.InvariantCultureIgnoreCase) || propertyName.Equals("passwordquestion", StringComparison.InvariantCultureIgnoreCase))
                 ))
             {
                 PropertyNotFound = true;

--- a/DNN Platform/Library/Entities/Users/Profile/ProfilePropertyAccess.cs
+++ b/DNN Platform/Library/Entities/Users/Profile/ProfilePropertyAccess.cs
@@ -154,7 +154,7 @@ namespace DotNetNuke.Entities.Users
             {
                 var profile = user.Profile;
                 var property = profile.ProfileProperties.Cast<ProfilePropertyDefinition>()
-                                                        .SingleOrDefault(p => p.PropertyName.ToLower() == propertyName.ToLower());
+                                                        .SingleOrDefault(p => String.Equals(p.PropertyName, propertyName, StringComparison.CurrentCultureIgnoreCase));
 
                 if(property != null)
                 {
@@ -196,7 +196,7 @@ namespace DotNetNuke.Entities.Users
         public static string GetRichValue(ProfilePropertyDefinition property, string formatString, CultureInfo formatProvider)
         {
             string result = "";
-            if (!String.IsNullOrEmpty(property.PropertyValue) || DisplayDataType(property).ToLowerInvariant() == "image")
+            if (!String.IsNullOrEmpty(property.PropertyValue) || DisplayDataType(property).Equals("image", StringComparison.InvariantCultureIgnoreCase))
             {
                 switch (DisplayDataType(property).ToLowerInvariant())
                 {

--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -176,9 +176,9 @@ namespace DotNetNuke.Entities.Users
             {
                 foreach (PermissionInfo permission in PermissionController.GetPermissionsByFolder())
                 {
-                    if (permission.PermissionKey.ToUpper() == "READ"
-                            || permission.PermissionKey.ToUpper() == "WRITE"
-                            || permission.PermissionKey.ToUpper() == "BROWSE")
+                    if (permission.PermissionKey.Equals("READ", StringComparison.OrdinalIgnoreCase)
+                            || permission.PermissionKey.Equals("WRITE", StringComparison.OrdinalIgnoreCase)
+                            || permission.PermissionKey.Equals("BROWSE", StringComparison.OrdinalIgnoreCase))
                     {
                         var folderPermission = new FolderPermissionInfo(permission)
                         {

--- a/DNN Platform/Library/Security/Permissions/PermissionController.cs
+++ b/DNN Platform/Library/Security/Permissions/PermissionController.cs
@@ -124,7 +124,6 @@ namespace DotNetNuke.Security.Permissions
 
         public static string BuildPermissions(IList Permissions, string PermissionKey)
         {
-            PermissionKey = PermissionKey.ToUpperInvariant();
             var permissionsBuilder = new StringBuilder();
             foreach (PermissionInfoBase permission in Permissions)
             {

--- a/DNN Platform/Library/Security/PortalSecurity.cs
+++ b/DNN Platform/Library/Security/PortalSecurity.cs
@@ -243,15 +243,15 @@ namespace DotNetNuke.Security
 
         private static RoleType GetRoleType(string roleName)
         {
-            if (roleName.ToUpper(CultureInfo.InvariantCulture).StartsWith(RoleFriendPrefix))
+            if (roleName.StartsWith(RoleFriendPrefix, StringComparison.InvariantCultureIgnoreCase))
             {
                 return RoleType.Friend;
             }
-            if (roleName.ToUpper(CultureInfo.InvariantCulture).StartsWith(RoleFollowerPrefix))
+            if (roleName.StartsWith(RoleFollowerPrefix, StringComparison.InvariantCultureIgnoreCase))
             {
                 return RoleType.Follower;
             }
-            if (roleName.ToUpper(CultureInfo.InvariantCulture).StartsWith(RoleOwnerPrefix))
+            if (roleName.StartsWith(RoleOwnerPrefix, StringComparison.InvariantCultureIgnoreCase))
             {
                 return RoleType.Owner;
             }

--- a/DNN Platform/Library/Security/Roles/DNNRoleProvider.cs
+++ b/DNN Platform/Library/Security/Roles/DNNRoleProvider.cs
@@ -388,7 +388,7 @@ namespace DotNetNuke.Security.Roles
 
         public override RoleGroupInfo GetRoleGroupByName(int portalId, string roleGroupName)
         {
-            roleGroupName = roleGroupName.ToUpperInvariant().Trim();
+            roleGroupName = roleGroupName.Trim();
             return GetRoleGroupsInternal(portalId).SingleOrDefault(
                 r => roleGroupName.Equals(r.RoleGroupName.Trim(), StringComparison.InvariantCultureIgnoreCase));
         }

--- a/DNN Platform/Library/Security/Roles/RoleController.cs
+++ b/DNN Platform/Library/Security/Roles/RoleController.cs
@@ -308,7 +308,7 @@ namespace DotNetNuke.Security.Roles
 
         public RoleInfo GetRoleByName(int portalId, string roleName)
         {
-            roleName = roleName.ToUpperInvariant().Trim();
+            roleName = roleName.Trim();
             return GetRoles(portalId).SingleOrDefault(r => roleName.Equals(r.RoleName.Trim(), StringComparison.InvariantCultureIgnoreCase) && r.PortalID == portalId);
         }
 

--- a/DNN Platform/Library/Services/Assets/AssetManager.cs
+++ b/DNN Platform/Library/Services/Assets/AssetManager.cs
@@ -275,7 +275,7 @@ namespace DotNetNuke.Services.Assets
             {
                 return folder;
             }
-            if (folder.FolderName.ToLowerInvariant() == newFolderName.ToLowerInvariant())
+            if (folder.FolderName.Equals(newFolderName, StringComparison.InvariantCultureIgnoreCase))
             {
                 folder.FolderPath = ReplaceFolderName(folder.FolderPath, folder.FolderName, newFolderName);
                 return FolderManager.Instance.UpdateFolder(folder);

--- a/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileServerHandler.cs
@@ -112,7 +112,7 @@ namespace DotNetNuke.Services.FileSystem
             if (context.Request.QueryString["link"] != null)
             {
                 URL = context.Request.QueryString["link"];
-                if (URL.ToLowerInvariant().StartsWith("fileid="))
+                if (URL.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase))
                 {
                     URL = ""; //restrict direct access by FileID
                 }
@@ -138,7 +138,7 @@ namespace DotNetNuke.Services.FileSystem
                     URL = Globals.LinkClick(URL, TabId, ModuleId, false);
                 }
 
-                if (UrlType == TabType.File && URL.ToLowerInvariant().StartsWith("fileid=") == false)
+                if (UrlType == TabType.File && URL.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase) == false)
                 {
                     //to handle legacy scenarios before the introduction of the FileServerHandler
                     var fileName = Path.GetFileName(URL);

--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -1282,7 +1282,7 @@ namespace DotNetNuke.Services.FileSystem
 
                 foreach (PermissionInfo permission in PermissionController.GetPermissionsByFolder())
                 {
-                    if (permission.PermissionKey.ToUpper() == "READ" || permission.PermissionKey.ToUpper() == "WRITE" || permission.PermissionKey.ToUpper() == "BROWSE")
+                    if (permission.PermissionKey.Equals("READ", StringComparison.InvariantCultureIgnoreCase) || permission.PermissionKey.Equals("WRITE", StringComparison.InvariantCultureIgnoreCase) || permission.PermissionKey.Equals("BROWSE", StringComparison.InvariantCultureIgnoreCase))
                     {
                         var folderPermission = new FolderPermissionInfo(permission)
                         {
@@ -1294,7 +1294,7 @@ namespace DotNetNuke.Services.FileSystem
 
                         folder.FolderPermissions.Add(folderPermission);
 
-                        if (permission.PermissionKey.ToUpper() == "READ")
+                        if (permission.PermissionKey.Equals("READ", StringComparison.InvariantCultureIgnoreCase))
                         {
                             AddAllUserReadPermission(folder, permission);
                         }

--- a/DNN Platform/Library/Services/Installer/InstallFile.cs
+++ b/DNN Platform/Library/Services/Installer/InstallFile.cs
@@ -293,7 +293,7 @@ namespace DotNetNuke.Services.Installer
                 Name = fileName.Substring(10, fileName.Length - 10);
                 Path = fileName.Substring(0, 10);
             }
-            if (Name.ToLowerInvariant() == "manifest.xml")
+            if (Name.Equals("manifest.xml", StringComparison.InvariantCultureIgnoreCase))
             {
                 Type = InstallFileType.Manifest;
             }
@@ -321,7 +321,7 @@ namespace DotNetNuke.Services.Installer
                         Type = InstallFileType.Resources;
                         break;
                     default:
-                        if (Extension.ToLowerInvariant().EndsWith("dataprovider") || Extension.ToLowerInvariant() == "sql")
+                        if (Extension.EndsWith("dataprovider", StringComparison.InvariantCultureIgnoreCase) || Extension.Equals("sql", StringComparison.InvariantCultureIgnoreCase))
                         {
                             Type = InstallFileType.Script;
                         }

--- a/DNN Platform/Library/Services/Installer/Installer.cs
+++ b/DNN Platform/Library/Services/Installer/Installer.cs
@@ -301,7 +301,7 @@ namespace DotNetNuke.Services.Installer
             {
                 packageType = Util.ReadAttribute(rootNav, "type");
             }
-            else if (rootNav.Name.ToLowerInvariant() == "languagepack")
+            else if (rootNav.Name.Equals("languagepack", StringComparison.InvariantCultureIgnoreCase))
             {
                 packageType = "LanguagePack";
             }
@@ -353,7 +353,7 @@ namespace DotNetNuke.Services.Installer
             {
                 packageType = Util.ReadAttribute(rootNav, "type");
             }
-            else if (rootNav.Name.ToLowerInvariant() == "languagepack")
+            else if (rootNav.Name.Equals("languagepack", StringComparison.InvariantCultureIgnoreCase))
             {
                 packageType = "LanguagePack";
             }

--- a/DNN Platform/Library/Services/Installer/InstallerInfo.cs
+++ b/DNN Platform/Library/Services/Installer/InstallerInfo.cs
@@ -349,7 +349,7 @@ namespace DotNetNuke.Services.Installer
                 {
 					//Add file to list
                     var file = new InstallFile(unzip, entry, this);
-                    if (file.Type == InstallFileType.Resources && (file.Name.ToLowerInvariant() == "containers.zip" || file.Name.ToLowerInvariant() == "skins.zip"))
+                    if (file.Type == InstallFileType.Resources && (file.Name.Equals("containers.zip", StringComparison.InvariantCultureIgnoreCase) || file.Name.Equals("skins.zip", StringComparison.InvariantCultureIgnoreCase)))
                     {
 						//Temporarily save the TempInstallFolder
                         string tmpInstallFolder = TempInstallFolder;

--- a/DNN Platform/Library/Services/Installer/Installers/FileInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/FileInstaller.cs
@@ -306,7 +306,7 @@ namespace DotNetNuke.Services.Installer.Installers
 			//Get the sourceFileName
 			string sourceFileName = Util.ReadElement(nav, "sourceFileName");
             var file = new InstallFile(fileName, sourceFileName, Package.InstallerInfo);
-            if ((!string.IsNullOrEmpty(BasePath)) && (BasePath.ToLowerInvariant().StartsWith("app_code") && file.Type == InstallFileType.Other))
+            if ((!string.IsNullOrEmpty(BasePath)) && (BasePath.StartsWith("app_code", StringComparison.InvariantCultureIgnoreCase) && file.Type == InstallFileType.Other))
             {
                 file.Type = InstallFileType.AppCode;
             }

--- a/DNN Platform/Library/Services/Installer/Installers/ScriptInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/ScriptInstaller.cs
@@ -201,7 +201,7 @@ namespace DotNetNuke.Services.Installer.Installers
 
         private bool IsValidScript(string fileExtension)
         {
-            return ProviderConfiguration.DefaultProvider.ToLowerInvariant() == fileExtension.ToLowerInvariant() || fileExtension.ToLowerInvariant() == "sql";
+            return ProviderConfiguration.DefaultProvider.Equals(fileExtension, StringComparison.InvariantCultureIgnoreCase) || fileExtension.Equals("sql", StringComparison.InvariantCultureIgnoreCase);
         }
 		
 		#endregion
@@ -250,16 +250,16 @@ namespace DotNetNuke.Services.Installer.Installers
             string type = nav.GetAttribute("type", "");
             if (file != null && IsCorrectType(file.Type))
             {
-                if (file.Name.ToLowerInvariant().StartsWith("install."))
+                if (file.Name.StartsWith("install.", StringComparison.InvariantCultureIgnoreCase))
                 {
 					//This is the initial script when installing
                     _installScript = file;
                 }
-                else if (file.Name.ToLowerInvariant().StartsWith("upgrade."))
+                else if (file.Name.StartsWith("upgrade.", StringComparison.InvariantCultureIgnoreCase))
                 {
                     _upgradeScript = file;
                 }
-                else if (type.ToLowerInvariant() == "install")
+                else if (type.Equals("install", StringComparison.InvariantCultureIgnoreCase))
                 {
 					//These are the Install/Upgrade scripts
                     InstallScripts[file.Version] = file;
@@ -282,7 +282,7 @@ namespace DotNetNuke.Services.Installer.Installers
             if (extension != null && (UnInstallScripts.ContainsValue(scriptFile) ))
             {
                 string fileExtension = extension.Substring(1);
-                if (scriptFile.Name.ToLowerInvariant().StartsWith("uninstall.") && IsValidScript(fileExtension))
+                if (scriptFile.Name.StartsWith("uninstall.", StringComparison.InvariantCultureIgnoreCase) && IsValidScript(fileExtension))
                 {
 					//Install Script
                     Log.AddInfo(Util.SQL_Executing + scriptFile.Name);

--- a/DNN Platform/Library/Services/Installer/Installers/SkinInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/SkinInstaller.cs
@@ -246,7 +246,7 @@ namespace DotNetNuke.Services.Installer.Installers
                 case "html":
                 case "ascx":
                 case "css":
-                    if (file.Path.ToLowerInvariant().IndexOf(Globals.glbAboutPage.ToLowerInvariant()) < 0)
+                    if (file.Path.IndexOf(Globals.glbAboutPage, StringComparison.InvariantCultureIgnoreCase) < 0)
                     {
                         SkinFiles.Add(PhysicalBasePath + file.FullName);
                     }

--- a/DNN Platform/Library/Services/Installer/LegacyUtil.cs
+++ b/DNN Platform/Library/Services/Installer/LegacyUtil.cs
@@ -164,7 +164,7 @@ namespace DotNetNuke.Services.Installer
             DirectoryInfo[] subFolders = installFolder.GetDirectories();
             if (subFolders.Length > 0)
             {
-                if ((subFolders[0].Name.ToLowerInvariant() == "containers" || subFolders[0].Name.ToLowerInvariant() == "skins"))
+                if ((subFolders[0].Name.Equals("containers", StringComparison.InvariantCultureIgnoreCase) || subFolders[0].Name.Equals("skins", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     isCombi = true;
                 }

--- a/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
@@ -377,7 +377,7 @@ namespace DotNetNuke.Services.Installer.Packages
                     {
                         var fileName = entry.Name;
                         string extension = Path.GetExtension(fileName);
-                        if (extension != null && (extension.ToLowerInvariant() == ".dnn" || extension.ToLowerInvariant() == ".dnn5"))
+                        if (extension != null && (extension.Equals(".dnn", StringComparison.InvariantCultureIgnoreCase) || extension.Equals(".dnn5", StringComparison.InvariantCultureIgnoreCase)))
                         {
                             //Manifest
                             var manifest = manifestReader.ReadToEnd();
@@ -392,7 +392,7 @@ namespace DotNetNuke.Services.Installer.Packages
                                 {
                                     packageType = XmlUtils.GetAttributeValue(rootNav, "type");
                                 }
-                                else if (rootNav.Name.ToLowerInvariant() == "languagepack")
+                                else if (rootNav.Name.Equals("languagepack", StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     packageType = "LanguagePack";
                                 }

--- a/DNN Platform/Library/Services/Installer/Writers/ModulePackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ModulePackageWriter.cs
@@ -154,7 +154,7 @@ namespace DotNetNuke.Services.Installer.Writers
 
             //Write controlSrc
             string controlSrc = Util.ReadElement(controlNav, "src");
-            if (!(controlSrc.ToLowerInvariant().StartsWith("desktopmodules") || !controlSrc.ToLowerInvariant().EndsWith(".ascx")))
+            if (!(controlSrc.StartsWith("desktopmodules", StringComparison.InvariantCultureIgnoreCase) || !controlSrc.EndsWith(".ascx", StringComparison.InvariantCultureIgnoreCase)))
             {
 				//this code allows a developer to reference an ASCX file in a different folder than the module folder ( good for ASCX files shared between modules where you want only a single copy )
                 //or it allows the developer to use webcontrols rather than usercontrols
@@ -321,7 +321,7 @@ namespace DotNetNuke.Services.Installer.Writers
                 }
 				
 				//In Legacy Modules the assembly is always in "bin" - ignore the path element
-                if (fileName.ToLowerInvariant().EndsWith(".dll"))
+                if (fileName.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
                 {
                     AddFile("bin/" + fileName, sourceFileName);
                 }

--- a/DNN Platform/Library/Services/Installer/Writers/PackageWriterBase.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/PackageWriterBase.cs
@@ -501,7 +501,7 @@ namespace DotNetNuke.Services.Installer.Writers
                 {
                     filePath = "[app_code]" + filePath;
                 }
-                if (file.Extension.ToLowerInvariant() != ".dnn" && (file.Attributes & FileAttributes.Hidden) == 0)
+                if (!file.Extension.Equals(".dnn", StringComparison.InvariantCultureIgnoreCase) && (file.Attributes & FileAttributes.Hidden) == 0)
                 {
                     AddFile(Path.Combine(filePath, file.Name));
                 }
@@ -556,8 +556,8 @@ namespace DotNetNuke.Services.Installer.Writers
                     fileName = fileName.Substring(0, fileName.IndexOf(","));
                 }
                 if (
-                    !(fileName.ToLowerInvariant().StartsWith("system") || fileName.ToLowerInvariant().StartsWith("microsoft") || fileName.ToLowerInvariant() == "dotnetnuke" ||
-                      fileName.ToLowerInvariant() == "dotnetnuke.webutility" || fileName.ToLowerInvariant() == "dotnetnuke.webcontrols"))
+                    !(fileName.StartsWith("system", StringComparison.InvariantCultureIgnoreCase) || fileName.StartsWith("microsoft", StringComparison.InvariantCultureIgnoreCase) || fileName.Equals("dotnetnuke", StringComparison.InvariantCultureIgnoreCase) ||
+                      fileName.Equals("dotnetnuke.webutility", StringComparison.InvariantCultureIgnoreCase) || fileName.Equals("dotnetnuke.webcontrols", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     AddFile(fileName + ".dll");
                 }

--- a/DNN Platform/Library/Services/Installer/Writers/ScriptComponentWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ScriptComponentWriter.cs
@@ -101,12 +101,12 @@ namespace DotNetNuke.Services.Installer.Writers
             string type = "Install";
             string version = Null.NullString;
             string fileName = Path.GetFileNameWithoutExtension(file.Name);
-            if (fileName.ToLowerInvariant() == "uninstall") //UnInstall.SqlDataprovider
+            if (fileName.Equals("uninstall", StringComparison.InvariantCultureIgnoreCase)) //UnInstall.SqlDataprovider
             {
                 type = "UnInstall";
                 version = Package.Version.ToString(3);
             }
-            else if (fileName.ToLowerInvariant() == "install") //Install.SqlDataprovider
+            else if (fileName.Equals("install", StringComparison.InvariantCultureIgnoreCase)) //Install.SqlDataprovider
             {
                 type = "Install";
                 version = new Version(0, 0, 0).ToString(3);

--- a/DNN Platform/Library/Services/Installer/Writers/SkinPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/SkinPackageWriter.cs
@@ -20,6 +20,7 @@
 #endregion
 #region Usings
 
+using System;
 using System.IO;
 using System.Xml;
 
@@ -123,7 +124,7 @@ namespace DotNetNuke.Services.Installer.Writers
                 {
                     filePath = filePath.Substring(1);
                 }
-                if (file.Extension.ToLowerInvariant() != ".dnn")
+                if (!file.Extension.Equals(".dnn", StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (string.IsNullOrEmpty(_SubFolder))
                     {

--- a/DNN Platform/Library/Services/Journal/JournalControllerImpl.cs
+++ b/DNN Platform/Library/Services/Journal/JournalControllerImpl.cs
@@ -189,7 +189,7 @@ namespace DotNetNuke.Services.Journal
 
         private bool IsImageFile(string fileName)
         {
-            return (Globals.glbImageFileTypes + ",").IndexOf(Path.GetExtension(fileName).ToLowerInvariant().Replace(".", "") + ",") > -1;        
+            return (Globals.glbImageFileTypes + ",").IndexOf(Path.GetExtension(fileName).Replace(".", "") + ",", StringComparison.InvariantCultureIgnoreCase) > -1;        
         }
 
         private bool ThumbnailCallback()

--- a/DNN Platform/Library/Services/Mail/SendTokenizedBulkEmail.cs
+++ b/DNN Platform/Library/Services/Mail/SendTokenizedBulkEmail.cs
@@ -312,7 +312,7 @@ namespace DotNetNuke.Services.Mail
                 userLanguage = _portalSettings.DefaultLanguage;
             }
 
-            return LanguageFilter.Any(s => userLanguage.ToLowerInvariant().StartsWith(s.ToLowerInvariant()));
+            return LanguageFilter.Any(s => userLanguage.StartsWith(s, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>add a user to the userlist, if it is not already in there</summary>

--- a/DNN Platform/Library/Services/Scheduling/ScheduleItem.cs
+++ b/DNN Platform/Library/Services/Scheduling/ScheduleItem.cs
@@ -150,13 +150,13 @@ namespace DotNetNuke.Services.Scheduling
                 int i;
                 for (i = 0; i <= a.Length - 1; i++)
                 {
-                    if (ObjectDependencies.ToLowerInvariant().IndexOf(a[i].Trim()) > -1)
+                    if (ObjectDependencies.IndexOf(a[i].Trim(), StringComparison.InvariantCultureIgnoreCase) > -1)
                     {
                         return true;
                     }
                 }
             }
-            else if (ObjectDependencies.ToLowerInvariant().IndexOf(strObjectDependencies.ToLowerInvariant()) > -1)
+            else if (ObjectDependencies.IndexOf(strObjectDependencies, StringComparison.InvariantCultureIgnoreCase) > -1)
             {
                 return true;
             }

--- a/DNN Platform/Library/Services/Search/SearchConfig.cs
+++ b/DNN Platform/Library/Services/Search/SearchConfig.cs
@@ -144,7 +144,7 @@ namespace DotNetNuke.Services.Search
                 }
                 else
                 {
-                    retValue = (setting.ToUpperInvariant().StartsWith("Y") || setting.ToUpperInvariant() == "TRUE");
+                    retValue = (setting.StartsWith("Y", StringComparison.InvariantCultureIgnoreCase) || setting.Equals("TRUE", StringComparison.InvariantCultureIgnoreCase));
                 }
             }
             catch (Exception exc)

--- a/DNN Platform/Library/Services/Syndication/RssHandler.cs
+++ b/DNN Platform/Library/Services/Syndication/RssHandler.cs
@@ -120,7 +120,7 @@ namespace DotNetNuke.Services.Syndication
             if (url.Trim() == "")
             {
                 url = TestableGlobals.Instance.NavigateURL(searchResult.TabId);
-                if (url.ToLowerInvariant().IndexOf(HttpContext.Current.Request.Url.Host.ToLowerInvariant()) == -1)
+                if (url.IndexOf(HttpContext.Current.Request.Url.Host, StringComparison.InvariantCultureIgnoreCase) == -1)
                 {
                     url = TestableGlobals.Instance.AddHTTP(HttpContext.Current.Request.Url.Host) + url;
                 }

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/CulturePropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/CulturePropertyAccess.cs
@@ -20,6 +20,7 @@
 #endregion
 #region Usings
 
+using System;
 using System.Globalization;
 
 using DotNetNuke.Entities.Users;
@@ -36,35 +37,35 @@ namespace DotNetNuke.Services.Tokens
         public string GetProperty(string propertyName, string format, CultureInfo formatProvider, UserInfo AccessingUser, Scope AccessLevel, ref bool PropertyNotFound)
         {
             CultureInfo ci = formatProvider;
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.EnglishName.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.EnglishName.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return PropertyAccess.FormatString(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(ci.EnglishName), format);
             }
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.Lcid.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.Lcid.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return ci.LCID.ToString();
             }
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.Name.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.Name.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return PropertyAccess.FormatString(ci.Name, format);
             }
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.NativeName.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.NativeName.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return PropertyAccess.FormatString(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(ci.NativeName), format);
             }
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.TwoLetterIsoCode.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.TwoLetterIsoCode.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return PropertyAccess.FormatString(ci.TwoLetterISOLanguageName, format);
             }
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.ThreeLetterIsoCode.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.ThreeLetterIsoCode.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return PropertyAccess.FormatString(ci.ThreeLetterISOLanguageName, format);
             }
-            if (propertyName.ToLowerInvariant() == CultureDropDownTypes.DisplayName.ToString().ToLowerInvariant())
+            if (propertyName.Equals(CultureDropDownTypes.DisplayName.ToString(), StringComparison.InvariantCultureIgnoreCase))
             {
                 return PropertyAccess.FormatString(ci.DisplayName, format);
             }
-            if (propertyName.ToLowerInvariant() == "languagename")
+            if (propertyName.Equals("languagename", StringComparison.InvariantCultureIgnoreCase))
             {
                 if(ci.IsNeutralCulture)
                 {
@@ -75,7 +76,7 @@ namespace DotNetNuke.Services.Tokens
                     return PropertyAccess.FormatString(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(ci.Parent.EnglishName), format);
                 }
             }
-            if (propertyName.ToLowerInvariant() == "languagenativename")
+            if (propertyName.Equals("languagenativename", StringComparison.InvariantCultureIgnoreCase))
             {
                 if(ci.IsNeutralCulture)
                 {
@@ -86,7 +87,7 @@ namespace DotNetNuke.Services.Tokens
                     return PropertyAccess.FormatString(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(ci.Parent.NativeName), format);
                 }
             }
-            if (propertyName.ToLowerInvariant() == "countryname")
+            if (propertyName.Equals("countryname", StringComparison.InvariantCultureIgnoreCase))
             {
                 if(ci.IsNeutralCulture)
                 {
@@ -99,7 +100,7 @@ namespace DotNetNuke.Services.Tokens
                     return PropertyAccess.FormatString(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(country.EnglishName), format);
                 }
             }
-            if (propertyName.ToLowerInvariant() == "countrynativename")
+            if (propertyName.Equals("countrynativename", StringComparison.InvariantCultureIgnoreCase))
             {
                 if(ci.IsNeutralCulture)
                 {

--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -1860,7 +1860,7 @@ namespace DotNetNuke.Services.Upgrade
                     {
                         foreach (PermissionInfo permission in PermissionController.GetPermissionsByFolder())
                         {
-                            if (permission.PermissionKey.ToUpper() == "READ")
+                            if (permission.PermissionKey.Equals("READ", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 //Add All Users Read Access to the folder
                                 int roleId = Int32.Parse(Globals.glbRoleAllUsers);
@@ -5799,7 +5799,7 @@ namespace DotNetNuke.Services.Upgrade
                     }
                 }
                 url += "&id=" + Host.GUID;
-                if (packageType.ToUpper() == DotNetNukeContext.Current.Application.Type.ToUpper())
+                if (packageType.Equals(DotNetNukeContext.Current.Application.Type, StringComparison.OrdinalIgnoreCase))
                 {
                     if (!String.IsNullOrEmpty(HostController.Instance.GetString("NewsletterSubscribeEmail")))
                     {

--- a/DNN Platform/Library/UI/Containers/ActionManager.cs
+++ b/DNN Platform/Library/UI/Containers/ActionManager.cs
@@ -290,7 +290,7 @@ namespace DotNetNuke.UI.Containers
             if (!String.IsNullOrEmpty(action.ClientScript))
             {
                 string Script = action.ClientScript;
-                int JSPos = Script.ToLowerInvariant().IndexOf("javascript:");
+                int JSPos = Script.IndexOf("javascript:", StringComparison.InvariantCultureIgnoreCase);
                 if (JSPos > -1)
                 {
                     Script = Script.Substring(JSPos + 11);

--- a/DNN Platform/Library/UI/Containers/Container.cs
+++ b/DNN Platform/Library/UI/Containers/Container.cs
@@ -260,10 +260,10 @@ namespace DotNetNuke.UI.Containers
 
             var showMessage = false;
             var adminMessage = Null.NullString;
-            if (viewRoles == PortalSettings.AdministratorRoleName.ToLowerInvariant()
-                            && (moduleEditRoles == PortalSettings.AdministratorRoleName.ToLowerInvariant() 
+            if (viewRoles.Equals(PortalSettings.AdministratorRoleName, StringComparison.InvariantCultureIgnoreCase)
+                            && (moduleEditRoles.Equals(PortalSettings.AdministratorRoleName, StringComparison.InvariantCultureIgnoreCase)
                                     || String.IsNullOrEmpty(moduleEditRoles))
-                            && pageEditRoles == PortalSettings.AdministratorRoleName.ToLowerInvariant())
+                            && pageEditRoles.Equals(PortalSettings.AdministratorRoleName, StringComparison.InvariantCultureIgnoreCase))
             {
                 adminMessage = Localization.GetString("ModuleVisibleAdministrator.Text");
                 showMessage = !ModuleConfiguration.HideAdminBorder && !Globals.IsAdminControl();

--- a/DNN Platform/Library/UI/ControlUtilities.cs
+++ b/DNN Platform/Library/UI/ControlUtilities.cs
@@ -103,7 +103,7 @@ namespace DotNetNuke.UI
             T ctrl;
 
             //load the control dynamically
-            if (ControlSrc.ToLowerInvariant().EndsWith(".ascx"))
+            if (ControlSrc.EndsWith(".ascx", StringComparison.InvariantCultureIgnoreCase))
             {
 				//load from a user control on the file system
                 ctrl = (T) containerControl.LoadControl("~/" + ControlSrc);

--- a/DNN Platform/Library/UI/Modules/Html5/ModuleActionsPropertyAccess.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/ModuleActionsPropertyAccess.cs
@@ -104,7 +104,7 @@ namespace DotNetNuke.UI.Modules.Html5
             }
             else
             {
-                moduleAction.Url = model.Script.ToLowerInvariant().StartsWith("javascript:") ? 
+                moduleAction.Url = model.Script.StartsWith("javascript:", StringComparison.InvariantCultureIgnoreCase) ? 
                                     model.Script : 
                                     string.Format("javascript:{0}", model.Script);
             }

--- a/DNN Platform/Library/UI/Skins/Controls/ControlPanel.cs
+++ b/DNN Platform/Library/UI/Skins/Controls/ControlPanel.cs
@@ -46,7 +46,7 @@ namespace DotNetNuke.UI.Skins.Controls
                 if(objControlPanel.IncludeInControlHierarchy)
                 {
                     objControlPanel.IsDockable = IsDockable;
-                    if (!Host.ControlPanel.ToLowerInvariant().EndsWith("controlbar.ascx"))
+                    if (!Host.ControlPanel.EndsWith("controlbar.ascx", StringComparison.InvariantCultureIgnoreCase))
                         Controls.Add(objControlPanel);
                     else
                     {

--- a/DNN Platform/Library/UI/Skins/Pane.cs
+++ b/DNN Platform/Library/UI/Skins/Pane.cs
@@ -186,8 +186,8 @@ namespace DotNetNuke.UI.Skins
         /// -----------------------------------------------------------------------------
         private Containers.Container LoadContainerByPath(string containerPath)
         {
-            if (containerPath.ToLowerInvariant().IndexOf("/skins/") != -1 || containerPath.ToLowerInvariant().IndexOf("/skins\\") != -1 || containerPath.ToLowerInvariant().IndexOf("\\skins\\") != -1 ||
-                containerPath.ToLowerInvariant().IndexOf("\\skins/") != -1)
+            if (containerPath.IndexOf("/skins/", StringComparison.InvariantCultureIgnoreCase) != -1 || containerPath.IndexOf("/skins\\", StringComparison.InvariantCultureIgnoreCase) != -1 || containerPath.IndexOf("\\skins\\", StringComparison.InvariantCultureIgnoreCase) != -1 ||
+                containerPath.IndexOf("\\skins/", StringComparison.InvariantCultureIgnoreCase) != -1)
             {
                 throw new Exception();
             }
@@ -256,7 +256,7 @@ namespace DotNetNuke.UI.Skins
             else
             {
                 containerSrc = PaneControl.Attributes["ContainerSrc"];
-                if (containerSrc.Contains("/") && !(containerSrc.ToLowerInvariant().StartsWith("[g]") || containerSrc.ToLowerInvariant().StartsWith("[l]")))
+                if (containerSrc.Contains("/") && !(containerSrc.StartsWith("[g]", StringComparison.InvariantCultureIgnoreCase) || containerSrc.StartsWith("[l]", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     containerSrc = string.Format(SkinController.IsGlobalSkin(PortalSettings.ActiveTab.SkinSrc) ? "[G]containers/{0}" : "[L]containers/{0}", containerSrc.TrimStart('/'));
                     validSrc = true;

--- a/DNN Platform/Library/UI/Skins/Skin.cs
+++ b/DNN Platform/Library/UI/Skins/Skin.cs
@@ -340,7 +340,7 @@ namespace DotNetNuke.UI.Skins
                         case "article":
                         case "aside":
                             //content pane
-                            if (objPaneControl.ID.ToLowerInvariant() != "controlpanel")
+                            if (!objPaneControl.ID.Equals("controlpanel", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 //Add to the PortalSettings (for use in the Control Panel)
                                 PortalSettings.ActiveTab.Panes.Add(objPaneControl.ID);
@@ -365,7 +365,7 @@ namespace DotNetNuke.UI.Skins
             try
             {
                 string skinSrc = skinPath;
-                if (skinPath.ToLowerInvariant().IndexOf(Globals.ApplicationPath, StringComparison.Ordinal) != -1)
+                if (skinPath.IndexOf(Globals.ApplicationPath, StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     skinPath = skinPath.Remove(0, Globals.ApplicationPath.Length);
                 }

--- a/DNN Platform/Library/UI/Skins/SkinControl.cs
+++ b/DNN Platform/Library/UI/Skins/SkinControl.cs
@@ -164,7 +164,7 @@ namespace DotNetNuke.UI.Skins
             // select current skin
             for (int intIndex = 0; intIndex < cboSkin.Items.Count; intIndex++)
             {
-                if (cboSkin.Items[intIndex].Value.ToLower() == Convert.ToString(ViewState["SkinSrc"]).ToLower())
+                if (cboSkin.Items[intIndex].Value.Equals(Convert.ToString(ViewState["SkinSrc"]), StringComparison.InvariantCultureIgnoreCase))
                 {
                     cboSkin.Items[intIndex].Selected = true;
                     break;

--- a/DNN Platform/Library/UI/Skins/SkinController.cs
+++ b/DNN Platform/Library/UI/Skins/SkinController.cs
@@ -178,16 +178,16 @@ namespace DotNetNuke.UI.Skins
             string skin = "[" + skinType.ToLowerInvariant() + "]" + skinFolder.ToLowerInvariant();
             if (skinFolder.ToLowerInvariant().Contains("skins"))
             {
-                if (Host.DefaultAdminSkin.ToLowerInvariant().StartsWith(skin) || Host.DefaultPortalSkin.ToLowerInvariant().StartsWith(skin) ||
-                    portalSettings.DefaultAdminSkin.ToLowerInvariant().StartsWith(skin) || portalSettings.DefaultPortalSkin.ToLowerInvariant().StartsWith(skin))
+                if (Host.DefaultAdminSkin.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase) || Host.DefaultPortalSkin.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase) ||
+                    portalSettings.DefaultAdminSkin.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase) || portalSettings.DefaultPortalSkin.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase))
                 {
                     canDelete = false;
                 }
             }
             else
             {
-                if (Host.DefaultAdminContainer.ToLowerInvariant().StartsWith(skin) || Host.DefaultPortalContainer.ToLowerInvariant().StartsWith(skin) ||
-                    portalSettings.DefaultAdminContainer.ToLowerInvariant().StartsWith(skin) || portalSettings.DefaultPortalContainer.ToLowerInvariant().StartsWith(skin))
+                if (Host.DefaultAdminContainer.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase) || Host.DefaultPortalContainer.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase) ||
+                    portalSettings.DefaultAdminContainer.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase) || portalSettings.DefaultPortalContainer.StartsWith(skin, StringComparison.InvariantCultureIgnoreCase))
                 {
                     canDelete = false;
                 }
@@ -330,7 +330,7 @@ namespace DotNetNuke.UI.Skins
         /// <param name="skinFile">The File Name without extension</param>
         private static string FormatSkinName(string skinFolder, string skinFile)
         {
-            if (skinFolder.ToLowerInvariant() == "_default")
+            if (skinFolder.Equals("_default", StringComparison.InvariantCultureIgnoreCase))
             {
                 // host folder
                 return skinFile;
@@ -475,7 +475,7 @@ namespace DotNetNuke.UI.Skins
                     if(Host.AllowedExtensionWhitelist.IsAllowedExtension(strExtension, extraExtensions))
                     {
                         //process embedded zip files
-						if (objZipEntry.Name.ToLowerInvariant() == RootSkin.ToLowerInvariant() + ".zip")
+						if (objZipEntry.Name.Equals(RootSkin.ToLowerInvariant() + ".zip", StringComparison.InvariantCultureIgnoreCase))
                         {
                             using (var objMemoryStream = new MemoryStream())
                             {
@@ -489,7 +489,7 @@ namespace DotNetNuke.UI.Skins
                                 strMessage += UploadLegacySkin(rootPath, RootSkin, skinName, objMemoryStream);
                             }
                         }
-                        else if (objZipEntry.Name.ToLowerInvariant() == RootContainer.ToLowerInvariant() + ".zip")
+                        else if (objZipEntry.Name.Equals(RootContainer.ToLowerInvariant() + ".zip", StringComparison.InvariantCultureIgnoreCase))
                         {
                             using(var objMemoryStream = new MemoryStream())
                             {

--- a/DNN Platform/Library/UI/Skins/SkinFileProcessor.cs
+++ b/DNN Platform/Library/UI/Skins/SkinFileProcessor.cs
@@ -154,7 +154,7 @@ namespace DotNetNuke.UI.Skins
                 //If the control is already in the hash table
                 if (m_ControlList.ContainsKey(Token))
                 {
-                    Message += SkinController.FormatMessage(string.Format(DUPLICATE_ERROR, objSkinControl.ControlKey.ToUpper()),
+                    Message += SkinController.FormatMessage(string.Format(DUPLICATE_ERROR, Token),
                                                             string.Format(DUPLICATE_DETAIL, m_ControlList[Token], objSkinControl.ControlSrc),
                                                             2,
                                                             true);
@@ -162,7 +162,7 @@ namespace DotNetNuke.UI.Skins
                 else
                 {
                     //Add it
-                    Message += SkinController.FormatMessage(string.Format(LOAD_SKIN_TOKEN, objSkinControl.ControlKey.ToUpper()), objSkinControl.ControlSrc, 2, false);
+                    Message += SkinController.FormatMessage(string.Format(LOAD_SKIN_TOKEN, Token), objSkinControl.ControlSrc, 2, false);
                     m_ControlList.Add(Token, objSkinControl.ControlSrc);
                 }
             }
@@ -556,7 +556,7 @@ namespace DotNetNuke.UI.Skins
                     }
                     else
                     {
-                        if (SkinControl.ToLowerInvariant().IndexOf("id=") == -1)
+                        if (SkinControl.IndexOf("id=", StringComparison.InvariantCultureIgnoreCase) == -1)
                         {
                             SkinControl = " id=\"ContentPane\"";
                         }
@@ -777,7 +777,7 @@ namespace DotNetNuke.UI.Skins
                 }
 
                 //process skin object
-                if (AttributeNode.ToLowerInvariant() == "dotnetnuke/server")
+                if (AttributeNode.Equals("dotnetnuke/server", StringComparison.InvariantCultureIgnoreCase))
                 {
                     //we have a valid skin object specification
                     Messages += SkinController.FormatMessage(OBJECT_PROC, Token, 2, false);
@@ -1055,7 +1055,7 @@ namespace DotNetNuke.UI.Skins
                             break;
                         case SkinParser.Portable:
                             //if the tag does not contain a reference to the skinpath
-                            if (strNewTag.ToLowerInvariant().IndexOf("<%= skinpath %>") == -1)
+                            if (strNewTag.IndexOf("<%= skinpath %>", StringComparison.InvariantCultureIgnoreCase) == -1)
                             {
                                 //insert the skinpath 
                                 strNewTag = m.Groups["tag"].Value + "<%= SkinPath %>" + m.Groups["content"].Value + m.Groups["endtag"].Value;

--- a/DNN Platform/Library/UI/Skins/SkinThumbNailControl.cs
+++ b/DNN Platform/Library/UI/Skins/SkinThumbNailControl.cs
@@ -209,7 +209,7 @@ namespace DotNetNuke.UI.Skins
         /// <param name="strSkinFile">The File Name without extension</param>
         private static string FormatSkinName(string strSkinFolder, string strSkinFile)
         {
-            if (strSkinFolder.ToLowerInvariant() == "_default") //host folder
+            if (strSkinFolder.Equals("_default", StringComparison.InvariantCultureIgnoreCase)) //host folder
             {
                 return strSkinFile;
             }
@@ -302,7 +302,7 @@ namespace DotNetNuke.UI.Skins
 					Logger.Error(ex);
 				}
             }
-            strThumbnail = Globals.ApplicationPath + "\\" + strThumbnail.Substring(strThumbnail.ToLowerInvariant().IndexOf("portals\\"));
+            strThumbnail = Globals.ApplicationPath + "\\" + strThumbnail.Substring(strThumbnail.IndexOf("portals\\", StringComparison.InvariantCultureIgnoreCase));
             return strThumbnail;
         }
 

--- a/DNN Platform/Library/UI/UIUtilities.cs
+++ b/DNN Platform/Library/UI/UIUtilities.cs
@@ -57,7 +57,7 @@ namespace DotNetNuke.UI
             {
                 Int32.TryParse(request.QueryString["mid"], out moduleId);
             }
-            if (request.QueryString["moduleid"] != null && (key.ToLowerInvariant() == "module" || key.ToLowerInvariant() == "help"))
+            if (request.QueryString["moduleid"] != null && (key.Equals("module", StringComparison.InvariantCultureIgnoreCase) || key.Equals("help", StringComparison.InvariantCultureIgnoreCase)))
             {
                 Int32.TryParse(request.QueryString["moduleid"], out moduleId);
             }

--- a/DNN Platform/Library/UI/UserControls/Address.cs
+++ b/DNN Platform/Library/UI/UserControls/Address.cs
@@ -435,7 +435,7 @@ namespace DotNetNuke.UI.UserControls
 					cboRegion.DataBind();
 					cboRegion.Items.Insert(0, new ListItem("<" + Localization.GetString("Not_Specified", Localization.SharedResourceFile) + ">", ""));
 				}
-				if (countryCode.ToLowerInvariant() == "us")
+				if (countryCode.Equals("us", StringComparison.InvariantCultureIgnoreCase))
 				{
 					valRegion1.Enabled = true;
 					valRegion2.Enabled = false;

--- a/DNN Platform/Library/UI/UserControls/TextEditor.cs
+++ b/DNN Platform/Library/UI/UserControls/TextEditor.cs
@@ -91,7 +91,7 @@ namespace DotNetNuke.UI.UserControls
             }
             set
             {
-                if (value.ToUpper() != "BASIC")
+                if (!value.Equals("BASIC", StringComparison.OrdinalIgnoreCase))
                 {
                     ViewState["DefaultMode"] = "RICH";
                 }
@@ -150,7 +150,7 @@ namespace DotNetNuke.UI.UserControls
             {
                 UserInfo objUserInfo = UserController.Instance.GetCurrentUserInfo();
 
-                if (value.ToUpper() != "BASIC")
+                if (!value.Equals("BASIC", StringComparison.OrdinalIgnoreCase))
                 {
                     ViewState["DesktopMode"] = "RICH";
 

--- a/DNN Platform/Library/UI/UserControls/URLControl.cs
+++ b/DNN Platform/Library/UI/UserControls/URLControl.cs
@@ -478,7 +478,7 @@ namespace DotNetNuke.UI.UserControls
                         else
                         {
                             string mCustomUrl = txtUrl.Text;
-                            if (mCustomUrl.ToLowerInvariant() == "http://")
+                            if (mCustomUrl.Equals("http://", StringComparison.InvariantCultureIgnoreCase))
                             {
                                 r = "";
                             }
@@ -676,7 +676,7 @@ namespace DotNetNuke.UI.UserControls
                 ViewState["UrlType"] = _Urltype;
                 if (_Urltype == "F")
                 {
-                    if (_Url.ToLowerInvariant().StartsWith("fileid="))
+                    if (_Url.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase))
                     {
                         TrackingUrl = _Url;
                         var objFile = FileManager.Instance.GetFile(int.Parse(_Url.Substring(7)));
@@ -705,7 +705,7 @@ namespace DotNetNuke.UI.UserControls
                 }
                 if (_Urltype == "M")
                 {
-                    if (_Url.ToLowerInvariant().StartsWith("userid="))
+                    if (_Url.StartsWith("userid=", StringComparison.InvariantCultureIgnoreCase))
                     {
                         UserInfo objUser = UserController.GetUserById(_objPortal.PortalID, int.Parse(_Url.Substring(7)));
                         if (objUser != null)

--- a/DNN Platform/Library/UI/UserControls/URLTrackingControl.cs
+++ b/DNN Platform/Library/UI/UserControls/URLTrackingControl.cs
@@ -173,7 +173,7 @@ namespace DotNetNuke.UI.UserControls
                     {
                         lblLogURL.Text = URL; //saved for loading Log grid
                         TabType URLType = Globals.GetURLType(_URL);
-                        if (URLType == TabType.File && _URL.ToLowerInvariant().StartsWith("fileid=") == false)
+                        if (URLType == TabType.File && _URL.StartsWith("fileid=", StringComparison.InvariantCultureIgnoreCase) == false)
                         {
                             //to handle legacy scenarios before the introduction of the FileServerHandler
                             var fileName = Path.GetFileName(_URL);

--- a/DNN Platform/Modules/Journal/Components/Utilities.cs
+++ b/DNN Platform/Modules/Journal/Components/Utilities.cs
@@ -111,16 +111,16 @@ namespace DotNetNuke.Modules.Journal.Components {
             foreach (Match match in matches) {
                 string sTempDesc = match.Groups[0].Value;
                 foreach (Match subM in MetaSubRegex.Matches(sTempDesc)) {
-                    if (subM.Groups[4].Value.ToUpperInvariant() == "OG:DESCRIPTION") {
+                    if (subM.Groups[4].Value.Equals("OG:DESCRIPTION", StringComparison.InvariantCultureIgnoreCase)) {
                         link.Description = subM.Groups[9].Value;
-                    } else if (subM.Groups[4].Value.ToUpperInvariant() == "DESCRIPTION".ToUpperInvariant()) {
+                    } else if (subM.Groups[4].Value.Equals("DESCRIPTION", StringComparison.InvariantCultureIgnoreCase)) {
                         link.Description = subM.Groups[9].Value;
                     }
-                    if (subM.Groups[4].Value.ToUpperInvariant() == "OG:TITLE") {
+                    if (subM.Groups[4].Value.Equals("OG:TITLE", StringComparison.InvariantCultureIgnoreCase)) {
                         link.Title = subM.Groups[9].Value;
                     }
                     
-                    if (subM.Groups[4].Value.ToUpperInvariant() == "OG:IMAGE") {
+                    if (subM.Groups[4].Value.Equals("OG:IMAGE", StringComparison.InvariantCultureIgnoreCase)) {
                         sImage = subM.Groups[9].Value;
                         ImageInfo img = new ImageInfo();
                         img.URL = sImage;

--- a/DNN Platform/Syndication/OPML/OpmlDownloadManager.cs
+++ b/DNN Platform/Syndication/OPML/OpmlDownloadManager.cs
@@ -188,7 +188,7 @@ namespace DotNetNuke.Services.Syndication
                 }
 
                 // match url
-                if (urlFromOpmlFile.ToLower() == uri.AbsoluteUri.ToLower())
+                if (urlFromOpmlFile.Equals(uri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
                 {
                     // found a good one - create DOM and set expiry (as found on disk)
                     Opml opmlFeed = Opml.LoadFromXml(opmlDoc);


### PR DESCRIPTION
Improvements to the management and processing of strings.  This change was limited to the changes that can be made that would not change behavior, or impact the possibility of a behavior change.

As such, the changes here are not "perfect," but represent the best efforts to improve the operation with strings in the core.  The goals here are to avoid calls that result in new strings being generated via calls such as ToLower(), ToUpper() etc and comparisons being made.

The following constructs were followed when making these changes.

*  Implementations that used ToUpperInvariant() or ToLowerInvariant() were moved to use StringComparison.InvariantCultureIgnoreCase
*  Comparisons that were done before with format specifiers but redundant calls to ToLower()/ToUpper() removed

I did not fix the following types of items that at some point in the future might be worth continuing to research.

*  ToLowerInvariant().Contains("") = These should be changed to IndexOf() if possible to avoid the string creation of ToLowerInvariant()
*  Situations where the same variable was called multiple times convertng the value
*  Situations where performance could be further improved by using OrdinalIgnoreCase rather than InvariantCultureIgnoreCase
*  Unique situation where both invariant & Ordnial was used.  (DotNetNuke.Services.FileSystem.FolderManager)

In testing the updated installation with these changes I am seeing an exponential reduction in the number of string objects in memory snapshots compared to the baseline version, with indications of less garbage collector cycles.  No adverse implementation details.

Fixes #2215