### PR TITLE
CI: Add Cake Task to generate our Nuget Packages

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Bundle</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (Bundle)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -17,28 +17,28 @@
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
-      <dependency id="DotNetNuke.Core" version="9.2.1" />
-      <dependency id="DotNetNuke.Instrumentation" version="9.2.1" />
-      <dependency id="DotNetNuke.Web" version="9.2.1" />
-      <dependency id="DotNetNuke.Web.Client" version="9.2.1" />
-      <dependency id="DotNetNuke.Web.Mvc" version="9.2.1" />
-      <dependency id="DotNetNuke.WebApi" version="9.2.1" />
-      <dependency id="DotNetNuke.Web.Deprecated" version="9.2.1" />
+      <dependency id="DotNetNuke.Core" version="$version$" />
+      <dependency id="DotNetNuke.Instrumentation" version="$version$" />
+      <dependency id="DotNetNuke.Web" version="$version$" />
+      <dependency id="DotNetNuke.Web.Client" version="$version$" />
+      <dependency id="DotNetNuke.Web.Mvc" version="$version$" />
+      <dependency id="DotNetNuke.WebApi" version="$version$" />
+      <dependency id="DotNetNuke.Web.Deprecated" version="$version$" />
     </dependencies>
   </metadata>
   <files>
-    <file src="DNN.Platform\DNN Platform\HttpModules\Bin\DotNetNuke.HttpModules.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\HttpModules\Bin\DotNetNuke.HttpModules.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\HttpModules\Bin\DotNetNuke.HttpModules.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\HttpModules\Bin\DotNetNuke.HttpModules.pdb" target="lib\"/>
 
-    <file src="DNN.Platform\DNN Platform\Modules\DigitalAssets\Bin\DotNetNuke.Modules.DigitalAssets.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\Modules\DigitalAssets\Bin\DotNetNuke.Modules.DigitalAssets.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Modules\DigitalAssets\Bin\DotNetNuke.Modules.DigitalAssets.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Modules\DigitalAssets\Bin\DotNetNuke.Modules.DigitalAssets.pdb" target="lib\"/>
 
-    <file src="DNN.Platform\DNN Platform\Tests\DNN.Integration.Test.Framework\bin\DNN.Integration.Test.Framework.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\Tests\DNN.Integration.Test.Framework\bin\DNN.Integration.Test.Framework.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Tests\DNN.Integration.Test.Framework\bin\DNN.Integration.Test.Framework.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Tests\DNN.Integration.Test.Framework\bin\DNN.Integration.Test.Framework.pdb" target="lib\"/>
 
-    <file src="DNN.Platform\DNN Platform\Tests\DotNetNuke.Tests.Utilities\bin\DotNetNuke.Tests.Utilities.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\Tests\DotNetNuke.Tests.Utilities\bin\DotNetNuke.Tests.Utilities.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Tests\DotNetNuke.Tests.Utilities\bin\DotNetNuke.Tests.Utilities.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Tests\DotNetNuke.Tests.Utilities\bin\DotNetNuke.Tests.Utilities.pdb" target="lib\"/>
 
-    <file src="DNN.Platform\DNN Platform\Controls\DotNetNuke.WebControls\bin\DotNetNuke.WebControls.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Controls\DotNetNuke.WebControls\bin\DotNetNuke.WebControls.dll" target="lib\"/>
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Core.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Core</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (Core)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -17,8 +17,8 @@
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.dll" target="lib\net40" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.pdb" target="lib\net40" />
-    <file src="DNN.Platform\Website\bin\Microsoft.ApplicationBlocks.Data.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.dll" target="lib\net40" />
+    <file src="..\..\..\Website\bin\DotNetNuke.pdb" target="lib\net40" />
+    <file src="..\..\..\Website\bin\Microsoft.ApplicationBlocks.Data.dll" target="lib\net40\" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Instrumentation</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (Instrumentation)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -17,9 +17,9 @@
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Instrumentation.pdb" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.dll" target="lib\net40\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Log4Net.pdb" target="lib\net40\"/>
+    <file src="..\..\..\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Instrumentation.pdb" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Log4Net.dll" target="lib\net40\"/>
+    <file src="..\..\..\Website\bin\DotNetNuke.Log4Net.pdb" target="lib\net40\"/>
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Providers.FolderProviders.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Providers.FolderProviders.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Providers.FolderProviders</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DotNetNuke.Providers.FolderProviders</title>
     <authors>DNN Corp.</authors>
     <owners>DNN Corp.</owners>
