### PR TITLE
Fixed issue Redirect After Login failed for culture specific portalalias

### DIFF
--- a/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -200,8 +200,9 @@ namespace DotNetNuke.Modules.Admin.Authentication
 
                 var alias = PortalAlias.HTTPAlias;
                 var comparison = StringComparison.InvariantCultureIgnoreCase;
+                // we need .TrimEnd('/') because a portlalias for a specific culture will not have a trailing /, while a returnurl will.
                 var isDefaultPage = redirectURL == "/"
-                    || (alias.Contains("/") && redirectURL.Equals(alias.Substring(alias.IndexOf("/", comparison)), comparison));
+                    || (alias.Contains("/") && redirectURL.TrimEnd('/').Equals(alias.Substring(alias.IndexOf("/", comparison)), comparison));
                 
                 if (string.IsNullOrEmpty(redirectURL) || isDefaultPage)
                 {


### PR DESCRIPTION
Fixes #2267 

Issue is reported in 9.2.1, but also occurs in 9.2.2 RC.
## Summary
Added` .TrimEnd('/')` to the following line, because a portalalias for a specific culture will not have a trailing /, while a returnurl will. Thus the `.Equals` did fail and the redirect to the configured tab did not occur.
`                var isDefaultPage = redirectURL == "/"
                    || (alias.Contains("/") && redirectURL.TrimEnd('/').Equals(alias.Substring(alias.IndexOf("/", comparison)), comparison));
`
## How to test
The issue was easily reproducible from the issue description.
