### PR TITLE
Initalize default Page Output Cache Provider

### DIFF
--- a/Website/Install/DotNetNuke.install.config.resources
+++ b/Website/Install/DotNetNuke.install.config.resources
@@ -56,6 +56,7 @@
     <HttpCompression>0</HttpCompression>
     <HttpCompressionLevel>0</HttpCompressionLevel>
     <ModuleCaching>MemoryModuleCachingProvider</ModuleCaching>
+    <PageCaching>MemoryOutputCachingProvider</PageCaching>
     <PageQuota></PageQuota>
     <PageStatePersister>P</PageStatePersister>
     <PaymentProcessor>PayPal</PaymentProcessor>


### PR DESCRIPTION
Closes #2577

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
Initializes default value for host setting 'Page Output Cache Provider' during install