### PR TITLE
Fixed issue where the browser covered the region and country dropdowns

### DIFF
--- a/DNN Platform/Website/Templates/Blank Website.template
+++ b/DNN Platform/Website/Templates/Blank Website.template
@@ -156,15 +156,15 @@
     </profiledefinition>
     <profiledefinition>
       <propertycategory>Location</propertycategory>
-      <propertyname>Region</propertyname>
-      <datatype>Region</datatype>
+      <propertyname>Country</propertyname>
+      <datatype>Country</datatype>
       <length>0</length>
       <defaultvisibility>2</defaultvisibility>
     </profiledefinition>
     <profiledefinition>
       <propertycategory>Location</propertycategory>
-      <propertyname>Country</propertyname>
-      <datatype>Country</datatype>
+      <propertyname>Region</propertyname>
+      <datatype>Region</datatype>
       <length>0</length>
       <defaultvisibility>2</defaultvisibility>
     </profiledefinition>

--- a/DNN Platform/Website/Templates/Default Website.template
+++ b/DNN Platform/Website/Templates/Default Website.template
@@ -156,15 +156,15 @@
     </profiledefinition>
     <profiledefinition>
       <propertycategory>Location</propertycategory>
-      <propertyname>Region</propertyname>
-      <datatype>Region</datatype>
+      <propertyname>Country</propertyname>
+      <datatype>Country</datatype>
       <length>0</length>
       <defaultvisibility>2</defaultvisibility>
     </profiledefinition>
     <profiledefinition>
       <propertycategory>Location</propertycategory>
-      <propertyname>Country</propertyname>
-      <datatype>Country</datatype>
+      <propertyname>Region</propertyname>
+      <datatype>Region</datatype>
       <length>0</length>
       <defaultvisibility>2</defaultvisibility>
     </profiledefinition>

--- a/Website/DesktopModules/Admin/Security/Profile.ascx
+++ b/Website/DesktopModules/Admin/Security/Profile.ascx
@@ -5,7 +5,13 @@
 (function ($, Sys) {
     function setUpProfile() {
     	$('.dnnButtonDropdown').dnnSettingDropdown();
-	    $('#<%=ProfileProperties.ClientID%>').parent().dnnPanels();
+        $('#<%=ProfileProperties.ClientID%>').parent().dnnPanels();
+        $('input[data-name="Country"]').attr('autocomplete', getRandomString());
+        $('input[data-name="Region"]').attr('autocomplete', getRandomString());
+
+    }
+    function getRandomString() {
+        return (Math.random() + 1).toString(36).substring(2, 6) + (Math.random() + 1).toString(36).substring(2, 6);
     }
 
     $(document).ready(function () {


### PR DESCRIPTION
Closes #2146 

## Summary
Switched the country and region fields so that the country is first. This field populated the region dropdown so it needs to be filled first in order to see a dropdown of the regions available in that country. Without this, the entered region disappears when the user selects a country after the region.

Implemented a workaround to prevent browsers to display their suggestions above the Dnn built-in ones. Due to a bug in chrome autocomplete="off" does not work, to really make sure that the browser does not try to autocomplete, we need a random value in the autocomplete parameter so that the browser had no fields to suggest in memory.

## How to test
- make sure to use chrome latest release, and in the browser settings make sure you have a couple of form fill records with addresses.

Before this fix:
- Try to enter a region
- Enter a country that has regions available (US or Canada should do)
- Notice the browser covers the Dnn dropdown
- Notice the typed region disappears for a dropdown with nothing selected after selecting a country.

After this fix:
- Add a new website and notice after the website creation, the profile editor now has the country above the region and the browser no longer suggest regions and countries on those fields.
- For existing users, I thought it could break custom profile forms to force the country above the region (them may not even use both). So for those users I would add in the release notes that they can switch the order of these fields to prevent the problem.
