### PR TITLE
Digital Assets: Azure folders are slow to open

### DIFF
--- a/DNN Platform/Connectors/Azure/Components/AzureConnector.cs
+++ b/DNN Platform/Connectors/Azure/Components/AzureConnector.cs
@@ -214,6 +214,10 @@ namespace Dnn.AzureConnector.Components
                 {
                     folderMapping.MappingName = DisplayName;
                 }
+                if (!folderMapping.FolderMappingSettings.ContainsKey(Constants.SyncBatchSize))
+                {
+                    folderMapping.FolderMappingSettings[Constants.SyncBatchSize] = Constants.DefaultSyncBatchSize.ToString();
+                }
 
                 FolderMappingController.Instance.UpdateFolderMapping(folderMapping);
 

--- a/DNN Platform/Connectors/Azure/Components/Constants.cs
+++ b/DNN Platform/Connectors/Azure/Components/Constants.cs
@@ -15,6 +15,8 @@ namespace Dnn.AzureConnector.Components
         public const string AzureContainerName = "Container";
         public const string DirectLink = "DirectLink";
         public const string UseHttps = "UseHttps";
+        public const string SyncBatchSize = "SyncBatchSize";
+        public const int DefaultSyncBatchSize = 2048;
 
         public const string LocalResourceFile =
             "~/DesktopModules/Connectors/Azure/App_LocalResources/SharedResources.resx";

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/App_LocalResources/Settings.ascx.resx
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/App_LocalResources/Settings.ascx.resx
@@ -200,5 +200,14 @@
   </data>
   <data name="plCustomDomain.Text" xml:space="preserve">
     <value>Custom Domain</value>
-  </data>  
+  </data>
+  <data name="tbSyncBatchSize.Error" xml:space="preserve">
+    <value>The syhchronization batch size should be numeric value</value>
+  </data>
+  <data name="plSyncBatchSize.Help" xml:space="preserve">
+    <value>Sets the maximum number of items that can be fetched from Azure storage on each request during folder synchronization. The lower the number, the more round trips will be necessary to fetch all items. Large numbers will lead to timeouts in case of large repositories.</value>
+  </data>
+  <data name="plSyncBatchSize.Text" xml:space="preserve">
+    <value>Synchronization Batch Size</value>
+  </data>
 </root>

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/App_LocalResources/Settings.ascx.resx
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/App_LocalResources/Settings.ascx.resx
@@ -202,7 +202,7 @@
     <value>Custom Domain</value>
   </data>
   <data name="tbSyncBatchSize.Error" xml:space="preserve">
-    <value>The syhchronization batch size should be numeric value</value>
+    <value>Syhchronization batch size must be a positive integer number</value>
   </data>
   <data name="plSyncBatchSize.Help" xml:space="preserve">
     <value>Sets the maximum number of items that can be fetched from Azure storage on each request during folder synchronization. The lower the number, the more round trips will be necessary to fetch all items. Large numbers will lead to timeouts in case of large repositories.</value>

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Constants.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Constants.cs
@@ -1,0 +1,23 @@
+﻿#region Copyright
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2018
+// by DotNetNuke Corporation
+// All Rights Reserved
+#endregion
+
+namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
+{
+    internal class Constants
+    {
+        public const string AccountName = "AccountName";
+        public const string AccountKey = "AccountKey";
+        public const string Container = "Container";
+        public const string UseHttps = "UseHttps";
+        public const string DirectLink = "DirectLink";
+        public const string CustomDomain = "CustomDomain";
+        public const string FolderProviderType = "AzureFolderProvider";
+        public const string PlaceHolderFileName = "dotnetnuke.placeholder.donotdelete";
+        public const string SyncBatchSize = "SyncBatchSize";
+        public const int DefaultSyncBatchSize = 2048;
+    }
+}

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx
@@ -39,3 +39,9 @@
     <asp:RegularExpressionValidator ID="rgBlobEndpoint" CssClass="dnnFormMessage dnnFormError"
             runat="server" ControlToValidate="tbCustomDomain" Display="Dynamic" ResourceKey="tbCustomDomain.Error" ValidationExpression="^http[s]?://([a-zA-Z0-9\-]+\.)*([a-zA-Z]{3,61}|[a-zA-Z]{1,}\.[a-zA-Z]{2,3})$"></asp:RegularExpressionValidator>
 </div>
+<div class="dnnFormItem">
+    <dnn:Label ID="plSyncBatchSize" runat="server" />
+    <asp:TextBox ID="tbSyncBatchSize" runat="server" MaxLength="6" Width="200" />
+    <asp:RegularExpressionValidator ID="rgInteger" CssClass="dnnFormMessage dnnFormError"
+            runat="server" ControlToValidate="tbSyncBatchSize" Display="Dynamic" ResourceKey="tbSyncBatchSize.Error" ValidationExpression="^\d+$"></asp:RegularExpressionValidator>
+</div>

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx.cs
@@ -12,7 +12,6 @@ using System.Web.UI.WebControls;
 using DotNetNuke.Instrumentation;
 using DotNetNuke.Services.FileSystem;
 using DotNetNuke.Services.Localization;
