### PR TITLE
Closes Issue#2885: Allow multiple DesktopModules in a single package

### DIFF
--- a/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
@@ -540,6 +540,12 @@ namespace DotNetNuke.Entities.Modules
                         case "moduleName":
                             ModuleName = reader.ReadElementContentAsString();
                             break;
+                        case "friendlyName":
+                            FriendlyName = reader.ReadElementContentAsString();
+                            break;
+                        case "description":
+                            Description = reader.ReadElementContentAsString();
+                            break;
                         case "foldername":
                             FolderName = reader.ReadElementContentAsString();
                             break;

--- a/DNN Platform/Library/Services/Installer/Installers/ModuleInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/ModuleInstaller.cs
@@ -296,8 +296,13 @@ namespace DotNetNuke.Services.Installer.Installers
             //Load the Desktop Module from the manifest
             _desktopModule = CBO.DeserializeObject<DesktopModuleInfo>(new StringReader(manifestNav.InnerXml));
 
-            _desktopModule.FriendlyName = Package.FriendlyName;
-            _desktopModule.Description = Package.Description;
+            // Allow a <component type="Module"> (i.e. a DesktopModule) to have its own friendlyname / description.
+            // This allows multiple DesktopModules in one Package, allowing large MVC packages which share one assembly
+            // but have many functions.
+            if( _desktopModule.FriendlyName == null || _desktopModule.FriendlyName.Trim().Length == 0 )
+                _desktopModule.FriendlyName = Package.FriendlyName;
+            if (_desktopModule.Description == null || _desktopModule.Description.Trim().Length == 0)
+                _desktopModule.Description = Package.Description;
             _desktopModule.Version = Globals.FormatVersion(Package.Version, "00", 4, ".");
             _desktopModule.CompatibleVersions = Null.NullString;
             _desktopModule.Dependencies = Null.NullString;


### PR DESCRIPTION
Please refer to Issue #2885 

Also PR #2886 2886 is the same as this, but was originally made against a 9.3.2 branch causing a minor conflict. This PR has been closed in favor of this one.

## Summary
A very simple change to the DesktopModule installation logic allowing multiple DesktopModules in a single Package.