### PR TITLE
Standardization of Obsolete Flags

### DIFF
--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/BufferingAppenderSkeleton.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/BufferingAppenderSkeleton.cs
@@ -220,7 +220,7 @@ namespace log4net.Appender
 		/// See <see cref="M:LoggingEvent.FixVolatileData(FixFlags)"/> for more information.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use Fix property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use Fix property. Scheduled removal in v10.0.0.")]
 		virtual public bool OnlyFixPartialEventData
 		{
 			get { return (Fix == FixFlags.Partial); }

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/ColoredConsoleAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/ColoredConsoleAppender.cs
@@ -174,7 +174,7 @@ namespace log4net.Appender
 		/// The instance of the <see cref="ColoredConsoleAppender" /> class is set up to write 
 		/// to the standard output stream.
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout property. Scheduled removal in v10.0.0.")]
 		public ColoredConsoleAppender(ILayout layout) : this(layout, false)
 		{
 		}
@@ -190,7 +190,7 @@ namespace log4net.Appender
 		/// the standard error output stream.  Otherwise, output is written to the standard
 		/// output stream.
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout & Target properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout & Target properties. Scheduled removal in v10.0.0.")]
 		public ColoredConsoleAppender(ILayout layout, bool writeToErrorStream) 
 		{
 			Layout = layout;

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/ConsoleAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/ConsoleAppender.cs
@@ -74,7 +74,7 @@ namespace log4net.Appender
 		/// The instance of the <see cref="ConsoleAppender" /> class is set up to write 
 		/// to the standard output stream.
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout property. Scheduled removal in v10.0.0.")]
 		public ConsoleAppender(ILayout layout) : this(layout, false)
 		{
 		}
@@ -90,7 +90,7 @@ namespace log4net.Appender
 		/// the standard error output stream.  Otherwise, output is written to the standard
 		/// output stream.
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout & Target properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout & Target properties. Scheduled removal in v10.0.0.")]
 		public ConsoleAppender(ILayout layout, bool writeToErrorStream) 
 		{
 			Layout = layout;

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/EventLogAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/EventLogAppender.cs
@@ -113,7 +113,7 @@ namespace log4net.Appender
 		/// Obsolete constructor.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout property. Scheduled removal in v10.0.0.")]
 		public EventLogAppender(ILayout layout) : this()
 		{
 			Layout = layout;

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/FileAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/FileAppender.cs
@@ -903,7 +903,7 @@ namespace log4net.Appender
 		/// Obsolete constructor.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout, File & AppendToFile properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout, File & AppendToFile properties. Scheduled removal in v10.0.0.")]
 		public FileAppender(ILayout layout, string filename, bool append)
 		{
 			Layout = layout;
@@ -923,7 +923,7 @@ namespace log4net.Appender
 		/// Obsolete constructor.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout & File properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout & File properties. Scheduled removal in v10.0.0.")]
 		public FileAppender(ILayout layout, string filename)
 			: this(layout, filename, true)
 		{

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/MemoryAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/MemoryAppender.cs
@@ -109,7 +109,7 @@ namespace log4net.Appender
 		/// See <see cref="M:LoggingEvent.FixVolatileData(bool)"/> for more information.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use Fix property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use Fix property. Scheduled removal in v10.0.0.")]
 		virtual public bool OnlyFixPartialEventData
 		{
 			get { return (Fix == FixFlags.Partial); }

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/SmtpAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/SmtpAppender.cs
@@ -223,7 +223,7 @@ namespace log4net.Appender
 		/// Obsolete property.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use the BufferingAppenderSkeleton Fix methods. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use the BufferingAppenderSkeleton Fix methods. Scheduled removal in v10.0.0.")]
 		public bool LocationInfo
 		{
 			get { return false; }

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Appender/TextWriterAppender.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Appender/TextWriterAppender.cs
@@ -70,7 +70,7 @@ namespace log4net.Appender
 		/// Obsolete constructor.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout & Writer properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout & Writer properties. Scheduled removal in v10.0.0.")]
 		public TextWriterAppender(ILayout layout, Stream os) : this(layout, new StreamWriter(os))
 		{
 		}
@@ -89,7 +89,7 @@ namespace log4net.Appender
 		/// Obsolete constructor.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Instead use the default constructor and set the Layout & Writer properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Instead use the default constructor and set the Layout & Writer properties. Scheduled removal in v10.0.0.")]
 		public TextWriterAppender(ILayout layout, TextWriter writer) 
 		{
 			Layout = layout;

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Config/AliasDomainAttribute.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Config/AliasDomainAttribute.cs
@@ -48,7 +48,7 @@ namespace log4net.Config
 	/// <author>Gert Driesen</author>
 	[AttributeUsage(AttributeTargets.Assembly,AllowMultiple=true)]
 	[Serializable]
-	[Obsolete("Use AliasRepositoryAttribute instead of AliasDomainAttribute. Scheduled removal in v11.0.0.")]
+	[Obsolete("Use AliasRepositoryAttribute instead of AliasDomainAttribute. Scheduled removal in v10.0.0.")]
 	public sealed class AliasDomainAttribute : AliasRepositoryAttribute
 	{
 		#region Public Instance Constructors

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Config/DOMConfigurator.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Config/DOMConfigurator.cs
@@ -43,7 +43,7 @@ namespace log4net.Config
 	/// </remarks>
 	/// <author>Nicko Cadell</author>
 	/// <author>Gert Driesen</author>
-	[Obsolete("Use XmlConfigurator instead of DOMConfigurator. Scheduled removal in v11.0.0.")]
+	[Obsolete("Use XmlConfigurator instead of DOMConfigurator. Scheduled removal in v10.0.0.")]
 	public sealed class DOMConfigurator
 	{
 		#region Private Instance Constructors
@@ -94,7 +94,7 @@ namespace log4net.Config
 		/// <c>log4net</c> that contains the configuration data.
 		/// </remarks>
 		/// <param name="repository">The repository to configure.</param>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(ILoggerRepository repository) 
 		{
 			XmlConfigurator.Configure(repository);
@@ -111,7 +111,7 @@ namespace log4net.Config
 		/// supplied as <paramref name="element"/>.
 		/// </remarks>
 		/// <param name="element">The element to parse.</param>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(XmlElement element) 
 		{
 			XmlConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), element);
@@ -130,7 +130,7 @@ namespace log4net.Config
 		/// </remarks>
 		/// <param name="repository">The repository to configure.</param>
 		/// <param name="element">The element to parse.</param>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(ILoggerRepository repository, XmlElement element) 
 		{
 			XmlConfigurator.Configure(repository, element);
@@ -178,7 +178,7 @@ namespace log4net.Config
 		///	</configuration>
 		/// </code>
 		/// </remarks>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(FileInfo configFile)
 		{
 			XmlConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), configFile);
@@ -201,7 +201,7 @@ namespace log4net.Config
 		/// Note that this method will NOT close the stream parameter.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(Stream configStream)
 		{
 			XmlConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), configStream);
@@ -251,7 +251,7 @@ namespace log4net.Config
 		///	</configuration>
 		/// </code>
 		/// </remarks>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(ILoggerRepository repository, FileInfo configFile)
 		{
 			XmlConfigurator.Configure(repository, configFile);
@@ -277,7 +277,7 @@ namespace log4net.Config
 		/// Note that this method will NOT close the stream parameter.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.Configure instead of DOMConfigurator.Configure. Scheduled removal in v10.0.0.")]
 		static public void Configure(ILoggerRepository repository, Stream configStream)
 		{
 			XmlConfigurator.Configure(repository, configStream);
@@ -313,7 +313,7 @@ namespace log4net.Config
 		/// </para>
 		/// </remarks>
 		/// <seealso cref="M:Configure(FileInfo)"/>
-		[Obsolete("Use XmlConfigurator.ConfigureAndWatch instead of DOMConfigurator.ConfigureAndWatch. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.ConfigureAndWatch instead of DOMConfigurator.ConfigureAndWatch. Scheduled removal in v10.0.0.")]
 		static public void ConfigureAndWatch(FileInfo configFile)
 		{
 			XmlConfigurator.ConfigureAndWatch(LogManager.GetRepository(Assembly.GetCallingAssembly()), configFile);
@@ -345,7 +345,7 @@ namespace log4net.Config
 		/// </para>
 		/// </remarks>
 		/// <seealso cref="M:Configure(FileInfo)"/>
-		[Obsolete("Use XmlConfigurator.ConfigureAndWatch instead of DOMConfigurator.ConfigureAndWatch. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use XmlConfigurator.ConfigureAndWatch instead of DOMConfigurator.ConfigureAndWatch. Scheduled removal in v10.0.0.")]
 		static public void ConfigureAndWatch(ILoggerRepository repository, FileInfo configFile)
 		{
 			XmlConfigurator.ConfigureAndWatch(repository, configFile);

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Config/DOMConfiguratorAttribute.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Config/DOMConfiguratorAttribute.cs
@@ -51,7 +51,7 @@ namespace log4net.Config
 	/// <author>Gert Driesen</author>
 	[AttributeUsage(AttributeTargets.Assembly)]
 	[Serializable]
-	[Obsolete("Use XmlConfiguratorAttribute instead of DOMConfiguratorAttribute. Scheduled removal in v11.0.0.")]
+	[Obsolete("Use XmlConfiguratorAttribute instead of DOMConfiguratorAttribute. Scheduled removal in v10.0.0.")]
 	public sealed class DOMConfiguratorAttribute : XmlConfiguratorAttribute
 	{
 	}

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Config/DomainAttribute.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Config/DomainAttribute.cs
@@ -49,7 +49,7 @@ namespace log4net.Config
 	/// <author>Gert Driesen</author>
 	[AttributeUsage(AttributeTargets.Assembly)]
 	[Serializable]
-	[Obsolete("Use RepositoryAttribute instead of DomainAttribute. Scheduled removal in v11.0.0.")]
+	[Obsolete("Use RepositoryAttribute instead of DomainAttribute. Scheduled removal in v10.0.0.")]
 	public sealed class DomainAttribute : RepositoryAttribute
 	{
 		#region Public Instance Constructors

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Core/LoggerManager.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Core/LoggerManager.cs
@@ -190,7 +190,7 @@ namespace log4net.Core
 		/// by the <paramref name="repository"/> argument.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository GetLoggerRepository(string repository)
 		{
 			return GetRepository(repository);
@@ -201,7 +201,7 @@ namespace log4net.Core
 		/// </summary>
 		/// <param name="repositoryAssembly">The assembly to use to lookup the repository.</param>
 		/// <returns>The default <see cref="ILoggerRepository"/> instance.</returns>
-		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository GetLoggerRepository(Assembly repositoryAssembly)
 		{
 			return GetRepository(repositoryAssembly);
@@ -608,7 +608,7 @@ namespace log4net.Core
 		/// </para>
 		/// </remarks>
 		/// <exception cref="LogException">The specified repository already exists.</exception>
-		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository CreateDomain(string repository)
 		{
 			return CreateRepository(repository);
@@ -657,7 +657,7 @@ namespace log4net.Core
 		/// </para>
 		/// </remarks>
 		/// <exception cref="LogException">The specified repository already exists.</exception>
-		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository CreateDomain(string repository, Type repositoryType)
 		{
 			return CreateRepository(repository, repositoryType);
@@ -709,7 +709,7 @@ namespace log4net.Core
 		/// same assembly specified will return the same repository instance.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository CreateDomain(Assembly repositoryAssembly, Type repositoryType)
 		{
 			return CreateRepository(repositoryAssembly, repositoryType);

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Core/LoggingEvent.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Core/LoggingEvent.cs
@@ -210,7 +210,7 @@ namespace log4net.Core
 		/// <summary>
 		/// Fix the MDC
 		/// </summary>
-		[Obsolete("Replaced by composite Properties. Scheduled removal in v11.0.0.")]
+		[Obsolete("Replaced by composite Properties. Scheduled removal in v10.0.0.")]
 		Mdc = 0x01,
 
 		/// <summary>
@@ -1173,7 +1173,7 @@ namespace log4net.Core
 		/// <b>Obsolete. Use <see cref="GetExceptionString"/> instead.</b>
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use GetExceptionString instead. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use GetExceptionString instead. Scheduled removal in v10.0.0.")]
 		public string GetExceptionStrRep() 
 		{
 			return GetExceptionString();
@@ -1241,7 +1241,7 @@ namespace log4net.Core
 		/// information.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use Fix property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use Fix property. Scheduled removal in v10.0.0.")]
 		public void FixVolatileData()
 		{
 			Fix = FixFlags.All;
@@ -1275,7 +1275,7 @@ namespace log4net.Core
 		/// settings are fixed.
 		/// </para>
 		/// </remarks>
-		[Obsolete("Use Fix property. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use Fix property. Scheduled removal in v10.0.0.")]
 		public void FixVolatileData(bool fastButLoose)
 		{
 			if (fastButLoose)

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Filter/MdcFilter.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Filter/MdcFilter.cs
@@ -40,7 +40,7 @@ namespace log4net.Filter
 	/// </remarks>
 	/// <author>Nicko Cadell</author>
 	/// <author>Gert Driesen</author>
-	/*[Obsolete("MdcFilter has been replaced by PropertyFilter. Scheduled removal in v11.0.0.")]*/
+	[Obsolete("MdcFilter has been replaced by PropertyFilter. Scheduled removal in v10.0.0.")]
 	public class MdcFilter : PropertyFilter
 	{
 	}

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Filter/NdcFilter.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Filter/NdcFilter.cs
@@ -41,7 +41,7 @@ namespace log4net.Filter
 	/// </remarks>
 	/// <author>Nicko Cadell</author>
 	/// <author>Gert Driesen</author>
-	/*[Obsolete("NdcFilter has been replaced by PropertyFilter. Scheduled removal in v11.0.0.")]*/
+	[Obsolete("NdcFilter has been replaced by PropertyFilter. Scheduled removal in v10.0.0.")]
 	public class NdcFilter : PropertyFilter
 	{
 		/// <summary>

--- a/DNN Platform/DotNetNuke.Log4net/log4net/LogManager.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/LogManager.cs
@@ -466,7 +466,7 @@ namespace log4net
 		/// </para>
 		/// </remarks>
 		/// <returns>The <see cref="ILoggerRepository"/> instance for the default repository.</returns>
-		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository GetLoggerRepository()
 		{
 			return GetRepository(Assembly.GetCallingAssembly());
@@ -484,7 +484,7 @@ namespace log4net
 		/// </para>
 		/// </remarks>
 		/// <param name="repository">The repository to lookup in.</param>
-		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository GetLoggerRepository(string repository)
 		{
 			return GetRepository(repository);
@@ -501,7 +501,7 @@ namespace log4net
 		/// </para>
 		/// </remarks>
 		/// <param name="repositoryAssembly">The assembly to use to lookup the repository.</param>
-		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use GetRepository instead of GetLoggerRepository. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository GetLoggerRepository(Assembly repositoryAssembly)
 		{
 			return GetRepository(repositoryAssembly);
@@ -576,7 +576,7 @@ namespace log4net
 		/// and has a no arg constructor. An instance of this type will be created to act
 		/// as the <see cref="ILoggerRepository"/> for the repository specified.</param>
 		/// <returns>The <see cref="ILoggerRepository"/> created for the repository.</returns>
-		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository CreateDomain(Type repositoryType)
 		{
 			return CreateRepository(Assembly.GetCallingAssembly(), repositoryType);
@@ -667,7 +667,7 @@ namespace log4net
 		/// as the <see cref="ILoggerRepository"/> for the repository specified.</param>
 		/// <returns>The <see cref="ILoggerRepository"/> created for the repository.</returns>
 		/// <exception cref="LogException">The specified repository already exists.</exception>
-		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository CreateDomain(string repository, Type repositoryType)
 		{
 			return LoggerManager.CreateRepository(repository, repositoryType);
@@ -711,7 +711,7 @@ namespace log4net
 		/// and has a no arg constructor. An instance of this type will be created to act
 		/// as the <see cref="ILoggerRepository"/> for the repository specified.</param>
 		/// <returns>The <see cref="ILoggerRepository"/> created for the repository.</returns>
-		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v11.0.0.")]
+		[Obsolete("Use CreateRepository instead of CreateDomain. Scheduled removal in v10.0.0.")]
 		public static ILoggerRepository CreateDomain(Assembly repositoryAssembly, Type repositoryType)
 		{
 			return LoggerManager.CreateRepository(repositoryAssembly, repositoryType);

--- a/DNN Platform/DotNetNuke.Log4net/log4net/MDC.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/MDC.cs
@@ -47,7 +47,7 @@ namespace log4net
 	/// <threadsafety static="true" instance="true" />
 	/// <author>Nicko Cadell</author>
 	/// <author>Gert Driesen</author>
-	/*[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v11.0.0.")]*/
+	[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v10.0.0.")]
 	public sealed class MDC
 	{
 		#region Private Instance Constructors
@@ -117,7 +117,7 @@ namespace log4net
 		/// is specified as <c>null</c> then the key value mapping will be removed.
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v10.0.0.")]
 		public static void Set(string key, string value)
 		{
 			ThreadContext.Properties[key] = value;
@@ -138,7 +138,7 @@ namespace log4net
 		/// Remove the specified entry from this thread's MDC
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v10.0.0.")]
 		public static void Remove(string key)
 		{
 			ThreadContext.Properties.Remove(key);
@@ -158,7 +158,7 @@ namespace log4net
 		/// Remove all the entries from this thread's MDC
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("MDC has been replaced by ThreadContext.Properties. Scheduled removal in v10.0.0.")]
 		public static void Clear()
 		{
 			ThreadContext.Properties.Clear();

--- a/DNN Platform/DotNetNuke.Log4net/log4net/NDC.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/NDC.cs
@@ -65,7 +65,7 @@ namespace log4net
 	/// <threadsafety static="true" instance="true" />
 	/// <author>Nicko Cadell</author>
 	/// <author>Gert Driesen</author>
-	/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+	[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 	public sealed class NDC
 	{
 		#region Private Instance Constructors
@@ -128,7 +128,7 @@ namespace log4net
 		/// Clears the stack of NDC data held on the current thread.
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 		public static void Clear() 
 		{
 			ThreadContext.Stacks["NDC"].Clear();
@@ -151,7 +151,7 @@ namespace log4net
 		/// parent thread.
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 		public static Stack CloneStack() 
 		{
 			return ThreadContext.Stacks["NDC"].InternalStack;
@@ -178,7 +178,7 @@ namespace log4net
 		/// this method.
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks", true)]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.", true)]
 		public static void Inherit(Stack stack) 
 		{
 			ThreadContext.Stacks["NDC"].InternalStack = stack;
@@ -240,7 +240,7 @@ namespace log4net
 		///	}
 		/// </code>
 		/// </example>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 		public static IDisposable Push(string message) 
 		{
 			return ThreadContext.Stacks["NDC"].Push(message);
@@ -278,7 +278,7 @@ namespace log4net
 		///	}
 		/// </code>
 		/// </example>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 		public static IDisposable PushFormat(string messageFormat, params object[] args)
 		{
 			return Push(string.Format(messageFormat, args));
@@ -299,7 +299,7 @@ namespace log4net
 		/// This method is not implemented.
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 		public static void Remove() 
 		{
 		}
@@ -323,7 +323,7 @@ namespace log4net
 		/// call. This can be used to return to a known context depth.
 		/// </para>
 		/// </remarks>
-		/*[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v11.0.0.")]*/
+		[Obsolete("NDC has been replaced by ThreadContext.Stacks. Scheduled removal in v10.0.0.")]
 		public static void SetMaxDepth(int maxDepth) 
 		{
 			if (maxDepth >= 0)

--- a/DNN Platform/DotNetNuke.Log4net/log4net/Util/SystemInfo.cs
+++ b/DNN Platform/DotNetNuke.Log4net/log4net/Util/SystemInfo.cs
@@ -394,7 +394,7 @@ namespace log4net.Util
 		/// will be set per AppDomain.
 		/// </para>
 		/// </remarks>
-        [Obsolete("Use ProcessStartTimeUtc and convert to local time if needed.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Use ProcessStartTimeUtc and convert to local time if needed.. Scheduled removal in v10.0.0.")]
 		public static DateTime ProcessStartTime
 		{
 			get { return s_processStartTimeUtc.ToLocalTime(); }

--- a/DNN Platform/DotNetNuke.Web/InternalServices/ContentWorkflowServiceController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/ContentWorkflowServiceController.cs
@@ -123,7 +123,7 @@ namespace DotNetNuke.Web.InternalServices
 
         }
 
-        [Obsolete("Obsolted in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolted in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         [HttpPost]
         [ValidateAntiForgeryToken]
         public HttpResponseMessage Review(NotificationDTO postData)

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFormEditor.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFormEditor.cs
@@ -147,7 +147,7 @@ namespace DotNetNuke.Web.UI.WebControls
 
         #region Private Methods
 
-        [Obsolete("Obsolted in Platform 7.4.1, please add encryptIds. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in Platform 7.4.1, please add encryptIds. Scheduled removal in v10.0.0.")]
         internal static void SetUpItems(IEnumerable<DnnFormItemBase> items, WebControl parentControl, string localResourceFile)
         {
             SetUpItems(items, parentControl, localResourceFile, false);

--- a/DNN Platform/Library/Common/Lists/ListController.cs
+++ b/DNN Platform/Library/Common/Lists/ListController.cs
@@ -393,19 +393,19 @@ namespace DotNetNuke.Common.Lists
             ClearEntriesCache(entry.ListName, entry.PortalID);
         }
 
-        [Obsolete("Obsoleted in 6.0.1 use IEnumerable<ListEntryInfo> GetListEntryInfoXXX(string) instead"), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Obsoleted in 6.0.1 use IEnumerable<ListEntryInfo> GetListEntryInfoXXX(string) instead. Scheduled removal in v10.0.0."), EditorBrowsable(EditorBrowsableState.Never)]
         public ListEntryInfoCollection GetListEntryInfoCollection(string listName)
         {
             return GetListEntryInfoCollection(listName, "", Null.NullInteger);
         }
 
-        [Obsolete("Obsoleted in 6.0.1 use IEnumerable<ListEntryInfo> GetListEntryInfoXXX(string, string, int) instead"), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Obsoleted in 6.0.1 use IEnumerable<ListEntryInfo> GetListEntryInfoXXX(string, string, int) instead. Scheduled removal in v10.0.0."), EditorBrowsable(EditorBrowsableState.Never)]
         public ListEntryInfoCollection GetListEntryInfoCollection(string listName, string parentKey)
         {
             return GetListEntryInfoCollection(listName, parentKey, Null.NullInteger);
         }
 
-        [Obsolete("Obsoleted in 6.0.1 use IEnumerable<ListEntryInfo> GetListEntryInfoXXX(string, string, int) instead"), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Obsoleted in 6.0.1 use IEnumerable<ListEntryInfo> GetListEntryInfoXXX(string, string, int) instead. Scheduled removal in v10.0.0."), EditorBrowsable(EditorBrowsableState.Never)]
         public ListEntryInfoCollection GetListEntryInfoCollection(string listName, string parentKey, int portalId)
         {
             var items = GetListEntryInfoItems(listName, parentKey, portalId);

--- a/DNN Platform/Library/Common/Lists/ListEntryCollection.cs
+++ b/DNN Platform/Library/Common/Lists/ListEntryCollection.cs
@@ -31,7 +31,7 @@ using DotNetNuke.Instrumentation;
 namespace DotNetNuke.Common.Lists
 {
     [Serializable]
-    [Obsolete("Obsoleted in 6.0.1.  Replaced by using generic collections of ListEntryInfo objects"), EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Obsoleted in 6.0.1.  Replaced by using generic collections of ListEntryInfo objects. Scheduled removal in v10.0.0."), EditorBrowsable(EditorBrowsableState.Never)]
     public class ListEntryInfoCollection : CollectionBase
     {
     	private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (ListEntryInfoCollection));

--- a/DNN Platform/Library/Common/Utilities/IPathUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/IPathUtils.cs
@@ -61,7 +61,7 @@ namespace DotNetNuke.Common.Utilities
         /// <param name="userID">The user identifier.</param>
         /// <param name="mode">The UserFolderElement to get.</param>
         /// <returns>The element from the user folder path.</returns>
-        [Obsolete("Deprecated in DNN 6.2.  No replacement, this should have been internal only. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 6.2.  No replacement, this should have been internal only. Scheduled removal in v10.0.0.")]
         string GetUserFolderPathElement(int userID, PathUtils.UserFolderElement mode);
 
         /// <summary>

--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -510,7 +510,7 @@ namespace DotNetNuke.Data
 
         #region Portal Methods
 
-        [Obsolete("Deprecated in Platform 7.4.0, please use CreatePortal version that contain's culturecode. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0, please use CreatePortal version that contain's culturecode. Scheduled removal in v10.0.0.")]
         public virtual int CreatePortal(string portalname, string currency, DateTime ExpiryDate, double HostFee,
                                         double HostSpace, int PageQuota, int UserQuota, int SiteLogHistory,
                                          string HomeDirectory, int CreatedByUserID)
@@ -3978,7 +3978,7 @@ namespace DotNetNuke.Data
             return ExecuteScalar<int>("GetContentWorkflowStateUsageCount", stateId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual int AddContentWorkflow(int portalId, string workflowName, string description, bool isDeleted, bool startAfterCreating, bool startAfterEditing, bool dispositionEnabled)
         {
             return ExecuteScalar<int>("AddContentWorkflow",
@@ -3991,19 +3991,19 @@ namespace DotNetNuke.Data
                 dispositionEnabled);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual IDataReader GetContentWorkflow(int workflowId)
         {
             return ExecuteReader("GetContentWorkflow", workflowId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual IDataReader GetContentWorkflows(int portalId)
         {
             return ExecuteReader("GetContentWorkflows", portalId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual void UpdateContentWorkflow(int workflowId, string workflowName, string description, bool isDeleted, bool startAfterCreating, bool startAfterEditing, bool dispositionEnabled)
         {
             ExecuteNonQuery("UpdateContentWorkflow",
@@ -4016,7 +4016,7 @@ namespace DotNetNuke.Data
                 dispositionEnabled);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual int AddContentWorkflowState(int workflowId, string stateName, int order,
             bool isActive, bool sendEmail, bool sendMessage, bool isDisposalState,
             string onCompleteMessageSubject, string onCompleteMessageBody,
@@ -4036,13 +4036,13 @@ namespace DotNetNuke.Data
                 onDiscardMessageBody);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual void DeleteContentWorkflowState(int stateId)
         {
             ExecuteNonQuery("DeleteContentWorkflowState", stateId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual void UpdateContentWorkflowState(int stateId, string stateName, int order,
             bool isActive, bool sendEmail, bool sendMessage, bool isDisposalState,
             string onCompleteMessageSubject, string onCompleteMessageBody,
@@ -4062,19 +4062,19 @@ namespace DotNetNuke.Data
                 onDiscardMessageBody);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual IDataReader GetContentWorkflowState(int stateId)
         {
             return ExecuteReader("GetContentWorkflowState", stateId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual IDataReader GetContentWorkflowStates(int workflowId)
         {
             return ExecuteReader("GetContentWorkflowStates", workflowId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger.AddWorkflowLog. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger.AddWorkflowLog. Scheduled removal in v10.0.0.")]
         public virtual int AddContentWorkflowLog(string action, string comment, int user, int workflowId, int contentItemId)
         {
             return ExecuteScalar<int>("AddContentWorkflowLog",
@@ -4085,13 +4085,13 @@ namespace DotNetNuke.Data
                 contentItemId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger.GetWorkflowLogs. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger.GetWorkflowLogs. Scheduled removal in v10.0.0.")]
         public virtual IDataReader GetContentWorkflowLogs(int contentItemId, int workflowId)
         {
             return ExecuteReader("GetContentWorkflowLogs", contentItemId, workflowId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual int DeleteContentWorkflowLogs(int contentItemId, int workflowId)
         {
             return ExecuteScalar<int>("DeleteContentWorkflowLogs", contentItemId, workflowId);
@@ -4140,13 +4140,13 @@ namespace DotNetNuke.Data
             return ExecuteReader("GetContentWorkflowStatePermissionsByStateID", stateId);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual IDataReader GetContentWorkflowSource(int workflowId, string sourceName)
         {
             return ExecuteReader("GetContentWorkflowSource", workflowId, sourceName);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public virtual int AddContentWorkflowSource(int workflowId, string sourceName, string sourceType)
         {
             return ExecuteScalar<int>("AddContentWorkflowSource", workflowId, sourceName, sourceType);
@@ -4348,20 +4348,19 @@ namespace DotNetNuke.Data
 
         #region Obsolete Methods
 
-        [Obsolete(
-            "Deprecated in 7.0.0.  This method is unneccessary.  You can get a reader and convert it to a DataSet.")]
+        [Obsolete("Deprecated in 7.0.0.  This method is unneccessary.  You can get a reader and convert it to a DataSet. Scheduled removal in v10.0.0.")]
         public virtual DataSet ExecuteDataSet(string procedureName, params object[] commandParameters)
         {
             return Globals.ConvertDataReaderToDataSet(ExecuteReader(procedureName, commandParameters));
         }
 
-        [Obsolete("Deprecated in 7.0.0.  This method is unneccessary.  Use the generic version ExecuteScalar<T>.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in 7.0.0.  This method is unneccessary.  Use the generic version ExecuteScalar<T>.. Scheduled removal in v10.0.0.")]
         public virtual object ExecuteScalar(string procedureName, params object[] commandParameters)
         {
             return ExecuteScalar<object>(procedureName, commandParameters);
         }
 
-        [Obsolete("Temporarily Added in DNN 5.4.2. This will be removed and replaced with named instance support.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Temporarily Added in DNN 5.4.2. This will be removed and replaced with named instance support.. Scheduled removal in v10.0.0.")]
         public virtual IDataReader ExecuteSQL(string sql, params IDataParameter[] commandParameters)
         {
             SqlParameter[] sqlCommandParameters = null;

--- a/DNN Platform/Library/Entities/Content/Common/ContentExtensions.cs
+++ b/DNN Platform/Library/Entities/Content/Common/ContentExtensions.cs
@@ -35,7 +35,7 @@ using DotNetNuke.Services.FileSystem;
 
 namespace DotNetNuke.Entities.Content
 {
-    [Obsolete("Moving ContentExtensions to the DotNetNuke.Entities.Content namespace was an error. Please use DotNetNuke.Entities.Content.Common.ContentExtensions. Scheduled removal in v11.0.0.")]
+    [Obsolete("Moving ContentExtensions to the DotNetNuke.Entities.Content namespace was an error. Please use DotNetNuke.Entities.Content.Common.ContentExtensions. Scheduled removal in v10.0.0.")]
     public static class ContentExtensions
     {
         //only forwarding public methods that existed as of 6.1.0

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflow.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflow.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Entities.Content.Workflow
     /// <summary>
     /// This entity represents a Workflow
     /// </summary>
-    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
     public class ContentWorkflow
     {
         /// <summary>

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowController.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowController.cs
@@ -39,7 +39,7 @@ using DotNetNuke.Services.Social.Notifications;
 namespace DotNetNuke.Entities.Content.Workflow
 // ReSharper enable CheckNamespace
 {
-    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
     public class ContentWorkflowController : ComponentBase<IContentWorkflowController, ContentWorkflowController>, IContentWorkflowController
     {
         private readonly ContentController contentController;
@@ -55,7 +55,7 @@ namespace DotNetNuke.Entities.Content.Workflow
         
         #region Engine
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public void DiscardWorkflow(int contentItemId, string comment, int portalId, int userId)
         {
             var item = contentController.GetContentItem(contentItemId);
@@ -66,7 +66,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             SetWorkflowState(stateId, item);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public void CompleteWorkflow(int contentItemId, string comment, int portalId, int userId)
         {
             var item = contentController.GetContentItem(contentItemId);
@@ -77,7 +77,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             SetWorkflowState(lastStateId, item);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public string ReplaceNotificationTokens(string text, ContentWorkflow workflow, ContentItem item, ContentWorkflowState state, int portalID, int userID, string comment = "")
         {
             var user = UserController.GetUserById(portalID, userID);
@@ -92,13 +92,13 @@ namespace DotNetNuke.Entities.Content.Workflow
             return result;
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public void CompleteState(int itemID, string subject, string body, string comment, int portalID, int userID)
         {
             CompleteState(itemID, subject, body, comment, portalID, userID, string.Empty);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public void StartWorkflow(int workflowID, int itemID, int userID)
         {
             var item = contentController.GetContentItem(itemID);
@@ -123,7 +123,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             AddWorkflowLog(item, ContentWorkflowLogType.StateInitiated, userID);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public void CompleteState(int itemID, string subject, string body, string comment, int portalID, int userID, string source, params string[] parameters)
         {
             var item = contentController.GetContentItem(itemID);
@@ -155,7 +155,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             }
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public void DiscardState(int itemID, string subject, string body, string comment, int portalID, int userID)
         {
             var item = contentController.GetContentItem(itemID);
@@ -179,7 +179,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             }
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public bool IsWorkflowCompleted(int itemID)
         {
             var item = contentController.GetContentItem(itemID); //Ensure DB values
@@ -188,7 +188,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             return IsWorkflowCompleted(workflow, item);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         public bool IsWorkflowOnDraft(int itemID)
         {
             var item = contentController.GetContentItem(itemID); //Ensure DB values
@@ -199,7 +199,7 @@ namespace DotNetNuke.Entities.Content.Workflow
         #endregion
 
         #region Log
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v10.0.0.")]
         public void AddWorkflowLog(ContentItem item, string action, string comment, int userID)
         {
             var workflow = GetWorkflow(item);
@@ -207,13 +207,13 @@ namespace DotNetNuke.Entities.Content.Workflow
             AddWorkflowLog(workflow != null ? workflow.WorkflowID : Null.NullInteger, item, action, comment, userID);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v10.0.0.")]
         public IEnumerable<ContentWorkflowLog> GetWorkflowLogs(int contentItemId, int workflowId)
         {
             return CBO.FillCollection<ContentWorkflowLog>(DataProvider.Instance().GetContentWorkflowLogs(contentItemId, workflowId));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
         public void DeleteWorkflowLogs(int contentItemID, int workflowID)
         {
             DataProvider.Instance().DeleteContentWorkflowLogs(contentItemID, workflowID);
@@ -221,13 +221,13 @@ namespace DotNetNuke.Entities.Content.Workflow
         #endregion
 
         #region State Permissions
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public IEnumerable<ContentWorkflowStatePermission> GetWorkflowStatePermissionByState(int stateID)
         {
             return CBO.FillCollection<ContentWorkflowStatePermission>(DataProvider.Instance().GetContentWorkflowStatePermissionsByStateID(stateID));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public void AddWorkflowStatePermission(ContentWorkflowStatePermission permission, int lastModifiedByUserID)
         {
             DataProvider.Instance().AddContentWorkflowStatePermission(permission.StateID,
@@ -238,7 +238,7 @@ namespace DotNetNuke.Entities.Content.Workflow
                                                                        lastModifiedByUserID);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public void UpdateWorkflowStatePermission(ContentWorkflowStatePermission permission, int lastModifiedByUserID)
         {
             DataProvider.Instance().UpdateContentWorkflowStatePermission(permission.WorkflowStatePermissionID,
@@ -250,7 +250,7 @@ namespace DotNetNuke.Entities.Content.Workflow
                                                                             lastModifiedByUserID);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public void DeleteWorkflowStatePermission(int workflowStatePermissionID)
         {
             DataProvider.Instance().DeleteContentWorkflowStatePermission(workflowStatePermissionID);
@@ -259,13 +259,13 @@ namespace DotNetNuke.Entities.Content.Workflow
 
         #region State
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public ContentWorkflowState GetWorkflowStateByID(int stateID)
         {
             return CBO.FillObject<ContentWorkflowState>(DataProvider.Instance().GetContentWorkflowState(stateID));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public void AddWorkflowState(ContentWorkflowState state)
         {
             var id = DataProvider.Instance().AddContentWorkflowState(state.WorkflowID,
@@ -282,7 +282,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             state.StateID = id;
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public void UpdateWorkflowState(ContentWorkflowState state)
         {
             DataProvider.Instance().UpdateContentWorkflowState(state.StateID,
@@ -298,7 +298,7 @@ namespace DotNetNuke.Entities.Content.Workflow
                                                                 state.OnDiscardMessageBody);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         public IEnumerable<ContentWorkflowState> GetWorkflowStates(int workflowID)
         {
             return CBO.FillCollection<ContentWorkflowState>(DataProvider.Instance().GetContentWorkflowStates(workflowID));
@@ -307,13 +307,13 @@ namespace DotNetNuke.Entities.Content.Workflow
 
         #region Workflow
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         public IEnumerable<ContentWorkflow> GetWorkflows(int portalID)
         {
             return CBO.FillCollection<ContentWorkflow>(DataProvider.Instance().GetContentWorkflows(portalID));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         public ContentWorkflow GetWorkflow(ContentItem item)
         {
             var state = GetWorkflowStateByID(item.StateID);
@@ -321,20 +321,20 @@ namespace DotNetNuke.Entities.Content.Workflow
             return GetWorkflowByID(state.WorkflowID);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         public void AddWorkflow(ContentWorkflow workflow)
         {
             var id = DataProvider.Instance().AddContentWorkflow(workflow.PortalID, workflow.WorkflowName, workflow.Description, workflow.IsDeleted, workflow.StartAfterCreating, workflow.StartAfterEditing, workflow.DispositionEnabled);
             workflow.WorkflowID = id;
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         public void UpdateWorkflow(ContentWorkflow workflow)
         {
             DataProvider.Instance().UpdateContentWorkflow(workflow.WorkflowID, workflow.WorkflowName, workflow.Description, workflow.IsDeleted, workflow.StartAfterCreating, workflow.StartAfterEditing, workflow.DispositionEnabled);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         public ContentWorkflow GetWorkflowByID(int workflowID)
         {
             var workflow = CBO.FillObject<ContentWorkflow>(DataProvider.Instance().GetContentWorkflow(workflowID));
@@ -348,7 +348,7 @@ namespace DotNetNuke.Entities.Content.Workflow
         #endregion
 
         #region Default Workflows
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v10.0.0.")]
         //TODO Mark what would be the replacement method
         public void CreateDefaultWorkflows(int portalId)
         {
@@ -445,7 +445,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             }
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v10.0.0.")]
         public ContentWorkflow GetDefaultWorkflow(int portalID)
         {
             var wf = GetWorkflows(portalID).First(); // We assume there is only 1 Workflow. This needs to be changed for other scenarios
@@ -455,21 +455,21 @@ namespace DotNetNuke.Entities.Content.Workflow
         #endregion
 
         #region Security Helpers
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         public bool IsAnyReviewer(int workflowID)
         {
             var workflow = GetWorkflowByID(workflowID);
             return workflow.States.Any(contentWorkflowState => IsReviewer(contentWorkflowState.StateID));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         public bool IsAnyReviewer(int portalID, int userID, int workflowID)
         {
             var workflow = GetWorkflowByID(workflowID);
             return workflow.States.Any(contentWorkflowState => IsReviewer(portalID, userID, contentWorkflowState.StateID));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         public bool IsReviewer(int stateID)
         {
             var permissions = GetWorkflowStatePermissionByState(stateID);
@@ -477,7 +477,7 @@ namespace DotNetNuke.Entities.Content.Workflow
             return IsReviewer(user, PortalSettings.Current, permissions);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         public bool IsReviewer(int portalID, int userID, int stateID)
         {
             var permissions = GetWorkflowStatePermissionByState(stateID);
@@ -487,14 +487,14 @@ namespace DotNetNuke.Entities.Content.Workflow
             return IsReviewer(user, portalSettings, permissions);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         public bool IsCurrentReviewer(int portalID, int userID, int itemID)
         {
             var item = contentController.GetContentItem(itemID);
             return IsReviewer(portalID, userID, item.StateID);
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         public bool IsCurrentReviewer(int itemID)
         {
             var item = contentController.GetContentItem(itemID);
@@ -503,13 +503,13 @@ namespace DotNetNuke.Entities.Content.Workflow
         #endregion
 
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public ContentWorkflowSource GetWorkflowSource(int workflowId, string sourceName)
         {
             return CBO.FillObject<ContentWorkflowSource>(DataProvider.Instance().GetContentWorkflowSource(workflowId, sourceName));
         }
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         public void SendWorkflowNotification(bool sendEmail, bool sendMessage, PortalSettings settings, IEnumerable<RoleInfo> roles, IEnumerable<UserInfo> users, string subject, string body,
                                              string comment, int userID)
         {

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowLog.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowLog.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Entities.Content.Workflow
     /// <summary>
     /// This entity represents a Workflow Log
     /// </summary>
-    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]   
+    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]   
     public class ContentWorkflowLog
     {
         /// <summary>

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowLogType.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowLogType.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Entities.Content.Workflow
     /// <summary>
     /// This enum represents the possible list of WorkflowLogType
     /// </summary>
-    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]   
+    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]   
     public enum ContentWorkflowLogType
     {
         WorkflowStarted = 0,

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowSource.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowSource.cs
@@ -24,7 +24,7 @@ using System;
 namespace DotNetNuke.Entities.Content.Workflow
 // ReSharper enable CheckNamespace
 {
-    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
     public class ContentWorkflowSource
     {
         public int WorkflowId { get; set; }

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowState.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowState.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Entities.Content.Workflow
     /// <summary>
     /// This entity represents a Workflow State
     /// </summary>
-    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]    
+    [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]    
     public class ContentWorkflowState 
     {
         /// <summary>

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowStatePermission.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/ContentWorkflowStatePermission.cs
@@ -29,7 +29,7 @@ namespace DotNetNuke.Entities.Content.Workflow
     /// <summary>
     /// This entity represents a state permission
     /// </summary>
-    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
     public class ContentWorkflowStatePermission : PermissionInfoBase
     {
         /// <summary>

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/IContentWorkflowAction.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/IContentWorkflowAction.cs
@@ -25,7 +25,7 @@ using System;
 namespace DotNetNuke.Entities.Content.Workflow
 // ReSharper enable CheckNamespace
 {
-    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
     public interface IContentWorkflowAction
     {
         string GetAction(string[] parameters);

--- a/DNN Platform/Library/Entities/Content/Workflow/Obsolete/IContentWorkflowController.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Obsolete/IContentWorkflowController.cs
@@ -28,113 +28,113 @@ using DotNetNuke.Security.Roles;
 namespace DotNetNuke.Entities.Content.Workflow
 // ReSharper enable CheckNamespace
 {
-    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
     public interface IContentWorkflowController
     {
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         void StartWorkflow(int workflowID, int itemID, int userID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         void CompleteState(int itemID, string subject, string body, string comment, int portalID, int userID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         void CompleteState(int itemID, string subject, string body, string comment, int portalID, int userID, string source, params string[] parameters);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         void DiscardState(int itemID, string subject, string body, string comment, int portalID, int userID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         bool IsWorkflowCompleted(int itemID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         bool IsWorkflowOnDraft(int itemID);
 
-        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
         void SendWorkflowNotification(bool sendEmail, bool sendMessage, PortalSettings settings, IEnumerable<RoleInfo> roles, IEnumerable<UserInfo> users, string subject, string body, string comment,
                               int userID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         void DiscardWorkflow(int contentItemId, string comment, int portalId, int userId);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowEngine. Scheduled removal in v10.0.0.")]
         void CompleteWorkflow(int contentItemId, string comment, int portalId, int userId);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Scheduled removal in v10.0.0.")]
         string ReplaceNotificationTokens(string text, ContentWorkflow workflow, ContentItem item, ContentWorkflowState state, int portalID, int userID, string comment = "");
 
-        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
         ContentWorkflowSource GetWorkflowSource(int workflowId, string sourceName);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         IEnumerable<ContentWorkflow> GetWorkflows(int portalID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v10.0.0.")]
         ContentWorkflow GetDefaultWorkflow(int portalID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         ContentWorkflow GetWorkflowByID(int workflowID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         ContentWorkflow GetWorkflow(ContentItem item);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         void AddWorkflow(ContentWorkflow workflow);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowManager. Scheduled removal in v10.0.0.")]
         void UpdateWorkflow(ContentWorkflow workflow);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v10.0.0.")]
         IEnumerable<ContentWorkflowLog> GetWorkflowLogs(int workflowId, int contentItemId);
 
-        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
         void DeleteWorkflowLogs(int workflowID, int contentItemID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         IEnumerable<ContentWorkflowState> GetWorkflowStates(int workflowID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         ContentWorkflowState GetWorkflowStateByID(int stateID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         void AddWorkflowState(ContentWorkflowState state);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         void UpdateWorkflowState(ContentWorkflowState state);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         IEnumerable<ContentWorkflowStatePermission> GetWorkflowStatePermissionByState(int stateID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         void AddWorkflowStatePermission(ContentWorkflowStatePermission permission, int lastModifiedByUserID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         void UpdateWorkflowStatePermission(ContentWorkflowStatePermission permission, int lasModifiedByUserId);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowStateManager. Scheduled removal in v10.0.0.")]
         void DeleteWorkflowStatePermission(int workflowStatePermissionID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         bool IsAnyReviewer(int portalID, int userID, int workflowID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         bool IsAnyReviewer(int workflowID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         bool IsCurrentReviewer(int portalId, int userID, int itemID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         bool IsCurrentReviewer(int itemID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         bool IsReviewer(int portalId, int userID, int stateID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowSecurity. Scheduled removal in v10.0.0.")]
         bool IsReviewer(int stateID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead IWorkflowLogger. Scheduled removal in v10.0.0.")]
         void AddWorkflowLog(ContentItem item, string action, string comment, int userID);
 
-        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0. Use instead ISystemWorkflowManager. Scheduled removal in v10.0.0.")]
         void CreateDefaultWorkflows(int portalId);
     }
 }

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -1522,7 +1522,7 @@ namespace DotNetNuke.Entities.Host
         /// <remarks>
         ///   Defaults to False
         /// </remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static bool jQueryDebug
         {
             get
@@ -1537,7 +1537,7 @@ namespace DotNetNuke.Entities.Host
         /// <remarks>
         ///   Defaults to False
         /// </remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static bool jQueryHosted
         {
             get
@@ -1553,7 +1553,7 @@ namespace DotNetNuke.Entities.Host
         ///   Defaults to the DefaultHostedUrl constant in the jQuery class.
         ///   The framework will default to the latest released 1.x version hosted on Google.
         /// </remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string jQueryUrl
         {
             get
@@ -1576,7 +1576,7 @@ namespace DotNetNuke.Entities.Host
 		///   Defaults to the DefaultHostedUrl constant in the jQuery class.
 		///   The framework will default to the latest released 1.x version hosted on Google.
 		/// </remarks>
-		[Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+		[Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
 		public static string jQueryMigrateUrl
 		{
 			get
@@ -1599,7 +1599,7 @@ namespace DotNetNuke.Entities.Host
         ///   Defaults to the DefaultUIHostedUrl constant in the jQuery class.
         ///   The framework will default to the latest released 1.x version hosted on Google.
         /// </remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string jQueryUIUrl
         {
             get
@@ -1635,7 +1635,7 @@ namespace DotNetNuke.Entities.Host
 		/// <remarks>
 		///   Defaults to False
 		/// </remarks>
-		[Obsolete("Not used anymore. Scheduled removal in v11.0.0.")]
+		[Obsolete("Not used anymore. Scheduled removal in v10.0.0.")]
 		public static bool EnableTelerikCdn
 		{
 			get
@@ -1647,7 +1647,7 @@ namespace DotNetNuke.Entities.Host
         /// <summary>
         /// Get Telerik CDN Basic Path.
         /// </summary>
-        [Obsolete("Not used anymore. Scheduled removal in v11.0.0.")]
+        [Obsolete("Not used anymore. Scheduled removal in v10.0.0.")]
         public static string TelerikCdnBasicUrl
 	    {
 			get
@@ -1659,7 +1659,7 @@ namespace DotNetNuke.Entities.Host
         /// <summary>
         /// Get Telerik CDN Secure Path.
         /// </summary>
-        [Obsolete("Not used anymore. Scheduled removal in v11.0.0.")]
+        [Obsolete("Not used anymore. Scheduled removal in v10.0.0.")]
         public static string TelerikCdnSecureUrl
 		{
 			get

--- a/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
@@ -42,7 +42,7 @@ namespace DotNetNuke.Entities.Host
 
         IList<IPFilterInfo> GetIPFilters();
 
-        [Obsolete("deprecated with 7.1.0 - please use IsIPBanned instead. Scheduled removal in v11.0.0.")]
+        [Obsolete("deprecated with 7.1.0 - please use IsIPBanned instead. Scheduled removal in v10.0.0.")]
         void IsIPAddressBanned(string ipAddress);
 
         bool IsIPBanned(string ipAddress);

--- a/DNN Platform/Library/Entities/IPFilter/IPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IPFilterController.cs
@@ -117,7 +117,7 @@ namespace DotNetNuke.Entities.Host
             return CBO.FillCollection<IPFilterInfo>(DataProvider.Instance().GetIPFilters());
         }
 
-        [Obsolete("deprecated with 7.1.0 - please use IsIPBanned instead to return the value and apply your own logic. Scheduled removal in v11.0.0.")]
+        [Obsolete("deprecated with 7.1.0 - please use IsIPBanned instead to return the value and apply your own logic. Scheduled removal in v10.0.0.")]
         public void IsIPAddressBanned(string ipAddress)
         {
             if (CheckIfBannedIPAddress(ipAddress))

--- a/DNN Platform/Library/Entities/Modules/ISearchable.cs
+++ b/DNN Platform/Library/Entities/Modules/ISearchable.cs
@@ -28,10 +28,10 @@ using DotNetNuke.Services.Search;
 
 namespace DotNetNuke.Entities.Modules
 {
-     [Obsolete("Deprecated in DNN 7.1. Replaced by ModuleSearchBase. Scheduled removal in v11.0.0.")]
+     [Obsolete("Deprecated in DNN 7.1. Replaced by ModuleSearchBase. Scheduled removal in v10.0.0.")]
     public interface ISearchable
     {
-        [Obsolete("Deprecated in DNN 7.1. Replaced by ModuleSearchBase.GetModifiedSearchDocuments. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1. Replaced by ModuleSearchBase.GetModifiedSearchDocuments. Scheduled removal in v10.0.0.")]
         SearchItemInfoCollection GetSearchItems(ModuleInfo modInfo);
     }
 }

--- a/DNN Platform/Library/Entities/Portals/PortalInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalInfo.cs
@@ -774,7 +774,7 @@ namespace DotNetNuke.Entities.Portals
         #endregion
 
         [XmlIgnore]
-        [Obsolete("Deprecated in DNN 6.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 6.0. Scheduled removal in v10.0.0.")]
         public int TimeZoneOffset { get; set; }
 
         #region IHydratable Members

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -247,7 +247,7 @@ namespace DotNetNuke.Entities.Portals
 
         public int SearchTabId { get; set; }
 
-        [Obsolete("Deprecated in 8.0.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in 8.0.0. Scheduled removal in v10.0.0.")]
         public int SiteLogHistory { get; set; }
 
 		public int SplashTabId { get; set; }
@@ -334,7 +334,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <remarks>Defaults to True</remarks>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in Platform 7.4.0.. Scheduled removal in v10.0.0.")]
         public bool EnableModuleEffect { get; internal set; }
 
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Entities/Profile/ProfilePropertyDefinition.cs
+++ b/DNN Platform/Library/Entities/Profile/ProfilePropertyDefinition.cs
@@ -520,7 +520,7 @@ namespace DotNetNuke.Entities.Profile
 
         #region Obsolete
 
-        [Obsolete("Deprecated in 6.2 as profile visibility has been extended, keep for compatible with upgrade.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in 6.2 as profile visibility has been extended, keep for compatible with upgrade.. Scheduled removal in v10.0.0.")]
         [Browsable(false)]
         [XmlIgnore]
         public UserVisibilityMode Visibility

--- a/DNN Platform/Library/Entities/Users/Profile/UserProfile.cs
+++ b/DNN Platform/Library/Entities/Users/Profile/UserProfile.cs
@@ -293,7 +293,7 @@ namespace DotNetNuke.Entities.Users
         /// <summary>
         /// property will return the file path of the photo url (designed to be used when files are loaded via the filesystem e.g for caching)
         /// </summary>
-        [Obsolete("Obsolete in 7.2.2, Use PhotoUrl instead of it.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in 7.2.2, Use PhotoUrl instead of it.. Scheduled removal in v10.0.0.")]
         public string PhotoURLFile
         {
             get

--- a/DNN Platform/Library/Framework/SecurityPolicy.cs
+++ b/DNN Platform/Library/Framework/SecurityPolicy.cs
@@ -193,7 +193,7 @@ namespace DotNetNuke.Framework
             return _HasPermission;
         }
 
-        [Obsolete("Replaced by correctly spelt method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Replaced by correctly spelt method. Scheduled removal in v10.0.0.")]
         public static bool HasRelectionPermission()
         {
             GetPermissions();

--- a/DNN Platform/Library/Framework/jQuery.cs
+++ b/DNN Platform/Library/Framework/jQuery.cs
@@ -77,7 +77,7 @@ namespace DotNetNuke.Framework
         /// <value></value>
         /// <returns></returns>
         /// <remarks>This is a simple wrapper around the Host.jQueryUrl property</remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string HostedUrl
         {
             get
@@ -97,7 +97,7 @@ namespace DotNetNuke.Framework
 		/// <value></value>
 		/// <returns></returns>
 		/// <remarks>This is a simple wrapper around the Host.jQueryUrl property</remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string HostedMigrateUrl
 		{
 			get
@@ -117,7 +117,7 @@ namespace DotNetNuke.Framework
         /// <value></value>
         /// <returns></returns>
         /// <remarks>This is a simple wrapper around the Host.jQueryUIUrl property</remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string HostedUIUrl
         {
             get
@@ -138,7 +138,7 @@ namespace DotNetNuke.Framework
         /// This property checks for both the minified version and the full uncompressed version of jQuery.
         /// These files should exist in the /Resources/Shared/Scripts/jquery directory.
         /// </remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static bool IsInstalled
         {
             get
@@ -156,7 +156,7 @@ namespace DotNetNuke.Framework
         /// This property checks for both the minified version and the full uncompressed version of jQuery UI.
         /// These files should exist in the /Resources/Shared/Scripts/jquery directory.
         /// </remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static bool IsUIInstalled
         {
             get
@@ -204,7 +204,7 @@ namespace DotNetNuke.Framework
         /// <value></value>
         /// <returns></returns>
         /// <remarks>This is a simple wrapper around the Host.jQueryDebug property</remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static bool UseDebugScript
         {
             get
@@ -224,7 +224,7 @@ namespace DotNetNuke.Framework
         /// <value></value>
         /// <returns></returns>
         /// <remarks>This is a simple wrapper around the Host.jQueryHosted property</remarks>
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static bool UseHostedScript
         {
             get
@@ -329,19 +329,19 @@ namespace DotNetNuke.Framework
 
         #region Public Methods
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string JQueryFileMapPath(bool getMinFile)
         {
             return HttpContext.Current.Server.MapPath(JQueryFile(getMinFile));
         }
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string JQueryUIFileMapPath(bool getMinFile)
         {
             return HttpContext.Current.Server.MapPath(JQueryUIFile(getMinFile));
         }
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string JQueryFile(bool getMinFile)
         {
             string jfile = jQueryDebugFile;
@@ -352,7 +352,7 @@ namespace DotNetNuke.Framework
             return jfile;
         }
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string JQueryMigrateFile(bool getMinFile)
 		{
 			string jfile = jQueryMigrateDebugFile;
@@ -363,7 +363,7 @@ namespace DotNetNuke.Framework
 			return jfile;
 		}
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string JQueryUIFile(bool getMinFile)
         {
             string jfile = jQueryUIDebugFile;
@@ -374,7 +374,7 @@ namespace DotNetNuke.Framework
             return jfile;
         }
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string GetJQueryScriptReference()
         {
             string scriptsrc = HostedUrl;
@@ -385,7 +385,7 @@ namespace DotNetNuke.Framework
             return scriptsrc;
         }
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string GetJQueryMigrateScriptReference()
 		{
 			string scriptsrc = HostedMigrateUrl;
@@ -396,7 +396,7 @@ namespace DotNetNuke.Framework
 			return scriptsrc;
 		}
 
-        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v11.0.0.")]
+        [Obsolete("This is managed through the JavaScript Library package. Scheduled removal in v10.0.0.")]
         public static string GetJQueryUIScriptReference()
         {
             string scriptsrc = HostedUIUrl;
@@ -436,21 +436,21 @@ namespace DotNetNuke.Framework
 
         #region Obsolete Members
 
-        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v10.0.0.")]
         public static void RegisterJQuery(Page page)
         {
             JavaScript.RequestRegistration(CommonJs.jQuery);
             JavaScript.RequestRegistration(CommonJs.jQueryMigrate);
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v10.0.0.")]
         public static void RegisterJQueryUI(Page page)
         {
             RegisterJQuery(page);
             JavaScript.RequestRegistration(CommonJs.jQueryUI);
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v10.0.0.")]
         public static void RegisterDnnJQueryPlugins(Page page)
         {
             RegisterJQueryUI(page);
@@ -458,7 +458,7 @@ namespace DotNetNuke.Framework
             JavaScript.RequestRegistration(CommonJs.DnnPlugins);
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - registration occurs automatically during page load. Scheduled removal in v10.0.0.")]
         public static void RegisterHoverIntent(Page page)
         {
             JavaScript.RequestRegistration(CommonJs.HoverIntent);
@@ -470,7 +470,7 @@ namespace DotNetNuke.Framework
 
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.jQuery);. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.jQuery);. Scheduled removal in v10.0.0.")]
         public static void RequestRegistration()
         {
 
@@ -478,21 +478,21 @@ namespace DotNetNuke.Framework
             JavaScript.RequestRegistration(CommonJs.jQueryMigrate);
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.jQueryUI);. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.jQueryUI);. Scheduled removal in v10.0.0.")]
         public static void RequestUIRegistration()
         {
 
             JavaScript.RequestRegistration(CommonJs.jQueryUI);
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.DnnPlugins);. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.DnnPlugins);. Scheduled removal in v10.0.0.")]
         public static void RequestDnnPluginsRegistration()
         {
 
             JavaScript.RequestRegistration(CommonJs.DnnPlugins);
         }
 
-        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.HoverIntent);. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.2.0 - use JavaScript.RequestRegistration(CommonJs.HoverIntent);. Scheduled removal in v10.0.0.")]
         public static void RequestHoverIntentRegistration()
         {
 

--- a/DNN Platform/Library/Obsolete/CBO.cs
+++ b/DNN Platform/Library/Obsolete/CBO.cs
@@ -51,42 +51,42 @@ namespace DotNetNuke.Common.Utilities
     public partial class CBO
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Obsolete in DotNetNuke 7.3.  Use CreateObject<T>(bool). Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in DotNetNuke 7.3.  Use CreateObject<T>(bool). Scheduled removal in v10.0.0.")]
         public static TObject CreateObject<TObject>()
         {
             return (TObject)CreateObjectInternal(typeof(TObject), false);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Obsolete in DotNetNuke 7.3.  Use CreateObject<T>(bool). Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in DotNetNuke 7.3.  Use CreateObject<T>(bool). Scheduled removal in v10.0.0.")]
         public static object CreateObject(Type objType, bool initialise)
         {
             return CreateObjectInternal(objType, initialise);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Obsolete in DotNetNuke 7.3.  Use FillDictionary<TKey, TValue>(string keyField, IDataReader dr). Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in DotNetNuke 7.3.  Use FillDictionary<TKey, TValue>(string keyField, IDataReader dr). Scheduled removal in v10.0.0.")]
         public static IDictionary<int, TItem> FillDictionary<TItem>(IDataReader dr) where TItem : IHydratable
         {
             return FillDictionaryFromReader("KeyID", dr, new Dictionary<int, TItem>(), true);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Obsolete in DotNetNuke 7.3.  Use FillDictionary<TKey, TValue>(string keyField, IDataReader dr, IDictionary<TKey, TValue> objDictionary). Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in DotNetNuke 7.3.  Use FillDictionary<TKey, TValue>(string keyField, IDataReader dr, IDictionary<TKey, TValue> objDictionary). Scheduled removal in v10.0.0.")]
         public static IDictionary<int, TItem> FillDictionary<TItem>(IDataReader dr, ref IDictionary<int, TItem> objToFill) where TItem : IHydratable
         {
             return FillDictionaryFromReader("KeyID", dr, objToFill, true);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Obsolete in DotNetNuke 7.3.  Replaced by FillObject<T> . Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in DotNetNuke 7.3.  Replaced by FillObject<T> . Scheduled removal in v10.0.0.")]
         public static object FillObject(IDataReader dr, Type objType)
         {
             return CreateObjectFromReader(objType, dr, true);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Obsolete in DotNetNuke 7.3.  Replaced by FillObject<T> . Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsolete in DotNetNuke 7.3.  Replaced by FillObject<T> . Scheduled removal in v10.0.0.")]
         public static object FillObject(IDataReader dr, Type objType, bool closeReader)
         {
             return CreateObjectFromReader(objType, dr, closeReader);

--- a/DNN Platform/Library/Obsolete/IModuleController.cs
+++ b/DNN Platform/Library/Obsolete/IModuleController.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Entities.Modules.Internal
     /// There is no guarantee that this interface will not change.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Modules instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Modules instead. Scheduled removal in v10.0.0.")]
     public interface IModuleController
     {
         /// <summary>

--- a/DNN Platform/Library/Obsolete/IPortalAliasController.cs
+++ b/DNN Platform/Library/Obsolete/IPortalAliasController.cs
@@ -30,7 +30,7 @@ namespace DotNetNuke.Entities.Portals.Internal
     /// There is no guarantee that this interface will not change.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Portals instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Portals instead. Scheduled removal in v10.0.0.")]
     public interface IPortalAliasController
     {
         /// <summary>

--- a/DNN Platform/Library/Obsolete/IPortalSettings.cs
+++ b/DNN Platform/Library/Obsolete/IPortalSettings.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 namespace DotNetNuke.Entities.Portals.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("Deprecated in DotNetNuke 7.3.0. Use PortalController.Instance.GetCurrentPortalSettings to get a mockable PortalSettings. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DotNetNuke 7.3.0. Use PortalController.Instance.GetCurrentPortalSettings to get a mockable PortalSettings. Scheduled removal in v10.0.0.")]
     public interface IPortalSettings
     {
         string AdministratorRoleName { get; }

--- a/DNN Platform/Library/Obsolete/IRoleController.cs
+++ b/DNN Platform/Library/Obsolete/IRoleController.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 namespace DotNetNuke.Security.Roles.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Security.Roles instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Security.Roles instead. Scheduled removal in v10.0.0.")]
     public interface IRoleController
     {
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Obsolete/ITabController.cs
+++ b/DNN Platform/Library/Obsolete/ITabController.cs
@@ -30,7 +30,7 @@ namespace DotNetNuke.Entities.Tabs.Internal
     /// There is no guarantee that this interface will not change.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Tabs instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Tabs instead. Scheduled removal in v10.0.0.")]
     public interface ITabController
     {
         void DeleteTabUrl(TabUrlInfo tabUrl, int portalId, bool clearCache);

--- a/DNN Platform/Library/Obsolete/IUserController.cs
+++ b/DNN Platform/Library/Obsolete/IUserController.cs
@@ -28,7 +28,7 @@ using System.ComponentModel;
 namespace DotNetNuke.Entities.Users.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Users instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use version in DotNetNuke.Entities.Users instead. Scheduled removal in v10.0.0.")]
     public interface IUserController
     {
         UserInfo GetUserByDisplayname(int portalId, string displayName);

--- a/DNN Platform/Library/Obsolete/LogController.cs
+++ b/DNN Platform/Library/Obsolete/LogController.cs
@@ -48,21 +48,21 @@ namespace DotNetNuke.Services.Log.EventLog
     public partial class LogController
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in 7.3. Use GetLogTypeInfo and use the LoggingIsActive property.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in 7.3. Use GetLogTypeInfo and use the LoggingIsActive property.. Scheduled removal in v10.0.0.")]
         public bool LoggingIsEnabled(string logType, int portalID)
         {
             return LoggingProvider.Instance().LoggingIsEnabled(logType, portalID);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in 7.3. Use LoggingProvider.Instance().SupportsEmailNotification().. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in 7.3. Use LoggingProvider.Instance().SupportsEmailNotification().. Scheduled removal in v10.0.0.")]
         public virtual bool SupportsEmailNotification()
         {
             return LoggingProvider.Instance().SupportsEmailNotification();
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in 7.3. Use LoggingProvider.Instance().SupportsInternalViewer().. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in 7.3. Use LoggingProvider.Instance().SupportsInternalViewer().. Scheduled removal in v10.0.0.")]
         public virtual bool SupportsInternalViewer()
         {
             return LoggingProvider.Instance().SupportsInternalViewer();

--- a/DNN Platform/Library/Obsolete/ModuleController.cs
+++ b/DNN Platform/Library/Obsolete/ModuleController.cs
@@ -62,21 +62,21 @@ namespace DotNetNuke.Entities.Modules
     public partial class ModuleController
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. No longer neccessary. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. No longer neccessary. Scheduled removal in v10.0.0.")]
         public void CopyTabModuleSettings(ModuleInfo fromModule, ModuleInfo toModule)
         {
             CopyTabModuleSettingsInternal(fromModule, toModule);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Use an alternate overload. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Use an alternate overload. Scheduled removal in v10.0.0.")]
         public void DeleteAllModules(int moduleId, int tabId, List<TabInfo> fromTabs)
         {
             DeleteAllModules(moduleId, tabId, fromTabs, true, false, false);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Scheduled removal in v10.0.0.")]
         public void DeleteModuleSettings(int moduleId)
         {
             dataProvider.DeleteModuleSettings(moduleId);
@@ -88,7 +88,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Scheduled removal in v10.0.0.")]
         public void DeleteTabModuleSettings(int tabModuleId)
         {
             dataProvider.DeleteTabModuleSettings(tabModuleId);
@@ -102,7 +102,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Please use the ModuleSettings property of the ModuleInfo object. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Please use the ModuleSettings property of the ModuleInfo object. Scheduled removal in v10.0.0.")]
         public Hashtable GetModuleSettings(int ModuleId)
         {
             var settings = new Hashtable();
@@ -135,21 +135,21 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Replaced by GetTabModulesByModule(moduleID). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Replaced by GetTabModulesByModule(moduleID). Scheduled removal in v10.0.0.")]
         public ArrayList GetModuleTabs(int moduleID)
         {
             return new ArrayList(GetTabModulesByModule(moduleID).ToArray());
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Replaced by GetModules(portalId). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Replaced by GetModules(portalId). Scheduled removal in v10.0.0.")]
         public ArrayList GetRecycleModules(int portalID)
         {
             return GetModules(portalID);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Please use the TabModuleSettings property of the ModuleInfo object. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Please use the TabModuleSettings property of the ModuleInfo object. Scheduled removal in v10.0.0.")]
         public Hashtable GetTabModuleSettings(int TabModuleId)
         {
             var settings = new Hashtable();

--- a/DNN Platform/Library/Obsolete/PortalAliasController.cs
+++ b/DNN Platform/Library/Obsolete/PortalAliasController.cs
@@ -40,7 +40,7 @@ namespace DotNetNuke.Entities.Portals
     public partial class PortalAliasController
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.DeletePortalAlias. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.DeletePortalAlias. Scheduled removal in v10.0.0.")]
         public void DeletePortalAlias(int portalAliasId)
         {
 
@@ -56,14 +56,14 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.GetPortalAliasesByPortalId. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.GetPortalAliasesByPortalId. Scheduled removal in v10.0.0.")]
         public ArrayList GetPortalAliasArrayByPortalID(int PortalID)
         {
             return new ArrayList(Instance.GetPortalAliasesByPortalId(PortalID).ToArray());
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.GetPortalAliasesByPortalId. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.GetPortalAliasesByPortalId. Scheduled removal in v10.0.0.")]
         public PortalAliasCollection GetPortalAliasByPortalID(int PortalID)
         {
             var portalAliasCollection = new PortalAliasCollection();
@@ -77,14 +77,14 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.3.  Replaced by PortalAliasController.Instance.GetPortalAlias. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.3.  Replaced by PortalAliasController.Instance.GetPortalAlias. Scheduled removal in v10.0.0.")]
         public static PortalAliasInfo GetPortalAliasInfo(string httpAlias)
         {
             return Instance.GetPortalAlias(httpAlias);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.GetPortalAliases. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.GetPortalAliases. Scheduled removal in v10.0.0.")]
         public static PortalAliasCollection GetPortalAliasLookup()
         {
             var portalAliasCollection = new PortalAliasCollection();
@@ -98,14 +98,14 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.3.  Replaced by PortalAliasController.Instance.GetPortalAlias. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.3.  Replaced by PortalAliasController.Instance.GetPortalAlias. Scheduled removal in v10.0.0.")]
         public static PortalAliasInfo GetPortalAliasLookup(string httpAlias)
         {
             return Instance.GetPortalAlias(httpAlias);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.UpdatePortalAlias. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in version 7.1.  Replaced by PortalAliasController.Instance.UpdatePortalAlias. Scheduled removal in v10.0.0.")]
         public void UpdatePortalAliasInfo(PortalAliasInfo portalAlias)
         {
             Instance.UpdatePortalAlias(portalAlias);

--- a/DNN Platform/Library/Obsolete/PortalController.cs
+++ b/DNN Platform/Library/Obsolete/PortalController.cs
@@ -53,7 +53,7 @@ namespace DotNetNuke.Entities.Portals
     public partial class PortalController
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v10.0.0.")]
         public int CreatePortal(string portalName, string firstName, string lastName, string username, string password, string email,
                         string description, string keyWords, string templatePath, string templateFile, string homeDirectory,
                         string portalAlias, string serverPath, string childPath, bool isChildPortal)
@@ -75,7 +75,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v10.0.0.")]
         public int CreatePortal(string portalName, UserInfo adminUser, string description, string keyWords, string templatePath,
                         string templateFile, string homeDirectory, string portalAlias,
                         string serverPath, string childPath, bool isChildPortal)
@@ -87,7 +87,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3.0. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3.0. Scheduled removal in v10.0.0.")]
         public void DeletePortalInfo(int portalId)
         {
             UserController.DeleteUsers(portalId, false, true);
@@ -100,7 +100,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. Replaced by PortalController.Instance.GetCurrentPortalSettings. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. Replaced by PortalController.Instance.GetCurrentPortalSettings. Scheduled removal in v10.0.0.")]
         public static PortalSettings GetCurrentPortalSettings()
         {
             return GetCurrentPortalSettingsInternal();
@@ -108,35 +108,35 @@ namespace DotNetNuke.Entities.Portals
 
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.4.0. Replaced by PortalController.Instance.GetPortalSettings. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.4.0. Replaced by PortalController.Instance.GetPortalSettings. Scheduled removal in v10.0.0.")]
         public static Dictionary<string, string> GetPortalSettingsDictionary(int portalId)
         {
             return Instance.GetPortalSettings(portalId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v10.0.0.")]
         public void ParseTemplate(int portalId, string templatePath, string templateFile, int administratorId, PortalTemplateModuleAction mergeTabs, bool isNewPortal)
         {
             ParseTemplateInternal(portalId, templatePath, templateFile, administratorId, mergeTabs, isNewPortal);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the other overloads. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the other overloads. Scheduled removal in v10.0.0.")]
         public void ParseTemplate(int portalId, string templatePath, string templateFile, int administratorId, PortalTemplateModuleAction mergeTabs, bool isNewPortal, out LocaleCollection localeCollection)
         {
             ParseTemplateInternal(portalId, templatePath, templateFile, administratorId, mergeTabs, isNewPortal, out localeCollection);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. Replaced by UpdatePortalExpiry(int, string). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. Replaced by UpdatePortalExpiry(int, string). Scheduled removal in v10.0.0.")]
         public void UpdatePortalExpiry(int portalId)
         {
             UpdatePortalExpiry(portalId, GetActivePortalLanguage(portalId));
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3.0. Use one of the alternate overloads. Scheduled removal in v10.0.0.")]
         public void UpdatePortalInfo(PortalInfo portal, bool clearCache)
         {
             UpdatePortalInternal(portal, clearCache);

--- a/DNN Platform/Library/Obsolete/PortalSettings.cs
+++ b/DNN Platform/Library/Obsolete/PortalSettings.cs
@@ -52,7 +52,7 @@ namespace DotNetNuke.Entities.Portals
 {
 	public partial class PortalSettings
 	{
-        [Obsolete("Deprecated in DNN 7.4. Replaced by PortalSettingsController.Instance().GetPortalAliasMappingMode. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.4. Replaced by PortalSettingsController.Instance().GetPortalAliasMappingMode. Scheduled removal in v10.0.0.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static PortalAliasMapping GetPortalAliasMappingMode(int portalId)
         {

--- a/DNN Platform/Library/Obsolete/PortalTemplateIOImpl.cs
+++ b/DNN Platform/Library/Obsolete/PortalTemplateIOImpl.cs
@@ -31,7 +31,7 @@ using DotNetNuke.Common;
 namespace DotNetNuke.Entities.Portals.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("Deprecated in DotNetNuke 7.3.0. Use PortalTemplateIO. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DotNetNuke 7.3.0. Use PortalTemplateIO. Scheduled removal in v10.0.0.")]
     public class PortalTemplateIOImpl : IPortalTemplateIO
     {
         #region IPortalTemplateIO Members

--- a/DNN Platform/Library/Obsolete/RoleController.cs
+++ b/DNN Platform/Library/Obsolete/RoleController.cs
@@ -39,14 +39,14 @@ namespace DotNetNuke.Security.Roles
     public partial class RoleController 
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.0. This function has been replaced by AddUserRole with additional params. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.0. This function has been replaced by AddUserRole with additional params. Scheduled removal in v10.0.0.")]
         public static void AddUserRole(UserInfo user, RoleInfo role, PortalSettings portalSettings, DateTime effectiveDate, DateTime expiryDate, int userId, bool notifyUser)
         {
             AddUserRole(user, role, portalSettings, RoleStatus.Approved, effectiveDate, expiryDate, notifyUser, false);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by overload with extra parameters. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by overload with extra parameters. Scheduled removal in v10.0.0.")]
         public void AddUserRole(int portalId, int userId, int roleId, DateTime expiryDate)
         {
             AddUserRole(portalId, userId, roleId, RoleStatus.Approved, false, Null.NullDate, expiryDate);
@@ -58,7 +58,7 @@ namespace DotNetNuke.Security.Roles
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by DeleteRole(role). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by DeleteRole(role). Scheduled removal in v10.0.0.")]
         public void DeleteRole(int roleId, int portalId)
         {
             RoleInfo role = GetRole(portalId, r => r.RoleID == roleId);
@@ -69,21 +69,21 @@ namespace DotNetNuke.Security.Roles
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by GetRoles(PortalId, predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by GetRoles(PortalId, predicate). Scheduled removal in v10.0.0.")]
         public ArrayList GetPortalRoles(int portalId)
         {
             return new ArrayList(Instance.GetRoles(portalId, r => r.SecurityMode != SecurityMode.SocialGroup && r.Status == RoleStatus.Approved).ToArray());
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This method has been replacd by GetRoleById. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This method has been replacd by GetRoleById. Scheduled removal in v10.0.0.")]
         public RoleInfo GetRole(int roleId, int portalId)
         {
             return GetRoleById(portalId, roleId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by GetRoles(PortalId, predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by GetRoles(PortalId, predicate). Scheduled removal in v10.0.0.")]
         public ArrayList GetRoles()
         {
             return new ArrayList(Instance.GetRoles(Null.NullInteger, r => r.SecurityMode != SecurityMode.SocialGroup && r.Status == RoleStatus.Approved).ToArray());
@@ -95,28 +95,28 @@ namespace DotNetNuke.Security.Roles
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This method has been replaced by RoleController.Instance.GetUsersByRole(portalId, roleName). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This method has been replaced by RoleController.Instance.GetUsersByRole(portalId, roleName). Scheduled removal in v10.0.0.")]
         public ArrayList GetUsersByRoleName(int portalId, string roleName)
         {
             return new ArrayList(Instance.GetUsersByRole(portalId, roleName).ToList());
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by RoleController.Instance.UpdateRole(role). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by RoleController.Instance.UpdateRole(role). Scheduled removal in v10.0.0.")]
         public void UpdateRole(RoleInfo role)
         {
             Instance.UpdateRole(role);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by overload with extra parameters. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by overload with extra parameters. Scheduled removal in v10.0.0.")]
         public void UpdateUserRole(int portalId, int userId, int roleId)
         {
             UpdateUserRole(portalId, userId, roleId, RoleStatus.Approved, false, false);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by overload with extra parameters. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. This function has been replaced by overload with extra parameters. Scheduled removal in v10.0.0.")]
         public void UpdateUserRole(int portalId, int userId, int roleId, bool cancel)
         {
             UpdateUserRole(portalId, userId, roleId, RoleStatus.Approved, false, cancel);

--- a/DNN Platform/Library/Obsolete/TabController.cs
+++ b/DNN Platform/Library/Obsolete/TabController.cs
@@ -56,7 +56,7 @@ namespace DotNetNuke.Entities.Tabs
     public partial class TabController
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. RUse alternate overload. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. RUse alternate overload. Scheduled removal in v10.0.0.")]
         public void CreateLocalizedCopy(List<TabInfo> tabs, Locale locale)
         {
             foreach (TabInfo t in tabs)
@@ -66,21 +66,21 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DotNetNuke 7.3. RUse alternate overload. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DotNetNuke 7.3. RUse alternate overload. Scheduled removal in v10.0.0.")]
         public void CreateLocalizedCopy(TabInfo originalTab, Locale locale)
         {
             CreateLocalizedCopy(originalTab, locale, true);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Method is not scalable. Use GetTabsByPortal. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Method is not scalable. Use GetTabsByPortal. Scheduled removal in v10.0.0.")]
         public ArrayList GetAllTabs()
         {
             return CBO.FillCollection(_dataProvider.GetAllTabs(), typeof(TabInfo));
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Method is not neccessary.  Use LINQ and GetPortalTabs(). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Method is not neccessary.  Use LINQ and GetPortalTabs(). Scheduled removal in v10.0.0.")]
         public List<TabInfo> GetCultureTabList(int portalid)
         {
             return (from kvp in GetTabsByPortal(portalid)
@@ -91,7 +91,7 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Method is not neccessary.  Use LINQ and GetPortalTabs(). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Method is not neccessary.  Use LINQ and GetPortalTabs(). Scheduled removal in v10.0.0.")]
         public List<TabInfo> GetDefaultCultureTabList(int portalid)
         {
             return (from kvp in GetTabsByPortal(portalid)
@@ -101,35 +101,35 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This method is obsolete.  It has been replaced by GetTab(ByVal TabId As Integer, ByVal PortalId As Integer, ByVal ignoreCache As Boolean) . Scheduled removal in v11.0.0.")]
+        [Obsolete("This method is obsolete.  It has been replaced by GetTab(ByVal TabId As Integer, ByVal PortalId As Integer, ByVal ignoreCache As Boolean) . Scheduled removal in v10.0.0.")]
         public TabInfo GetTab(int tabId)
         {
             return GetTab(tabId, GetPortalId(tabId, Null.NullInteger), false);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Use LINQ queries on tab collections thata re cached. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Use LINQ queries on tab collections thata re cached. Scheduled removal in v10.0.0.")]
         public TabInfo GetTabByUniqueID(Guid uniqueID)
         {
             return CBO.FillObject<TabInfo>(_dataProvider.GetTabByUniqueID(uniqueID));
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Use GetTabsByPortal(portalId).Count. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Use GetTabsByPortal(portalId).Count. Scheduled removal in v10.0.0.")]
         public int GetTabCount(int portalId)
         {
             return GetTabsByPortal(portalId).Count;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This method is obsolete.  It has been replaced by GetTabsByParent(ByVal ParentId As Integer, ByVal PortalId As Integer) . Scheduled removal in v11.0.0.")]
+        [Obsolete("This method is obsolete.  It has been replaced by GetTabsByParent(ByVal ParentId As Integer, ByVal PortalId As Integer) . Scheduled removal in v10.0.0.")]
         public ArrayList GetTabsByParentId(int parentId)
         {
             return new ArrayList(GetTabsByParent(parentId, GetPortalId(parentId, Null.NullInteger)));
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Use one of the alternate MoveTabxxx methods). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Use one of the alternate MoveTabxxx methods). Scheduled removal in v10.0.0.")]
         public void MoveTab(TabInfo tab, TabMoveType type)
         {
             //Get the List of tabs with the same parent

--- a/DNN Platform/Library/Obsolete/TestableModuleController.cs
+++ b/DNN Platform/Library/Obsolete/TestableModuleController.cs
@@ -27,7 +27,7 @@ using DotNetNuke.Framework;
 namespace DotNetNuke.Entities.Modules.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use ModuleController instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use ModuleController instead. Scheduled removal in v10.0.0.")]
     public class TestableModuleController : ServiceLocator<IModuleController, TestableModuleController>, IModuleController
     {
         protected override Func<IModuleController> GetFactory()

--- a/DNN Platform/Library/Obsolete/TestablePortalAliasController.cs
+++ b/DNN Platform/Library/Obsolete/TestablePortalAliasController.cs
@@ -28,7 +28,7 @@ using DotNetNuke.Framework;
 namespace DotNetNuke.Entities.Portals.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use PortalAliasController instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use PortalAliasController instead. Scheduled removal in v10.0.0.")]
     public class TestablePortalAliasController : ServiceLocator<IPortalAliasController, TestablePortalAliasController>, IPortalAliasController
     {
         protected override Func<IPortalAliasController> GetFactory()

--- a/DNN Platform/Library/Obsolete/TestablePortalController.cs
+++ b/DNN Platform/Library/Obsolete/TestablePortalController.cs
@@ -27,7 +27,7 @@ using DotNetNuke.Framework;
 namespace DotNetNuke.Entities.Portals.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use PortalController instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use PortalController instead. Scheduled removal in v10.0.0.")]
     public class TestablePortalController : ServiceLocator<IPortalController, TestablePortalController>
     {
         protected override Func<IPortalController> GetFactory()

--- a/DNN Platform/Library/Obsolete/TestablePortalSettings.cs
+++ b/DNN Platform/Library/Obsolete/TestablePortalSettings.cs
@@ -29,7 +29,7 @@ using DotNetNuke.Entities.Portals;
 namespace DotNetNuke.Entities.Portals.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("Deprecated in DotNetNuke 7.3.0. Use PortalController.Instance.GetCurrentPortalSettings to get a mockable PortalSettings. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DotNetNuke 7.3.0. Use PortalController.Instance.GetCurrentPortalSettings to get a mockable PortalSettings. Scheduled removal in v10.0.0.")]
     public class TestablePortalSettings : ComponentBase<IPortalSettings, TestablePortalSettings>, IPortalSettings
     {
         public string AdministratorRoleName

--- a/DNN Platform/Library/Obsolete/TestableRoleController.cs
+++ b/DNN Platform/Library/Obsolete/TestableRoleController.cs
@@ -28,7 +28,7 @@ using DotNetNuke.Framework;
 namespace DotNetNuke.Security.Roles.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use RoleController instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use RoleController instead. Scheduled removal in v10.0.0.")]
     public class TestableRoleController : ServiceLocator<IRoleController, TestableRoleController>, IRoleController
     {
         protected override Func<IRoleController> GetFactory()

--- a/DNN Platform/Library/Obsolete/TestableTabController.cs
+++ b/DNN Platform/Library/Obsolete/TestableTabController.cs
@@ -31,7 +31,7 @@ using DotNetNuke.Framework;
 namespace DotNetNuke.Entities.Tabs.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use TabController instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use TabController instead. Scheduled removal in v10.0.0.")]
     public class TestableTabController : ServiceLocator<DotNetNuke.Entities.Tabs.Internal.ITabController, TestableTabController>, ITabController
     {
         protected override Func<DotNetNuke.Entities.Tabs.Internal.ITabController> GetFactory()

--- a/DNN Platform/Library/Obsolete/TestableUserController.cs
+++ b/DNN Platform/Library/Obsolete/TestableUserController.cs
@@ -34,7 +34,7 @@ using DotNetNuke.Framework;
 namespace DotNetNuke.Entities.Users.Internal
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This class has been obsoleted in 7.3.0 - please use UserController instead. Scheduled removal in v11.0.0.")]
+    [Obsolete("This class has been obsoleted in 7.3.0 - please use UserController instead. Scheduled removal in v10.0.0.")]
     public class TestableUserController : ServiceLocator<IUserController, TestableUserController>, IUserController
     {
         protected override Func<IUserController> GetFactory()

--- a/DNN Platform/Library/Obsolete/UserController.cs
+++ b/DNN Platform/Library/Obsolete/UserController.cs
@@ -56,7 +56,7 @@ namespace DotNetNuke.Entities.Users
     public partial class UserController
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.2.2. This method has been replaced by UserController.MoveUserToPortal and UserControllar.CopyUserToPortal. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2. This method has been replaced by UserController.MoveUserToPortal and UserControllar.CopyUserToPortal. Scheduled removal in v10.0.0.")]
         public static void CopyUserToPortal(UserInfo user, PortalInfo portal, bool mergeUser, bool deleteUser)
         {
             if (deleteUser)
@@ -70,7 +70,7 @@ namespace DotNetNuke.Entities.Users
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.3. Replaced by UserController.Instance.GetCurrentUserInfo(). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3. Replaced by UserController.Instance.GetCurrentUserInfo(). Scheduled removal in v10.0.0.")]
         public static UserInfo GetCurrentUserInfo()
         {
             return GetCurrentUserInternal();
@@ -84,14 +84,14 @@ namespace DotNetNuke.Entities.Users
 		/// <param name="newPassword">The new password.</param>
 		/// <param name="resetToken">The reset token, typically supplied through a password reset email.</param>
 		/// <returns>A Boolean indicating success or failure.</returns>
-		[Obsolete("Deprecate in 7.4.2, Use ChangePasswordByToken(int portalid, string username, string newPassword, string answer, string resetToken, out string errorMessage).. Scheduled removal in v11.0.0.")]
+		[Obsolete("Deprecate in 7.4.2, Use ChangePasswordByToken(int portalid, string username, string newPassword, string answer, string resetToken, out string errorMessage).. Scheduled removal in v10.0.0.")]
 		public static bool ChangePasswordByToken(int portalid, string username, string newPassword, string resetToken, out string errorMessage)
 		{
 			return ChangePasswordByToken(portalid, username, newPassword, string.Empty, resetToken, out errorMessage);
 		}
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 6.1, keep this method to compatible with upgrade wizard.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 6.1, keep this method to compatible with upgrade wizard.. Scheduled removal in v10.0.0.")]
         public static UserInfo FillUserInfo(int portalId, IDataReader dr, bool closeDataReader)
         {
             UserInfo objUserInfo = null;

--- a/DNN Platform/Library/Security/Permissions/PermissionController.cs
+++ b/DNN Platform/Library/Security/Permissions/PermissionController.cs
@@ -240,7 +240,7 @@ namespace DotNetNuke.Security.Permissions
 		
 		#endregion
 
-        [Obsolete("Deprecated in DNN 7.3.0. Replaced by GetPermissionsByModule(int, int). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.3.0. Replaced by GetPermissionsByModule(int, int). Scheduled removal in v10.0.0.")]
         public ArrayList GetPermissionsByModuleID(int moduleId)
         {
             var module = ModuleController.Instance.GetModule(moduleId, Null.NullInteger, true);

--- a/DNN Platform/Library/Services/ClientCapability/ClientCapability.cs
+++ b/DNN Platform/Library/Services/ClientCapability/ClientCapability.cs
@@ -96,9 +96,7 @@ namespace DotNetNuke.Services.ClientCapability
         /// <summary>
         /// A key-value collection containing all capabilities supported by requester
         /// </summary>
-        [Obsolete(
-            "This method is not memory efficient and should be avoided as the Match class now exposes an accessor keyed on property name."
-            )]
+        [Obsolete("This method is not memory efficient and should be avoided as the Match class now exposes an accessor keyed on property name. Scheduled removal in v10.0.0.")]
         public IDictionary<string, string> Capabilities
         {
             get

--- a/DNN Platform/Library/Services/ClientCapability/IClientCapability.cs
+++ b/DNN Platform/Library/Services/ClientCapability/IClientCapability.cs
@@ -93,7 +93,7 @@ namespace DotNetNuke.Services.ClientCapability
         /// <summary>
         /// A key-value collection containing all capabilities supported by requester
         /// </summary>    
-        [Obsolete("This method is not memory efficient and should be avoided as the Match class now exposes an accessor keyed on property name.. Scheduled removal in v11.0.0.")]    
+        [Obsolete("This method is not memory efficient and should be avoided as the Match class now exposes an accessor keyed on property name.. Scheduled removal in v10.0.0.")]    
         IDictionary<string, string> Capabilities { get; set; }
 
         /// <summary>

--- a/DNN Platform/Library/Services/EventQueue/EventQueueController.cs
+++ b/DNN Platform/Library/Services/EventQueue/EventQueueController.cs
@@ -297,7 +297,7 @@ namespace DotNetNuke.Services.EventQueue
 		
 		#region "Obsolete Methods"
 
-        [Obsolete("This method is obsolete. Use Sendmessage(message, eventName) instead. Scheduled removal in v11.0.0.")]
+        [Obsolete("This method is obsolete. Use Sendmessage(message, eventName) instead. Scheduled removal in v10.0.0.")]
         public bool SendMessage(EventMessage message, string eventName, bool encryptMessage)
         {
             return SendMessage(message, eventName);

--- a/DNN Platform/Library/Services/FileSystem/FolderInfo.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderInfo.cs
@@ -317,13 +317,13 @@ namespace DotNetNuke.Services.FileSystem
 
         #region Obsolete Methods
 
-        [Obsolete("Deprecated in DNN 7.1.  Use the parameterless constructor and object initializers. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.  Use the parameterless constructor and object initializers. Scheduled removal in v10.0.0.")]
         public FolderInfo(int portalId, string folderpath, int storageLocation, bool isProtected, bool isCached, DateTime lastUpdated)
             : this(Guid.NewGuid(), portalId, folderpath, storageLocation, isProtected, isCached, lastUpdated)
         {
         }
 
-        [Obsolete("Deprecated in DNN 7.1.  Use the parameterless constructor and object initializers. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.  Use the parameterless constructor and object initializers. Scheduled removal in v10.0.0.")]
         public FolderInfo(Guid uniqueId, int portalId, string folderpath, int storageLocation, bool isProtected, bool isCached, DateTime lastUpdated)
         {
             FolderID = Null.NullInteger;

--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -2245,7 +2245,7 @@ namespace DotNetNuke.Services.FileSystem
         /// <param name="newFolderPath">The new folder path.</param>
         /// <returns>The moved folder.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.1.  It has been replaced by FolderManager.Instance.MoveFolder(IFolderInfo folder, IFolderInfo destinationFolder) . Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.  It has been replaced by FolderManager.Instance.MoveFolder(IFolderInfo folder, IFolderInfo destinationFolder) . Scheduled removal in v10.0.0.")]
         public virtual IFolderInfo MoveFolder(IFolderInfo folder, string newFolderPath)
         {
             Requires.NotNull("folder", folder);

--- a/DNN Platform/Library/Services/FileSystem/IFileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/IFileManager.cs
@@ -99,7 +99,7 @@ namespace DotNetNuke.Services.FileSystem
         /// <summary>
         /// Gets the system defined content types
         /// </summary>
-		[Obsolete("Deprecated in DNN 7.4.2.  It has been replaced by FileContentTypeManager.Instance.ContentTypes. Scheduled removal in v11.0.0.")]
+		[Obsolete("Deprecated in DNN 7.4.2.  It has been replaced by FileContentTypeManager.Instance.ContentTypes. Scheduled removal in v10.0.0.")]
         IDictionary<string, string> ContentTypes { get; }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace DotNetNuke.Services.FileSystem
         /// </summary>
         /// <param name="extension">The file extension.</param>
         /// <returns>The Content Type for the specified extension.</returns>
-		[Obsolete("Deprecated in DNN 7.4.2.  It has been replaced by FileContentTypeManager.Instance.GetContentType(string extension). Scheduled removal in v11.0.0.")]
+		[Obsolete("Deprecated in DNN 7.4.2.  It has been replaced by FileContentTypeManager.Instance.GetContentType(string extension). Scheduled removal in v10.0.0.")]
         string GetContentType(string extension);
 
         /// <summary>

--- a/DNN Platform/Library/Services/FileSystem/IFolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/IFolderManager.cs
@@ -307,7 +307,7 @@ namespace DotNetNuke.Services.FileSystem
         /// <param name="newFolderPath">The new folder path.</param>
         /// <returns>The moved folder.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Deprecated in DNN 7.1.  It has been replaced by FolderManager.Instance.MoveFolder(IFolderInfo folder, IFolderInfo destinationFolder) . Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.  It has been replaced by FolderManager.Instance.MoveFolder(IFolderInfo folder, IFolderInfo destinationFolder) . Scheduled removal in v10.0.0.")]
         IFolderInfo MoveFolder(IFolderInfo folder, string newFolderPath);
 
         #endregion

--- a/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
@@ -528,92 +528,92 @@ namespace DotNetNuke.Services.Installer.Packages
 
         #region Deprecated Methods
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by SaveExtensionPackage(PackageInfo package). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by SaveExtensionPackage(PackageInfo package). Scheduled removal in v10.0.0.")]
         public static int AddPackage(PackageInfo package, bool includeDetail)
         {
             Instance.SaveExtensionPackage(package);
             return package.PackageID;
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by DeleteExtensionPackage(PackageInfo package). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by DeleteExtensionPackage(PackageInfo package). Scheduled removal in v10.0.0.")]
         public static void DeletePackage(PackageInfo package)
         {
             Instance.DeleteExtensionPackage(package);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by DeleteExtensionPackage(PackageInfo package). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by DeleteExtensionPackage(PackageInfo package). Scheduled removal in v10.0.0.")]
         public static void DeletePackage(int packageID)
         {
             Instance.DeleteExtensionPackage(Instance.GetExtensionPackage(Null.NullInteger, p => p.PackageID == packageID));
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static PackageInfo GetPackage(int packageID)
         {
             return Instance.GetExtensionPackage(Null.NullInteger, p => p.PackageID == packageID);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static PackageInfo GetPackage(int packageID, bool ignoreCache)
         {
             return Instance.GetExtensionPackage(Null.NullInteger, p => p.PackageID == packageID);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static PackageInfo GetPackageByName(string name)
         {
             return Instance.GetExtensionPackage(Null.NullInteger, p => p.Name == name);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackage(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static PackageInfo GetPackageByName(int portalId, string name)
         {
             return Instance.GetExtensionPackage(portalId, p => p.Name == name);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static List<PackageInfo> GetPackages()
         {
             return Instance.GetExtensionPackages(Null.NullInteger).ToList();
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static List<PackageInfo> GetPackages(int portalId)
         {
             return Instance.GetExtensionPackages(portalId).ToList();
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static List<PackageInfo> GetPackagesByType(string type)
         {
             return Instance.GetExtensionPackages(Null.NullInteger, p => p.PackageType.Equals(type, StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackages(int portalId, Func<PackageInfo, bool> predicate). Scheduled removal in v10.0.0.")]
         public static List<PackageInfo> GetPackagesByType(int portalId, string type)
         {
             return Instance.GetExtensionPackages(portalId, p => p.PackageType.Equals(type, StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackageType(Func<PackageType, bool> predicate). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackageType(Func<PackageType, bool> predicate). Scheduled removal in v10.0.0.")]
         public static PackageType GetPackageType(string type)
         {
             return Instance.GetExtensionPackageType(t => t.PackageType == type);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackageTypes(). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by GetExtensionPackageTypes(). Scheduled removal in v10.0.0.")]
         public static List<PackageType> GetPackageTypes()
         {
             return Instance.GetExtensionPackageTypes().ToList();
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by SaveExtensionPackage(PackageInfo package). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by SaveExtensionPackage(PackageInfo package). Scheduled removal in v10.0.0.")]
         public static void SavePackage(PackageInfo package)
         {
             Instance.SaveExtensionPackage(package);
         }
 
-        [Obsolete("Deprecated in DNN 7.2, Replaced by SaveExtensionPackage(PackageInfo package). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2, Replaced by SaveExtensionPackage(PackageInfo package). Scheduled removal in v10.0.0.")]
         public static void UpdatePackage(PackageInfo package)
         {
             Instance.SaveExtensionPackage(package);

--- a/DNN Platform/Library/Services/Journal/IJournalController.cs
+++ b/DNN Platform/Library/Services/Journal/IJournalController.cs
@@ -287,10 +287,10 @@ namespace DotNetNuke.Services.Journal
         /// <param name="displayName">User's display name.</param>
         void LikeComment(int journalId, int commentId, int userId, string displayName);
 
-        [Obsolete("Deprecated in DNN 7.2.2. Use SaveJournalItem(JournalItem, ModuleInfo). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2. Use SaveJournalItem(JournalItem, ModuleInfo). Scheduled removal in v10.0.0.")]
         void SaveJournalItem(JournalItem journalItem, int tabId);
 
-        [Obsolete("Deprecated in DNN 7.2.2. Use UpdateJournalItem(JournalItem, ModuleInfo). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2. Use UpdateJournalItem(JournalItem, ModuleInfo). Scheduled removal in v10.0.0.")]
         void UpdateJournalItem(JournalItem journalItem, int tabId);
     }
 }

--- a/DNN Platform/Library/Services/Journal/JournalControllerImpl.cs
+++ b/DNN Platform/Library/Services/Journal/JournalControllerImpl.cs
@@ -763,13 +763,13 @@ namespace DotNetNuke.Services.Journal
 
         #region Obsolete Methods
 
-        [Obsolete("Deprecated in DNN 7.2.2. Use SaveJournalItem(JournalItem, ModuleInfo). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2. Use SaveJournalItem(JournalItem, ModuleInfo). Scheduled removal in v10.0.0.")]
         public void SaveJournalItem(JournalItem journalItem, int tabId)
         {
             SaveJournalItem(journalItem, tabId, Null.NullInteger);
         }
 
-        [Obsolete("Deprecated in DNN 7.2.2. Use UpdateJournalItem(JournalItem, ModuleInfo). Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2. Use UpdateJournalItem(JournalItem, ModuleInfo). Scheduled removal in v10.0.0.")]
         public void UpdateJournalItem(JournalItem journalItem, int tabId)
         {
             UpdateJournalItem(journalItem, tabId, Null.NullInteger);

--- a/DNN Platform/Library/Services/Scheduling/SchedulingController.cs
+++ b/DNN Platform/Library/Services/Scheduling/SchedulingController.cs
@@ -41,7 +41,7 @@ namespace DotNetNuke.Services.Scheduling
 {
     public class SchedulingController
     {
-        [Obsolete("Obsoleted in 7.3.0 - use alternate overload. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.3.0 - use alternate overload. Scheduled removal in v10.0.0.")]
         public static int AddSchedule(string TypeFullName, int TimeLapse, string TimeLapseMeasurement, int RetryTimeLapse, string RetryTimeLapseMeasurement, int RetainHistoryNum, string AttachToEvent,
                               bool CatchUpEnabled, bool Enabled, string ObjectDependencies, string Servers, string FriendlyName)
         {
@@ -228,7 +228,7 @@ namespace DotNetNuke.Services.Scheduling
 #pragma warning restore 618
 		}
 
-        [Obsolete("Obsoleted in 7.3.0 - use alternate overload. Scheduled removal in v11.0.0.")]
+        [Obsolete("Obsoleted in 7.3.0 - use alternate overload. Scheduled removal in v10.0.0.")]
         public static void UpdateSchedule(int ScheduleID, string TypeFullName, int TimeLapse, string TimeLapseMeasurement, int RetryTimeLapse, string RetryTimeLapseMeasurement, int RetainHistoryNum,
                                           string AttachToEvent, bool CatchUpEnabled, bool Enabled, string ObjectDependencies, string Servers, string FriendlyName, DateTime ScheduleStartDate)
         {

--- a/DNN Platform/Library/Services/Search/IndexingProvider.cs
+++ b/DNN Platform/Library/Services/Search/IndexingProvider.cs
@@ -46,13 +46,13 @@ namespace DotNetNuke.Services.Search
             throw new NotImplementedException();
         }
 
-        [Obsolete("Deprecated in DNN 7.4.2 Use 'IndexSearchDocuments' instead for lower memory footprint during search.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.4.2 Use 'IndexSearchDocuments' instead for lower memory footprint during search.. Scheduled removal in v10.0.0.")]
         public virtual IEnumerable<SearchDocument> GetSearchDocuments(int portalId, DateTime startDateLocal)
         {
             return Enumerable.Empty<SearchDocument>();
         }
 
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         public abstract SearchItemInfoCollection GetSearchIndexItems(int portalId);
 
         private const string TimePostfix = "UtcTime";

--- a/DNN Platform/Library/Services/Search/ModuleIndexer.cs
+++ b/DNN Platform/Library/Services/Search/ModuleIndexer.cs
@@ -313,7 +313,7 @@ namespace DotNetNuke.Services.Search
         /// </remarks>
         /// <param name="portalId">The Id of the Portal</param>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         public override SearchItemInfoCollection GetSearchIndexItems(int portalId)
         {
             var searchItems = new SearchItemInfoCollection();
@@ -355,7 +355,7 @@ namespace DotNetNuke.Services.Search
         /// </remarks>
         /// <param name="portalId">The Id of the Portal</param>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'GetSearchModules' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'GetSearchModules' instead.. Scheduled removal in v10.0.0.")]
         protected SearchContentModuleInfoCollection GetModuleList(int portalId)
         {
             var results = new SearchContentModuleInfoCollection();

--- a/DNN Platform/Library/Services/Search/SearchConfig.cs
+++ b/DNN Platform/Library/Services/Search/SearchConfig.cs
@@ -37,7 +37,7 @@ namespace DotNetNuke.Services.Search
     /// The SearchConfig class provides a configuration class for Search
     /// </summary>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     [Serializable]
     public class SearchConfig
     {

--- a/DNN Platform/Library/Services/Search/SearchCriteria.cs
+++ b/DNN Platform/Library/Services/Search/SearchCriteria.cs
@@ -34,7 +34,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     public class SearchCriteria
     {
         public string Criteria { get; set; }

--- a/DNN Platform/Library/Services/Search/SearchCriteriaCollection.cs
+++ b/DNN Platform/Library/Services/Search/SearchCriteriaCollection.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     public class SearchCriteriaCollection : CollectionBase
     {
 		#region Constructors

--- a/DNN Platform/Library/Services/Search/SearchDataStore.cs
+++ b/DNN Platform/Library/Services/Search/SearchDataStore.cs
@@ -53,7 +53,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     public class SearchDataStore : SearchDataStoreProvider
     {
 		#region Private Methods

--- a/DNN Platform/Library/Services/Search/SearchDataStoreController.cs
+++ b/DNN Platform/Library/Services/Search/SearchDataStoreController.cs
@@ -43,40 +43,40 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     public class SearchDataStoreController
     {
-        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to return a NullInteger value. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to return a NullInteger value. Scheduled removal in v10.0.0.")]
         public static int AddSearchItem(SearchItemInfo item)
         {
             return Null.NullInteger;
         }
 
-        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to do nothing. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to do nothing. Scheduled removal in v10.0.0.")]
         public static void DeleteSearchItem(int SearchItemId)
         {            
         }
 
-        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to do nothing. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to do nothing. Scheduled removal in v10.0.0.")]
         public static void DeleteSearchItemWords(int SearchItemId)
         {            
         }
 
-        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v10.0.0.")]
         public static SearchItemInfo GetSearchItem(int ModuleId, string SearchKey)
         {
             var empty=new SearchItemInfo();
             return empty;
         }
 
-        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v10.0.0.")]
         public static Dictionary<string, SearchItemInfo> GetSearchItems(int ModuleId)
         {
             var empty = new Dictionary<string, SearchItemInfo>();
             return empty;
         }
 
-        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v10.0.0.")]
         public static ArrayList GetSearchItems(int PortalId, int TabId, int ModuleId)
         {
             var empty = new ArrayList();
@@ -92,14 +92,14 @@ namespace DotNetNuke.Services.Search
         /// <param name="PortalID">A Id of the Portal</param>
         /// <param name="Word">The word</param>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v10.0.0.")]
         public static SearchResultsInfoCollection GetSearchResults(int PortalID, string Word)
         {
             var empty = new SearchResultsInfoCollection();
             return empty;
         }
 
-        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.2  Implementation changed to return empty result set. Scheduled removal in v10.0.0.")]
         public static SearchResultsInfoCollection GetSearchResults(int PortalId, int TabId, int ModuleId)
         {
             var empty = new SearchResultsInfoCollection();
@@ -144,7 +144,7 @@ namespace DotNetNuke.Services.Search
             return dicSearchSettings;
         }
 
-        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to do nothing. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.2.2  Implementation changed to do nothing. Scheduled removal in v10.0.0.")]
         public static void UpdateSearchItem(SearchItemInfo item)
         {            
         }

--- a/DNN Platform/Library/Services/Search/SearchDataStoreProvider.cs
+++ b/DNN Platform/Library/Services/Search/SearchDataStoreProvider.cs
@@ -32,7 +32,7 @@ using DotNetNuke.Services.Search.Internals;
 
 namespace DotNetNuke.Services.Search
 {
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     public abstract class SearchDataStoreProvider
     {
 		#region "Shared/Static Methods"

--- a/DNN Platform/Library/Services/Search/SearchEngine.cs
+++ b/DNN Platform/Library/Services/Search/SearchEngine.cs
@@ -311,7 +311,7 @@ namespace DotNetNuke.Services.Search
         /// </remarks>
         /// <param name="indexer">The Index Provider that will index the content of the portal</param>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         protected SearchItemInfoCollection GetContent(IndexingProvider indexer)
         {
             var searchItems = new SearchItemInfoCollection();
@@ -336,7 +336,7 @@ namespace DotNetNuke.Services.Search
         /// <param name="portalId">The Id of the Portal</param>
         /// <param name="indexer">The Index Provider that will index the content of the portal</param>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         protected SearchItemInfoCollection GetContent(int portalId, IndexingProvider indexer)
         {
             var searchItems = new SearchItemInfoCollection();

--- a/DNN Platform/Library/Services/Search/SearchItemInfo.cs
+++ b/DNN Platform/Library/Services/Search/SearchItemInfo.cs
@@ -39,7 +39,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     [Serializable]
     public class SearchItemInfo
     {

--- a/DNN Platform/Library/Services/Search/SearchItemInfoCollection.cs
+++ b/DNN Platform/Library/Services/Search/SearchItemInfoCollection.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     [Serializable]
     public class SearchItemInfoCollection : CollectionBase
     {

--- a/DNN Platform/Library/Services/Search/SearchResultsInfo.cs
+++ b/DNN Platform/Library/Services/Search/SearchResultsInfo.cs
@@ -37,7 +37,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     [Serializable]
     public class SearchResultsInfo
     {

--- a/DNN Platform/Library/Services/Search/SearchResultsInfoCollection.cs
+++ b/DNN Platform/Library/Services/Search/SearchResultsInfoCollection.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v11.0.0.")]
+    [Obsolete("Deprecated in DNN 7.1.  No longer used in the Search infrastructure.. Scheduled removal in v10.0.0.")]
     [Serializable]
     public class SearchResultsInfoCollection : CollectionBase
     {

--- a/DNN Platform/Library/Services/Search/TabIndexer.cs
+++ b/DNN Platform/Library/Services/Search/TabIndexer.cs
@@ -144,7 +144,7 @@ namespace DotNetNuke.Services.Search
             return total;
         }
 
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         public override SearchItemInfoCollection GetSearchIndexItems(int portalId)
         {
             return null;

--- a/DNN Platform/Library/Services/Search/UserIndexer.cs
+++ b/DNN Platform/Library/Services/Search/UserIndexer.cs
@@ -430,7 +430,7 @@ namespace DotNetNuke.Services.Search
 
         #region Obsoleted Methods
 
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v11.0.0.")]
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         public override SearchItemInfoCollection GetSearchIndexItems(int portalId)
         {
             return null;

--- a/DNN Platform/Library/Services/SystemDateTime/SystemDateTime.cs
+++ b/DNN Platform/Library/Services/SystemDateTime/SystemDateTime.cs
@@ -60,7 +60,7 @@ namespace DotNetNuke.Services.SystemDateTime
     {
         private static readonly DataProvider Provider = DataProvider.Instance();
 
-        [Obsolete("Deprecated in DNN 7.1.2.  Replaced by DateUtils.GetDatabaseUtcTime, which includes caching. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 7.1.2.  Replaced by DateUtils.GetDatabaseUtcTime, which includes caching. Scheduled removal in v10.0.0.")]
         public static DateTime GetCurrentTimeUtc()
         {
             return Provider.GetDatabaseTimeUtc();

--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -3939,7 +3939,7 @@ namespace DotNetNuke.Services.Upgrade
         /// <remarks>
         /// </remarks>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Deprecated in DNN 9.3.0, will be removed in 11.0.0. Use the overloaded method with the 'superUser' parameter instead.")]
+        [Obsolete("Deprecated in DNN 9.3.0, will be removed in 11.0.0. Use the overloaded method with the 'superUser' parameter instead. Scheduled removal in v11.0.0.")]
         public static int AddPortal(XmlNode node, bool status, int indent)
         {
             return AddPortal(node, status, indent, null);

--- a/DNN Platform/Library/UI/Utilities/ClientAPI.cs
+++ b/DNN Platform/Library/UI/Utilities/ClientAPI.cs
@@ -80,7 +80,7 @@ namespace DotNetNuke.UI.Utilities
         /// <param name="strJSFunction">Javascript function name to execute</param>
         /// <remarks>
         /// </remarks>
-        [Obsolete("This method has been deprecated and its code replaced in the 7.1.0 release. Scheduled removal in v11.0.0.")]
+        [Obsolete("This method has been deprecated and its code replaced in the 7.1.0 release. Scheduled removal in v10.0.0.")]
         public static void AddBodyOnloadEventHandler(Page objPage, string strJSFunction)
         {
             //legacy implementation replaced

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNListEditControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNListEditControl.cs
@@ -109,7 +109,7 @@ namespace DotNetNuke.UI.WebControls
         /// <summary>
         /// List gets the List associated with the control
         /// </summary>
-        [Obsolete("Obsoleted in 6.0.1 use ListEntries instead"), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Obsoleted in 6.0.1 use ListEntries instead. Scheduled removal in v10.0.0."), EditorBrowsable(EditorBrowsableState.Never)]
         protected ListEntryInfoCollection List
         {
             get

--- a/DNN Platform/Library/WebControls/WebControlBase.cs
+++ b/DNN Platform/Library/WebControls/WebControlBase.cs
@@ -103,7 +103,7 @@ namespace DotNetNuke.UI.WebControls
 
         public abstract string HtmlOutput { get; }
 
-        [Obsolete("There is no longer the concept of an Admin Page.  All pages are controlled by Permissions", true)]
+        [Obsolete("There is no longer the concept of an Admin Page.  All pages are controlled by Permissions. Scheduled removal in v11.0.0.", true)]
         public bool IsAdminMenu
         {
             get

--- a/DNN Platform/Tests/DNN.Integration.Test.Framework/Controllers/ModuleController.cs
+++ b/DNN Platform/Tests/DNN.Integration.Test.Framework/Controllers/ModuleController.cs
@@ -20,7 +20,7 @@ namespace DNN.Integration.Test.Framework.Controllers
         private const string PermissionKeyMarker = @"$[permission_key]";
         private const string FriendlyNameMarker = @"$[friendly_name]";
 
-        [Obsolete("typo in name, use AddModulePermission instead. Scheduled removal in v11.0.0.")]
+        [Obsolete("typo in name, use AddModulePermission instead. Scheduled removal in v10.0.0.")]
         public static int AddModuleOPermission(int roleId, int moduleId, string permissionCode, string permissionKey, int portalId = 0)
         {
             return AddModulePermission(roleId, moduleId, permissionCode, permissionKey, portalId);

--- a/Website/admin/Skins/LeftMenu.ascx.cs
+++ b/Website/admin/Skins/LeftMenu.ascx.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.UI.Skins.Controls
     /// <returns></returns>
     /// <remarks></remarks>
     /// -----------------------------------------------------------------------------
-    [Obsolete("This skin object has been expired, create empty object to compact old skin. please ask skin vendor to update the skin if it referenced to this control.. Scheduled removal in v11.0.0.")]
+    [Obsolete("This skin object has been expired, create empty object to compact old skin. please ask skin vendor to update the skin if it referenced to this control.. Scheduled removal in v10.0.0.")]
     public partial class LeftMenu : SkinObjectBase
     {
         


### PR DESCRIPTION
Updates across the entire repository to standardize the scheduled removal of API methods to adhere to the published Deprecation Policy as created by the TAG Team in mid-2018.  This aligns all items that will be removed as part of the 10.0 release to have a proper note.

It should be noted, that ALL items deprecated 8.x or prior have been updated to be removed as part of 10.0, this change is intentional and in adherence to the published policy.  Additionally, a blog post is being published today that outlines this change and the reasoning behind the change.
