### PR TITLE
CK Editor: Browser - Taking a long time to load [Performance Issue]

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
@@ -23,7 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using DotNetNuke.Common;
 using DotNetNuke.Common.Internal;
 using DotNetNuke.Common.Utilities;
@@ -39,7 +38,7 @@ namespace DotNetNuke.Services.FileSystem
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(StandardFolderProvider));
 
-        private static readonly Regex InvalidFileUrlCharsRegex = new Regex(@"[%;?:@&=+$,]", RegexOptions.Compiled);
+        private static readonly char[] InvalidFileUrlChars = new char[] { '%', ';', '?', ':', '@', '&', '=', '+', '$', ',' };
 
         #region Public Properties
 
@@ -193,13 +192,16 @@ namespace DotNetNuke.Services.FileSystem
         {
             Requires.NotNull("file", file);
 
-            var portalSettings = GetPortalSettings(file.PortalId);
+            var portalSettings = file.PortalId == PortalSettings.Current.PortalId ?
+                PortalSettings.Current : 
+                GetPortalSettings(file.PortalId);
+
             var rootFolder = file.PortalId == Null.NullInteger ? Globals.HostPath : portalSettings.HomeDirectory;
 
             var fullPath = rootFolder + file.Folder + file.FileName;
 
             //check if a filename has a character that is not valid for urls
-            if (InvalidFileUrlCharsRegex.IsMatch(fullPath))
+            if (fullPath.IndexOfAny(InvalidFileUrlChars) >= 0)
             {
                 return Globals.LinkClick(String.Format("fileid={0}", file.FileId), Null.NullInteger, Null.NullInteger);
             }

--- a/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
@@ -192,7 +192,7 @@ namespace DotNetNuke.Services.FileSystem
         {
             Requires.NotNull("file", file);
 
-            var portalSettings = file.PortalId == PortalSettings.Current.PortalId ?
+            var portalSettings = file.PortalId == PortalSettings.Current?.PortalId ?
                 PortalSettings.Current : 
                 GetPortalSettings(file.PortalId);
 


### PR DESCRIPTION
partially fixes https://github.com/DNN-Connect/CKEditorProvider/issues/121

This is an improvement into the DNN.Platform that will help to avoid performance issues when loading list of files on a browsing using CKEditor.
Having a huge amount of files (tested 80K files in one folder), it was detected that application invokes `GetUrl` method on every iteration. Using performance analyzer I found it invokes and builds portal setting every time we want to get URL.

Suggested 2 simple but very important improvements:
1. Avoid regex. Instead of that, I used `Arrays` and `IndexOfAny` to check for an invalid characters. It is 5X times faster vs. regular expressions we used before.
2. No need to create portal settings every time. We are getting list of files linked to a particular portal, so just ensuring that we use current portal id we can re-user instance of current settings. 