### PR TITLE
use full sermver for nuget packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 .builds
 *.dotCover
 *.ldf
+Artifacts/
 
 # git merge artifacts
 *.orig

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -30,6 +30,11 @@ Task("UpdateDnnManifests")
 
 public string GetBuildNumber()
 {
+    return version.LegacySemVerPadded;
+}
+
+public string GetProductVersion()
+{
     return version.MajorMinorPatch;
 }
 

--- a/build.cake
+++ b/build.cake
@@ -114,21 +114,20 @@ Task("BuildAll")
 	});
 
 Task("CompileSource")
-    .IsDependentOn("GitVersion")
+    .IsDependentOn("UpdateDnnManifests")
 	.IsDependentOn("Restore-NuGet-Packages")
 	.Does(() =>
 	{
 		MSBuild(createCommunityPackages, c =>
 		{
 			c.Configuration = configuration;
-			c.WithProperty("BUILD_NUMBER", GetBuildNumber());
+			c.WithProperty("BUILD_NUMBER", GetProductVersion());
 			c.Targets.Add("CompileSource");
 		});
 	});
 
 Task("CreateInstall")
 	.IsDependentOn("CompileSource")
-    .IsDependentOn("UpdateDnnManifests")
 	.Does(() =>
 	{
 		CreateDirectory("./Artifacts");
@@ -136,14 +135,13 @@ Task("CreateInstall")
 		MSBuild(createCommunityPackages, c =>
 		{
 			c.Configuration = configuration;
-			c.WithProperty("BUILD_NUMBER", GetBuildNumber());
+			c.WithProperty("BUILD_NUMBER", GetProductVersion());
 			c.Targets.Add("CreateInstall");
 		});
 	});
 
 Task("CreateUpgrade")
 	.IsDependentOn("CompileSource")
-    .IsDependentOn("UpdateDnnManifests")
 	.Does(() =>
 	{
 		CreateDirectory("./Artifacts");
@@ -151,14 +149,13 @@ Task("CreateUpgrade")
 		MSBuild(createCommunityPackages, c =>
 		{
 			c.Configuration = configuration;
-			c.WithProperty("BUILD_NUMBER", GetBuildNumber());
+			c.WithProperty("BUILD_NUMBER", GetProductVersion());
 			c.Targets.Add("CreateUpgrade");
 		});
 	});
     
 Task("CreateSymbols")
 	.IsDependentOn("CompileSource")
-    .IsDependentOn("UpdateDnnManifests")
 	.Does(() =>
 	{
 		CreateDirectory("./Artifacts");
@@ -166,7 +163,7 @@ Task("CreateSymbols")
 		MSBuild(createCommunityPackages, c =>
 		{
 			c.Configuration = configuration;
-			c.WithProperty("BUILD_NUMBER", GetBuildNumber());
+			c.WithProperty("BUILD_NUMBER", GetProductVersion());
 			c.Targets.Add("CreateSymbols");
 		});
 	});   
@@ -191,7 +188,7 @@ Task("CreateSource")
 		MSBuild(createCommunityPackages, c =>
 		{
 			c.Configuration = configuration;
-			c.WithProperty("BUILD_NUMBER", GetBuildNumber());
+			c.WithProperty("BUILD_NUMBER", GetProductVersion());
 			c.Targets.Add("CreateSource");
 		});
 	});
@@ -205,7 +202,7 @@ Task("CreateDeploy")
 		MSBuild(createCommunityPackages, c =>
 		{
 			c.Configuration = configuration;
-			c.WithProperty("BUILD_NUMBER", GetBuildNumber());
+			c.WithProperty("BUILD_NUMBER", GetProductVersion());
 			c.Targets.Add("CreateDeploy");
 		});
 	});


### PR DESCRIPTION
## Summary

Currently NuGet packages receive the version which is used for the Platform itself, like `9.3.0`.

This PR changes cake scripts so that the number will match the full build number such as `9.3.0-alpha024` or `9.3.0-RC1`. 

This way those packages will be nicely deployable to MyGet/NuGet, where each version has to be unique