### PR TITLE
Removed MVC Specific Code from ModuleControlPipeline

### DIFF
--- a/DNN Platform/DotNetNuke.ModulePipeline/ModuleControlPipeline.cs
+++ b/DNN Platform/DotNetNuke.ModulePipeline/ModuleControlPipeline.cs
@@ -167,27 +167,8 @@ namespace DotNetNuke.ModulePipeline
 
         public Control CreateModuleControl(ModuleInfo moduleConfiguration)
         {
-            string extension = Path.GetExtension(moduleConfiguration.ModuleControl.ControlSrc.ToLowerInvariant());
-            var moduleControl = new ModuleControlBase();
-            moduleControl.ModuleContext.Configuration = moduleConfiguration;
-
-            switch (extension)
-            {
-                case ".mvc":
-                    var segments = moduleConfiguration.ModuleControl.ControlSrc.Replace(".mvc", "").Split('/');
-
-                    moduleControl.LocalResourceFile = String.Format("~/DesktopModules/MVC/{0}/{1}/{2}.resx",
-                                        moduleConfiguration.DesktopModule.FolderName,
-                                        Localization.LocalResourceDirectory,
-                                        segments[0]);
-                    break;
-                default:
-                    moduleControl.LocalResourceFile = moduleConfiguration.ModuleControl.ControlSrc.Replace(Path.GetFileName(moduleConfiguration.ModuleControl.ControlSrc), "") +
-                                        Localization.LocalResourceDirectory + "/" +
-                                        Path.GetFileName(moduleConfiguration.ModuleControl.ControlSrc);
-                    break;
-            }
-            return moduleControl;
+            IModuleControlFactory factory = GetModuleControlFactory(moduleConfiguration.ModuleControl.ControlSrc);
+            return factory.CreateModuleControl(moduleConfiguration);
         }
 #endif
     }

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcModuleControlFactory.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcModuleControlFactory.cs
@@ -18,23 +18,39 @@
 
 using System.Web.UI;
 using DotNetNuke.Entities.Modules;
+using DotNetNuke.Services.Localization;
 using DotNetNuke.UI.Modules;
 
 namespace DotNetNuke.Web.Mvc
 {
-    public class MvcModuleControlFactory : IModuleControlFactory
+    public class MvcModuleControlFactory : BaseModuleControlFactory
     {
-        public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
+        public override Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             return new MvcHostControl(controlKey);
         }
 
-        public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
+        public override Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return new MvcHostControl();
         }
 
-        public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
+        public override ModuleControlBase CreateModuleControl(ModuleInfo moduleConfiguration)
+        {
+            ModuleControlBase moduleControl = base.CreateModuleControl(moduleConfiguration);
+
+            var segments = moduleConfiguration.ModuleControl.ControlSrc.Replace(".mvc", "").Split('/');
+
+            moduleControl.LocalResourceFile = string.Format("~/DesktopModules/MVC/{0}/{1}/{2}.resx",
+                               moduleConfiguration.DesktopModule.FolderName,
+                               Localization.LocalResourceDirectory,
+                               segments[0]);
+
+            return moduleControl;
+
+        }
+
+        public override Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return new MvcSettingsControl();
         }

