### PR TITLE
Additional Installer Fix for Azure

### DIFF
--- a/DNN Platform/Library/Services/Installer/Util.cs
+++ b/DNN Platform/Library/Services/Installer/Util.cs
@@ -575,9 +575,6 @@ namespace DotNetNuke.Services.Installer
         /// <param name="destFileName">The Destination file</param>
         public static void WriteStream(Stream sourceStream, string destFileName)
         {
-            //Delete the file
-            FileSystemUtils.DeleteFile(destFileName);
-
             var file = new FileInfo(destFileName);
             if (file.Directory != null && !file.Directory.Exists)
                 file.Directory.Create();


### PR DESCRIPTION
This is an additional fix for #2766 

Upon further testing, thanks to @meetmandeep, it has been determined that the locking behavior was actually introduced by the codes prior attempts to delete the file, and then immediately write it.  This is due to the file structures used in azure.

Given that the code that copies files in other locations are using overwrite options, which are safe, and supported, I removed the "Delete" call from the method.  This has been tested already in Azure and has reliability resolved the issues.

