### PR TITLE
Add system.data to web.config file for VSTS unit tests to pass.

### DIFF
--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -6,6 +6,7 @@
     </sectionGroup>
     <sectionGroup name="dotnetnuke">
       <!-- the requirePermission attribute will cause a syntax warning - please ignore - it is required for Medium Trust support-->
+      <section name="system.data" type="System.Data.Common.DbProviderFactoriesConfigurationHandler, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       <section name="data" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
       <section name="logging" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
       <section name="scheduling" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
@@ -30,6 +31,12 @@
     </sectionGroup>
     <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow" />
   </configSections>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SqlServerCe.4.0" />
+      <add name="Microsoft SQL Server Compact Data Provider 4.0" invariant="System.Data.SqlServerCe.4.0" description=".NET Framework Data Provider for Microsoft SQL Server Compact" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91" />
+    </DbProviderFactories>
+  </system.data>
   <connectionStrings>
     <clear/>
     <add name="SiteSqlServer" connectionString="Server=.;Database=DNN_Platform;Integrated Security=True" providerName="System.Data.SqlClient" />


### PR DESCRIPTION
Fixes Issue #2234

## Summary
Had to add a config section in the App.Config to explicitly tell the framework where to get the Data Provider named System.Data.SqlServerCe.4.0