### PR TITLE
Sitemap.aspx does not produce alternate links in multilingual website

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/SitemapBuilder.cs
+++ b/DNN Platform/Library/Services/Sitemap/SitemapBuilder.cs
@@ -362,17 +362,18 @@ namespace DotNetNuke.Services.Sitemap
             writer.WriteElementString("changefreq", sitemapUrl.ChangeFrequency.ToString().ToLowerInvariant());
             writer.WriteElementString("priority", sitemapUrl.Priority.ToString("F01", CultureInfo.InvariantCulture));
 
-            //if (sitemapUrl.AlternateUrls != null)
-            //{
-            //    foreach (AlternateUrl alternate in sitemapUrl.AlternateUrls)
-            //    {
-            //        writer.WriteStartElement("link", "http://www.w3.org/1999/xhtml");
-            //        writer.WriteAttributeString("rel", "alternate");
-            //        writer.WriteAttributeString("hreflang", alternate.Language);
-            //        writer.WriteAttributeString("href", alternate.Url);
-            //        writer.WriteEndElement();
-            //    }
-            //}
+            if (sitemapUrl.AlternateUrls != null)
+            {
+                foreach (var alternate in sitemapUrl.AlternateUrls)
+                {
+                    writer.WriteStartElement("link", "http://www.w3.org/1999/xhtml");
+                    writer.WriteAttributeString("rel", "alternate");
+                    writer.WriteAttributeString("hreflang", alternate.Language);
+                    writer.WriteAttributeString("href", alternate.Url);
+                    writer.WriteEndElement();
+                }
+            }
+
             writer.WriteEndElement();
         }
 


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2819

See demo: [DEMO](https://drive.google.com/file/d/1ewxm5j7-fvbOeey1CZpac9A3xcMrFBgY/view?usp=sharing)

To validate generated sitemap, there is a bunch of validators available. Validation requires sitemap.xml to be available on public. To pass xml from local environment to public, I generated sitemap locally and mock xml response using [mocky.io](https://www.mocky.io/). Passing public URL to the validator does the trick. No issues detected.

Please be noted, adding `xhtml:link` tags makes xml broken to be displayed in browser, however, document parses correctly in a sitemap validators and looks as per official google documentation, see [Sitemap](https://support.google.com/webmasters/answer/189077) chapter.