### PR TITLE
Missing encoding in email alternate view

### DIFF
--- a/DNN Platform/Library/Services/Mail/Mail.cs
+++ b/DNN Platform/Library/Services/Mail/Mail.cs
@@ -104,15 +104,7 @@ namespace DotNetNuke.Services.Mail
             mailMessage.Subject = HtmlUtils.StripWhiteSpace(subject, true);
             mailMessage.BodyEncoding = bodyEncoding;
 
-            //added support for multipart html messages
-            //add text part as alternate view
-            var PlainView = AlternateView.CreateAlternateViewFromString(ConvertToText(body), null, "text/plain");
-            mailMessage.AlternateViews.Add(PlainView);
-            if (mailMessage.IsBodyHtml)
-            {
-                var HTMLView = AlternateView.CreateAlternateViewFromString(body, null, "text/html");
-                mailMessage.AlternateViews.Add(HTMLView);
-            }
+            AddAlternateView(mailMessage, body, bodyEncoding);
 
             smtpServer = smtpServer.Trim();
             if (SmtpServerRegex.IsMatch(smtpServer))
@@ -196,6 +188,19 @@ namespace DotNetNuke.Services.Mail
             }
             
             return retValue;
+        }
+
+        internal static void AddAlternateView(MailMessage mailMessage, string body, Encoding bodyEncoding)
+        {   
+            //added support for multipart html messages
+            //add text part as alternate view
+            var PlainView = AlternateView.CreateAlternateViewFromString(ConvertToText(body), bodyEncoding, "text/plain");
+            mailMessage.AlternateViews.Add(PlainView);
+            if (mailMessage.IsBodyHtml)
+            {
+                var HTMLView = AlternateView.CreateAlternateViewFromString(body, bodyEncoding, "text/html");
+                mailMessage.AlternateViews.Add(HTMLView);
+            }
         }
 
         #endregion

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Services\CryptographyProviders\FipsCompilanceCryptographyProviderTests.cs" />
     <Compile Include="Services\CryptographyProviders\CoreCryptographyProviderTests.cs" />
     <Compile Include="Services\Localization\LocalizationTests.cs" />
+    <Compile Include="Services\Mail\MailTests.cs" />
     <Compile Include="Services\Mobile\PreviewProfileControllerTests.cs" />
     <Compile Include="Services\Mobile\RedirectionControllerTests.cs" />
     <Compile Include="Services\Tokens\TokenReplaceTests.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mail/MailTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mail/MailTests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Text;
 using NUnit.Framework;
 
 namespace DotNetNuke.Tests.Core.Services.Mail
@@ -35,7 +38,126 @@ namespace DotNetNuke.Tests.Core.Services.Mail
             //act
             var result = sut("<style>\r\nHello</style>World");     
             //assert
