### PR TITLE
Fixes Build Process for DotNetNuke.ModulePipeline to Copy Correct NET472 Assembly

### DIFF
--- a/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
+++ b/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="XCOPY &quot;$(TargetDir)DotNetNuke.ModulePipeline.*&quot; &quot;..\..\Website\bin&quot; /S /Y" />
+    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\net472\DotNetNuke.ModulePipeline.*&quot; &quot;..\..\Website\bin&quot; /S /Y" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Fixes: #2806

## Summary
Fixes the build process to force copy the correct NET472 assembly of `DotNetNuke.ModulePipeline`. 

This project is our first multi-targeting library for both net472 and netstandard2.0 which will help us migrate to .NET Core. The project will not register any `System.Web` objects if it is build against netstandard 2.0 (see snippet below). Since it was copying the netstandard2.0 library it was not properly registering the `IModuleControlFactory`

DI Registration Code
```C#
public void ConfigureServices(IServiceCollection services)
{
    // MULTI-TARGETTING PIPELINE
    // -------------------------
    // This file multi-targets .NET Framework and .NET Standard,
    // which is needed as DNN migrates to .NET Core. The 'NET472'
    // pre-processor directives are to fully support Legacy DNN.
    // As the Pipeline is upgraded to be more complaint with 
    // .NET Standard 2.0 use the apprioprate pre-processor directives.
#if NET472
    services.AddSingleton<IModuleControlPipeline, ModuleControlPipeline>();
#endif
}
```