### PR TITLE
DNN-22612: update the tab info in cache object instead of clear whole cache during workflow process.

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/ITabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/ITabController.cs
@@ -421,5 +421,12 @@ namespace DotNetNuke.Entities.Tabs
         /// <param name="localizedTab">The localized tab.</param>
         /// <param name="isTranslated">if set to <c>true</c> means the tab has already been translated.</param>
         void UpdateTranslationStatus(TabInfo localizedTab, bool isTranslated);
+
+        /// <summary>
+        /// Refresh the tabinfo in cache object of portal tabs collection, use this instead of clear the whole cache to improve performance.
+        /// </summary>
+        /// <param name="portalId"></param>
+        /// <param name="tabId"></param>
+        void RefreshCache(int portalId, int tabId);
     }
 }

--- a/DNN Platform/Library/Entities/Tabs/TabCollection.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabCollection.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Security;
-
+using DotNetNuke.Collections;
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Services.Localization;
@@ -328,6 +328,20 @@ namespace DotNetNuke.Entities.Tabs
         public TabInfo WithTabName(string tabName)
         {
             return (from t in _list where !string.IsNullOrEmpty(t.TabName) && t.TabName.Equals(tabName, StringComparison.InvariantCultureIgnoreCase) select t).FirstOrDefault();
+        }
+
+        internal void RefreshCache(TabInfo tab)
+        {
+            if (ContainsKey(tab.TabID))
+            {
+                Remove(tab.TabID);
+                _list.RemoveAll(t => t.TabID == tab.TabID);
+                _localizedTabs.ForEach(kvp =>
+                {
+                    kvp.Value.RemoveAll(t => t.TabID == tab.TabID);
+                });
+            }
+            Add(tab);
         }
 
         #endregion

--- a/DNN Platform/Library/Entities/Tabs/TabCollection.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabCollection.cs
@@ -330,18 +330,22 @@ namespace DotNetNuke.Entities.Tabs
             return (from t in _list where !string.IsNullOrEmpty(t.TabName) && t.TabName.Equals(tabName, StringComparison.InvariantCultureIgnoreCase) select t).FirstOrDefault();
         }
 
-        internal void RefreshCache(TabInfo tab)
+        internal void RefreshCache(int tabId, TabInfo updatedTab)
         {
-            if (ContainsKey(tab.TabID))
+            if (ContainsKey(tabId))
             {
-                Remove(tab.TabID);
-                _list.RemoveAll(t => t.TabID == tab.TabID);
+                Remove(tabId);
+                _list.RemoveAll(t => t.TabID == tabId);
                 _localizedTabs.ForEach(kvp =>
                 {
-                    kvp.Value.RemoveAll(t => t.TabID == tab.TabID);
+                    kvp.Value.RemoveAll(t => t.TabID == tabId);
                 });
             }
-            Add(tab);
+
+            if (updatedTab != null)
+            {
+                Add(updatedTab);
+            }
         }
 
         #endregion

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -1002,6 +1002,16 @@ namespace DotNetNuke.Entities.Tabs
             CacheController.FlushPageIndexFromCache();
         }
 
+        public void RefreshCache(int portalId, int tabId)
+        {
+            var portalTabs = GetTabsByPortal(portalId);
+            if (portalTabs.WithTabId(tabId) != null)
+            {
+                var updateTab = GetTab(tabId, portalId, true);
+                portalTabs.RefreshCache(updateTab);
+            }
+        }
+
         /// <summary>
         /// Converts one single tab to a neutral culture
         /// clears the tab cache optionally

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -1008,7 +1008,7 @@ namespace DotNetNuke.Entities.Tabs
             if (portalTabs.WithTabId(tabId) != null)
             {
                 var updateTab = GetTab(tabId, portalId, true);
-                portalTabs.RefreshCache(updateTab);
+                portalTabs.RefreshCache(tabId, updateTab);
             }
         }
 

--- a/DNN Platform/Library/Entities/Tabs/TabWorkflowTracker.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabWorkflowTracker.cs
@@ -131,7 +131,7 @@ namespace DotNetNuke.Entities.Tabs
                     }
 
                     _workflowEngine.StartWorkflow(workflow.WorkflowID, tabInfo.ContentItemId, userId);
-                    _tabController.ClearCache(portalId);
+                    _tabController.RefreshCache(portalId, tabId);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Fix #2246 .