### PR TITLE
Addition of [Obsolete] Attribute to Users Online

### DIFF
--- a/DNN Platform/HttpModules/Users Online/UsersOnlineModule.cs
+++ b/DNN Platform/HttpModules/Users Online/UsersOnlineModule.cs
@@ -29,8 +29,10 @@ using DotNetNuke.Entities.Users;
 
 namespace DotNetNuke.HttpModules.UsersOnline
 {
+    [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
     public class UsersOnlineModule : IHttpModule
     {
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public string ModuleName
         {
             get
@@ -52,6 +54,7 @@ namespace DotNetNuke.HttpModules.UsersOnline
 
         #endregion
 
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public void OnAuthorizeRequest(object s, EventArgs e)
         {
             //First check if we are upgrading/installing

--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -2480,21 +2480,25 @@ namespace DotNetNuke.Data
 
         #region Users Online Methods
 
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public virtual void DeleteUsersOnline(int timeWindow)
         {
             ExecuteNonQuery("DeleteUsersOnline", timeWindow);
         }
 
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public virtual IDataReader GetOnlineUser(int userId)
         {
             return ExecuteReader("GetOnlineUser", userId);
         }
 
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public virtual IDataReader GetOnlineUsers(int portalId)
         {
             return ExecuteReader("GetOnlineUsers", portalId);
         }
 
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public virtual void UpdateUsersOnline(Hashtable userList)
         {
             if ((userList.Count == 0))

--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -579,7 +579,8 @@ namespace DotNetNuke.Entities.Host
         /// <remarks>
         ///   Defaults to False
         /// </remarks>
-        /// -----------------------------------------------------------------------------
+        /// ----------------------------------------------------------------------------- 
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public static bool EnableUsersOnline
         {
             get
@@ -1492,6 +1493,7 @@ namespace DotNetNuke.Entities.Host
         ///   Defaults to 15
         /// </remarks>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public static int UsersOnlineTimeWindow
         {
             get

--- a/DNN Platform/Library/Entities/Users/Membership/UserMembership.cs
+++ b/DNN Platform/Library/Entities/Users/Membership/UserMembership.cs
@@ -105,6 +105,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets whether the User Is Online
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public bool IsOnLine { get; set; }
 
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -1203,6 +1203,7 @@ namespace DotNetNuke.Entities.Users
         /// <param name="portalId">The Id of the Portal</param>
         /// <returns>An ArrayList of UserInfo objects</returns>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public static ArrayList GetOnlineUsers(int portalId)
         {
             return MembershipProvider.Instance().GetOnlineUsers(GetEffectivePortalId(portalId));

--- a/DNN Platform/Library/Entities/Users/Users Online/AnonymousUserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/Users Online/AnonymousUserInfo.cs
@@ -29,7 +29,6 @@ namespace DotNetNuke.Entities.Users
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
     /// Namespace:  DotNetNuke.Entities.Users
-    /// Class:      PurgeUsersOnline
     /// -----------------------------------------------------------------------------
     /// <summary>
     /// The AnonymousUserInfo class provides an Entity for an anonymous user

--- a/DNN Platform/Library/Entities/Users/Users Online/AnonymousUserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/Users Online/AnonymousUserInfo.cs
@@ -37,6 +37,7 @@ namespace DotNetNuke.Entities.Users
     /// </remarks>
     /// -----------------------------------------------------------------------------
     [Serializable]
+    [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
     public class AnonymousUserInfo : BaseUserInfo
     {
         private string _UserID;
@@ -46,6 +47,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets the User Id for this online user
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public string UserID
         {
             get

--- a/DNN Platform/Library/Entities/Users/Users Online/BaseUserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/Users Online/BaseUserInfo.cs
@@ -38,6 +38,7 @@ namespace DotNetNuke.Entities.Users
     /// </remarks>
     /// -----------------------------------------------------------------------------
     [Serializable]
+    [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
     public abstract class BaseUserInfo
     {
         private DateTime _CreationDate;
@@ -50,6 +51,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets the PortalId for this online user
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public int PortalID
         {
             get
@@ -67,6 +69,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets the TabId for this online user
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public int TabID
         {
             get
@@ -84,6 +87,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets the CreationDate for this online user
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public DateTime CreationDate
         {
             get
@@ -101,6 +105,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets the LastActiveDate for this online user
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public DateTime LastActiveDate
         {
             get

--- a/DNN Platform/Library/Entities/Users/Users Online/OnlineUserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/Users Online/OnlineUserInfo.cs
@@ -38,6 +38,7 @@ namespace DotNetNuke.Entities.Users
     /// </remarks>
     /// -----------------------------------------------------------------------------
     [Serializable]
+    [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
     public class OnlineUserInfo : BaseUserInfo
     {
         private int _UserID;
@@ -47,6 +48,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets and sets the User Id for this online user
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public int UserID
         {
             get

--- a/DNN Platform/Library/Entities/Users/Users Online/PurgeUsersOnline.cs
+++ b/DNN Platform/Library/Entities/Users/Users Online/PurgeUsersOnline.cs
@@ -41,6 +41,7 @@ namespace DotNetNuke.Entities.Users
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
+    [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
     public class PurgeUsersOnline : SchedulerClient
     {
         /// -----------------------------------------------------------------------------
@@ -51,6 +52,7 @@ namespace DotNetNuke.Entities.Users
         /// </remarks>
         /// <param name="objScheduleHistoryItem">A SchedulerHistiryItem</param>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public PurgeUsersOnline(ScheduleHistoryItem objScheduleHistoryItem)
         {
             ScheduleHistoryItem = objScheduleHistoryItem;
@@ -61,6 +63,7 @@ namespace DotNetNuke.Entities.Users
         /// UpdateUsersOnline updates the Users Online information
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         private void UpdateUsersOnline()
         {
             var objUserOnlineController = new UserOnlineController();
@@ -81,6 +84,7 @@ namespace DotNetNuke.Entities.Users
         /// DoWork does th4 Scheduler work
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public override void DoWork()
         {
             try

--- a/DNN Platform/Library/Entities/Users/Users Online/UserOnlineController.cs
+++ b/DNN Platform/Library/Entities/Users/Users Online/UserOnlineController.cs
@@ -44,6 +44,8 @@ namespace DotNetNuke.Entities.Users
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
+
+    [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
     public class UserOnlineController
     {
     	private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (UserOnlineController));
@@ -56,6 +58,7 @@ namespace DotNetNuke.Entities.Users
         /// Clears the cached Users Online Information
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public void ClearUserList()
         {
             string key = "OnlineUserList";
@@ -67,6 +70,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets the Online time window
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public int GetOnlineTimeWindow()
         {
             return Host.Host.UsersOnlineTimeWindow;
@@ -77,6 +81,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets the cached Users Online Information
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public Hashtable GetUserList()
         {
             var userList = (Hashtable)DataCache.GetCache(CacheKey);
@@ -100,6 +105,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets whether the Users Online functionality is enabled
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public bool IsEnabled()
         {
             return Host.Host.EnableUsersOnline;
@@ -110,6 +116,7 @@ namespace DotNetNuke.Entities.Users
         /// Determines whether a User is online
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public bool IsUserOnline(UserInfo user)
         {
             bool isOnline = false;
@@ -125,6 +132,7 @@ namespace DotNetNuke.Entities.Users
         /// Sets the cached Users Online Information
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public void SetUserList(Hashtable userList)
         {
             DataCache.SetCache(CacheKey, userList);
@@ -136,6 +144,7 @@ namespace DotNetNuke.Entities.Users
         /// </summary>
         /// <param name="context">An HttpContext Object</param>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         private void TrackAnonymousUser(HttpContext context)
         {
             string cookieName = "DotNetNukeAnonymous";
@@ -223,6 +232,7 @@ namespace DotNetNuke.Entities.Users
         /// </summary>
         /// <param name="context">An HttpContext Object</param>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         private void TrackAuthenticatedUser(HttpContext context)
         {
             //Retrieve Portal Settings
@@ -259,6 +269,7 @@ namespace DotNetNuke.Entities.Users
         /// Tracks an online User
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public void TrackUsers()
         {
             HttpContext context = HttpContext.Current;
@@ -287,6 +298,7 @@ namespace DotNetNuke.Entities.Users
         /// Update the Users Online information
         /// </summary>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public void UpdateUsersOnline()
         {
             //Get a Current User List

--- a/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/AspNetMembershipProvider.cs
@@ -1026,6 +1026,7 @@ namespace DotNetNuke.Security.Membership
         /// </remarks>
         /// <param name="timeWindow">Time Window in Minutes</param>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public override void DeleteUsersOnline(int timeWindow)
         {
             _dataProvider.DeleteUsersOnline(timeWindow);
@@ -1066,6 +1067,7 @@ namespace DotNetNuke.Security.Membership
         /// <param name="portalId">The Id of the Portal</param>
         /// <returns>An ArrayList of UserInfo objects</returns>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public override ArrayList GetOnlineUsers(int portalId)
         {
             int totalRecords = 0;
@@ -1533,6 +1535,7 @@ namespace DotNetNuke.Security.Membership
         /// <param name="user">The user.</param>
         /// <returns>A Boolean indicating whether the user is online.</returns>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public override bool IsUserOnline(UserInfo user)
         {
             bool isOnline = false;
@@ -1798,6 +1801,7 @@ namespace DotNetNuke.Security.Membership
         /// </summary>
         /// <param name="userList">List of users to update</param>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public override void UpdateUsersOnline(Hashtable userList)
         {
             _dataProvider.UpdateUsersOnline(userList);

--- a/DNN Platform/Library/Security/Membership/MembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/MembershipProvider.cs
@@ -83,9 +83,14 @@ namespace DotNetNuke.Security.Membership
         public abstract UserInfo UserLogin(int portalId, string username, string password, string authType, string verificationCode, ref UserLoginStatus loginStatus);
 
         // Users Online
+
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public abstract void DeleteUsersOnline(int TimeWindow);
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public abstract ArrayList GetOnlineUsers(int PortalId);
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public abstract bool IsUserOnline(UserInfo user);
+        [Obsolete("Support for users online was removed in 8.x, other solutions exist outside of the DNN Platform.  Scheduled removal in v11.0.0.")]
         public abstract void UpdateUsersOnline(Hashtable UserList);
 
         // Legacy

--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -67,7 +67,6 @@
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
-      <add name="UsersOnline" type="DotNetNuke.HttpModules.UsersOnline.UsersOnlineModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="Personalization" type="DotNetNuke.HttpModules.Personalization.PersonalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="Analytics" type="DotNetNuke.HttpModules.Analytics.AnalyticsModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
@@ -96,7 +95,6 @@
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" />
       <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" />
       <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" />
-      <add name="UsersOnline" type="DotNetNuke.HttpModules.UsersOnline.UsersOnlineModule, DotNetNuke.HttpModules" />
       <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" />
       <add name="Personalization" type="DotNetNuke.HttpModules.Personalization.PersonalizationModule, DotNetNuke.HttpModules" />
       <add name="Analytics" type="DotNetNuke.HttpModules.Analytics.AnalyticsModule, DotNetNuke.HttpModules" />


### PR DESCRIPTION
Back in DNN 8.x, or earlier, the UsersOnline HttpModule was removed from the default installations of DNN.  The configuration settings and actual source code for this feature were left inside the platform, however, they have not been tested or supported.

As such, the methods supporting this are legacy and no-longer properly managed.  To follow the published deprecation standards, since no prior notice was given.  I've flagged all implementation methods for the UserOnline feature for removal in v11.0.0.  

The DNN Community initiative, which has the supplemental UsersOnline module, could easily extract this code and install as an extension, which would be the preferred long-term solution as it.

One additional change was included, to update the configuration file on a UnitTest project to match the proper current configuration file.
