### PR TITLE
Removes old license files upon upgrade

### DIFF
--- a/DNN Platform/Website/Install/Cleanup/09.04.00.txt
+++ b/DNN Platform/Website/Install/Cleanup/09.04.00.txt
@@ -1,0 +1,44 @@
+Licenses\Anthem (Public Domain).txt
+Licenses\Brettle NeatUpload (LGPL).txt
+Licenses\Client Dependency Framework(Ms-PL).txt
+Licenses\CountryListBox (Public Domain).txt
+Licenses\DotNetOpenID (New BSD).txt
+Licenses\FCKEditor (LGPL).txt
+Licenses\GeoIP (Custom).txt
+Licenses\Highlighter (Perl).txt
+Licenses\hoverintent (MIT,GPL).txt
+Licenses\HtmlDiff (MIT).txt
+Licenses\jQuery (MIT).txt
+Licenses\jQuery Boxy Plugin (MIT).txt
+Licenses\jQuery Cycle (MIT,GPL).txt
+Licenses\jQuery FileUpload (MIT).txt
+Licenses\jQuery Iframe Transport (MIT).txt
+Licenses\jQuery Slides Plugin (Apache).txt
+Licenses\jQuery Templates (MIT,GPL).txt
+Licenses\jQuery Tokeninput (MIT,GPL).txt
+Licenses\jQuery UI (MIT).txt
+Licenses\jquery-history.license.txt
+Licenses\json2 (Public Domain).txt
+Licenses\Knockout (MIT).txt
+Licenses\Knockout Mapping (MIT).txt
+Licenses\Licenses.txt
+Licenses\LiteDB (MIT).txt
+Licenses\log4net (Apache).txt
+Licenses\Lucene.Net (Apache).txt
+Licenses\Lucene.Net.Contrib (Apache).txt
+Licenses\MbUnit (MIT).txt
+Licenses\MooTools (MIT).txt
+Licenses\Moq (BSD).txt
+Licenses\MSBuild Community Tasks Project (BSD).txt
+Licenses\OceanBrowserDetection (MIT).txt
+Licenses\SearchSpider (LGPL).txt
+Licenses\Selectize (Apache).txt
+Licenses\SharpZipLib (LGPL).txt
+Licenses\SwfObject (MIT).txt
+Licenses\Telerik RadControls for ASP.NET AJAX (Custom).pdf
+Licenses\VideoBox (MIT).txt
+Licenses\WatiN (Apache).txt
+Licenses\WebFormsMVP (MsPL).txt
+Licenses\YUI (BSD).txt
+Licenses\zClip (MIT).txt
+Licenses\ZeroClipboard (MIT).txt

--- a/DNN_Platform.sln
+++ b/DNN_Platform.sln
@@ -109,6 +109,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FBD3B3FB-C9A6-43D2-8FE7-6A0A19DF0D0C}"
 	ProjectSection(SolutionItems) = preProject
 		DNN Platform\Tests\App.config = DNN Platform\Tests\App.config
+		..\cake.config = ..\cake.config
 		Packages\repositories.config = Packages\repositories.config
 		SolutionInfo.cs = SolutionInfo.cs
 	EndProjectSection
@@ -306,6 +307,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Cleanup", "Cleanup", "{3ABA
 		DNN Platform\Website\Install\Cleanup\09.01.00.txt = DNN Platform\Website\Install\Cleanup\09.01.00.txt
 		DNN Platform\Website\Install\Cleanup\09.01.01.txt = DNN Platform\Website\Install\Cleanup\09.01.01.txt
 		DNN Platform\Website\Install\Cleanup\09.02.00.txt = DNN Platform\Website\Install\Cleanup\09.02.00.txt
+		DNN Platform\Website\Install\Cleanup\09.04.00.txt = DNN Platform\Website\Install\Cleanup\09.04.00.txt
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{15EE268D-2073-4489-9BB2-26E34D65A8DC}"

--- a/DNN_Platform.sln
+++ b/DNN_Platform.sln
@@ -109,7 +109,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FBD3B3FB-C9A6-43D2-8FE7-6A0A19DF0D0C}"
 	ProjectSection(SolutionItems) = preProject
 		DNN Platform\Tests\App.config = DNN Platform\Tests\App.config
-		..\cake.config = ..\cake.config
 		Packages\repositories.config = Packages\repositories.config
 		SolutionInfo.cs = SolutionInfo.cs
 	EndProjectSection


### PR DESCRIPTION
Closes #2740 

Issues #2716  and #2729 accounted for new installations (delete old licenses and then update them to today's reality), but that did not cover the upgrade scenario, this PR solves that and deletes the old license files upon upgrade.