### PR TITLE
Fixes an issue with the boolean values in the Google Analytics Connector

### DIFF
--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -134,8 +134,8 @@ namespace DNN.Connectors.GoogleAnalytics
                 { "TrackAdministrators", trackForAdmin},
                 { "AnonymizeIp", anonymizeIp},
                 { "TrackUserId", trackUserId},
-                { "DataConsent", HandleCustomBoolean(portalSettings.DataConsentActive) },
-                { "isDeactivating", HandleCustomBoolean(false) }
+                { "DataConsent", HandleCustomBoolean(portalSettings.DataConsentActive.ToString()) },
+                { "isDeactivating", HandleCustomBoolean("false") }
             };
 
             return configItems;

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -134,7 +134,7 @@ namespace DNN.Connectors.GoogleAnalytics
                 { "TrackAdministrators", trackForAdmin},
                 { "AnonymizeIp", anonymizeIp},
                 { "TrackUserId", trackUserId},
-                { "DataConsent", portalSettings.DataConsentActive ? "true" : ""},
+                { "DataConsent", HandleCustomBoolean(portalSettings.DataConsentActive) },
                 { "isDeactivating", ""}
             };
 

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -149,7 +149,7 @@ namespace DNN.Connectors.GoogleAnalytics
         /// <returns></returns>
         private string HandleCustomBoolean(string value)
         {
-            if (value.ToLowerInvariant().Trim() == "true")
+            if (value.Trim().Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 return "true";
             }

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -87,7 +87,7 @@ namespace DNN.Connectors.GoogleAnalytics
             var analyticsConfig = AnalyticsConfiguration.GetConfig("GoogleAnalytics");
             var portalSettings = new PortalSettings(portalId);
 
-            // Important, knockout handles emptry strings as false and any other string as true
+            // Important, knockout handles empty strings as false and any other string as true
             // so we need to pass empty strings when we mean false, however it passes us back the string "false"
             // when saving the settings in the SaveConfig method, so we need to handle that case too
             var trackingId = string.Empty;

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -190,7 +190,7 @@ namespace DNN.Connectors.GoogleAnalytics
                 else
                 {
                     trackingID = values["TrackingID"] != null ? values["TrackingID"].ToLowerInvariant().Trim() : string.Empty;
-                    urlParameter = values["UrlParameter"] != null ? values["UrlParameter"].ToLowerInvariant().Trim() : string.Empty;
+                    urlParameter = values["UrlParameter"]?.Trim() ?? string.Empty;
                     trackForAdmin = values["TrackAdministrators"] != null ? values["TrackAdministrators"].ToLowerInvariant().Trim() : string.Empty;
                     anonymizeIp = values["AnonymizeIp"] != null ? values["AnonymizeIp"].ToLowerInvariant().Trim() : string.Empty;
                     trackUserId = values["TrackUserId"] != null ? values["TrackUserId"].ToLowerInvariant().Trim() : string.Empty;

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -135,7 +135,7 @@ namespace DNN.Connectors.GoogleAnalytics
                 { "AnonymizeIp", anonymizeIp},
                 { "TrackUserId", trackUserId},
                 { "DataConsent", HandleCustomBoolean(portalSettings.DataConsentActive) },
-                { "isDeactivating", ""}
+                { "isDeactivating", HandleCustomBoolean(false) }
             };
 
             return configItems;

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -89,7 +89,7 @@ namespace DNN.Connectors.GoogleAnalytics
 
             // Important, knockout handles emptry strings as false and any other string as true
             // so we need to pass empty strings when we mean false, however it passes us back the string "false"
-            // when saving the settins in the SaveConfig method, so we need to handle that case too
+            // when saving the settings in the SaveConfig method, so we need to handle that case too
             var trackingId = string.Empty;
             var urlParameter = string.Empty;
             var trackForAdmin = string.Empty;

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using DotNetNuke.Entities.Portals;
+﻿using DotNetNuke.Entities.Portals;
 using DotNetNuke.Services.Analytics.Config;
 using DotNetNuke.Services.Connections;
 using DotNetNuke.Services.Exceptions;
 using DotNetNuke.Services.Localization;
+using System;
+using System.Collections.Generic;
 
 namespace DNN.Connectors.GoogleAnalytics
 {
@@ -88,11 +87,14 @@ namespace DNN.Connectors.GoogleAnalytics
             var analyticsConfig = AnalyticsConfiguration.GetConfig("GoogleAnalytics");
             var portalSettings = new PortalSettings(portalId);
 
-            var trackingId = String.Empty;
-            var urlParameter = String.Empty;
-            var trackForAdmin = false;
-            var anonymizeIp = false;
-            var trackUserId = false;
+            // Important, knockout handles emptry strings as false and any other string as true
+            // so we need to pass empty strings when we mean false, however it passes us back the string "false"
+            // when saving the settins in the SaveConfig method, so we need to handle that case too
+            var trackingId = string.Empty;
+            var urlParameter = string.Empty;
+            var trackForAdmin = string.Empty;
+            var anonymizeIp = string.Empty;
+            var trackUserId = string.Empty;
 
             if (analyticsConfig != null)
             {
@@ -108,22 +110,13 @@ namespace DNN.Connectors.GoogleAnalytics
                             urlParameter = setting.SettingValue;
                             break;
                         case "trackforadmin":
-                            if (!bool.TryParse(setting.SettingValue, out trackForAdmin))
-                            {
-                                trackForAdmin = true;
-                            }
+                            trackForAdmin = HandleCustomBoolean(setting.SettingValue);
                             break;
                         case "anonymizeip":
-                            if (!bool.TryParse(setting.SettingValue, out anonymizeIp))
-                            {
-                                anonymizeIp = false;
-                            }
+                            anonymizeIp = HandleCustomBoolean(setting.SettingValue);
                             break;
                         case "trackuserid":
-                            if (!bool.TryParse(setting.SettingValue, out trackUserId))
-                            {
-                                trackUserId = false;
-                            }
+                            trackUserId = HandleCustomBoolean(setting.SettingValue);
                             break;
                     }
                 }
@@ -131,21 +124,36 @@ namespace DNN.Connectors.GoogleAnalytics
 
             if (portalSettings.DataConsentActive)
             {
-                anonymizeIp = true;
+                anonymizeIp = "true";
             }
 
             var configItems = new Dictionary<string, string>
             {
                 { "TrackingID", trackingId },
                 { "UrlParameter", urlParameter},
-                { "TrackAdministrators", trackForAdmin.ToString()},
-                { "AnonymizeIp", anonymizeIp.ToString()},
-                { "TrackUserId", trackUserId.ToString()},
-                { "DataConsent", portalSettings.DataConsentActive.ToString()},
-                { "isDeactivating", false.ToString()}
+                { "TrackAdministrators", trackForAdmin},
+                { "AnonymizeIp", anonymizeIp},
+                { "TrackUserId", trackUserId},
+                { "DataConsent", portalSettings.DataConsentActive ? "true" : ""},
+                { "isDeactivating", ""}
             };
 
             return configItems;
+        }
+
+        /// <summary>
+        /// Handles custom conversion from "true" => "true"
+        /// Anything else to "" to support the strange knockout handling of string as booleans
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private string HandleCustomBoolean(string value)
+        {
+            if (value.ToLowerInvariant().Trim() == "true")
+            {
+                return "true";
+            }
+            return "";
         }
 
         public bool SaveConfig(int portalId, IDictionary<string, string> values, ref bool validated, out string customErrorMessage)
