### PR TITLE
update version labels for various build types / branch names

### DIFF
--- a/Build/Cake/create-database.cake
+++ b/Build/Cake/create-database.cake
@@ -1,4 +1,3 @@
-#addin "Cake.FileHelpers"
 
 string connectionString = @"server=(localdb)\MSSQLLocalDB";
 

--- a/Build/cake/unit-tests.cake
+++ b/Build/cake/unit-tests.cake
@@ -1,5 +1,3 @@
-#tool "nuget:?package=Microsoft.TestPlatform&version=15.7.0"
-#tool "nuget:?package=NUnitTestAdapter&version=2.1.1"
 
 Task("EnsureAllProjectsBuilt")
   .IsDependentOn("UpdateDnnManifests")

--- a/Build/cake/version.cake
+++ b/Build/cake/version.cake
@@ -1,7 +1,3 @@
-#addin Cake.XdtTransform
-#addin "Cake.FileHelpers"
-#addin Cake.Powershell
-#tool "nuget:?package=GitVersion.CommandLine&prerelease"
 
 GitVersion version;
 var buildId = EnvironmentVariable("BUILD_BUILDID") ?? "0";

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,15 @@
+#addin nuget:?package=Cake.XdtTransform&version=0.16.0
+#addin nuget:?package=Cake.FileHelpers&version=3.1.0
+#addin nuget:?package=Cake.Powershell&version=0.4.7
+
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
+#tool "nuget:?package=Microsoft.TestPlatform&version=15.7.0"
+#tool "nuget:?package=NUnitTestAdapter&version=2.1.1"
+
 #load "local:?path=Build/cake/version.cake"
 #load "local:?path=Build/cake/create-database.cake"
 #load "local:?path=Build/cake/unit-tests.cake"
+
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////

--- a/devfactory.yml
+++ b/devfactory.yml
@@ -1,9 +1,0 @@
-devfactory:
-  version: 1
-  excludes:
-    - "**/DNN Platform/Components/ClientDependency/Source/**"
-    - "**/DNN Platform/DotNetNuke.Log4net/**"
-    - "**/DNN Platform/Controls/CountryListBox/**"
-    - "**/DNN Platform/DotNetNuke.Instrumentation/**"
-    - "**/DNN Platform/DotNetNuke.WebUtility/**"
-    - "**/DNN Platform/Tests/**"

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,4 +1,5 @@
 next-version: 9.4.0
+commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment
 branches:
@@ -7,4 +8,29 @@ branches:
     tag: 'alpha'
     increment: Patch
     is-mainline: true
+    source-branches: []
+  release:
+    regex: release?[/-]
+    mode: ContinuousDelivery
+    tag: 'rc'
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: true
+    source-branches: []
+  pull-request:
+    regex: (pull|pull\-requests|pr)[/-]
+    tag: 'pr'
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    is-release-branch: false
+    source-branches: []
+  catch-all:
+    regex: (.*?)
+    tag: 'unstable'
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    is-release-branch: false
     source-branches: []


### PR DESCRIPTION
## Summary
This pull request should change the build labels for pull requests to -pr from -PullRequest, release* to -rc, and other branch as -unstable. 