### PR TITLE
Marked DependencyProvider as Internal

### DIFF
--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -555,7 +555,7 @@ namespace DotNetNuke.Common
         /// <value>
         /// The Dependency Service.
         /// </value>
-        public static IServiceProvider DependencyProvider { get; set; }
+        internal static IServiceProvider DependencyProvider { get; set; }
 
         /// <summary>
         /// Redirects the specified URL.

--- a/DNN Platform/Library/Entities/Modules/ModuleSettingsBase.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleSettingsBase.cs
@@ -20,9 +20,10 @@
 #endregion
 #region Usings
 
+using System;
 using System.Collections;
 using System.ComponentModel;
-
+using DotNetNuke.Common;
 using DotNetNuke.UI.Modules;
 
 #endregion
@@ -31,6 +32,20 @@ namespace DotNetNuke.Entities.Modules
 {
     public class ModuleSettingsBase : PortalModuleBase, ISettingsControl
     {
+        /// <summary>
+        /// Gets or sets the Dependency Provider to resolve registered 
+        /// services with the container.
+        /// </summary>
+        /// <value>
+        /// The Dependency Service.
+        /// </value>
+        protected IServiceProvider DependencyProvider { get; }
+
+        public ModuleSettingsBase()
+        {
+            DependencyProvider = Globals.DependencyProvider;
+        }
+
         public Hashtable ModuleSettings
         {
             get

--- a/DNN Platform/Library/Entities/Modules/ModuleSettingsBase.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleSettingsBase.cs
@@ -32,20 +32,6 @@ namespace DotNetNuke.Entities.Modules
 {
     public class ModuleSettingsBase : PortalModuleBase, ISettingsControl
     {
-        /// <summary>
-        /// Gets or sets the Dependency Provider to resolve registered 
-        /// services with the container.
-        /// </summary>
-        /// <value>
-        /// The Dependency Service.
-        /// </value>
-        protected IServiceProvider DependencyProvider { get; }
-
-        public ModuleSettingsBase()
-        {
-            DependencyProvider = Globals.DependencyProvider;
-        }
-
         public Hashtable ModuleSettings
         {
             get

--- a/DNN Platform/Library/Entities/Modules/PortalModuleBase.cs
+++ b/DNN Platform/Library/Entities/Modules/PortalModuleBase.cs
@@ -66,6 +66,20 @@ namespace DotNetNuke.Entities.Modules
         private string _localResourceFile;
         private ModuleInstanceContext _moduleContext;
 
+        /// <summary>
+        /// Gets or sets the Dependency Provider to resolve registered 
+        /// services with the container.
+        /// </summary>
+        /// <value>
+        /// The Dependency Service.
+        /// </value>
+        protected IServiceProvider DependencyProvider { get; }
+        
+        public PortalModuleBase()
+        {
+            DependencyProvider = Globals.DependencyProvider;
+        }
+
         [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ModuleActionCollection Actions
         {

--- a/DNN Platform/Library/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Library/Properties/AssemblyInfo.cs
@@ -53,6 +53,7 @@ using DotNetNuke.Application;
 [assembly: InternalsVisibleTo("DotNetNuke.Provider.AspNetProvider")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Content")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Web")]
+[assembly: InternalsVisibleTo("DotNetNuke.Tests.Web.Mvc")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Urls")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Professional")]
 [assembly: InternalsVisibleTo("DotNetNuke.SiteExportImport")]

--- a/DNN Platform/Library/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Library/Properties/AssemblyInfo.cs
@@ -46,6 +46,8 @@ using DotNetNuke.Application;
 // used by Moq. Paste in a single line.
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("DotNetNuke.Web")]
+[assembly: InternalsVisibleTo("DotNetNuke.Web.Mvc")]
+[assembly: InternalsVisibleTo("DotNetNuke.Web.Razor")]
 [assembly: InternalsVisibleTo("DotNetNuke.HttpModules")]
 [assembly: InternalsVisibleTo("DotNetNuke.Modules.MemberDirectory")]
 [assembly: InternalsVisibleTo("DotNetNuke.Provider.AspNetProvider")]

--- a/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
@@ -22,7 +22,7 @@
 
 using System;
 using System.ComponentModel;
-
+using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
 
 #endregion
@@ -38,7 +38,22 @@ namespace DotNetNuke.Services.Authentication
     [Serializable]
     public abstract class AuthenticationConfigBase
     {
+        /// <summary>
+        /// Gets or sets the Dependency Provider to resolve registered 
+        /// services with the container.
+        /// </summary>
+        /// <value>
+        /// The Dependency Service.
+        /// </value>
+        protected IServiceProvider DependencyProvider { get; }
+
+        public AuthenticationConfigBase()
+        {
+            DependencyProvider = Globals.DependencyProvider;
+        }
+
         protected AuthenticationConfigBase(int portalID)
+            : this()
         {
             PortalID = portalID;
         }

--- a/DNN Platform/Library/Services/Authentication/AuthenticationLogoffBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationLogoffBase.cs
@@ -21,7 +21,7 @@
 #region Usings
 
 using System;
-
+using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
 
@@ -39,6 +39,20 @@ namespace DotNetNuke.Services.Authentication
     {
         private string _AuthenticationType = Null.NullString;
         private string _RedirectURL = Null.NullString;
+
+        /// <summary>
+        /// Gets or sets the Dependency Provider to resolve registered 
+        /// services with the container.
+        /// </summary>
+        /// <value>
+        /// The Dependency Service.
+        /// </value>
+        protected IServiceProvider DependencyProvider { get; }
+
+        public AuthenticationLogoffBase()
+        {
+            DependencyProvider = Globals.DependencyProvider;
+        }
 
         /// -----------------------------------------------------------------------------
         /// <summary>


### PR DESCRIPTION
Fixes: #2794 

## Summary
Marks the `Globals.Common.DependencyProvider` as internal and only accessible within the Core Libraries of DNN. Web Forms modules now contain a protected instance of the `DependencyProvider` which gives Web Forms developers access to the Service Locator since Dependency Injection does not work with the Web Forms Modules.

This will couple the Service Locator with the lifetime of the Web Forms module and prevent developers from abusing the Service Locator.

## New Usage
```C#
public partial class MyView : PortalModuleBase
{
    protected IMessageService MessageService { get; }

    public MyView()
    {
        MessageService = DependencyProvider.GetService<IMessageService>();
    }        
}
```

```C#
public partial class MySettings : PortalModuleBase
{
    protected IMessageService MessageService { get; }

    public MyView()
    {
        MessageService = DependencyProvider.GetService<IMessageService>();
    }        
}
```