@@ -11,7 +11,7 @@
     <copyright>DotNetNuke is copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
-    <file src="DNN.Platform\DNN Platform\Providers\FolderProviders\bin\Providers\DotNetNuke.Providers.FolderProviders.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\Providers\FolderProviders\bin\Providers\DotNetNuke.Providers.FolderProviders.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Providers\FolderProviders\bin\Providers\DotNetNuke.Providers.FolderProviders.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Providers\FolderProviders\bin\Providers\DotNetNuke.Providers.FolderProviders.pdb" target="lib\"/>
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.SiteExportImport.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.SiteExportImport.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.SiteExportImport</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Site Export/Import</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -16,16 +16,16 @@
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
-      <dependency id="DotNetNuke.Core" version="9.2.1" />
-      <dependency id="DotNetNuke.Instrumentation" version="9.2.1" />
-      <dependency id="DotNetNuke.Web" version="9.2.1" />
+      <dependency id="DotNetNuke.Core" version="$version$" />
+      <dependency id="DotNetNuke.Instrumentation" version="$version$" />
+      <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>
   </metadata>
   <files>
-    <file src="DNN.Platform\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.pdb" target="lib\"/>
 
-    <file src="DNN.Platform\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.Library.dll" target="lib\"/>
-    <file src="DNN.Platform\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.Library.pdb" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.Library.dll" target="lib\"/>
+    <file src="..\..\..\DNN Platform\Modules\DnnExportImport\bin\DotNetNuke.SiteExportImport.Library.pdb" target="lib\"/>
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Web.Client</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (Client Resources)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -17,7 +17,7 @@
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Client.pdb" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.Client.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.Client.pdb" target="lib\net40\" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Web.Deprecated</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (Deprecated Components)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -16,13 +16,13 @@
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
-      <dependency id="DotNetNuke.Web" version="9.2.1" />
+      <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Deprecated.pdb" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\Telerik.Web.UI.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\Licenses\Telerik RadControls for ASP.NET AJAX (Custom).pdf" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.Deprecated.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.Deprecated.pdb" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\Telerik.Web.UI.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\Licenses\Telerik RadControls for ASP.NET AJAX (Custom).pdf" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Web.Mvc</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (ASP.NET MVC)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -16,11 +16,11 @@
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
-      <dependency id="DotNetNuke.Web" version="9.2.1" />
+      <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Mvc.dll" target="lib\net45\"/>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.Mvc.pdb" target="lib\net45\"/>
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.Mvc.dll" target="lib\net45\"/>
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.Mvc.pdb" target="lib\net45\"/>
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.Web</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (Web)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -17,9 +17,9 @@
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
   </metadata>
   <files>
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.Web.pdb" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.dll" target="lib\net40\" />
-    <file src="DNN.Platform\Website\bin\DotNetNuke.WebUtility.pdb" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.Web.pdb" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.WebUtility.dll" target="lib\net40\" />
+    <file src="..\..\..\Website\bin\DotNetNuke.WebUtility.pdb" target="lib\net40\" />
   </files>
 </package>

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>DotNetNuke.WebApi</id>
-    <version>9.2.1</version>
+    <version>$version$</version>
     <title>DNN Platform (ASP.NET Web API)</title>
     <authors>DNN Corp</authors>
     <owners>DNN Corp</owners>
@@ -15,7 +15,7 @@
     <copyright>DNN and DotNetNuke are copyright 2002-2018 by DNN Corp. All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" />
