### PR TITLE
DNN-29425 Reduce number of calls for ModuleSettings

### DIFF
--- a/DNN Platform/Library/Common/Utilities/DataCache.cs
+++ b/DNN Platform/Library/Common/Utilities/DataCache.cs
@@ -164,6 +164,7 @@ namespace DotNetNuke.Common.Utilities
 
         public const string ModuleCacheKey = "Modules{0}";
         public const string ModuleSettingsCacheKey = "ModuleSettings{0}";
+        public static string ModuleSettingsByModuleIdCacheKey => "ModuleSettingsModuleId{0}";
         public const int ModuleCacheTimeOut = 20;
         public const CacheItemPriority ModuleCachePriority = CacheItemPriority.AboveNormal;
 

--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -222,6 +222,8 @@ namespace DotNetNuke.Entities.Modules
                 string cacheKey = String.Format(DataCache.ModuleSettingsCacheKey, tab.TabID);
                 DataCache.RemoveCache(cacheKey);
             }
+
+            DataCache.RemoveCache(string.Format(DataCache.ModuleSettingsByModuleIdCacheKey, moduleId));
         }
 
         private static void ClearTabModuleSettingsCache(int tabModuleId, string settingName)

--- a/DNN Platform/Library/Obsolete/ModuleController.cs
+++ b/DNN Platform/Library/Obsolete/ModuleController.cs
@@ -105,6 +105,18 @@ namespace DotNetNuke.Entities.Modules
         [Obsolete("Deprecated in DNN 7.3.  Please use the ModuleSettings property of the ModuleInfo object")]
         public Hashtable GetModuleSettings(int ModuleId)
         {
+            var cacheKey = string.Format(DataCache.ModuleSettingsByModuleIdCacheKey, ModuleId);
+            var moduleSettings = ModuleId <= 0 ? GetModuleSettingsInternal(ModuleId) :
+             CBO.GetCachedObject<Hashtable>(
+                new CacheItemArgs(cacheKey, DataCache.ModuleCacheTimeOut, DataCache.ModuleCachePriority),
+                c => GetModuleSettingsInternal(ModuleId)
+             );
+
+            return moduleSettings;
+        }
+
+        private Hashtable GetModuleSettingsInternal(int ModuleId)
+        {
             var settings = new Hashtable();
             IDataReader dr = null;
             try


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
Number of calls for stored procedure GetModuleSettings was reported very high. It was identified that these calls are generating from CKEditorProvider from class: SettingsUtil functions: CheckExistsModuleInstanceSettings and CheckExistsModuleSettings

It could be seen that current version of CKEditorProvider has already been modified to use other function call which is subsequently using cache. 
These are probable reasons for clients using older version of CKEditorProvider 

- DNN up to 9.1.x is using older version of CKEditorProvider
- For custom builds, CKEditorProvider might not be updated and hence continue using older version

The provided solution is to use cache for GetModuleSettings to avoid heavy stress from database.