### PR TITLE
Correction of File Access Issues

### DIFF
--- a/DNN Platform/Library/Services/Installer/Util.cs
+++ b/DNN Platform/Library/Services/Installer/Util.cs
@@ -582,8 +582,8 @@ namespace DotNetNuke.Services.Installer
             if (file.Directory != null && !file.Directory.Exists)
                 file.Directory.Create();
 
-            TryToCreateAndExecute(destFileName, (f) => StreamToStream(sourceStream, f), 1000);
-
+            //HACK: Temporary fix, upping retry limit due to locking for existing filesystem access.  This "fixes" azure, but isn't the most elegant
+            TryToCreateAndExecute(destFileName, (f) => StreamToStream(sourceStream, f), 3500);
         }
 
         /// <summary>
@@ -595,18 +595,16 @@ namespace DotNetNuke.Services.Installer
         /// <returns>true if action occur and false otherwise</returns>
         public static bool TryToCreateAndExecute(string path, Action<FileStream> action, int milliSecondMax = Timeout.Infinite)
         {
-            bool result = false;
-            DateTime dateTimestart = DateTime.Now;
+            var result = false;
+            var dateTimeStart = DateTime.Now;
             Tuple < AutoResetEvent, FileSystemWatcher > tuple = null;
 
             while (true)
             {
                 try
                 {
-                    using (var file = File.Open(path,
-                        FileMode.Create,
-                        FileAccess.ReadWrite,
-                        FileShare.Write))
+                    //Open for create, requesting read/write access, allow others to read/write as well
+                    using (var file = File.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
                     {
                         action(file);
                         result = true;
@@ -640,7 +638,7 @@ namespace DotNetNuke.Services.Installer
                     int milliSecond = Timeout.Infinite;
                     if (milliSecondMax != Timeout.Infinite)
                     {
-                        milliSecond = (int) (DateTime.Now - dateTimestart).TotalMilliseconds;
+                        milliSecond = (int) (DateTime.Now - dateTimeStart).TotalMilliseconds;
                         if (milliSecond >= milliSecondMax)
                         {
                             result = false;


### PR DESCRIPTION
Adjustments to the installer process to resolve issues with Resource File Installation impacting users on Azure (Fixes #2766).

A few highlights on the changes included

* Cleanup of resource management when writing files inside of the zip loop
* Adjustment of retry logic, making two changes
  *  Adjustment of the retry to attempt for 3.5 seconds, rather than only 1 second for a better opportunity to process the file
  *  Changing the file share process to allow others to read/write the file.  Rather than just write

This should allow real-time items to read the file, even if we are writing to it.  Which should resolve the lock issues.




