### PR TITLE
Portal deletion removes home folder linked to other portal

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2819,16 +2819,13 @@ namespace DotNetNuke.Entities.Portals
                     {
                         var homeDirectory = portal.HomeDirectoryMapPath;
                         // check whether home directory is not used by other portal
-                        // it happens when new portal creation failed, but home directory defined by user is alredy in use with other portal
-                        var homeDirectoryInUse = portals.OfType<PortalInfo>().Any(
-                            x => x.PortalID != portal.PortalID &&
+                        // it happens when new portal creation failed, but home directory defined by user is already in use with other portal
+                        var homeDirectoryInUse = portals.OfType<PortalInfo>().Any(x => 
+                            x.PortalID != portal.PortalID &&
                             x.HomeDirectoryMapPath.Equals(homeDirectory, StringComparison.OrdinalIgnoreCase));
+
                         if (!homeDirectoryInUse)
                         {
-                            if (homeDirectory.EndsWith("\\"))
-                            {
-                                homeDirectory = homeDirectory.Substring(0, homeDirectory.Length - 1);
-                            }
                             if (Directory.Exists(homeDirectory))
                             {
                                 Globals.DeleteFolderRecursive(homeDirectory);

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2791,8 +2791,8 @@ namespace DotNetNuke.Entities.Portals
             string message = string.Empty;
 
             //check if this is the last portal
-            int portalCount = Instance.GetPortals().Count;
-            if (portalCount > 1)
+            var portals = Instance.GetPortals();
+            if (portals.Count > 1)
             {
                 if (portal != null)
                 {
@@ -2815,19 +2815,24 @@ namespace DotNetNuke.Entities.Portals
                         }
                     }
                     //delete upload directory
-                    Globals.DeleteFolderRecursive(serverPath + "Portals\\" + portal.PortalID);
                     if (!string.IsNullOrEmpty(portal.HomeDirectory))
                     {
-                        string homeDirectory = portal.HomeDirectoryMapPath;
-
-                        if (homeDirectory.EndsWith("\\"))
+                        var homeDirectory = portal.HomeDirectoryMapPath;
+                        // check whether home directory is not used by other portal
+                        // it happens when new portal creation failed, but home directory defined by user is alredy in use with other portal
+                        var homeDirectoryInUse = portals.OfType<PortalInfo>().Any(
+                            x => x.PortalID != portal.PortalID &&
+                            x.HomeDirectoryMapPath.Equals(homeDirectory, StringComparison.OrdinalIgnoreCase));
+                        if (!homeDirectoryInUse)
                         {
-                            homeDirectory = homeDirectory.Substring(0, homeDirectory.Length - 1);
-                        }
-
-                        if (Directory.Exists(homeDirectory))
-                        {
-                            Globals.DeleteFolderRecursive(homeDirectory);
+                            if (homeDirectory.EndsWith("\\"))
+                            {
+                                homeDirectory = homeDirectory.Substring(0, homeDirectory.Length - 1);
+                            }
+                            if (Directory.Exists(homeDirectory))
+                            {
+                                Globals.DeleteFolderRecursive(homeDirectory);
+                            }
                         }
                     }
                     //remove database references


### PR DESCRIPTION
This PR is addition to [PR 2297](https://github.com/dnnsoftware/Dnn.Platform/pull/2297)

## Problem

On portal creation, when exception occurred, application removes folder that is already in use with other portal.

## Scenario

1. Create a DNN Site for future Portal ID by modifying home directory [PortalID] token, e.g. if current portal ID is 0 then create a portal with [PortalID] = 2. So, home directory path should be like: Portals/2
2. Create a site without modifying [PortalID]. So, home directory path should be like: Portals/[PortalID].
We get an exception and error message "Portal Folder Portal/2 is already Used".
3. Check folder Portals/2 created in step 1. It is fully removed.

## Rootcause

When [PortalID] folder token is not defined explicitly, system assigns portal id automatically (portal id created in db). We have got the case when home folder gets the same path as in step 1.
On exception, application tries to remove 'creating' portal. See [Try Delete Creating Portal](https://github.com/dnnsoftware/Dnn.AdminExperience/blob/23a96a164b095100249c41ab57f2726ac92673fb/Extensions/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs#L525). With that, it also removes Portals/2.


## Solution

Need to verify whether folder that is going to be removed is not linked to other portal.