### PR TITLE
IP is missing in the logs when user request comes with IPv6 

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1491,6 +1491,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Services\UserProfile\UserProfilePicHandler.cs" />
+    <Compile Include="Services\UserRequest\IPAddressFamily.cs" />
     <Compile Include="Services\UserRequest\IUserRequestIPAddressController.cs" />
     <Compile Include="Services\UserRequest\UserRequestIPAddressController.cs" />
     <Compile Include="Services\Zip\SharpZipLibRedirect.cs" />

--- a/DNN Platform/Library/Services/UserRequest/IPAddressFamily.cs
+++ b/DNN Platform/Library/Services/UserRequest/IPAddressFamily.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2018
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
 
 namespace DotNetNuke.Services.UserRequest
 {

--- a/DNN Platform/Library/Services/UserRequest/IPAddressFamily.cs
+++ b/DNN Platform/Library/Services/UserRequest/IPAddressFamily.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace DotNetNuke.Services.UserRequest
+{
+    /// <summary>
+    /// IP address family
+    /// </summary>
+    public enum IPAddressFamily
+    {
+        IPv4,
+        IPv6
+    }
+}

--- a/DNN Platform/Library/Services/UserRequest/IUserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/IUserRequestIPAddressController.cs
@@ -26,10 +26,18 @@ namespace DotNetNuke.Services.UserRequest
     public interface IUserRequestIPAddressController
     {
         /// <summary>
-        ///  To retrieve IP of user making request to application
+        ///  To retrieve IPv4 of user making request to application.
         /// </summary>
         /// <param name="request"></param>
         /// <returns>IP address</returns>
         string GetUserRequestIPAddress(HttpRequestBase request);
+
+        /// <summary>
+        ///  To retrieve IPv4/IPv6 of user making request to application
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="ipFamily"></param>
+        /// <returns>IP address</returns>
+        string GetUserRequestIPAddress(HttpRequestBase request, IPAddressFamily ipFamily);
     }
 }


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2691

In this RP I extended existing mechanism to read IP address from request. Default IP remains IPv4, nothing is changed in terms of application functionality and public API's. Only thing is now it is possible to extract IPv6 from request. I used it just for the admin logs purposes when user is logging in. So administrators can now check logs and determine IPv6 addresses. 

See how does it look:

![image](https://user-images.githubusercontent.com/22524011/56045978-f328a100-5d4a-11e9-947e-8c3b1fadcf07.png)

