### PR TITLE
Fix for Custom Authentication Providers

### DIFF
--- a/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -471,7 +471,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
                         //if there are social authprovider only
                         if (_oAuthControls.Count == 0)
                         {
-                            //Portal has no login controls enabled so load default DNN control, don't show the panel
+                            //Portal has no login controls enabled so load default DNN control
                             DisplayLoginControl(defaultLoginControl, false, false);
                         }
                     }

--- a/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -422,7 +422,6 @@ namespace DotNetNuke.Modules.Admin.Authentication
                         if (authSystem.AuthenticationType == "DNN")
                         {
                             defaultLoginControl = authLoginControl;
-                            pnlLoginContainer.Visible = true;
                         }
 
                         //Check if AuthSystem is Enabled
@@ -472,7 +471,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
                         //if there are social authprovider only
                         if (_oAuthControls.Count == 0)
                         {
-                            //Portal has no login controls enabled so load default DNN control
+                            //Portal has no login controls enabled so load default DNN control, don't show the panel
                             DisplayLoginControl(defaultLoginControl, false, false);
                         }
                     }
@@ -614,6 +613,9 @@ namespace DotNetNuke.Modules.Admin.Authentication
             {
                 pnlLoginContainer.Controls.Add(new LiteralControl("<br />"));
             }
+
+            //Display the container
+            pnlLoginContainer.Visible = true;
         }
 
         private void DisplayTabbedLoginControl(AuthenticationLoginBase authLoginControl, TabStripTabCollection Tabs)


### PR DESCRIPTION
Issue #2749 documents a loss of display of the authentication provider when using a non-standard DNN Provider when the DNN Provider is not included.

It appears that Pull Request #1897 moved the location whereby the login control is displayed, this changed the behavior that resulted in any custom providers not displaying unless the DNN.

This PR reverts that portion of this change.  Long-term, this might not be the best solution, but this should restore functionality for users in the time being.

For those on 9.3, 9.3.1, or 9.3.2 a temporary workaround would be to remove the `Visible="false"` from line 13 of /DesktopModules/Admin/Authentication/login.ascx 



