### PR TITLE
DDRMenu: Add Support for Web Pages (Razor 3) Renderer

### DIFF
--- a/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
+++ b/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
@@ -13,6 +13,7 @@
     <SccProvider>
     </SccProvider>
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -68,10 +69,6 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetNuke.Web.Razor">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\DotNetNuke.Web.Razor\bin\DotNetNuke.Web.Razor.dll</HintPath>
-    </Reference>
     <Reference Include="DotNetNuke.WebControls">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Controls\DotNetNuke.WebControls\bin\DotNetNuke.WebControls.dll</HintPath>

--- a/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
+++ b/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
@@ -193,6 +193,10 @@
       <Project>{03e3afa5-ddc9-48fb-a839-ad4282ce237e}</Project>
       <Name>DotNetNuke.Web.Client</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\DotNetNuke.Web.Razor\DotNetNuke.Web.Razor.csproj">
+      <Project>{9806c125-8ca9-48cc-940a-ccd0442c5993}</Project>
+      <Name>DotNetNuke.Web.Razor</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Library\DotNetNuke.Library.csproj">
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
       <Name>DotNetNuke.Library</Name>

--- a/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
+++ b/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
@@ -13,7 +13,6 @@
     <SccProvider>
     </SccProvider>
     <UseGlobalApplicationHostFile />
-    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -69,6 +68,10 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetNuke.Web.Razor">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\DotNetNuke.Web.Razor\bin\DotNetNuke.Web.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="DotNetNuke.WebControls">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Controls\DotNetNuke.WebControls\bin\DotNetNuke.WebControls.dll</HintPath>
@@ -192,10 +195,6 @@
     <ProjectReference Include="..\..\DotNetNuke.Web.Client\DotNetNuke.Web.Client.csproj">
       <Project>{03e3afa5-ddc9-48fb-a839-ad4282ce237e}</Project>
       <Name>DotNetNuke.Web.Client</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\DotNetNuke.Web.Razor\DotNetNuke.Web.Razor.csproj">
-      <Project>{9806c125-8ca9-48cc-940a-ccd0442c5993}</Project>
-      <Name>DotNetNuke.Web.Razor</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Library\DotNetNuke.Library.csproj">
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>

--- a/DNN Platform/Modules/DDRMenu/TemplateEngine/RazorTemplateProcessor.cs
+++ b/DNN Platform/Modules/DDRMenu/TemplateEngine/RazorTemplateProcessor.cs
@@ -7,6 +7,7 @@ using System.Web;
 using System.Web.UI;
 using System.Web.WebPages;
 using DotNetNuke.Web.DDRMenu.DNNCommon;
+using DotNetNuke.Web.Razor;
 
 namespace DotNetNuke.Web.DDRMenu.TemplateEngine
 {
@@ -46,12 +47,21 @@ namespace DotNetNuke.Web.DDRMenu.TemplateEngine
 
         private StringWriter RenderTemplate(string virtualPath, dynamic model)
         {
-            var page = (WebPage)WebPageBase.CreateInstanceFromVirtualPath(virtualPath);
+            var page = WebPageBase.CreateInstanceFromVirtualPath(virtualPath);
             var httpContext = new HttpContextWrapper(HttpContext.Current);
             var pageContext = new WebPageContext(httpContext, page, model);
 
             var writer = new StringWriter();
-            page.ExecutePageHierarchy(pageContext, writer);
+
+            if (page is WebPage)
+            {
+                page.ExecutePageHierarchy(pageContext, writer);
+            }
+            else
+            {
+                var razorEngine = new RazorEngine(virtualPath, null, null);
+                razorEngine.Render<dynamic>(writer, model);
+            }
 
             return writer;
         }

--- a/DNN Platform/Modules/DDRMenu/TemplateEngine/RazorTemplateProcessor.cs
+++ b/DNN Platform/Modules/DDRMenu/TemplateEngine/RazorTemplateProcessor.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
 using System.Text;
+using System.Web;
 using System.Web.UI;
-
+using System.Web.WebPages;
 using DotNetNuke.Web.DDRMenu.DNNCommon;
-using DotNetNuke.Web.Razor;
 
 namespace DotNetNuke.Web.DDRMenu.TemplateEngine
 {
@@ -40,13 +40,20 @@ namespace DotNetNuke.Web.DDRMenu.TemplateEngine
                 model.SkinPath = resolver.Resolve("/", PathResolver.RelativeTo.Skin);
                 var modelDictionary = model as IDictionary<string, object>;
                 liveDefinition.TemplateArguments.ForEach(a => modelDictionary.Add(a.Name, a.Value));
-
-                var razorEngine = new RazorEngine(liveDefinition.TemplateVirtualPath, null, null);
-                var writer = new StringWriter();
-                razorEngine.Render<dynamic>(writer, model);
-
-                htmlWriter.Write(writer.ToString());
+                htmlWriter.Write(RenderTemplate(liveDefinition.TemplateVirtualPath, model));
             }
+        }
+
+        private StringWriter RenderTemplate(string virtualPath, dynamic model)
+        {
+            var page = (WebPage)WebPageBase.CreateInstanceFromVirtualPath(virtualPath);
+            var httpContext = new HttpContextWrapper(HttpContext.Current);
+            var pageContext = new WebPageContext(httpContext, page, model);
+
+            var writer = new StringWriter();
+            page.ExecutePageHierarchy(pageContext, writer);
+
+            return writer;
         }
 
         protected static string ConvertToJson(List<ClientOption> options)


### PR DESCRIPTION
Closes: #2637 

## Summary
The DDRMenu depends on `DotNetNuke.Web.Razor` which will be marked as deprecated in 9.x and removed in 11.0. As the platform moves forward we need to give developers and vendors ample time to migrate from the RazorEngine to [Microsoft's Razor 3](https://docs.microsoft.com/en-us/aspnet/web-pages/overview/getting-started/program-asp-net-web-pages-in-visual-studio) Implementation.

This PR adds an additional render support for `System.Web.WebPages.WebPage` which falls back to the RazorEngine if it isn't implemented.

Consider the following DDRMenu Razor Template
```
@using DotNetNuke.Web.DDRMenu;
@using System.Dynamic;
@inherits DotNetNuke.Web.Razor.DotNetNukeWebPage<dynamic>
... omitted code
```

This snippet currently works, and works with the proposed changeset. Developers should start migrating their templates to use System.Web.WebPages.WebPage which will be supported on 11.0 and up (until .NET Core).

```
@using DotNetNuke.Web.DDRMenu;
@inherits System.Web.WebPages.WebPage
... omitted code
```

## Developer Change
As developers migrate their templates we recommend that they use:

```
@inherits System.Web.WebPages.WebPage
```