### PR TITLE
Member Directory Search: adding unused text to page

### DIFF
--- a/DNN Platform/Modules/MemberDirectory/module.css
+++ b/DNN Platform/Modules/MemberDirectory/module.css
@@ -340,3 +340,6 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 .dnnForm .dnnFormItem .mdFilterLists input, .dnnForm .dnnFormItem .mdFilterLists select { width: 45%;}
 .dnnForm .dnnFormItem .mdFilterBy { background-color: #F0F0F0; margin-left: 36%; width: 50%;}
 
+.ui-helper-hidden-accessible {
+	display:none;
+}

--- a/DNN Platform/Modules/MemberDirectory/module.css
+++ b/DNN Platform/Modules/MemberDirectory/module.css
@@ -339,7 +339,4 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 .dnnForm .dnnFormItem .mdFilterLists input { float: none;}
 .dnnForm .dnnFormItem .mdFilterLists input, .dnnForm .dnnFormItem .mdFilterLists select { width: 45%;}
 .dnnForm .dnnFormItem .mdFilterBy { background-color: #F0F0F0; margin-left: 36%; width: 50%;}
-
-.ui-helper-hidden-accessible {
-	display:none;
-}
+.ui-helper-hidden-accessible { display:none; }

--- a/Website/Resources/Shared/scripts/jquery/jquery-ui.js
+++ b/Website/Resources/Shared/scripts/jquery/jquery-ui.js
@@ -8283,13 +8283,12 @@ $.widget( "ui.autocomplete", {
 			}
 		} );
 
-		var liveRegionContainer = this.element.closest("div.dnnForm") || this.document[0].body;
 		this.liveRegion = $( "<div>", {
 			role: "status",
 			"aria-live": "assertive",
 			"aria-relevant": "additions"
 		} )
-			.appendTo( liveRegionContainer );
+			.appendTo( this.document[ 0 ].body );
 
 		this._addClass( this.liveRegion, null, "ui-helper-hidden-accessible" );
 

--- a/Website/Resources/Shared/scripts/jquery/jquery-ui.js
+++ b/Website/Resources/Shared/scripts/jquery/jquery-ui.js
@@ -8283,12 +8283,13 @@ $.widget( "ui.autocomplete", {
 			}
 		} );
 
+		var liveRegionContainer = this.element.closest("div.dnnForm") || this.document[0].body;
 		this.liveRegion = $( "<div>", {
 			role: "status",
 			"aria-live": "assertive",
 			"aria-relevant": "additions"
 		} )
-			.appendTo( this.document[ 0 ].body );
+			.appendTo( liveRegionContainer );
 
 		this._addClass( this.liveRegion, null, "ui-helper-hidden-accessible" );
 


### PR DESCRIPTION
fixes #2391

### Summary

When searching member directory users, once autocomplete popup opened, application is adding the text next to the main form.

### Steps to reproduce

1. Create multiple dnn users
2. Create a new page
3. Add Member Directory module to a newly created page, click on publish
4. Start typing user name in a search box
5. Observe the text "..results are available, use up and down key" which is added at the bottom of the page

### Rootcause
Text which is added is a part of [Live Region](https://www.oreilly.com/library/view/javascript-cookbook/9781449390211/ch14s09.html). It is used to voice additional info by screen readers. 
Live Region is marked with `.ui-helper-hidden-accessible` style, but it is not defined on a module level css. Similarly to other modules, we should hide helper text `display:none;`

### Sample of the issue
![image](https://user-images.githubusercontent.com/22524011/46827102-72d7b200-cda0-11e8-95aa-10ada7bc79ff.png)