-using Microsoft.WindowsAzure;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -25,18 +24,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
     public partial class Settings : FolderMappingSettingsControlBase
     {
     	private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (Settings));
-        #region Constants
 
-        private const string AccountName = "AccountName";
-        private const string AccountKey = "AccountKey";
-        private const string Container = "Container";
-        private const string UseHttps = "UseHttps";
-		private const string DirectLink = "DirectLink";
-        private const string CustomDomain = "CustomDomain";
-        private const string FolderProviderType = "AzureFolderProvider";
-
-        #endregion
-        
         #region Overrided Methods
 
         /// <summary>
@@ -45,24 +33,24 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
         /// <param name="folderMappingSettings">The Hashtable containing the folder mapping settings.</param>
         public override void LoadSettings(Hashtable folderMappingSettings)
         {
-            var folderProvider = FolderProvider.Instance(FolderProviderType);
-            if (folderMappingSettings.ContainsKey(AccountName))
+            var folderProvider = FolderProvider.Instance(Constants.FolderProviderType);
+            if (folderMappingSettings.ContainsKey(Constants.AccountName))
             {
-                tbAccountName.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, AccountName);                
+                tbAccountName.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, Constants.AccountName);                
             }
 
-            if (folderMappingSettings.ContainsKey(AccountKey))
+            if (folderMappingSettings.ContainsKey(Constants.AccountKey))
             {
-                tbAccountKey.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, AccountKey);                
+                tbAccountKey.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, Constants.AccountKey);                
             }
 
             if (tbAccountName.Text.Length > 0 && tbAccountKey.Text.Length > 0)
             {
                 var bucketName = "";
 
-                if (folderMappingSettings.ContainsKey(Container))
+                if (folderMappingSettings.ContainsKey(Constants.Container))
                 {
-                    bucketName = folderMappingSettings[Container].ToString();
+                    bucketName = folderMappingSettings[Constants.Container].ToString();
                 }
 
                 LoadContainers();
@@ -75,16 +63,25 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
                 }
             }
 
-            if (folderMappingSettings.ContainsKey(UseHttps))
+            if (folderMappingSettings.ContainsKey(Constants.UseHttps))
             {
-                chkUseHttps.Checked = bool.Parse(folderMappingSettings[UseHttps].ToString());
+                chkUseHttps.Checked = bool.Parse(folderMappingSettings[Constants.UseHttps].ToString());
             }
 
-			chkDirectLink.Checked = !folderMappingSettings.ContainsKey(DirectLink) || folderMappingSettings[DirectLink].ToString().ToLowerInvariant() == "true";
+			chkDirectLink.Checked = !folderMappingSettings.ContainsKey(Constants.DirectLink) || folderMappingSettings[Constants.DirectLink].ToString().ToLowerInvariant() == "true";
 
-            if (folderMappingSettings.ContainsKey(CustomDomain))
+            if (folderMappingSettings.ContainsKey(Constants.CustomDomain))
             {
-                tbCustomDomain.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, CustomDomain);
+                tbCustomDomain.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, Constants.CustomDomain);
+            }
+
+            if (folderMappingSettings.ContainsKey(Constants.SyncBatchSize) && folderMappingSettings[Constants.SyncBatchSize] != null)
+            {
+                tbSyncBatchSize.Text = folderMappingSettings[Constants.SyncBatchSize].ToString();
+            }
+            else
+            {
+                tbSyncBatchSize.Text = Constants.DefaultSyncBatchSize.ToString();
             }
         }
 
@@ -109,6 +106,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
             var container = GetContainer();
             var useHttps = GetUseHttps();
             var customDomain = GetCustomDomain();
+            var synchBatchSize = GetSynchBatchSize();
 
             if (AreThereFolderMappingsWithSameSettings(folderMapping, accountName, container))
             {
@@ -118,12 +116,13 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
                 throw new Exception();
             }
             
-            folderMapping.FolderMappingSettings[AccountName] = accountName;
-            folderMapping.FolderMappingSettings[AccountKey] = accountKey;
-            folderMapping.FolderMappingSettings[Container] = container;
-            folderMapping.FolderMappingSettings[UseHttps] = useHttps;
-			folderMapping.FolderMappingSettings[DirectLink] = chkDirectLink.Checked;
-            folderMapping.FolderMappingSettings[CustomDomain] = customDomain;
+            folderMapping.FolderMappingSettings[Constants.AccountName] = accountName;
+            folderMapping.FolderMappingSettings[Constants.AccountKey] = accountKey;
+            folderMapping.FolderMappingSettings[Constants.Container] = container;
+            folderMapping.FolderMappingSettings[Constants.UseHttps] = useHttps;
+			folderMapping.FolderMappingSettings[Constants.DirectLink] = chkDirectLink.Checked;
+            folderMapping.FolderMappingSettings[Constants.CustomDomain] = customDomain;
+            folderMapping.FolderMappingSettings[Constants.SyncBatchSize] = synchBatchSize;
 
             folderMappingController.UpdateFolderMapping(folderMapping);
         }
