### PR TITLE
Fixes issue 2360. Biography as Multi line text by default

### DIFF
--- a/DNN Platform/Website/Templates/Blank Website.template
+++ b/DNN Platform/Website/Templates/Blank Website.template
@@ -59,7 +59,7 @@
     <profiledefinition>
       <propertycategory>Basic</propertycategory>
       <propertyname>Biography</propertyname>
-      <datatype>RichText</datatype>
+      <datatype>Multi-line Text</datatype>
       <length>0</length>
       <defaultvisibility>2</defaultvisibility>
     </profiledefinition>

--- a/DNN Platform/Website/Templates/Default Website.template
+++ b/DNN Platform/Website/Templates/Default Website.template
@@ -59,7 +59,7 @@
     <profiledefinition>
       <propertycategory>Basic</propertycategory>
       <propertyname>Biography</propertyname>
-      <datatype>RichText</datatype>
+      <datatype>Multi-line Text</datatype>
       <length>0</length>
       <defaultvisibility>2</defaultvisibility>
     </profiledefinition>


### PR DESCRIPTION
Fixes #2360 

## Summary
Changed "Blank website.template" and "Default website.template" to have Biography profile property as Multi line text in stead of Richt Text.
ProfileController.AddDefaultDefinitions already had Multi Line Text for Biography, so no change needed there.

## Tested
Portal installs with both template and checked the type of the Biography fields in a user's profile.
