### PR TITLE
Added DNN Upgrade script for 9.4: .NET 4.7.2

### DIFF
--- a/Website/Install/Config/09.04.00.config
+++ b/Website/Install/Config/09.04.00.config
@@ -1,0 +1,6 @@
+<configuration>
+  <nodes configfile="web.config">
+    <node path="/configuration/system.web/compilation" action="update" key="targetFramework" value="4.7.2" collision="ignore" />
+    <node path="/configuration/system.web/httpRuntime" action="update" key="targetFramework" value="4.7.2" collision="ignore" />
+  </nodes>
+</configuration>

--- a/Website/Install/Config/09.04.00.config
+++ b/Website/Install/Config/09.04.00.config
@@ -1,6 +1,6 @@
 <configuration>
   <nodes configfile="web.config">
-    <node path="/configuration/system.web/compilation" action="update" key="targetFramework" value="4.7.2" collision="ignore" />
-    <node path="/configuration/system.web/httpRuntime" action="update" key="targetFramework" value="4.7.2" collision="ignore" />
+    <node path="/configuration/system.web/compilation" action="updateattribute" name="targetFramework" value="4.7.2" />
+    <node path="/configuration/system.web/httpRuntime" action="updateattribute" name="targetFramework" value="4.7.2" />
   </nodes>
 </configuration>


### PR DESCRIPTION
fixes: #2788 

## Summary
Adds upgrade script to update the targetFramework elements in the web.config to be .NET 4.7.2. This is needed to properly upgrade websites to 9.4 as .NET 4.7.2 is introduced in the new version
