### PR TITLE
Removes duplication of license files for javascript libraries

### DIFF
--- a/DNN Platform/JavaScript Libraries/Knockout/Knockout.dnn
+++ b/DNN Platform/JavaScript Libraries/Knockout/Knockout.dnn
@@ -30,14 +30,6 @@
             </jsfile>
           </jsfiles>
         </component>
-        <component type="File">
-          <files>
-            <basePath>Licenses</basePath>
-            <file>
-              <name>Knockout (MIT).txt</name>
-            </file>
-          </files>
-        </component>
         <component type="Cleanup" version="02.02.01" fileName="02.02.01.txt" />
       </components>
     </package>

--- a/DNN Platform/JavaScript Libraries/KnockoutMapping/KnockoutMapping.dnn
+++ b/DNN Platform/JavaScript Libraries/KnockoutMapping/KnockoutMapping.dnn
@@ -33,15 +33,7 @@
               <name>knockout.mapping.js</name>
             </jsfile>
           </jsfiles>
-        </component>
-        <component type="File">
-          <files>
-            <basePath>Licenses</basePath>
-            <file>
-              <name>Knockout Mapping (MIT).txt</name>
-            </file>
-          </files>
-        </component>
+        </component>       
         <component type="Cleanup" version="02.04.01" fileName="02.04.01.txt" />
       </components>
     </package>

--- a/DNN Platform/JavaScript Libraries/Selectize/Selectize.dnn
+++ b/DNN Platform/JavaScript Libraries/Selectize/Selectize.dnn
@@ -29,15 +29,7 @@
               <name>selectize.min.js</name>
             </jsfile>
           </jsfiles>
-        </component>
-        <component type="File">
-          <files>
-            <basePath>Licenses</basePath>
-            <file>
-              <name>Selectize (Apache).txt</name>
-            </file>
-          </files>
-        </component>
+        </component>        
         <component type="File">
           <files>
             <basePath>Resources\Libraries\Selectize\00_12_06</basePath>

--- a/DNN Platform/JavaScript Libraries/jQuery/jQuery.dnn
+++ b/DNN Platform/JavaScript Libraries/jQuery/jQuery.dnn
@@ -32,15 +32,7 @@
               <name>jquery.min.map</name>
             </jsfile>
           </jsfiles>
-        </component>
-        <component type="File">
-          <files>
-            <basePath>Licenses</basePath>
-            <file>
-              <name>jQuery (MIT).txt</name>
-            </file>
-          </files>
-        </component>
+        </component>        
         <component type="Cleanup" version="01.09.01" fileName="01.09.01.txt" />
       </components>
     </package>

--- a/DNN Platform/JavaScript Libraries/jQueryMigrate/jQueryMigrate.dnn
+++ b/DNN Platform/JavaScript Libraries/jQueryMigrate/jQueryMigrate.dnn
@@ -31,15 +31,7 @@
               <name>jquery-migrate.js</name>
             </jsfile>
           </jsfiles>
-        </component>
-        <component type="File">
-          <files>
-            <basePath>Licenses</basePath>
-            <file>
-              <name>jQuery (MIT).txt</name>
-            </file>
-          </files>
-        </component>
+        </component>       
         <component type="Cleanup" version="01.02.01" fileName="01.02.01.txt" />
       </components>
     </package>

--- a/DNN Platform/JavaScript Libraries/jQueryUI/jQueryUI.dnn
+++ b/DNN Platform/JavaScript Libraries/jQueryUI/jQueryUI.dnn
@@ -31,15 +31,7 @@
               <name>jquery-ui.js</name>
             </jsfile>
           </jsfiles>
-        </component>
-        <component type="File">
-          <files>
-            <basePath>Licenses</basePath>
-            <file>
-              <name>jQuery UI (MIT).txt</name>
-            </file>
-          </files>
-        </component>
+        </component>        
         <component type="Cleanup" version="01.10.03" fileName="01.10.03.txt" />
         <component type="Cleanup" version="01.11.03" fileName="01.11.03.txt" />
       </components>


### PR DESCRIPTION
Redo of previously submitted PR #2912  that got messed up.

Closes #2904 

Removes a duplication of license files already in the Licenses folder but also put there by the installer.