### PR TITLE
Add GitHub security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We make every effort to ensure speedy analysis of reported issues and, where required, provide workarounds and updated application releases to fix them. If you see suspected issues/security scan results please report them by sending an email to:
+
+[security@dnnsoftware.com](mailto:security@dnnsoftware.com)
+
+All submitted information is viewed only by members of the DNN Security Task Force, and will not be discussed outside the Task Force without the permission of the person/company who reported the issue. Each confirmed issue is assigned a severity level (critical, moderate, or low) corresponding to its potential impact on the security of DNN installations.
+
+* **Critical** means the issue can be exploited by a remote attacker to gain access to DNN data or functionality. All critical issue security bulletins include a recommended workaround or fix that should be applied as soon as possible.
+* **Moderate** means the issue can compromise data or functionality on a portal/website only if some other condition is met (e.g. a particular module or a user within a particular role is required). Moderate issue security bulletins typically include recommended actions to resolve the issue.
+* **Low** means the issue is very difficult to exploit or has a limited potential impact.
+
+The Security Task Force then issues a security bulletin via DNN security forum posts and, where judged necessary, email. The bulletin provides details about the issue, the DNN versions impacted, and suggested fixes or workarounds. Security bulletins are issued as required. 


### PR DESCRIPTION
This is just a copy of the content from https://www.dnnsoftware.com/community/security/security-center.  We may want to look at adjusting the security process to make use of GitHub's new functionality.

The template for the security policy also has a section about supported versions, but I wanted to start with what's there, and then we can add.  Here's a rough sketch of some content we might want to consider:

>
>## Supported Versions
>
>Only the latest release of DNN Platform receives security patches.  We do make an effort to provide workarounds or backports of patches when possible.
>The last release of DNN Platform 10.x is intended to be marked as a Long Term Support (LTS) version, which will receive official patch support while ongoing work continues on later versions.
>
>| Version           | Supported          |
>| ----------------- | ------------------ |
>| LTS (10.x)        | :white_check_mark: |
>| Current (9.4.x)   | :white_check_mark: |
>| 9.3.x             | :x:                |
>| 8.x               | :x:                |
>
>