-            Assert.AreEqual("World", result.Trim());
+            Assert.AreEqual("Hello World", result.Trim());
+        }
+        [Test]
+        public void GivenBodyIsNotHtmlWhenAddAlternateViewThenShouldContainsPlainViewOnly()
+        {
+            // special character
+            MailMessage mailMessage = new MailMessage()
+            {
+                IsBodyHtml = false
+            };
+            ContentType plain = new ContentType("text/plain")
+            {
+                CharSet = "us-ascii"
+            };
+            AlternateView plainView = AlternateView.CreateAlternateViewFromString("body\n", plain);
+            
+            DotNetNuke.Services.Mail.Mail.AddAlternateView(mailMessage, "body\n", Encoding.ASCII);
+
+            AssertEqualAlternativeView(plainView, mailMessage.AlternateViews[0]);
+            Assert.AreEqual(1, mailMessage.AlternateViews.Count);
+        }
+
+        [Test]
+        public void GivenBodyHtmlWhenAddAlternateViewThenShouldContainsPlainAndHtmlViews()
+        {
+            // special character
+            MailMessage mailMessage = new MailMessage()
+            {
+                IsBodyHtml = true
+            };
+            ContentType plain = new ContentType("text/plain")
+            {
+                CharSet = "us-ascii"
+            };
+            ContentType html = new ContentType("text/html")
+            {
+                CharSet = "us-ascii"
+            };
+            AlternateView plainView = AlternateView.CreateAlternateViewFromString("body\n", plain);
+            AlternateView htmlView = AlternateView.CreateAlternateViewFromString("body\n", html);
+
+            DotNetNuke.Services.Mail.Mail.AddAlternateView(mailMessage, "body\n", Encoding.ASCII);
+
+            AssertEqualAlternativeView(plainView, mailMessage.AlternateViews[0]);
+            AssertEqualAlternativeView(htmlView, mailMessage.AlternateViews[1]);
+            Assert.AreEqual(2, mailMessage.AlternateViews.Count);
+        }
+
+        private static void AssertEqualAlternativeView(AlternateView expected, AlternateView actual)
+        {
+            Assert.AreEqual(expected.ContentType, expected.ContentType);
+            Assert.AreEqual(expected.ContentStream, expected.ContentStream);
+        }
+        
+        [Test]
+        public void GivenEncodingIsAsciiWhenAddAlternateViewThenCharsetShouldAlwaysAscii()
+        {
+            // special character
+            MailMessage mailMessage = new MailMessage()
+            {
+                IsBodyHtml = true
+            };
+            ContentType plain = new ContentType("text/plain")
+            {
+                CharSet = "us-ascii"
+            };
+            ContentType html = new ContentType("text/html")
+            {
+                CharSet = "us-ascii"
+            };
+
+            DotNetNuke.Services.Mail.Mail.AddAlternateView(mailMessage, "body\n", Encoding.ASCII);
+
+            Assert.AreEqual(plain, mailMessage.AlternateViews[0].ContentType);
+            Assert.AreEqual(html, mailMessage.AlternateViews[1].ContentType);
+
+            // no special character
+            mailMessage = new MailMessage()
+            {
+                IsBodyHtml = true
+            };
+
+            DotNetNuke.Services.Mail.Mail.AddAlternateView(mailMessage, "body", Encoding.ASCII);
+
+            Assert.AreEqual(plain, mailMessage.AlternateViews[0].ContentType);
+            Assert.AreEqual(html, mailMessage.AlternateViews[1].ContentType);
+        }
+
+        [Test]
+        public void GivenBodyEncodingIsUTF8WhenAddAlternateViewThenCharsetShouldAwaysUTF8()
+        {
+            // special character
+            MailMessage mailMessage = new MailMessage()
+            {
+                IsBodyHtml = true
+            };
+            ContentType plain = new ContentType("text/plain")
+            {
+                CharSet = "utf-8"
+            };
+            ContentType html = new ContentType("text/html")
+            {
+                CharSet = "utf-8"
+            };
+
+            DotNetNuke.Services.Mail.Mail.AddAlternateView(mailMessage, "body\n", Encoding.UTF8);
+
+            Assert.AreEqual(plain, mailMessage.AlternateViews[0].ContentType);
+            Assert.AreEqual(html, mailMessage.AlternateViews[1].ContentType);
+
+            // no special character
+            mailMessage = mailMessage = new MailMessage()
+            {
+                IsBodyHtml = true
+            };
+
+            DotNetNuke.Services.Mail.Mail.AddAlternateView(mailMessage, "body", Encoding.UTF8);
+
+            Assert.AreEqual(plain, mailMessage.AlternateViews[0].ContentType);
+            Assert.AreEqual(html, mailMessage.AlternateViews[1].ContentType);
         }
     }
 }


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->
Fixes #2899

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
Set AlternativeView.Encoding with bodyEncoding
- This is to ensure AlternativeView encoding is always consistent with bodyEncoding and not relying on the body text
- Extract the code to AddAlternateView method to allow UTs
Notes: UT covered existing behavior even not part of the changes. Minor fix to the existing test method (ConvertToText_removes_styles_including_css_defs) 
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
Confirmation Video - https://drive.google.com/file/d/1tiz3ce6gJtVrD4ZclsRX-Z3PDaryFbSr/view