--- a/DNN Platform/DotNetNuke.Web.Razor/RazorModuleControlFactory.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/RazorModuleControlFactory.cs
@@ -24,22 +24,22 @@ using DotNetNuke.UI.Modules;
 namespace DotNetNuke.Web.Razor
 {
     [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
-    public class RazorModuleControlFactory : IModuleControlFactory
+    public class RazorModuleControlFactory : BaseModuleControlFactory
     {
         [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
-        public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
+        public override Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             return new RazorHostControl("~/" + controlSrc);
         }
 
         [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
-        public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
+        public override Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return CreateControl(containerControl, String.Empty, moduleConfiguration.ModuleControl.ControlSrc);
         }
 
         [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
-        public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
+        public override Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return CreateControl(containerControl, String.Empty, controlSrc);
         }

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1526,6 +1526,7 @@
     </Compile>
     <Compile Include="UI\ControlUtilities.cs" />
     <Compile Include="UI\FavIcon.cs" />
+    <Compile Include="UI\Modules\BaseModuleControlFactory.cs" />
     <Compile Include="UI\Modules\CachedModuleControl.cs" />
     <Compile Include="UI\Modules\Html5\Html5HostControl.cs">
       <SubType>Code</SubType>

--- a/DNN Platform/Library/UI/Modules/BaseModuleControlFactory.cs
+++ b/DNN Platform/Library/UI/Modules/BaseModuleControlFactory.cs
@@ -1,0 +1,28 @@
+﻿using DotNetNuke.Entities.Modules;
+using DotNetNuke.Services.Localization;
+using System.IO;
+using System.Web.UI;
+
+namespace DotNetNuke.UI.Modules
+{
+    public abstract class BaseModuleControlFactory : IModuleControlFactory
+    {
+        public abstract Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc);
+
+        public abstract Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration);
+
+        public virtual ModuleControlBase CreateModuleControl(ModuleInfo moduleConfiguration)
+        {
+            var moduleControl = new ModuleControlBase();
+            moduleControl.ModuleContext.Configuration = moduleConfiguration;
+
+            moduleControl.LocalResourceFile = moduleConfiguration.ModuleControl.ControlSrc.Replace(Path.GetFileName(moduleConfiguration.ModuleControl.ControlSrc), "") +
+                                       Localization.LocalResourceDirectory + "/" +
+                                       Path.GetFileName(moduleConfiguration.ModuleControl.ControlSrc);
+
+            return moduleControl;
+        }
+
+        public abstract Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc);
+    }
+}

--- a/DNN Platform/Library/UI/Modules/Html5/Html5ModuleControlFactory.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/Html5ModuleControlFactory.cs
@@ -25,19 +25,19 @@ using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.UI.Modules.Html5
 {
-    public class Html5ModuleControlFactory : IModuleControlFactory
+    public class Html5ModuleControlFactory : BaseModuleControlFactory
     {
-        public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
+        public override Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             return new Html5HostControl("~/" + controlSrc);
         }
 
-        public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
+        public override Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return CreateControl(containerControl, String.Empty, moduleConfiguration.ModuleControl.ControlSrc);
         }
 
-        public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
+        public override Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return CreateControl(containerControl, String.Empty, controlSrc);
         }

--- a/DNN Platform/Library/UI/Modules/IModuleControlFactory.cs
+++ b/DNN Platform/Library/UI/Modules/IModuleControlFactory.cs
@@ -25,9 +25,8 @@ namespace DotNetNuke.UI.Modules
     public interface IModuleControlFactory
     {
         Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc);
-
         Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration);
-
+        ModuleControlBase CreateModuleControl(ModuleInfo moduleConfiguration);
         Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc);
     }
 }

--- a/DNN Platform/Library/UI/Modules/ReflectedModuleControlFactory.cs
+++ b/DNN Platform/Library/UI/Modules/ReflectedModuleControlFactory.cs
@@ -23,21 +23,21 @@ using DotNetNuke.Framework;
 
 namespace DotNetNuke.UI.Modules
 {
-    public class ReflectedModuleControlFactory : IModuleControlFactory
+    public class ReflectedModuleControlFactory : BaseModuleControlFactory
     {
-        public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
+        public override Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             // load from a typename in an assembly ( ie. server control)
             var objType = Reflection.CreateType(controlSrc);
             return (containerControl.LoadControl(objType, null));
         }
 
-        public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
+        public override Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return CreateControl(containerControl, String.Empty, moduleConfiguration.ModuleControl.ControlSrc);
         }
 
-        public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
+        public override Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return CreateControl(containerControl, String.Empty, controlSrc);
         }

--- a/DNN Platform/Library/UI/Modules/WebFormsModuleControlFactory.cs
+++ b/DNN Platform/Library/UI/Modules/WebFormsModuleControlFactory.cs
@@ -23,19 +23,19 @@ using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.UI.Modules
 {
-    public class WebFormsModuleControlFactory : IModuleControlFactory
+    public class WebFormsModuleControlFactory : BaseModuleControlFactory
     {
-        public Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
+        public override Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
             return ControlUtilities.LoadControl<Control>(containerControl, controlSrc);
         }
 
-        public Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
+        public override Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
             return CreateControl(containerControl, String.Empty, moduleConfiguration.ModuleControl.ControlSrc);
         }
 
-        public Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
+        public override Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
             return CreateControl(containerControl, String.Empty, controlSrc);
         }


### PR DESCRIPTION
Fixes: #2780 

## Summary
Removed MVC specific code from the shared ModuleControlPipeline. Added extension point using inheritance in the `BaseModuleControlFactory` which is inherited in each specific module pattern. This creates a special extension to have module specific code.

CC: @bdukes 
