### PR TITLE
Tweak version calculation

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,8 +1,9 @@
 next-version: 9.3.0
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
+mode: ContinuousDeployment
 branches:
   development:
     regex: development      
-    tag: ''
+    tag: 'alpha'
     is-mainline: true
     source-branches: []


### PR DESCRIPTION
I propose that version are always prerelease, unless built from a tagged commit.

| branch/tag | version |
| -- | -- |
| `development` | `9.3.0-alpha.123` |
| `release/9.4.0` | `9.3.0-beta.12` |
| `v9.3.0` (tag) | `9.3.0` |