### PR TITLE
Fixes PetaPoco lacking mapper

### DIFF
--- a/DNN Platform/Library/Data/PetaPoco/PetaPocoDataContext.cs
+++ b/DNN Platform/Library/Data/PetaPoco/PetaPocoDataContext.cs
@@ -61,8 +61,8 @@ namespace DotNetNuke.Data.PetaPoco
         {
             Requires.NotNullOrEmpty("connectionStringName", connectionStringName);
 
-            _database = new Database(connectionStringName);
             _mapper = new PetaPocoMapper(tablePrefix);
+            _database = new Database(connectionStringName, _mapper);
             TablePrefix = tablePrefix;
             FluentMappers = mappers;
         }


### PR DESCRIPTION
Without a mapper PetaPoco will default to using the object name as table name. DNN's petapoco mapper should be used when creating the DB to set the default mapper.

This fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/971