### PR TITLE
Fix for #2809 and #2760 and #2778

### DIFF
--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -819,7 +819,7 @@ namespace DotNetNuke.Common
                 }
                 if (string.IsNullOrEmpty(cultureCode))
                 {
-                    cultureCode = !string.IsNullOrEmpty(settings.DefaultLanguage) ? settings.DefaultLanguage : Thread.CurrentThread.CurrentCulture.Name;
+                    cultureCode = Thread.CurrentThread.CurrentCulture.Name;
                 }
             }
 

--- a/Website/Default.aspx
+++ b/Website/Default.aspx
@@ -1,4 +1,4 @@
-<%@ Page Language="C#" AutoEventWireup="True" Inherits="DotNetNuke.Framework.DefaultPage" CodeBehind="Default.aspx.cs" Async="true" %>
+<%@ Page Language="C#" AutoEventWireup="True" Inherits="DotNetNuke.Framework.DefaultPage" CodeBehind="Default.aspx.cs" %>
 <%@ Register TagPrefix="dnncrm" Namespace="DotNetNuke.Web.Client.ClientResourceManagement" Assembly="DotNetNuke.Web.Client" %>
 <%@ Register TagPrefix="dnn" Namespace="DotNetNuke.Common.Controls" Assembly="DotNetNuke" %>
 <asp:literal id="skinDocType" runat="server" ViewStateMode="Disabled"/>


### PR DESCRIPTION
After discussion in TAG meeting May 21st: this rolls back Async and a change made on Nov 8 2018 to the way NavigateUrl gets the locale for a tab/page.

