### PR TITLE
Show Module Labels

### DIFF
--- a/Website/admin/Menus/ModuleActions/ModuleActions.ascx
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.ascx
@@ -58,7 +58,8 @@
                     supportsMove: <% = SupportsMove.ToString().ToLower() %>,
                     supportsQuickSettings: supportsQuickSettings,
                     displayQuickSettings: displayQuickSettings,
-                    isShared : <% = IsShared.ToString().ToLower() %>
+                    isShared : <% = IsShared.ToString().ToLower() %>,
+                    moduleTitle: '<% = Localization.GetSafeJSString(ModuleTitle) %>'
                 }
             );
         }

--- a/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -84,6 +84,8 @@ namespace DotNetNuke.Admin.Containers
             return Localization.GetString(key, Localization.GlobalResourceFile);
         }
 
+        protected string ModuleTitle { get; set; }
+
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -117,7 +119,7 @@ namespace DotNetNuke.Admin.Containers
             {
                 SupportsQuickSettings = false;
                 DisplayQuickSettings = false;
-
+                ModuleTitle = ModuleContext.Configuration.ModuleTitle;
                 var moduleDefinitionId = ModuleContext.Configuration.ModuleDefID;
                 var quickSettingsControl = ModuleControlController.GetModuleControlByControlKey("QuickSettings", moduleDefinitionId);
 

--- a/Website/admin/Menus/ModuleActions/ModuleActions.css
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.css
@@ -178,10 +178,11 @@ div.actionMenu ul.dnn_mact > li.actionQuickSettings div.qsFooter a.secondarybtn 
   text-align: center;
   font-size: 13px;
 }
-div.actionMenu ul.dnn_mact li.dnn_shared {
+div.actionMenu ul.dnn_mact li.dnn_menu_label {
   display: inline-block;
+  pointer-events: none;
 }
-div.actionMenu ul.dnn_mact li.dnn_shared > div {
+div.actionMenu ul.dnn_mact li.dnn_menu_label > div {
   display: inline-block;
   padding: 0.5em 0;
   -webkit-writing-mode: vertical-rl;

--- a/Website/admin/Menus/ModuleActions/ModuleActions.js
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.js
@@ -15,6 +15,8 @@
         var isShared = opts.isShared;
         var supportsQuickSettings = opts.supportsQuickSettings;
         var displayQuickSettings = opts.displayQuickSettings;
+        var sharedText = opts.sharedText;
+        var moduleTitle = opts.moduleTitle;
 
         function completeMove(targetPane, moduleOrder) {
             //remove empty pane class
@@ -307,7 +309,10 @@
             }
         }
 
-        function buildSharedMenu(root, rootText, rootClass) {
+        function buildMenuLabel(root, rootText, rootClass) {
+            if (!rootText || rootText.length == 0) {
+                return;                
+            }
             root.append("<li class=\"" + rootClass + "\"><div>" + rootText + "</div>");
         }
 
@@ -369,6 +374,7 @@
                 $form.append("<div id=\"moduleActions-" + moduleId + "\" class=\"actionMenu\"><ul class=\"dnn_mact\"></ul></div>");
                 var menu = $form.find("div:last");
                 var menuRoot = menu.find("ul");
+                var menuLabel = menuTitle;
                 if (customCount > 0) {
                     buildMenu(menuRoot, "Edit", "actionMenuEdit", "pencil",  customActions, customCount);
                 }
@@ -384,8 +390,9 @@
                 }
 
                 if (isShared) {
-                    buildSharedMenu(menuRoot, opts.sharedText, "dnn_shared");
+                    menuLabel = menuLabel && menuLabel.length > 0 ? sharedText + ': ' + menuLabel : sharedText;
                 }
+                buildMenuLabel(menuRoot, menuLabel, "dnn_menu_label");
                 watchResize(moduleId);
             }
         }

--- a/Website/admin/Menus/ModuleActions/ModuleActions.less
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.less
@@ -222,14 +222,15 @@ div.actionMenu ul.dnn_mact > li.actionQuickSettings div.qsFooter a.secondarybtn{
     font-size: 13px;
 }
 
-div.actionMenu ul.dnn_mact li.dnn_shared {
+div.actionMenu ul.dnn_mact li.dnn_menu_label {
     display: inline-block;
     width: 20px;
     height: 100px;
     background-color: @menu_backgroundColor;
+    pointer-events: none;
 }
 
-div.actionMenu ul.dnn_mact li.dnn_shared > div {
+div.actionMenu ul.dnn_mact li.dnn_menu_label > div {
     display: inline-block;
     width: 20px;
     height: 20px;


### PR DESCRIPTION
fixes [2353](https://github.com/dnnsoftware/Dnn.Platform/issues/2353)

Similar indicator is already shown for the shared modules. It is placed vertically in a right corner. To stay with the same design, module label is added in a same way. 
I'm open to discuss more ideas.

Short DEMO: [mp4](https://drive.google.com/file/d/1C2EFMusxS2npDRwDpN0qfoFsKir4NpEZ/view)