### PR TITLE
Deprecate Razor Modules for DNN 11.0

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
@@ -23,21 +23,21 @@ using DotNetNuke.Web.Razor.Helpers;
 
 namespace DotNetNuke.Web.Razor
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public abstract class DotNetNukeWebPage : WebPageBase
     {
         private dynamic _model;
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected internal DnnHelper Dnn { get; internal set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected internal HtmlHelper Html { get; internal set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected internal UrlHelper Url { get; internal set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void ConfigurePage(WebPageBase parentPage)
         {
             base.ConfigurePage(parentPage);
@@ -46,7 +46,7 @@ namespace DotNetNuke.Web.Razor
             Context = parentPage.Context;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public dynamic Model
         {
             get { return _model ?? (_model = PageContext.Model); }
@@ -54,12 +54,12 @@ namespace DotNetNuke.Web.Razor
         }
     }
 
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public abstract class DotNetNukeWebPage<TModel> :DotNetNukeWebPage where TModel : class
     {
         private TModel _model;
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public new TModel Model
         {
             get { return _model ?? (_model = PageContext.Model as TModel); }

--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
@@ -16,22 +16,28 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Web.WebPages;
 
 using DotNetNuke.Web.Razor.Helpers;
 
 namespace DotNetNuke.Web.Razor
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public abstract class DotNetNukeWebPage : WebPageBase
     {
         private dynamic _model;
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected internal DnnHelper Dnn { get; internal set; }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected internal HtmlHelper Html { get; internal set; }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected internal UrlHelper Url { get; internal set; }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void ConfigurePage(WebPageBase parentPage)
         {
             base.ConfigurePage(parentPage);
@@ -40,6 +46,7 @@ namespace DotNetNuke.Web.Razor
             Context = parentPage.Context;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public dynamic Model
         {
             get { return _model ?? (_model = PageContext.Model); }
@@ -47,10 +54,12 @@ namespace DotNetNuke.Web.Razor
         }
     }
 
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public abstract class DotNetNukeWebPage<TModel> :DotNetNukeWebPage where TModel : class
     {
         private TModel _model;
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public new TModel Model
         {
             get { return _model ?? (_model = PageContext.Model as TModel); }

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/DnnHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/DnnHelper.cs
@@ -31,18 +31,18 @@ using System;
 
 namespace DotNetNuke.Web.Razor.Helpers
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class DnnHelper
     {
         private readonly ModuleInstanceContext _context;
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public DnnHelper(ModuleInstanceContext context)
         {
             _context = context;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public ModuleInfo Module
         {
             get
@@ -51,7 +51,7 @@ namespace DotNetNuke.Web.Razor.Helpers
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public TabInfo Tab
         {
             get
@@ -60,7 +60,7 @@ namespace DotNetNuke.Web.Razor.Helpers
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public PortalSettings Portal
         {
             get
@@ -69,7 +69,7 @@ namespace DotNetNuke.Web.Razor.Helpers
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public UserInfo User
         {
             get

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/DnnHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/DnnHelper.cs
@@ -25,20 +25,24 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.UI.Modules;
+using System;
 
 #endregion
 
 namespace DotNetNuke.Web.Razor.Helpers
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class DnnHelper
     {
         private readonly ModuleInstanceContext _context;
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public DnnHelper(ModuleInstanceContext context)
         {
             _context = context;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public ModuleInfo Module
         {
             get
@@ -47,6 +51,7 @@ namespace DotNetNuke.Web.Razor.Helpers
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public TabInfo Tab
         {
             get
@@ -55,6 +60,7 @@ namespace DotNetNuke.Web.Razor.Helpers
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public PortalSettings Portal
         {
             get
@@ -63,6 +69,7 @@ namespace DotNetNuke.Web.Razor.Helpers
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public UserInfo User
         {
             get

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/HtmlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/HtmlHelper.cs
@@ -29,32 +29,32 @@ using System.Web;
 
 namespace DotNetNuke.Web.Razor.Helpers
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class HtmlHelper
     {
         private readonly string _resourceFile;
         private ModuleInstanceContext _context;
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public HtmlHelper(ModuleInstanceContext context, string resourcefile)
         {
             _context = context;
             _resourceFile = resourcefile;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public object GetLocalizedString(string key)
         {
             return Localization.GetString(key, _resourceFile);
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public object GetLocalizedString(string key, string culture)
         {
             return Localization.GetString(key, _resourceFile, culture);
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public HtmlString Raw(string text)
         {
             return new HtmlString(text);

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/HtmlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/HtmlHelper.cs
@@ -20,35 +20,41 @@
 #endregion
 #region Usings
 
-using System.Web;
 using DotNetNuke.Services.Localization;
 using DotNetNuke.UI.Modules;
+using System;
+using System.Web;
 
 #endregion
 
 namespace DotNetNuke.Web.Razor.Helpers
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class HtmlHelper
     {
         private readonly string _resourceFile;
         private ModuleInstanceContext _context;
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public HtmlHelper(ModuleInstanceContext context, string resourcefile)
         {
             _context = context;
             _resourceFile = resourcefile;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public object GetLocalizedString(string key)
         {
             return Localization.GetString(key, _resourceFile);
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public object GetLocalizedString(string key, string culture)
         {
             return Localization.GetString(key, _resourceFile, culture);
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public HtmlString Raw(string text)
         {
             return new HtmlString(text);

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/UrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/UrlHelper.cs
@@ -22,25 +22,30 @@
 
 using DotNetNuke.Common;
 using DotNetNuke.UI.Modules;
+using System;
 
 #endregion
 
 namespace DotNetNuke.Web.Razor.Helpers
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class UrlHelper
     {
         private readonly ModuleInstanceContext _context;
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public UrlHelper(ModuleInstanceContext context)
         {
             _context = context;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public string NavigateToControl()
         {
             return Globals.NavigateURL(_context.TabId);
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public string NavigateToControl(string controlKey)
         {
             return Globals.NavigateURL(_context.TabId, controlKey, "mid=" + _context.ModuleId);

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/UrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/UrlHelper.cs
@@ -28,24 +28,24 @@ using System;
 
 namespace DotNetNuke.Web.Razor.Helpers
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class UrlHelper
     {
         private readonly ModuleInstanceContext _context;
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public UrlHelper(ModuleInstanceContext context)
         {
             _context = context;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public string NavigateToControl()
         {
             return Globals.NavigateURL(_context.TabId);
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public string NavigateToControl(string controlKey)
         {
             return Globals.NavigateURL(_context.TabId, controlKey, "mid=" + _context.ModuleId);

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorEngine.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorEngine.cs
@@ -36,8 +36,10 @@ using DotNetNuke.Web.Razor.Helpers;
 
 namespace DotNetNuke.Web.Razor
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorEngine
     {
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public RazorEngine(string razorScriptFile, ModuleInstanceContext moduleContext, string localResourceFile)
         {
             RazorScriptFile = razorScriptFile;
@@ -62,16 +64,25 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected string RazorScriptFile { get; set; }
+
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected ModuleInstanceContext ModuleContext { get; set; }
+
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected string LocalResourceFile { get; set; }
+
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public DotNetNukeWebPage Webpage { get; set; }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected HttpContextBase HttpContext
         {
             get { return new HttpContextWrapper(System.Web.HttpContext.Current); }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public Type RequestedModelType()
         {
             if (Webpage != null)
@@ -85,6 +96,7 @@ namespace DotNetNuke.Web.Razor
             return null;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public void Render<T>(TextWriter writer, T model)
         {
             try
@@ -97,6 +109,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public void Render(TextWriter writer)
         {
             try
@@ -109,6 +122,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public void Render(TextWriter writer, WebPageContext context)
         {
             try

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorEngine.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorEngine.cs
@@ -36,10 +36,10 @@ using DotNetNuke.Web.Razor.Helpers;
 
 namespace DotNetNuke.Web.Razor
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorEngine
     {
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public RazorEngine(string razorScriptFile, ModuleInstanceContext moduleContext, string localResourceFile)
         {
             RazorScriptFile = razorScriptFile;
@@ -64,25 +64,25 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected string RazorScriptFile { get; set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected ModuleInstanceContext ModuleContext { get; set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected string LocalResourceFile { get; set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public DotNetNukeWebPage Webpage { get; set; }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected HttpContextBase HttpContext
         {
             get { return new HttpContextWrapper(System.Web.HttpContext.Current); }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public Type RequestedModelType()
         {
             if (Webpage != null)
@@ -96,7 +96,7 @@ namespace DotNetNuke.Web.Razor
             return null;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public void Render<T>(TextWriter writer, T model)
         {
             try
@@ -109,7 +109,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public void Render(TextWriter writer)
         {
             try
@@ -122,7 +122,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public void Render(TextWriter writer, WebPageContext context)
         {
             try

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorHostControl.cs
@@ -33,15 +33,18 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Razor
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorHostControl : ModuleControlBase, IActionable
     {
         private readonly string _razorScriptFile;
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public RazorHostControl(string scriptFile)
         {
             _razorScriptFile = scriptFile;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected virtual string RazorScriptFile
         {
             get { return _razorScriptFile; }
@@ -61,6 +64,7 @@ namespace DotNetNuke.Web.Razor
 		    }
 	    }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);
@@ -73,7 +77,8 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
-		public ModuleActionCollection ModuleActions
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        public ModuleActionCollection ModuleActions
 		{
 			get
 			{

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorHostControl.cs
@@ -33,18 +33,18 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Razor
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorHostControl : ModuleControlBase, IActionable
     {
         private readonly string _razorScriptFile;
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public RazorHostControl(string scriptFile)
         {
             _razorScriptFile = scriptFile;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected virtual string RazorScriptFile
         {
             get { return _razorScriptFile; }
@@ -64,7 +64,7 @@ namespace DotNetNuke.Web.Razor
 		    }
 	    }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);
@@ -77,7 +77,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public ModuleActionCollection ModuleActions
 		{
 			get

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorModuleBase.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorModuleBase.cs
@@ -30,8 +30,10 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Razor
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorModuleBase : ModuleUserControlBase
     {
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected virtual string RazorScriptFile
         {
             get
@@ -56,6 +58,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorModuleBase.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorModuleBase.cs
@@ -30,10 +30,10 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Razor
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorModuleBase : ModuleUserControlBase
     {
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected virtual string RazorScriptFile
         {
             get
@@ -58,7 +58,7 @@ namespace DotNetNuke.Web.Razor
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorModuleControlFactory.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorModuleControlFactory.cs
@@ -23,22 +23,22 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Razor
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorModuleControlFactory : IModuleControlFactory
     {
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             return new RazorHostControl("~/" + controlSrc);
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return CreateControl(containerControl, String.Empty, moduleConfiguration.ModuleControl.ControlSrc);
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return CreateControl(containerControl, String.Empty, controlSrc);

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorModuleControlFactory.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorModuleControlFactory.cs
@@ -23,18 +23,22 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Razor
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public class RazorModuleControlFactory : IModuleControlFactory
     {
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             return new RazorHostControl("~/" + controlSrc);
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return CreateControl(containerControl, String.Empty, moduleConfiguration.ModuleControl.ControlSrc);
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return CreateControl(containerControl, String.Empty, controlSrc);

--- a/DNN Platform/Modules/RazorHost/AddScript.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/AddScript.ascx.cs
@@ -32,6 +32,7 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Modules.RazorHost
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class AddScript : ModuleUserControlBase
     {
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
@@ -41,6 +42,7 @@ namespace DotNetNuke.Modules.RazorHost
             fileExtension.Text = "." + scriptFileType.SelectedValue.ToLowerInvariant();
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -50,6 +52,7 @@ namespace DotNetNuke.Modules.RazorHost
             scriptFileType.SelectedIndexChanged += scriptFileType_SelectedIndexChanged;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
@@ -57,6 +60,7 @@ namespace DotNetNuke.Modules.RazorHost
             DisplayExtension();
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected void cmdCancel_Click(object sender, EventArgs e)
         {
             try
@@ -69,6 +73,7 @@ namespace DotNetNuke.Modules.RazorHost
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected void cmdAdd_Click(object sender, EventArgs e)
         {
             try

--- a/DNN Platform/Modules/RazorHost/AddScript.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/AddScript.ascx.cs
@@ -32,7 +32,7 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Modules.RazorHost
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class AddScript : ModuleUserControlBase
     {
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
@@ -42,7 +42,7 @@ namespace DotNetNuke.Modules.RazorHost
             fileExtension.Text = "." + scriptFileType.SelectedValue.ToLowerInvariant();
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -52,7 +52,7 @@ namespace DotNetNuke.Modules.RazorHost
             scriptFileType.SelectedIndexChanged += scriptFileType_SelectedIndexChanged;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
@@ -60,7 +60,7 @@ namespace DotNetNuke.Modules.RazorHost
             DisplayExtension();
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected void cmdCancel_Click(object sender, EventArgs e)
         {
             try
@@ -73,7 +73,7 @@ namespace DotNetNuke.Modules.RazorHost
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected void cmdAdd_Click(object sender, EventArgs e)
         {
             try

--- a/DNN Platform/Modules/RazorHost/CreateModule.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/CreateModule.ascx.cs
@@ -42,7 +42,7 @@ using DotNetNuke.UI.Skins.Controls;
 
 namespace DotNetNuke.Modules.RazorHost
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class CreateModule : ModuleUserControlBase
     {
 		private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(CreateModule));
@@ -50,7 +50,7 @@ namespace DotNetNuke.Modules.RazorHost
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected string ModuleControl
         {
             get
@@ -59,7 +59,7 @@ namespace DotNetNuke.Modules.RazorHost
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected string RazorScriptFile
         {
             get
@@ -270,7 +270,7 @@ namespace DotNetNuke.Modules.RazorHost
             lblModuleControl.Text = string.Format(Localization.GetString("SourceControl", LocalResourceFile), ModuleControl);
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -280,7 +280,7 @@ namespace DotNetNuke.Modules.RazorHost
             scriptList.SelectedIndexChanged += scriptList_SelectedIndexChanged;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);

--- a/DNN Platform/Modules/RazorHost/CreateModule.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/CreateModule.ascx.cs
@@ -42,6 +42,7 @@ using DotNetNuke.UI.Skins.Controls;
 
 namespace DotNetNuke.Modules.RazorHost
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class CreateModule : ModuleUserControlBase
     {
 		private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(CreateModule));
@@ -49,6 +50,7 @@ namespace DotNetNuke.Modules.RazorHost
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected string ModuleControl
         {
             get
@@ -57,6 +59,7 @@ namespace DotNetNuke.Modules.RazorHost
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected string RazorScriptFile
         {
             get
@@ -267,6 +270,7 @@ namespace DotNetNuke.Modules.RazorHost
             lblModuleControl.Text = string.Format(Localization.GetString("SourceControl", LocalResourceFile), ModuleControl);
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -276,6 +280,7 @@ namespace DotNetNuke.Modules.RazorHost
             scriptList.SelectedIndexChanged += scriptList_SelectedIndexChanged;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);

--- a/DNN Platform/Modules/RazorHost/EditScript.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/EditScript.ascx.cs
@@ -35,12 +35,13 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Modules.RazorHost
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class EditScript : ModuleUserControlBase
     {
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
-
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected string RazorScriptFile
         {
             get
@@ -108,6 +109,7 @@ namespace DotNetNuke.Modules.RazorHost
             }
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -119,6 +121,7 @@ namespace DotNetNuke.Modules.RazorHost
             scriptList.SelectedIndexChanged += scriptList_SelectedIndexChanged;
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);

--- a/DNN Platform/Modules/RazorHost/EditScript.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/EditScript.ascx.cs
@@ -35,13 +35,13 @@ using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Modules.RazorHost
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class EditScript : ModuleUserControlBase
     {
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected string RazorScriptFile
         {
             get
@@ -109,7 +109,7 @@ namespace DotNetNuke.Modules.RazorHost
             }
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
@@ -121,7 +121,7 @@ namespace DotNetNuke.Modules.RazorHost
             scriptList.SelectedIndexChanged += scriptList_SelectedIndexChanged;
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);

--- a/DNN Platform/Modules/RazorHost/RazorHost.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/RazorHost.ascx.cs
@@ -25,15 +25,18 @@ using DotNetNuke.Entities.Modules.Actions;
 using DotNetNuke.Security;
 using DotNetNuke.Services.Localization;
 using DotNetNuke.Web.Razor;
+using System;
 
 #endregion
 
 namespace DotNetNuke.Modules.RazorHost
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class RazorHost : RazorModuleBase, IActionable
     {
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         protected override string RazorScriptFile
         {
             get
@@ -50,6 +53,7 @@ namespace DotNetNuke.Modules.RazorHost
 
         #region IActionable Members
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public ModuleActionCollection ModuleActions
         {
             get

--- a/DNN Platform/Modules/RazorHost/RazorHost.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/RazorHost.ascx.cs
@@ -31,12 +31,12 @@ using System;
 
 namespace DotNetNuke.Modules.RazorHost
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class RazorHost : RazorModuleBase, IActionable
     {
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         protected override string RazorScriptFile
         {
             get
@@ -53,7 +53,7 @@ namespace DotNetNuke.Modules.RazorHost
 
         #region IActionable Members
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public ModuleActionCollection ModuleActions
         {
             get

--- a/DNN Platform/Modules/RazorHost/RazorHostSettingsExtensions.cs
+++ b/DNN Platform/Modules/RazorHost/RazorHostSettingsExtensions.cs
@@ -25,10 +25,10 @@ using DotNetNuke.Security;
 
 namespace DotNetNuke.Modules.RazorHost
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public static class RazorHostSettingsExtensions
     {
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public static Settings LoadRazorSettingsControl(this UserControl parent, ModuleInfo configuration, string localResourceFile)
         {
             var control = (Settings) parent.LoadControl("~/DesktopModules/RazorModules/RazorHost/Settings.ascx");

--- a/DNN Platform/Modules/RazorHost/RazorHostSettingsExtensions.cs
+++ b/DNN Platform/Modules/RazorHost/RazorHostSettingsExtensions.cs
@@ -18,14 +18,17 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+using System;
 using System.Web.UI;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Security;
 
 namespace DotNetNuke.Modules.RazorHost
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public static class RazorHostSettingsExtensions
     {
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public static Settings LoadRazorSettingsControl(this UserControl parent, ModuleInfo configuration, string localResourceFile)
         {
             var control = (Settings) parent.LoadControl("~/DesktopModules/RazorModules/RazorHost/Settings.ascx");

--- a/DNN Platform/Modules/RazorHost/Settings.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/Settings.ascx.cs
@@ -20,6 +20,7 @@
 #endregion
 #region Usings
 
+using System;
 using System.IO;
 using System.Web.UI.WebControls;
 
@@ -29,10 +30,12 @@ using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.Modules.RazorHost
 {
+    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class Settings : ModuleSettingsBase
     {
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public override void LoadSettings()
         {
             string basePath = Server.MapPath(razorScriptFolder);
@@ -52,6 +55,7 @@ namespace DotNetNuke.Modules.RazorHost
             base.LoadSettings();
         }
 
+        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
         public override void UpdateSettings()
         {
             ModuleController.Instance.UpdateModuleSetting(ModuleId, "ScriptFile", scriptList.SelectedValue);

--- a/DNN Platform/Modules/RazorHost/Settings.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/Settings.ascx.cs
@@ -30,12 +30,12 @@ using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.Modules.RazorHost
 {
-    [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+    [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
     public partial class Settings : ModuleSettingsBase
     {
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public override void LoadSettings()
         {
             string basePath = Server.MapPath(razorScriptFolder);
@@ -55,7 +55,7 @@ namespace DotNetNuke.Modules.RazorHost
             base.LoadSettings();
         }
 
-        [Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
+        [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public override void UpdateSettings()
         {
             ModuleController.Instance.UpdateModuleSetting(ModuleId, "ScriptFile", scriptList.SelectedValue);


### PR DESCRIPTION
Closes: #2613 

## Summary
Marks all **public** and **protected** APIs in 

* `DotNetNuke.Web.Razor`
* `DotNetNuke.Modules.RazorHost`

```
[Obsolete("Deprecated in 9.3.1, will be removed in 11.0.0, use Razor Pages instead")]
```

As we build out Razor Pages modules we will update the messages where applicable to point to what they should be using instead.