### PR TITLE
Don't send wrong params to extension URL providers

### DIFF
--- a/DNN Platform/Library/Entities/Urls/RewriteController.cs
+++ b/DNN Platform/Library/Entities/Urls/RewriteController.cs
@@ -527,6 +527,23 @@ namespace DotNetNuke.Entities.Urls
                                                                     ref List<string> messages,
                                                                     Guid parentTraceId)
         {
+            if (result.TabId < 0)
+            {
+                // Tab is unresolved.
+                // This happens when there are nested portal aliases, for example:
+                //   www.mysite.com
+                //   www.mysite.com/en-us
+                // In such (very typical) scenario, when resolving for example
+                //   http://www.mysite.com/en-us/Admin/ctl/UrlProviderSettings/Display/settings/ProviderId/1?popUp=true
+                // for the first alias, we get "en-us" and "Admin" included in urlParms.
+                // Also, since "Admin" was considered a parameter and not a tab, TabId = -1 (unresolved)
+                // Next, the second alias is resolved, and then we get correct urlParms and TabId.
+                // So, we skip calling downstream providers if TabId < 0
+                rewriteParms = false;
+                newAction = false;
+                return newUrl;
+            }
+
             string rewrittenUrl;
             rewriteParms = ExtensionUrlProviderController.TransformFriendlyUrlPath(newUrl, 
                                                                                     tabKeyVal, 


### PR DESCRIPTION
Fixes #2335

## Summary
I think I found a better way to fix #2335.
I learned is that this issue occurs when there are nested portal aliases (which is very typical). For example:
* www.mysite.com
* www.mysite.com/en-us

When the rewrite controller resolves a URL, it loops through all existing portal aliases. And for each alias, at some point it calls this method:
https://github.com/dnnsoftware/Dnn.Platform/blob/8cd56bc93abf2178e6e9be29f7818db256126b51/DNN%20Platform/Library/Entities/Urls/RewriteController.cs#L519-L546
which in turn makes the call to registered extension URL providers.

Let's consider following URL:
http://www.mysite.com/en-us/Admin/ctl/UrlProviderSettings/Display/settings/ProviderId/1?popUp=true

In the first iteration (alias = www.mysite.com), we get "en-us" and "Admin" included in `urlParms`. Notice this is technically not wrong from first alias' perspective. And since "Admin" was considered a parameter (and not a tab), `result.TabId` is `-1` (unresolved).
In the next iteration however (alias = www.mysite.com/en-us), we get correct `urlParms` ("ctl", "UrlProviderSettings", "Display", "settings", "ProviderId", "1") and `result.TabId` is also correctly resolved.

So I think we should simply skip calling downstream providers if `result.TabId < 0`.

I did some testing with and without languages enabled, and also with aliases like "en.mysite.com" and "www.mysite.com/en-us" enabled at the same time, and it seems to be working fine. Home page is resolved correctly in all cases as well.