### PR TITLE
Fix Newtonsoft.Json package install during DNN Upgrade.

### DIFF
--- a/DNN Platform/Components/Newtonsoft/DotNetNuke.Newtonsoft.Json.dnn
+++ b/DNN Platform/Components/Newtonsoft/DotNetNuke.Newtonsoft.Json.dnn
@@ -24,25 +24,6 @@
             </assembly>
           </assemblies>
         </component>
-        <component type="Config">
-          <config>
-            <configFile>web.config</configFile>
-            <install>
-              <configuration>
-                <nodes>
-                  <node path="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='Newtonsoft.Json']" action="update" targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='Newtonsoft.Json']/ab:bindingRedirect" collision="save"  nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
-                    <bindingRedirect oldVersion="0.0.0.0-32767.32767.32767.32767" newVersion="10.0.0.0" />
-                  </node>
-                </nodes>
-              </configuration>
-            </install>
-            <uninstall>
-              <configuration>
-                <nodes />
-              </configuration>
-            </uninstall>
-          </config>
-        </component>
       </components>
     </package>
   </packages>

--- a/DNN Platform/Website/Install/Config/BindingRedirect.config
+++ b/DNN Platform/Website/Install/Config/BindingRedirect.config
@@ -1,10 +1,10 @@
 <configuration>
   <nodes configfile="Web.config">
-    <node path="/configuration/runtime/ab:assemblyBinding" 
-          action="update" 
-          collision="save" 
-          targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='$$name$$'][ab:assemblyIdentity/@publicKeyToken='$$publicKeyToken$$']" 
-          nameSpace="urn:schemas-microsoft-com:asm.v1" 
+    <node path="/configuration/runtime/ab:assemblyBinding"
+          action="update"
+          collision="save"
+          targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='$$name$$'][ab:assemblyIdentity/@publicKeyToken='$$publicKeyToken$$'][ab:bindingRedirect]"
+          nameSpace="urn:schemas-microsoft-com:asm.v1"
           nameSpacePrefix="ab">
       <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="$$name$$" publicKeyToken="$$publicKeyToken$$" />

--- a/DNN Platform/Website/Install/Config/RemoveBindingRedirect.config
+++ b/DNN Platform/Website/Install/Config/RemoveBindingRedirect.config
@@ -1,8 +1,8 @@
 <configuration>
   <nodes configfile="Web.config">
-    <node path="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='$$name$$'][ab:assemblyIdentity/@publicKeyToken='$$publicKeyToken$$']" 
-          action="remove" 
-          nameSpace="urn:schemas-microsoft-com:asm.v1" 
+    <node path="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='$$name$$'][ab:assemblyIdentity/@publicKeyToken='$$publicKeyToken$$'][ab:bindingRedirect]"
+          action="remove"
+          nameSpace="urn:schemas-microsoft-com:asm.v1"
           nameSpacePrefix="ab" />
   </nodes>
 </configuration>


### PR DESCRIPTION
Fixes #2121 

## Summary

The Config component in the manifest of Newtonsoft.Json package is not needed. The binding redirect is ensured by the AssemblyInstaller through the [AddOrUpdateBindingRedirect()](https://github.com/dnnsoftware/Dnn.Platform/blob/development/DNN%20Platform/Library/Services/Installer/Installers/AssemblyInstaller.cs#L194) method call inside the InstallFile() method.
This also broke the DNN upgrade from a version prior to 9.2.0 when the web.config contained additional `<codebase>` assembly bindings before the one with the `<bindingRedirect>`.
Moreover besides that, it also updated the web.config with the binding redirect twice, in both scenarios (clean install and DNN upgrade).