@@ -165,9 +173,9 @@ namespace DNN.Connectors.GoogleAnalytics
 
                 string trackingID;
                 string urlParameter;
-                bool trackForAdmin;
-                bool anonymizeIp;
-                bool trackUserId;
+                string trackForAdmin;
+                string anonymizeIp;
+                string trackUserId;
 
                 isValid = true;
 
@@ -175,18 +183,17 @@ namespace DNN.Connectors.GoogleAnalytics
                 {
                     trackingID = null;
                     urlParameter = null;
-                    trackForAdmin = false;
-                    anonymizeIp = false;
-                    trackUserId = false;
+                    trackForAdmin = null;
+                    anonymizeIp = null;
+                    trackUserId = null;
                 }
                 else
                 {
-                    trackingID = values["TrackingID"] != null ? values["TrackingID"].ToString().Trim() : String.Empty;
-                    urlParameter = values["UrlParameter"] != null ? values["UrlParameter"].ToString().Trim() : String.Empty;
-
-                    bool.TryParse(values["TrackAdministrators"].ToLowerInvariant(), out trackForAdmin);
-                    bool.TryParse(values["AnonymizeIp"].ToLowerInvariant(), out anonymizeIp);
-                    bool.TryParse(values["TrackUserId"].ToLowerInvariant(), out trackUserId);
+                    trackingID = values["TrackingID"] != null ? values["TrackingID"].ToLowerInvariant().Trim() : string.Empty;
+                    urlParameter = values["UrlParameter"] != null ? values["UrlParameter"].ToLowerInvariant().Trim() : string.Empty;
+                    trackForAdmin = values["TrackAdministrators"] != null ? values["TrackAdministrators"].ToLowerInvariant().Trim() : string.Empty;
+                    anonymizeIp = values["AnonymizeIp"] != null ? values["AnonymizeIp"].ToLowerInvariant().Trim() : string.Empty;
+                    trackUserId = values["TrackUserId"] != null ? values["TrackUserId"].ToLowerInvariant().Trim() : string.Empty;
 
                     if (String.IsNullOrEmpty(trackingID))
                     {
@@ -219,24 +226,23 @@ namespace DNN.Connectors.GoogleAnalytics
                     config.Settings.Add(new AnalyticsSetting
                     {
                         SettingName = "TrackForAdmin",
-                        SettingValue = trackForAdmin.ToString().ToLowerInvariant()
+                        SettingValue = trackForAdmin
                     });
 
                     config.Settings.Add(new AnalyticsSetting
                     {
                         SettingName = "AnonymizeIp",
-                        SettingValue = anonymizeIp.ToString().ToLowerInvariant()
+                        SettingValue = anonymizeIp
                     });
 
                     config.Settings.Add(new AnalyticsSetting
                     {
                         SettingName = "TrackUserId",
-                        SettingValue = trackUserId.ToString().ToLowerInvariant()
+                        SettingValue = trackUserId
                     });
 
                     AnalyticsConfiguration.SaveConfig("GoogleAnalytics", config);
                 }
-
 
                 return isValid;
             }

--- a/DNN Platform/Connectors/GoogleAnalytics/Scripts/connector.js
+++ b/DNN Platform/Connectors/GoogleAnalytics/Scripts/connector.js
@@ -55,11 +55,9 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
             if (bindViewModel.buttons().length === 1) {
 
                 activateDeleteButton(conn);
-
             }
-
+            utility.notify((utility.resx.Connectors || utility.resx.PersonaBar).txt_Saved, true);
         }
-
     };
 
     var activateDeleteButton = function (conn) {
@@ -126,11 +124,9 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
     };
 
     return {
-
         init: init,
         onSave: onSave,
         getActionButtons: getActionButtons
-
     };
 
 });


### PR DESCRIPTION
Right or wrong the connectors infrastructure only supports passing strings as config values. Knockout has a strange behaviour where it treats any string as true and empty strings as false. However we get back from the connector UI either "true" or "false" for some reason. This PR handles this difference of behaviour when sending and receiving the settings for boolean values.

I have tested that it saves "false" or "true" in the database and that this PR restores the module UI problem, however I am not sure then where those database values are used, so testing that could be nice :)

It also adds a confirmation on save since that part was missing compared to the Azure Connector.