### PR TITLE
Google Analytics: Toggle Anonymize IP when DataConsent is Enabled

### DIFF
--- a/DNN Platform/Connectors/GoogleAnalytics/App_LocalResources/SharedResources.resx
+++ b/DNN Platform/Connectors/GoogleAnalytics/App_LocalResources/SharedResources.resx
@@ -141,4 +141,7 @@
   <data name="TrackUserId.Text" xml:space="preserve">
     <value>Track UserID:</value>
   </data>
+  <data name="DataConsent.Text" xml:space="preserve">
+    <value>Note: Data Consent is enabled, automatically enforcing this setting.</value>
+  </data>
 </root>

--- a/DNN Platform/Connectors/GoogleAnalytics/Connector.css
+++ b/DNN Platform/Connectors/GoogleAnalytics/Connector.css
@@ -2,10 +2,15 @@
     width: 100%;
 }
 
-    #connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div input[type='text'], #connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div textarea, .connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div input[type='text'] {
-        width: 65% !important;
-    }
+#connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div input[type='text'], #connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div textarea, .connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div input[type='text'] {
+    width: 65% !important;
+}
 
-    #connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div label, .connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div label {
-        width: 25% !important;
-    }
+#connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div label, .connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div label {
+    width: 25% !important;
+}
+
+#connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div span, .connector-CoreGoogleAnalyticsConnector > div.edit-fields > div > div span {
+    font-size:0.75em;
+    font-style:italic;
+}

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -129,6 +129,11 @@ namespace DNN.Connectors.GoogleAnalytics
                 }
             }
 
+            if (portalSettings.DataConsentActive)
+            {
+                anonymizeIp = true;
+            }
+
             var configItems = new Dictionary<string, string>
             {
                 { "TrackingID", trackingId },

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using DotNetNuke.Entities.Portals;
 using DotNetNuke.Services.Analytics.Config;
 using DotNetNuke.Services.Connections;
 using DotNetNuke.Services.Exceptions;
@@ -85,6 +86,8 @@ namespace DNN.Connectors.GoogleAnalytics
         {
 
             var analyticsConfig = AnalyticsConfiguration.GetConfig("GoogleAnalytics");
+            var portalSettings = new PortalSettings(portalId);
+
             var trackingId = String.Empty;
             var urlParameter = String.Empty;
             var trackForAdmin = false;
@@ -133,6 +136,7 @@ namespace DNN.Connectors.GoogleAnalytics
                 { "TrackAdministrators", trackForAdmin.ToString()},
                 { "AnonymizeIp", anonymizeIp.ToString()},
                 { "TrackUserId", trackUserId.ToString()},
+                { "DataConsent", portalSettings.DataConsentActive.ToString()},
                 { "isDeactivating", false.ToString()}
             };
 
@@ -150,7 +154,8 @@ namespace DNN.Connectors.GoogleAnalytics
             try
             {
 
-                bool isDeactivating = false;
+                var isDeactivating = false;
+
                 bool.TryParse(values["isDeactivating"].ToLowerInvariant(), out isDeactivating);
 
                 string trackingID;

--- a/DNN Platform/Connectors/GoogleAnalytics/Scripts/connector.js
+++ b/DNN Platform/Connectors/GoogleAnalytics/Scripts/connector.js
@@ -73,7 +73,7 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
 
                     // Set the isDeactivating flag to true to override the default save behaviour
                     // Temporary workaround until delete functionality on connectors is improved
-                    conn.configurations[3].value("true");
+                    conn.configurations[6].value("true");
                     wasDeactivated = true;
                     conn.save(conn, e, onSaveComplete.bind(this, conn, conn.id));
                 }
@@ -104,7 +104,7 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
 
                         // Set the isDeactivating flag to true to override the default save behaviour
                         // Temporary workaround until delete functionality on connectors is improved
-                        conn.configurations[5].value("true");
+                        conn.configurations[6].value("true");
                         wasDeactivated = true;
                         conn.save(conn, e, onSaveComplete.bind(this, conn, conn.id));
                     }

--- a/DNN Platform/Connectors/GoogleAnalytics/connector.htm
+++ b/DNN Platform/Connectors/GoogleAnalytics/connector.htm
@@ -17,7 +17,9 @@
 
     <div>
         <label for="chkAnonymizeIp" data-bind="html: configurations[3].localizedName"></label>
-        <input id="chkAnonymizeIp" type="checkbox" data-bind="checked: configurations[3].value, checkedValue: configurations[3].value" />
+        <input id="chkAnonymizeIp" type="checkbox" data-bind="checked: configurations[3].value, checkedValue: configurations[3].value, disable: configurations[5].value" />
+
+        <span data-bind="visible: configurations[5].value, html: configurations[5].localizedName"></span>
     </div>
 
     <div>

--- a/DNN Platform/Library/Services/Analytics/GoogleAnalyticsEngine.cs
+++ b/DNN Platform/Library/Services/Analytics/GoogleAnalyticsEngine.cs
@@ -42,13 +42,16 @@ namespace DotNetNuke.Services.Analytics
         public override string RenderScript(string scriptTemplate)
         {
             AnalyticsConfiguration config = GetConfig();
+
             if (config == null)
             {
                 return "";
             }
+
             var trackingId = "";
             var urlParameter = "";
             var trackForAdmin = true;
+
             foreach (AnalyticsSetting setting in config.Settings)
             {
                 switch (setting.SettingName.ToLowerInvariant())
@@ -67,6 +70,7 @@ namespace DotNetNuke.Services.Analytics
                         break;
                 }
             }
+
             if (String.IsNullOrEmpty(trackingId))
             {
                 return "";
@@ -91,7 +95,9 @@ namespace DotNetNuke.Services.Analytics
             {
                 scriptTemplate = scriptTemplate.Replace("[PAGE_URL]", "");
             }
+
             scriptTemplate = scriptTemplate.Replace("[CUSTOM_SCRIPT]", RenderCustomScript(config));
+
             return scriptTemplate;
         }
 
@@ -99,8 +105,8 @@ namespace DotNetNuke.Services.Analytics
         {
             try
             {
-                bool anonymize = false;
-                bool trackingUserId = false;
+                var anonymize = false;
+                var trackingUserId = false;
 
                 foreach (AnalyticsSetting setting in config.Settings)
                 {
@@ -120,18 +126,19 @@ namespace DotNetNuke.Services.Analytics
                 }
 
 
-                var sb = new System.Text.StringBuilder();
-                if (anonymize)
+                var customScripts = new System.Text.StringBuilder();
+
+                if (anonymize || PortalSettings.Current.DataConsentActive)
                 {
-                    sb.Append("ga('set', 'anonymizeIp', true);");
+                    customScripts.Append("ga('set', 'anonymizeIp', true);");
                 }
 
                 if (trackingUserId)
                 {
-                    sb.AppendFormat("ga('set', 'userId', {0});", UserController.Instance.GetCurrentUserInfo().UserID);
+                    customScripts.AppendFormat("ga('set', 'userId', {0});", UserController.Instance.GetCurrentUserInfo().UserID);
                 }
 
-                return sb.ToString();
+                return customScripts.ToString();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

When the `DataConsentActive` property is true, we will always set the google analytics configuration for `anonymizeIp` to `true`. Then in the admin ui, we disable the checkbox and display a notice that this setting is automatically enforced when data consent is enabled.

![image](https://user-images.githubusercontent.com/1687117/57824240-68333000-7768-11e9-803d-ee74f02b8293.png)
