### PR TITLE
DNN-9651: drop duplicate index and unused column

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/09.03.00.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/09.03.00.SqlDataProvider
@@ -101,6 +101,14 @@ END
 
 GO
 
+/***** DNN-9651: Drop duplicate index and unused calculated column *****/
+IF Exists (SELECT * FROM sys.indexes WHERE OBJECT_ID = OBJECT_ID(N'{databaseOwner}[{objectQualifier}Users]') AND name = N'IX_{objectQualifier}Users_LowerEmail')
+	DROP INDEX IX_{objectQualifier}Users_LowerEmail ON {databaseOwner}[{objectQualifier}Users];
+GO
+
+IF Exists (SELECT * FROM sys.columns WHERE OBJECT_ID = OBJECT_ID(N'{databaseOwner}[{objectQualifier}Users]') AND name = N'LowerEmail')
+	ALTER TABLE {databaseOwner}[{objectQualifier}Users] DROP COLUMN LowerEmail;
+GO
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/


### PR DESCRIPTION
Removes the duplicate index `IX_Users_LowerEmail` and removes the calculated column `LowerEmail` column because it's not utilized in the platform. 