### PR TITLE
Addition of Obsolete Attribute to DDR Localisation Implementations

### DIFF
--- a/DNN Platform/Modules/DDRMenu/Localisation/Apollo.cs
+++ b/DNN Platform/Modules/DDRMenu/Localisation/Apollo.cs
@@ -9,12 +9,14 @@ namespace DotNetNuke.Web.DDRMenu.Localisation
 {
     using DotNetNuke.Entities.Portals;
 
+    [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
     public class Apollo : ILocalisation
 	{
 		private bool haveChecked;
 		private MethodInfo apiMember;
 
-		public bool HaveApi()
+        [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
+        public bool HaveApi()
 		{
 			if (!haveChecked)
 			{
@@ -38,12 +40,14 @@ namespace DotNetNuke.Web.DDRMenu.Localisation
 			return (apiMember != null);
 		}
 
-		public TabInfo LocaliseTab(TabInfo tab, int portalId)
+        [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
+        public TabInfo LocaliseTab(TabInfo tab, int portalId)
 		{
 			return apiMember.Invoke(null, new object[] {tab}) as TabInfo ?? tab;
 		}
 
-		public DNNNodeCollection LocaliseNodes(DNNNodeCollection nodes)
+        [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
+        public DNNNodeCollection LocaliseNodes(DNNNodeCollection nodes)
 		{
 			return null;
 		}

--- a/DNN Platform/Modules/DDRMenu/Localisation/Ealo.cs
+++ b/DNN Platform/Modules/DDRMenu/Localisation/Ealo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.UI.WebControls;
 using effority.Ealo.Specialized;
@@ -9,12 +10,14 @@ namespace DotNetNuke.Web.DDRMenu.Localisation
 {
     using DotNetNuke.Entities.Portals;
 
+    [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
     public class Ealo : ILocalisation
 	{
 		private bool haveChecked;
 		private bool found;
 
-		public bool HaveApi()
+        [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
+        public bool HaveApi()
 		{
 			if (!haveChecked)
 			{
@@ -25,12 +28,14 @@ namespace DotNetNuke.Web.DDRMenu.Localisation
 			return found;
 		}
 
-		public TabInfo LocaliseTab(TabInfo tab, int portalId)
+        [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
+        public TabInfo LocaliseTab(TabInfo tab, int portalId)
 		{
 			return EaloWorker.LocaliseTab(tab, portalId);
 		}
 
-		public DNNNodeCollection LocaliseNodes(DNNNodeCollection nodes)
+        [Obsolete("Deprecated in 9.4.0, due to limited developer support.  Scheduled removal in v10.0.0.")]
+        public DNNNodeCollection LocaliseNodes(DNNNodeCollection nodes)
 		{
 			return null;
 		}


### PR DESCRIPTION
DDR Menu included localization support for two third-party solutions; EALO and Apollo.  Both of these products are no longer supported and the respective implementations DO NOT work in 9.x DNN.

Given that neither solution works, these methods have been flagged for special removal in version 10.0 to be completed alongside all other breaking changes.

Fixes #2724 