### PR TITLE
Fixed nuspec to include Icon & Project URL

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Providers.FolderProviders.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Providers.FolderProviders.nuspec
@@ -8,6 +8,8 @@
     <owners>DNN Corp.</owners>
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>http://www.dnnsoftware.com/favicon.ico</iconUrl>
+    <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides API references needed to develop custom folder providers, or to consume folder providers
     </description>

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -8,6 +8,8 @@
     <owners>DNN Corp</owners>
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <iconUrl>http://www.dnnsoftware.com/favicon.ico</iconUrl>
+    <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       This package contains components required for developing WebAPI based services for DNN Platform.
     </description>


### PR DESCRIPTION
Fixes: #2684 

## Summary
Added icon URL and project URL for the following nuspec files that were missing:
* DotNetNuke.Providers.FolderProviders
* DotNetNuke.WebApi
