### PR TITLE
Account Login Module: Login Button Disabled

### DIFF
--- a/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
+++ b/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
@@ -44,14 +44,33 @@
     <script type="text/javascript">
         /*globals jQuery, window, Sys */
         (function ($, Sys) {
-            function setUpLogin() {
-                var actionLinks = $("a#dnn_ctr<%=ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN_cmdLogin");
-                actionLinks.click(function () {
-                    if ($(this).hasClass("dnnDisabledAction")) {
-                        return false;
-                    }
-
-                    actionLinks.addClass("dnnDisabledAction");
+            const disabledActionClass = "dnnDisabledAction";
+            const actionLinks = $('a[id^="dnn_ctr<%=ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN"]');
+            function isActionDisabled($el) {
+                return $el && $el.hasClass(disabledActionClass);
+            }
+            function disableAction($el) {
+                if ($el == null || $el.hasClass(disabledActionClass)) {
+                    return;
+                }
+                $el.addClass(disabledActionClass);
+            }
+            function enableAction($el) {
+                if ($el == null) {
+                    return;
+                }
+                $el.removeClass(disabledActionClass);
+            }
+            function setUpLogin() {                
+                $.each(actionLinks || [], function (index, action) {
+                    var $action = $(action);
+                    $action.click(function () {
+                        var $el = $(this);
+                        if (isActionDisabled($el)) {
+                            return false;
+                        }
+                        disableAction($el);
+                    });
                 });
             }
 		
@@ -59,11 +78,10 @@
                 $(document).on('keydown', '.dnnLoginService', function (e) {
                     if ($(e.target).is('input:text,input:password') && e.keyCode === 13) {
                         var $loginButton = $('#dnn_ctr<%=ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN_cmdLogin');
-                        if ($loginButton.hasClass("dnnDisabledAction")) {
+                        if (isActionDisabled($loginButton)) {
                             return false;
                         }
-
-                        $loginButton.addClass("dnnDisabledAction");
+                        disableAction($loginButton);
                         window.setTimeout(function () { eval($loginButton.attr('href')); }, 100);
                         e.preventDefault();
                         return false;
@@ -72,6 +90,9 @@
 
                 setUpLogin();
                 Sys.WebForms.PageRequestManager.getInstance().add_endRequest(function () {
+                    $.each(actionLinks || [], function (index, item) {
+                        enableAction($(item));
+                    });
                     setUpLogin();
                 });
             });


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2487

Login form action buttons (login, cancel, register, reset password) gets disabled every time user clicks on a particular action link. This behavior is expected and needed to avoid double click to raise same request multiple times.
When post back request completed the state of the buttons is not restored. In this PR it is fixed so all action links are enabled at the end of every post back request.