### PR TITLE
CI: Fixing broken builds due to change in build number variable

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -222,7 +222,7 @@ Task("CreateNugetPackages")
 		//basic nuget package configuration
 		var nuGetPackSettings = new NuGetPackSettings
 		{
-			Version = buildNumber,
+			Version = GetBuildNumber(),
 			OutputDirectory = @"./Artifacts/",
 			IncludeReferencedProjects = true,
 			Properties = new Dictionary<string, string>


### PR DESCRIPTION
#2270 changed the `buildNumber` variable to `GetBuildNumber()`, and #2323 was merged which was submitted and merged using the original variable. 