### PR TITLE
View.html file is not rendered via Module Creator update

### DIFF
--- a/DNN Platform/Admin Modules/Dnn.Modules.ModuleCreator/Templates/Web/Module - HTML/template.ascx
+++ b/DNN Platform/Admin Modules/Dnn.Modules.ModuleCreator/Templates/Web/Module - HTML/template.ascx
@@ -1,6 +1,6 @@
-// 
-// *NOTE: Please manage your content in the  associated _CONTROL_.html file in this folder
-// 
+<!--
+    *NOTE: Please manage your content in the  associated _CONTROL_.html file in this folder
+--> 
 
 <%@ Control Language="C#" ClassName="_OWNER_._MODULE_._CONTROL_" Inherits="DotNetNuke.Entities.Modules.PortalModuleBase" %>
 
@@ -33,12 +33,12 @@
     {
         base.OnLoad(e);
 
-        const string ModuleName = "_OWNER_._MODULE_";
+        const string ModulePath = @"DesktopModules\_OWNER_\_MODULE_";
 
         if (!Page.IsPostBack)
         {
             //Load the HTML file
-            var path = Path.Combine(Server.MapPath(ModuleName), "_CONTROL_.html");
+            var path = Path.Combine(Server.MapPath(ModulePath), "_CONTROL_.html");
             if (File.Exists(path))
             {
                 var content = string.Empty;


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2853

Issue caused due to wrong path to the View.html file. Module is created dynamically from templates and is saved to the `DesktopModules\_OWNER_\_MODULE_` folder, where _owner_ and _module_ are names provided by the user when creating module.  

See demo of the fix: [DEMO](https://drive.google.com/file/d/1Yk1w-y4h-Oh95AW9RcCmmjRb0CUpSqvw/view?usp=sharing)