### PR TITLE
Wrong text in welcome email when users are added manually

### DIFF
--- a/DNN Platform/Library/Entities/Users/UserRegistrationEmailNotifier.cs
+++ b/DNN Platform/Library/Entities/Users/UserRegistrationEmailNotifier.cs
@@ -1,4 +1,5 @@
-﻿using DotNetNuke.Common;
+﻿using System;
+using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Services.Mail;
@@ -8,6 +9,8 @@ namespace DotNetNuke.Entities.Users
 {
     public class UserRegistrationEmailNotifier
     {
+        private static Lazy<UserInfo> CurrentUser => new Lazy<UserInfo>(() => UserController.Instance.GetCurrentUserInfo());
+
         public UserRegistrationEmailNotifier()
         {
         }
@@ -15,8 +18,8 @@ namespace DotNetNuke.Entities.Users
         public static void NotifyAdministrator(UserInfo user)
         {
             // avoid self-notification (i.e. on site installation/super user creation)
-            var currentUser = UserController.Instance.GetCurrentUserInfo();
-            if (currentUser != null && (currentUser.UserID == Null.NullInteger || currentUser.UserID == user.UserID))
+            if (CurrentUser.Value != null && 
+                (CurrentUser.Value.UserID == Null.NullInteger || CurrentUser.Value.UserID == user.UserID))
             {
                 return;
             }
@@ -35,7 +38,9 @@ namespace DotNetNuke.Entities.Users
             switch (PortalSettings.Current.UserRegistration)
             {
                 case (int)PortalRegistrationType.PrivateRegistration:
-                    NotifyUser(user, MessageType.UserRegistrationPrivate);
+                    NotifyUser(user, CurrentUser.Value != null && CurrentUser.Value.IsSuperUser ?
+                        MessageType.UserRegistrationPrivateNoApprovalRequired :
+                        MessageType.UserRegistrationPrivate);
                     break;
                 case (int)PortalRegistrationType.PublicRegistration:
                     NotifyUser(user, MessageType.UserRegistrationPublic);

--- a/DNN Platform/Library/Entities/Users/UserRegistrationEmailNotifier.cs
+++ b/DNN Platform/Library/Entities/Users/UserRegistrationEmailNotifier.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.Entities.Users
             switch (PortalSettings.Current.UserRegistration)
             {
                 case (int)PortalRegistrationType.PrivateRegistration:
-                    NotifyUser(user, CurrentUser != null ?
+                    NotifyUser(user, CurrentUser != null && CurrentUser.UserID != Null.NullInteger ?
                         MessageType.UserRegistrationPrivateNoApprovalRequired :
                         MessageType.UserRegistrationPrivate);
                     break;

--- a/DNN Platform/Library/Entities/Users/UserRegistrationEmailNotifier.cs
+++ b/DNN Platform/Library/Entities/Users/UserRegistrationEmailNotifier.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Entities.Users
 {
     public class UserRegistrationEmailNotifier
     {
-        private static Lazy<UserInfo> CurrentUser => new Lazy<UserInfo>(() => UserController.Instance.GetCurrentUserInfo());
+        private static UserInfo CurrentUser => UserController.Instance.GetCurrentUserInfo();
 
         public UserRegistrationEmailNotifier()
         {
@@ -18,8 +18,8 @@ namespace DotNetNuke.Entities.Users
         public static void NotifyAdministrator(UserInfo user)
         {
             // avoid self-notification (i.e. on site installation/super user creation)
-            if (CurrentUser.Value != null && 
-                (CurrentUser.Value.UserID == Null.NullInteger || CurrentUser.Value.UserID == user.UserID))
+            if (CurrentUser != null && 
+                (CurrentUser.UserID == Null.NullInteger || CurrentUser.UserID == user.UserID))
             {
                 return;
             }
@@ -38,7 +38,7 @@ namespace DotNetNuke.Entities.Users
             switch (PortalSettings.Current.UserRegistration)
             {
                 case (int)PortalRegistrationType.PrivateRegistration:
-                    NotifyUser(user, CurrentUser.Value != null && CurrentUser.Value.IsSuperUser ?
+                    NotifyUser(user, CurrentUser != null ?
                         MessageType.UserRegistrationPrivateNoApprovalRequired :
                         MessageType.UserRegistrationPrivate);
                     break;

--- a/DNN Platform/Library/Services/Mail/Mail.cs
+++ b/DNN Platform/Library/Services/Mail/Mail.cs
@@ -291,6 +291,10 @@ namespace DotNetNuke.Services.Mail
                     subject = "EMAIL_USER_REGISTRATION_PRIVATE_SUBJECT";
                     body = "EMAIL_USER_REGISTRATION_PRIVATE_BODY";
                     break;
+                case MessageType.UserRegistrationPrivateNoApprovalRequired:
+                    subject = "EMAIL_USER_REGISTRATION_PUBLIC_SUBJECT";
+                    body = "EMAIL_USER_REGISTRATION_PUBLIC_BODY";
+                    break;
                 case MessageType.UserRegistrationPublic:
                     subject = "EMAIL_USER_REGISTRATION_PUBLIC_SUBJECT";
                     body = "EMAIL_USER_REGISTRATION_PUBLIC_BODY";

--- a/DNN Platform/Library/Services/Mail/MessageType.cs
+++ b/DNN Platform/Library/Services/Mail/MessageType.cs
@@ -26,6 +26,7 @@ namespace DotNetNuke.Services.Mail
         ProfileUpdated,
         UserRegistrationAdmin,
         UserRegistrationPrivate,
+        UserRegistrationPrivateNoApprovalRequired,
         UserRegistrationPublic,
         UserRegistrationVerified,
         UserUpdatedOwnPassword,


### PR DESCRIPTION
fixes: https://github.com/dnnsoftware/Dnn.AdminExperience/issues/367

Summary:
Recently we moved email sending functionality from UI to the Platform.
In this PR I'm checking whether user is a host or not to have a message with a right text to be sent to user while registration. In short, user gets approved automatically when performed by a host manually in a private mode, so we just want to send welcome email without any approval notifications.