### PR TITLE
Checking for option of EnableEmailasUsername before validating user

### DIFF
--- a/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -264,17 +264,29 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
 
                 //DNN-6093
                 //check if we use email address here rather than username
-                if(PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false))
+                UserInfo userByEmail = null;
+                var emailUsedAsUsername = PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false);                
+
+                if (emailUsedAsUsername)
                 {
-                    var testUser = UserController.GetUserByEmail(PortalId, userName); // one additonal call to db to see if an account with that email actually exists
-                    if(testUser != null)
+                    // one additonal call to db to see if an account with that email actually exists
+                    userByEmail = UserController.GetUserByEmail(PortalId, userName);                     
+
+                    if (userByEmail != null)
                     {
-                        userName = testUser.Username; //we need the username of the account in order to authenticate in the next step
+                        //we need the username of the account in order to authenticate in the next step
+                        userName = userByEmail.Username; 
                     }
                 }
 
-				var objUser = UserController.ValidateUser(PortalId, userName, txtPassword.Text, "DNN", string.Empty, PortalSettings.PortalName, IPAddress, ref loginStatus);
-				var authenticated = Null.NullBoolean;
+                UserInfo objUser = null;
+
+                if (!emailUsedAsUsername || userByEmail != null)
+                {
+                    objUser = UserController.ValidateUser(PortalId, userName, txtPassword.Text, "DNN", string.Empty, PortalSettings.PortalName, IPAddress, ref loginStatus);
+                }
+
+                var authenticated = Null.NullBoolean;
 				var message = Null.NullString;
 				if (loginStatus == UserLoginStatus.LOGIN_USERNOTAPPROVED)
 				{
@@ -285,7 +297,7 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
 					authenticated = (loginStatus != UserLoginStatus.LOGIN_FAILURE);
 				}
 
-                if (objUser != null && loginStatus != UserLoginStatus.LOGIN_FAILURE && PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", PortalId, false))
+                if (objUser != null && loginStatus != UserLoginStatus.LOGIN_FAILURE && emailUsedAsUsername)
                 {
                     //make sure internal username matches current e-mail address
                     if (objUser.Username.ToLower() != objUser.Email.ToLower())


### PR DESCRIPTION
Fixes #2367 

## Summary
If EnableEmailasUsername is set, then verify user obtained by GetbyEmail must not be null. 
