### PR TITLE
DNN23855_Clear user cache onlogin failure

### DIFF
--- a/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
@@ -707,6 +707,12 @@ namespace DotNetNuke.Security.Membership
             return settings[settingKey] == null ? string.Empty : settings[settingKey].ToString();
         }
 
+        private bool IsUserLocked(string userName)
+        {
+            var aspnetUser = System.Web.Security.Membership.GetUser(userName);
+            return aspnetUser?.IsLockedOut ?? false;
+        }
+
         #endregion
 
         #region Public Methods
@@ -1830,9 +1836,7 @@ namespace DotNetNuke.Security.Membership
                         }
                     }
 
-                }
-
-                DataCache.ClearUserCache(portalId, username);
+                }                
 
                 //Verify User Credentials
                 bool bValid = false;
@@ -1841,6 +1845,12 @@ namespace DotNetNuke.Security.Membership
                 {
                     //Clear the user object
                     user = null;
+
+                    if (IsUserLocked(username))
+                    {
+                        DataCache.ClearUserCache(portalId, username);
+                        DataCache.ClearCache(GetCacheKey(username));
+                    }
                 }                              
             }
             else

--- a/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
@@ -707,12 +707,6 @@ namespace DotNetNuke.Security.Membership
             return settings[settingKey] == null ? string.Empty : settings[settingKey].ToString();
         }
 
-        private bool IsUserLocked(string userName)
-        {
-            var aspnetUser = System.Web.Security.Membership.GetUser(userName);
-            return aspnetUser?.IsLockedOut ?? false;
-        }
-
         #endregion
 
         #region Public Methods
@@ -1846,12 +1840,10 @@ namespace DotNetNuke.Security.Membership
                     //Clear the user object
                     user = null;
 
-                    if (IsUserLocked(username))
-                    {
-                        DataCache.ClearUserCache(portalId, username);
-                        DataCache.ClearCache(GetCacheKey(username));
-                    }
-                }                              
+                    //Clear cache for user so that locked out & other status could be updated
+                    DataCache.ClearUserCache(portalId, username);
+                    DataCache.ClearCache(GetCacheKey(username));
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #2343

## Summary
After max invalid attempts reached user still Unlock in Admin UI, though membership table showing Locked out true.

