### PR TITLE
Splits the Lists table population in 500 items batches

### DIFF
--- a/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Data.SqlDataProvider
+++ b/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Data.SqlDataProvider
@@ -901,6 +901,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (498, N'BannedPasswords', N'failure132', N'drowssap', 0, 0, 0, -1, N'', -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (499, N'BannedPasswords', N'failure133', N'coffee', 0, 0, 0, -1, N'', -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (500, N'BannedPasswords', N'failure134', N'amanda', 0, 0, 0, -1, N'', -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (501, N'BannedPasswords', N'failure135', N'adidas', 0, 0, 0, -1, N'', -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (502, N'BannedPasswords', N'failure136', N'diamond', 0, 0, 0, -1, N'', -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (503, N'BannedPasswords', N'failure137', N'startrek', 0, 0, 0, -1, N'', -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -1401,6 +1413,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (998, N'Region', N'KOP', N'Koulpélogo', 21, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (999, N'Region', N'KOS', N'Kossi', 21, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1000, N'Region', N'KOT', N'Kouritenga', 21, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1001, N'Region', N'KOW', N'Kourwéogo', 21, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1002, N'Region', N'LER', N'Léraba', 21, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1003, N'Region', N'LOR', N'Loroum', 21, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -1900,6 +1924,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1497, N'Region', N'32', N'Santo Domingo', 57, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1498, N'Region', N'01', N'Adrar', 58, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1499, N'Region', N'02', N'Chlef', 58, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1500, N'Region', N'03', N'Laghouat', 58, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1501, N'Region', N'04', N'Oum-El-Bouaghi', 58, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1502, N'Region', N'05', N'Batna', 58, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -2401,6 +2437,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1998, N'Region', N'SHF', N'Sheffield', 219, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (1999, N'Region', N'SHN', N'St. Helens', 219, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2000, N'Region', N'SHR', N'Shropshire', 219, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2001, N'Region', N'SKP', N'Stockport', 219, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2002, N'Region', N'SLF', N'City of Salford', 219, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2003, N'Region', N'SLG', N'Slough', 219, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -2901,6 +2949,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2498, N'Region', N'CL', N'Caltanissetta', 103, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2499, N'Region', N'CN', N'Cuneo', 103, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2500, N'Region', N'CO', N'Como', 103, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2501, N'Region', N'CR', N'Cremona', 103, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2502, N'Region', N'CS', N'Cosenza', 103, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2503, N'Region', N'CT', N'Catania', 103, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -3401,6 +3461,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2998, N'Region', N'TIZ', N'Tiznit', 129, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (2999, N'Region', N'TNG', N'Tanger-Asilah', 129, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3000, N'Region', N'TNT', N'Tan-Tan', 129, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3001, N'Region', N'ZAG', N'Zagora', 129, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3002, N'Region', N'AN', N'Anenii Noi', 131, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3003, N'Region', N'BA', N'Bălţi', 131, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -3901,6 +3973,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3498, N'Region', N'DR', N'Drenthe', 156, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3499, N'Region', N'FL', N'Flevoland', 156, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3500, N'Region', N'FR', N'Friesland', 156, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3501, N'Region', N'GE', N'Gelderland', 156, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3502, N'Region', N'GR', N'Groningen', 156, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3503, N'Region', N'LI', N'Limburg', 156, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -4401,6 +4485,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3998, N'Region', N'CH', N'Choiseul', 182, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (3999, N'Region', N'CT', N'Honiara', 182, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4000, N'Region', N'GU', N'Guadalcanal', 182, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4001, N'Region', N'IS', N'Isabel', 182, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4002, N'Region', N'MK', N'Makira', 182, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4003, N'Region', N'ML', N'Malaita', 182, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -4901,6 +4997,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4498, N'Region', N'AL', N'Aileu', 652, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4499, N'Region', N'AN', N'Ainaro', 652, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4500, N'Region', N'BA', N'Baucau', 652, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4501, N'Region', N'BO', N'Bobonaro', 652, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4502, N'Region', N'CO', N'Cova Lima', 652, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4503, N'Region', N'DI', N'Dili', 652, 1, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
@@ -5401,6 +5509,18 @@ INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Val
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4998, N'Currency', N'BDT', N'Taka (BDT)', 0, 0, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (4999, N'Currency', N'BBD', N'Barbados Dollar (BBD)', 0, 0, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (5000, N'Currency', N'BYR', N'Belarussian Ruble (BYR)', 0, 0, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] OFF
+
+GO
+
+DECLARE @CreateBy int = -1
+DECLARE @UpdateBy int = NULL
+DECLARE @UpdateByNotNull int = -1
+DECLARE @CreateOn datetime = {ts '2000-01-01 00:00:00'}
+DECLARE @UpdateOn datetime = NULL
+DECLARE @UpdateOnNotNull datetime = {ts '2000-01-01 00:00:00'}
+
+SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Lists] ON
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (5001, N'Currency', N'BZD', N'Belize Dollar (BZD)', 0, 0, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (5002, N'Currency', N'XOF', N'CFA Franc BCEAO (XOF)', 0, 0, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)
 INSERT INTO {databaseOwner}[{objectQualifier}Lists] ([EntryID], [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (5003, N'Currency', N'BMD', N'Bermudian Dollar (BMD)', 0, 0, 0, -1, NULL, -1, 1, @CreateBy, @CreateOn, @UpdateBy, @UpdateOn)


### PR DESCRIPTION
Closes #2743 

## Summary
This PR splits the creation of rows in the Lists table into 500 item batches intead of a single bath with more than 5000 lines. This is to prevent a timeout issue during installation on some environments.
