### PR TITLE
Locked cache file caused site load failure

### DIFF
--- a/DNN Platform/Library/Services/ModuleCache/FileProvider.cs
+++ b/DNN Platform/Library/Services/ModuleCache/FileProvider.cs
@@ -225,30 +225,37 @@ namespace DotNetNuke.Services.ModuleCache
 
         public override void PurgeExpiredItems(int portalId)
         {
-            var filesNotDeleted = new StringBuilder();
-            int i = 0;
-            string cacheFolder = GetCacheFolder(portalId);
-            if (Directory.Exists(cacheFolder) && IsPathInApplication(cacheFolder))
+            try
             {
-                foreach (string File in Directory.GetFiles(cacheFolder, String.Format("*{0}", AttribFileExtension)))
+                var filesNotDeleted = new StringBuilder();
+                int i = 0;
+                string cacheFolder = GetCacheFolder(portalId);
+                if (Directory.Exists(cacheFolder) && IsPathInApplication(cacheFolder))
                 {
-                    if (IsFileExpired(File))
+                    foreach (string File in Directory.GetFiles(cacheFolder, String.Format("*{0}", AttribFileExtension)))
                     {
-                        string fileToDelete = File.Replace(AttribFileExtension, DataFileExtension);
-                        if (!FileSystemUtils.DeleteFileWithWait(fileToDelete, 100, 200))
+                        if (IsFileExpired(File))
                         {
-                            filesNotDeleted.Append(String.Format("{0};", fileToDelete));
-                        }
-                        else
-                        {
-                            i += 1;
+                            string fileToDelete = File.Replace(AttribFileExtension, DataFileExtension);
+                            if (!FileSystemUtils.DeleteFileWithWait(fileToDelete, 100, 200))
+                            {
+                                filesNotDeleted.Append(String.Format("{0};", fileToDelete));
+                            }
+                            else
+                            {
+                                i += 1;
+                            }
                         }
                     }
                 }
+                if (filesNotDeleted.Length > 0)
+                {
+                    throw new IOException(String.Format("Deleted {0} files, however, some files are locked.  Could not delete the following files: {1}", i, filesNotDeleted));
+                }
             }
-            if (filesNotDeleted.Length > 0)
+            catch (Exception ex)
             {
-                throw new IOException(String.Format("Deleted {0} files, however, some files are locked.  Could not delete the following files: {1}", i, filesNotDeleted));
+                Exceptions.Exceptions.LogException(ex);
             }
         }
 
@@ -277,31 +284,38 @@ namespace DotNetNuke.Services.ModuleCache
 
         public override void Remove(int tabModuleId)
         {
-            ModuleInfo tabModule = ModuleController.Instance.GetTabModule(tabModuleId);
+            try
+            {
+                ModuleInfo tabModule = ModuleController.Instance.GetTabModule(tabModuleId);
 
-            int portalId = tabModule.PortalID;
-            if (portalId == Null.NullInteger)
-            {
-                portalId = PortalSettings.Current.PortalId;
-            }
+                int portalId = tabModule.PortalID;
+                if (portalId == Null.NullInteger)
+                {
+                    portalId = PortalSettings.Current.PortalId;
+                }
 
-            string cacheFolder = GetCacheFolder(portalId);
-            var filesNotDeleted = new StringBuilder();
-            int i = 0;
-            foreach (string File in Directory.GetFiles(cacheFolder, tabModuleId + "_*.*"))
-            {
-                if (!FileSystemUtils.DeleteFileWithWait(File, 100, 200))
+                string cacheFolder = GetCacheFolder(portalId);
+                var filesNotDeleted = new StringBuilder();
+                int i = 0;
+                foreach (string File in Directory.GetFiles(cacheFolder, tabModuleId + "_*.*"))
                 {
-                    filesNotDeleted.Append(File + ";");
+                    if (!FileSystemUtils.DeleteFileWithWait(File, 100, 200))
+                    {
+                        filesNotDeleted.Append(File + ";");
+                    }
+                    else
+                    {
+                        i += 1;
+                    }
                 }
-                else
+                if (filesNotDeleted.Length > 0)
                 {
-                    i += 1;
+                    throw new IOException("Deleted " + i + " files, however, some files are locked.  Could not delete the following files: " + filesNotDeleted);
                 }
             }
-            if (filesNotDeleted.Length > 0)
+            catch (Exception ex)
             {
-                throw new IOException("Deleted " + i + " files, however, some files are locked.  Could not delete the following files: " + filesNotDeleted);
+                Exceptions.Exceptions.LogException(ex);
             }
         }
 

--- a/DNN Platform/Library/Services/OutputCache/Providers/FileProvider.cs
+++ b/DNN Platform/Library/Services/OutputCache/Providers/FileProvider.cs
@@ -337,10 +337,6 @@ namespace DotNetNuke.Services.OutputCache.Providers
 
                 foundFile = true;
             }
