### PR TITLE
Fixed: dragdrop fails for modules with friendlyname starting with number

### DIFF
--- a/Website/Resources/Shared/scripts/dnn.dragDrop.js
+++ b/Website/Resources/Shared/scripts/dnn.dragDrop.js
@@ -38,7 +38,7 @@
         var $module;
 
         var getModuleId = function ($mod) {
-            var result = $mod.attr("class").match(/DnnModule-([0-9]+)(?:\W|$)/);
+            var result = $mod.attr("class").match(/\bDnnModule-([0-9]+)\b/);
             return (result && result.length === 2) ? result[1] : null;
         };
 

--- a/Website/Resources/Shared/scripts/dnn.dragDrop.js
+++ b/Website/Resources/Shared/scripts/dnn.dragDrop.js
@@ -38,7 +38,7 @@
         var $module;
 
         var getModuleId = function ($mod) {
-            var result = $mod.attr("class").match(/DnnModule-([0-9]+)/);
+            var result = $mod.attr("class").match(/DnnModule-([0-9]+)(?:\W|$)/);
             return (result && result.length === 2) ? result[1] : null;
         };
 


### PR DESCRIPTION
Fixes #2276

## Summary
In dnn.DragDrop.js I changed the regular expression that's used to get the moduleId from a class attribute.
It used to work in cases like this:
`class="DnnModule DnnModule-OpenContent DnnModule-4084"`.

but would fail in cases like this:
`class="DnnModule DnnModule-40FingersWebshopSearch DnnModule-3767"`

With the fix, the latter also works.

This is the same solution @iJungleboy proposed in a previous Jira ticket mentioned in the issue. I tried and tested the solution on DNN 8.0.4, 9.2.1, 9.2.2RC.