-      <dependency id="DotNetNuke.Web" version="9.2.1" />
+      <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Web.Http" targetFramework="net40" />

--- a/build.cake
+++ b/build.cake
@@ -105,42 +105,10 @@ Task("BuildAll")
 	.IsDependentOn("CreateUpgrade")
     .IsDependentOn("CreateDeploy")
 	.IsDependentOn("CreateSymbols")
-    
+    .IsDependentOn("CreateNugetPackages")
     
     .Does(() =>
 	{
-
-	});
-
-Task("CreateNugetPackages")
-
-	.Does(() =>
-	{
-		var nuGetPackSettings = new NuGetPackSettings
-		{
-			Version = buildNumber,
-			OutputDirectory = @"./Artifacts/",
-			IncludeReferencedProjects = true,
-			Properties = new Dictionary<string, string>
-			{
-				{ "Configuration", "Release" }
-			}
-		};
-
-
-
-		//look for solutions and start building them
-		var nuspecFiles = GetFiles("./Build/Tools/NuGet/DotNetNuke.*.nuspec");
-	
-		Information("Found {0} nuspec files.", nuspecFiles.Count);
-	
-		foreach (var spec in nuspecFiles){
-			var specPath = spec.ToString();
-
-			Information("Starting to pack: {0}", specPath);
-			NuGetPack(specPath, nuGetPackSettings);
-		}
-
 
 	});
 
@@ -234,6 +202,38 @@ Task("CreateDeploy")
 			c.WithProperty("BUILD_NUMBER", buildNumber);
 			c.Targets.Add("CreateDeploy");
 		});
+	});
+
+Task("CreateNugetPackages")
+	.IsDependentOn("CompileSource")
+	.Does(() =>
+	{
+		//look for solutions and start building them
+		var nuspecFiles = GetFiles("./Build/Tools/NuGet/DotNetNuke.*.nuspec");
+	
+		Information("Found {0} nuspec files.", nuspecFiles.Count);
+
+		//basic nuget package configuration
+		var nuGetPackSettings = new NuGetPackSettings
+		{
+			Version = buildNumber,
+			OutputDirectory = @"./Artifacts/",
+			IncludeReferencedProjects = true,
+			Properties = new Dictionary<string, string>
+			{
+				{ "Configuration", "Release" }
+			}
+		};
+	
+		//loop through each nuspec file and create the package
+		foreach (var spec in nuspecFiles){
+			var specPath = spec.ToString();
+
+			Information("Starting to pack: {0}", specPath);
+			NuGetPack(specPath, nuGetPackSettings);
+		}
+
+
 	});
 
 Task("ExternalExtensions")

--- a/build.cake
+++ b/build.cake
@@ -112,6 +112,38 @@ Task("BuildAll")
 
 	});
 
+Task("CreateNugetPackages")
+
+	.Does(() =>
+	{
+		var nuGetPackSettings = new NuGetPackSettings
+		{
+			Version = buildNumber,
+			OutputDirectory = @"./Artifacts/",
+			IncludeReferencedProjects = true,
+			Properties = new Dictionary<string, string>
+			{
+				{ "Configuration", "Release" }
+			}
+		};
+
+
+
+		//look for solutions and start building them
+		var nuspecFiles = GetFiles("./Build/Tools/NuGet/DotNetNuke.*.nuspec");
+	
+		Information("Found {0} nuspec files.", nuspecFiles.Count);
+	
+		foreach (var spec in nuspecFiles){
+			var specPath = spec.ToString();
+
+			Information("Starting to pack: {0}", specPath);
+			NuGetPack(specPath, nuGetPackSettings);
+		}
+
+
+	});
+
 Task("CompileSource")
 	.IsDependentOn("Restore-NuGet-Packages")
 	.Does(() =>


### PR DESCRIPTION
This adds a new task `CreateNugetPackages`, which gathers up all the nuspec files from `Build/Tools/NuGet` and generates the nuget package. I had to update the version numbers with the `$version$` replacement-token feature of nupack. 