### PR TITLE
Fixed bug in Azure folders

### DIFF
--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
@@ -136,7 +136,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
                                         c =>
                                         {
                                             var container = GetContainer(folderMapping);
-                                            var synchBatchSize = Convert.ToInt32(GetSetting(folderMapping, Constants.SyncBatchSize) ?? Constants.DefaultSyncBatchSize.ToString());
+                                            var synchBatchSize = GetIntegerSetting(folderMapping, Constants.SyncBatchSize, Constants.DefaultSyncBatchSize);
 
                                             BlobContinuationToken continuationToken = null;
                                             BlobResultSegment resultSegment = null;

--- a/DNN Platform/Providers/FolderProviders/Components/BaseRemoteStorageProvider.cs
+++ b/DNN Platform/Providers/FolderProviders/Components/BaseRemoteStorageProvider.cs
@@ -107,6 +107,16 @@ namespace DotNetNuke.Providers.FolderProviders.Components
             return Boolean.Parse(folderMapping.FolderMappingSettings[settingName].ToString());
         }
         
+        protected static int GetIntegerSetting(FolderMappingInfo folderMapping, string settingName, int defaultValue)
+        {
+            int value;
+            if (int.TryParse(GetSetting(folderMapping, settingName), out value))
+            {
+                return value;
+            }
+            return defaultValue;
+        }
+
         protected abstract Stream GetFileStreamInternal(FolderMappingInfo folderMapping, string uri);
 
         protected abstract IList<IRemoteStorageItem> GetObjectList(FolderMappingInfo folderMapping);


### PR DESCRIPTION
## Summary
Fixes a bug in ea26f8356df3efeb874653e9b7b3b92813c158de.
When the **Sync Batch Size** parameter is left blank, it's saved as an empty string instead of a null string. And empty strings throw an error when cast to integer.

## Steps to reproduce
1. Login as Host
2. Open Persona Bar > Manage > Global/Site Assets
3. Add New Folder Type > Set up Azure Folder Provider (**leave Sync Batch Size blank**)
4. Add New folder with Azure Folder type
5. Synchronize the folder and subfolders

## Current behavior
Following error occurs:

![image](https://user-images.githubusercontent.com/30123437/56604026-6a75f480-65d7-11e9-8b09-e48f55264f13.png)