-            catch (FileNotFoundException)
-            {
-                foundFile = false;
-            }
             catch (Exception ex)
             {
                 Exceptions.Exceptions.LogException(ex);

--- a/DNN Platform/Library/Services/OutputCache/Providers/FileProvider.cs
+++ b/DNN Platform/Library/Services/OutputCache/Providers/FileProvider.cs
@@ -112,22 +112,29 @@ namespace DotNetNuke.Services.OutputCache.Providers
 
         private void PurgeCache(string folder)
         {
-            var filesNotDeleted = new StringBuilder();
-            int i = 0;
-            foreach (string file in Directory.GetFiles(folder, "*.resources"))
+            try
             {
-                if (!(FileSystemUtils.DeleteFileWithWait(file, 100, 200)))
+                var filesNotDeleted = new StringBuilder();
+                int i = 0;
+                foreach (string file in Directory.GetFiles(folder, "*.resources"))
                 {
-                    filesNotDeleted.Append(file + ";");
+                    if (!(FileSystemUtils.DeleteFileWithWait(file, 100, 200)))
+                    {
+                        filesNotDeleted.Append(file + ";");
+                    }
+                    else
+                    {
+                        i += 1;
+                    }
                 }
-                else
+                if (filesNotDeleted.Length > 0)
                 {
-                    i += 1;
+                    throw new IOException("Deleted " + i + " files, however, some files are locked.  Could not delete the following files: " + filesNotDeleted);
                 }
             }
-            if (filesNotDeleted.Length > 0)
+            catch (Exception ex)
             {
-                throw new IOException("Deleted " + i + " files, however, some files are locked.  Could not delete the following files: " + filesNotDeleted);
+                Exceptions.Exceptions.LogException(ex);
             }
         }
 
@@ -226,44 +233,51 @@ namespace DotNetNuke.Services.OutputCache.Providers
 
         public override void Remove(int tabId)
         {
-            Dictionary<int, int> portals = PortalController.GetPortalDictionary();
-            if (portals.ContainsKey(tabId) && portals[tabId] > Null.NullInteger)
+            try
             {
-                var filesNotDeleted = new StringBuilder();
-                int i = 0;
-                string cacheFolder = GetCacheFolder(portals[tabId]);
-
-                if (!(string.IsNullOrEmpty(cacheFolder)))
+                Dictionary<int, int> portals = PortalController.GetPortalDictionary();
+                if (portals.ContainsKey(tabId) && portals[tabId] > Null.NullInteger)
                 {
-                    foreach (string file in Directory.GetFiles(cacheFolder, string.Concat(tabId, "_*.*")))
-                    {
-                        if (!(FileSystemUtils.DeleteFileWithWait(file, 100, 200)))
-                        {
-                            filesNotDeleted.Append(string.Concat(file, ";"));
-                        }
-                        else
-                        {
-                            i += 1;
-                        }
-                    }
-                    if (filesNotDeleted.Length > 0)
-                    {
-                        var log = new LogInfo {LogTypeKey = EventLogController.EventLogType.HOST_ALERT.ToString()};
+                    var filesNotDeleted = new StringBuilder();
+                    int i = 0;
+                    string cacheFolder = GetCacheFolder(portals[tabId]);
 
-                        var logDetail = new LogDetailInfo
+                    if (!(string.IsNullOrEmpty(cacheFolder)))
+                    {
+                        foreach (string file in Directory.GetFiles(cacheFolder, string.Concat(tabId, "_*.*")))
                         {
-                            PropertyName = "FileOutputCacheProvider",
-                            PropertyValue =
-                                string.Format(
-                                    "Deleted {0} files, however, some files are locked.  Could not delete the following files: {1}",
-                                    i, filesNotDeleted)
-                        };
-                        var properties = new LogProperties {logDetail};
-                        log.LogProperties = properties;
+                            if (!(FileSystemUtils.DeleteFileWithWait(file, 100, 200)))
+                            {
+                                filesNotDeleted.Append(string.Concat(file, ";"));
+                            }
+                            else
+                            {
+                                i += 1;
+                            }
+                        }
+                        if (filesNotDeleted.Length > 0)
+                        {
+                            var log = new LogInfo { LogTypeKey = EventLogController.EventLogType.HOST_ALERT.ToString() };
 
-                        LogController.Instance.AddLog(log);
+                            var logDetail = new LogDetailInfo
+                            {
+                                PropertyName = "FileOutputCacheProvider",
+                                PropertyValue =
+                                    string.Format(
+                                        "Deleted {0} files, however, some files are locked.  Could not delete the following files: {1}",
+                                        i, filesNotDeleted)
+                            };
+                            var properties = new LogProperties { logDetail };
+                            log.LogProperties = properties;
+
+                            LogController.Instance.AddLog(log);
+                        }
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                Exceptions.Exceptions.LogException(ex);
             }
         }
 
@@ -304,7 +318,7 @@ namespace DotNetNuke.Services.OutputCache.Providers
 
         public override bool StreamOutput(int tabId, string cacheKey, HttpContext context)
         {
-            bool foundFile;
+            bool foundFile = false;
             try
             {
                 string attribFile = GetAttribFileName(tabId, cacheKey);
@@ -319,13 +333,17 @@ namespace DotNetNuke.Services.OutputCache.Providers
                     return false;
                 }
 
-				context.Response.WriteFile(captureFile);
+                context.Response.WriteFile(captureFile);
 
                 foundFile = true;
             }
             catch (FileNotFoundException)
             {
                 foundFile = false;
+            }
+            catch (Exception ex)
+            {
+                Exceptions.Exceptions.LogException(ex);
             }
             return foundFile;
         }


### PR DESCRIPTION
There is a site failure due to following exception:

`DotNetNuke.Web.Common.Internal.DotNetNukeHttpApplication - System.UnauthorizedAccessException: Access to the path 'D:\home\site\wwwroot\Portals\0-System\Cache\Pages\55_8137927E7998C915DC56554B051AC3B3FFB9F67A8301079DD8BB1C1DC407D9F3.attrib.resources' is denied.`

Folder permission is a most often reason. 
In this PR I'm adding try/catch blocks to all places in which we perform handling of cached files. For some methods I didn't find exception handling in the calling/parent code.
To prevent site crashing we expect more logs to be captured for the further investigation.