### PR TITLE
HTML Editor Management Module: some labels are in white color

### DIFF
--- a/DNN Platform/Modules/HtmlEditorManager/module.css
+++ b/DNN Platform/Modules/HtmlEditorManager/module.css
@@ -20,7 +20,7 @@
 #dnnEditorConfig .dnnFormItem > div.languageComboBox{width: 47%;margin-bottom: 18px;max-width: 445px;display: inline-block !important;}
 
 /* New CK Editor Classes */
-.html-editor-manager { padding: 1em; background: #eee; border: solid 1px #ccc; overflow:hidden;}
+.html-editor-manager { padding: 1em; background: #eee; color: #333 !important; border: solid 1px #ccc; overflow:hidden;}
 /*.html-editor-manager h2 {float:left; width: 33%; padding:0;}
 .html-editor-manager h2, .html-editor-manager h4 { display:inline-block; margin: 0;}
 .html-editor-manager span {font-style:italic; color: #666;}*/ 


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2500

`HTML Editor Management` module has its own css where some basic styles are defined, i.e. background color, borders, padding's and etc.. I found default text color is missing here, so it inherits the color from the skin. 
Since we have background defined, we should care about text color on that background. 

See result:

![image](https://user-images.githubusercontent.com/22524011/49471986-fea51200-f816-11e8-862b-a0c9259ec1a3.png)
