### PR TITLE
Unique build numbers on VSTS

### DIFF
--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -9,10 +9,7 @@ var buildId = EnvironmentVariable("Build.BuildId") ?? string.Empty;
 Task("BuildServerSetVersion")
   .IsDependentOn("GitVersion")
   .Does(() => {
-    StartPowershellScript("Write-Host", args =>
-        {
-            args.AppendQuoted($"##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
-        });
+    StartPowershellScript("Write-Host", $"##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
 });
 
 Task("GitVersion")

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -9,7 +9,7 @@ var buildId = EnvironmentVariable("BUILD_BUILDID") ?? "0";
 Task("BuildServerSetVersion")
   .IsDependentOn("GitVersion")
   .Does(() => {
-    StartPowershellScript("Write-Host ##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
+    StartPowershellScript($"Write-Host ##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
 });
 
 Task("GitVersion")

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -1,14 +1,18 @@
 #addin Cake.XdtTransform
 #addin "Cake.FileHelpers"
+#addin Cake.Powershell
 #tool "nuget:?package=GitVersion.CommandLine&prerelease"
 
 GitVersion version;
+var buildId = EnvironmentVariable("Build.BuildId") ?? string.Empty;
 
 Task("BuildServerSetVersion")
+  .IsDependentOn("GitVersion")
   .Does(() => {
-    GitVersion(new GitVersionSettings {
-      OutputType = GitVersionOutput.BuildServer
-    });
+    StartPowershellScript("Write-Host", args =>
+        {
+            args.AppendQuoted($"##vso[build.updatebuildnumber]{version.FullSemver}.{buildId}");
+        });
 });
 
 Task("GitVersion")

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -11,7 +11,7 @@ Task("BuildServerSetVersion")
   .Does(() => {
     StartPowershellScript("Write-Host", args =>
         {
-            args.AppendQuoted($"##vso[build.updatebuildnumber]{version.FullSemver}.{buildId}");
+            args.AppendQuoted($"##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
         });
 });
 

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -9,7 +9,7 @@ var buildId = EnvironmentVariable("BUILD_BUILDID") ?? "0";
 Task("BuildServerSetVersion")
   .IsDependentOn("GitVersion")
   .Does(() => {
-    StartPowershellScript("Write-Host", $"##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
+    StartPowershellScript("Write-Host ##vso[build.updatebuildnumber]{version.FullSemVer}.{buildId}");
 });
 
 Task("GitVersion")

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -4,7 +4,7 @@
 #tool "nuget:?package=GitVersion.CommandLine&prerelease"
 
 GitVersion version;
-var buildId = EnvironmentVariable("Build.BuildId") ?? string.Empty;
+var buildId = EnvironmentVariable("BUILD_BUILDID) ?? "0";
 
 Task("BuildServerSetVersion")
   .IsDependentOn("GitVersion")

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -4,7 +4,7 @@
 #tool "nuget:?package=GitVersion.CommandLine&prerelease"
 
 GitVersion version;
-var buildId = EnvironmentVariable("BUILD_BUILDID) ?? "0";
+var buildId = EnvironmentVariable("BUILD_BUILDID") ?? "0";
 
 Task("BuildServerSetVersion")
   .IsDependentOn("GitVersion")


### PR DESCRIPTION
## Summary

An apparent bug on VSTS causes issues accessing builds with duplicate numbers which happen when we have multiple triggers for the same commit (such as trigger by merging, manually, or by AdminExperience)

This PR changes the build number by appending the incremented build id from VSTS to the gitversion number.