@@ -139,8 +138,8 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
 
             return folderMappings
                 .Where(fm => fm.FolderMappingID != folderMapping.FolderMappingID && fm.FolderProviderType == folderMapping.FolderProviderType)
-                .Any(fm => fm.FolderMappingSettings[AccountName].ToString().Equals(accountName, StringComparison.InvariantCulture) &&
-                           fm.FolderMappingSettings[Container].ToString().Equals(container, StringComparison.InvariantCultureIgnoreCase));
+                .Any(fm => fm.FolderMappingSettings[Constants.AccountName].ToString().Equals(accountName, StringComparison.InvariantCulture) &&
+                           fm.FolderMappingSettings[Constants.Container].ToString().Equals(container, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private string GetUseHttps()
@@ -246,17 +245,22 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
 
         private string GetAccountKey()
         {
-            return FolderProvider.Instance(FolderProviderType).EncryptValue(tbAccountKey.Text);            
+            return FolderProvider.Instance(Constants.FolderProviderType).EncryptValue(tbAccountKey.Text);            
         }
 
         private string GetAccountName()
         {
-            return FolderProvider.Instance(FolderProviderType).EncryptValue(tbAccountName.Text);            
+            return FolderProvider.Instance(Constants.FolderProviderType).EncryptValue(tbAccountName.Text);            
         }
 
         private string GetCustomDomain()
         {
-            return FolderProvider.Instance(FolderProviderType).EncryptValue(tbCustomDomain.Text);
+            return FolderProvider.Instance(Constants.FolderProviderType).EncryptValue(tbCustomDomain.Text);
+        }
+
+        private string GetSynchBatchSize()
+        {
+            return tbSyncBatchSize.Text;
         }
 
         private void LoadContainers()

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx.cs
@@ -36,7 +36,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
             var folderProvider = FolderProvider.Instance(Constants.FolderProviderType);
             if (folderMappingSettings.ContainsKey(Constants.AccountName))
             {
-                tbAccountName.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, Constants.AccountName);                
+                tbAccountName.Text = folderProvider.GetEncryptedSetting(folderMappingSettings, Constants.AccountName);
             }
 
             if (folderMappingSettings.ContainsKey(Constants.AccountKey))
@@ -68,7 +68,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
                 chkUseHttps.Checked = bool.Parse(folderMappingSettings[Constants.UseHttps].ToString());
             }
 
-			chkDirectLink.Checked = !folderMappingSettings.ContainsKey(Constants.DirectLink) || folderMappingSettings[Constants.DirectLink].ToString().ToLowerInvariant() == "true";
+            chkDirectLink.Checked = !folderMappingSettings.ContainsKey(Constants.DirectLink) || folderMappingSettings[Constants.DirectLink].ToString().ToLowerInvariant() == "true";
 
             if (folderMappingSettings.ContainsKey(Constants.CustomDomain))
             {

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx.designer.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/Settings.ascx.designer.cs
@@ -200,5 +200,32 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.RegularExpressionValidator rgBlobEndpoint;
+        
+        /// <summary>
+        /// plSyncBatchSize control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.UserControl plSyncBatchSize;
+        
+        /// <summary>
+        /// tbSyncBatchSize control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox tbSyncBatchSize;
+        
+        /// <summary>
+        /// rgInteger control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.RegularExpressionValidator rgInteger;
     }
 }

--- a/DNN Platform/Providers/FolderProviders/DotNetNuke.Providers.FolderProviders.csproj
+++ b/DNN Platform/Providers/FolderProviders/DotNetNuke.Providers.FolderProviders.csproj
@@ -83,6 +83,7 @@
     <Compile Include="AzureFolderProvider\AzureBlob.cs" />
     <Compile Include="AzureFolderProvider\AzureRemoteStorageItem.cs" />
     <Compile Include="AzureFolderProvider\BlobItemExtensions.cs" />
+    <Compile Include="AzureFolderProvider\Constants.cs" />
     <Compile Include="AzureFolderProvider\Settings.ascx.cs">
       <DependentUpon>Settings.ascx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2697

After some investigation we found it loads Azure content using very small batches of data in a loop. On every Azure folder click, system synchronizes content and makes huge amount of iterations to upload all files. See:
 https://github.com/dnnsoftware/Dnn.Platform/blob/99686770464291109629a62c8d0611dbe5b2ec0a/DNN%20Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs#L159

To improve performance, I added `SyncBatchSize` setting which is now available on UI. It is possible to configure size of batches to load from Azure in one call. Customer can make it configured to their needs, smaller values means we will need more round trips to fetch all files, large numbers will potentially lead to timeouts in case of big repositories, but at same time will improve performance for a small repos. 

Below you'll find few changes:
1. `SyncBatchSise` setting is added to UI. It gets saved in database and used to load certain number of files from Azure during one call.
2. I did a small refactoring for the constants. I moved constant strings to one file and used it in a few places within one project.

![image](https://user-images.githubusercontent.com/22524011/56232869-6ce1c700-608a-11e9-9242-92aa0a902457.png)

![image](https://user-images.githubusercontent.com/22524011/56232934-969aee00-608a-11e9-9a6a-38680560f7f3.png)

