### PR TITLE
CI: Added Cake.LongPath.Module

### DIFF
--- a/tools/Modules/packages.config
+++ b/tools/Modules/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake.LongPath.Module" version="0.5.0" />
+</packages>


### PR DESCRIPTION
Adding [Cake.LongPath.Module](https://github.com/cake-contrib/Cake.LongPath.Module) to support long paths during CI build
