### PR TITLE
Show Module Labels (Typo)

### DIFF
--- a/Website/admin/Menus/ModuleActions/ModuleActions.js
+++ b/Website/admin/Menus/ModuleActions/ModuleActions.js
@@ -374,7 +374,7 @@
                 $form.append("<div id=\"moduleActions-" + moduleId + "\" class=\"actionMenu\"><ul class=\"dnn_mact\"></ul></div>");
                 var menu = $form.find("div:last");
                 var menuRoot = menu.find("ul");
-                var menuLabel = menuTitle;
+                var menuLabel = moduleTitle;
                 if (customCount > 0) {
                     buildMenu(menuRoot, "Edit", "actionMenuEdit", "pencil",  customActions, customCount);
                 }


### PR DESCRIPTION
### Summary

This is a quick fix for a typo I did in a previous [PR 2354](https://github.com/dnnsoftware/Dnn.Platform/pull/2354)
Due to wrong variable name there is an error occurred. `moduleTitle` should be used instead of `menuTitle`.

![image](https://user-images.githubusercontent.com/22524011/47802902-f77f7580-dd39-11e8-8d7e-3aae76d446f2.png)
