### PR TITLE
Fixed broken LockStrategy unit tests

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/LockStrategyTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/LockStrategyTests.cs
@@ -43,7 +43,7 @@ namespace DotNetNuke.Tests.Core.Collections
         }
 
         [Test, ExpectedException(typeof (LockRecursionException))]
-        public void DoubleReadLockThrows()
+        public virtual void DoubleReadLockThrows()
         {
             using (var strategy = GetLockStrategy())
             {
@@ -136,7 +136,7 @@ namespace DotNetNuke.Tests.Core.Collections
         }
 
         [Test, ExpectedException(typeof (LockRecursionException))]
-        public void DoubleWriteLockThrows()
+        public virtual void DoubleWriteLockThrows()
         {
             using (ILockStrategy strategy = GetLockStrategy())
             {

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/ReaderWriterLockStrategyTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Collections/ReaderWriterLockStrategyTests.cs
@@ -31,5 +31,17 @@ namespace DotNetNuke.Tests.Core.Collections
         {
             return new ReaderWriterLockStrategy();
         }
+
+        [Test] // no ExpectedException attribute
+        public override void DoubleReadLockThrows()
+        {
+            base.DoubleReadLockThrows();
+        }
+
+        [Test] // no ExpectedException attribute
+        public override void DoubleWriteLockThrows()
+        {
+            base.DoubleWriteLockThrows();
+        }
     }
 }


### PR DESCRIPTION
## Summary
This pull request fixes unit tests broken by #2423.

There is the following hierarchy:
```
LockStrategyTests
 |
 +--> ExclusiveLockStrategyTests
 |
 +--> ReaderWriterLockStrategyTests
```

The `ReaderWriterLockStrategy` class no longer throws exception when user attemps to acquire the lock recursively, so unit tests in `ReaderWriterLockStrategyTests` no longer have the `ExpectedException` attribute.

Tests in `ExclusiveLockStrategyTests` remain unchanged.