### PR TITLE
DNN-31366 - Deleted page can still be selected as parent page

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -2473,7 +2473,8 @@ namespace DotNetNuke.Entities.Tabs
                                  false,
                                  false,
                                  false,
-                                 false);
+                                 false,
+                                 true);
         }
 
         /// <summary>
@@ -2497,7 +2498,8 @@ namespace DotNetNuke.Entities.Tabs
                                  includeDeleted,
                                  includeURL,
                                  false,
-                                 false);
+                                 false,
+                                 true);
         }
 
         /// <summary>
@@ -2525,7 +2527,8 @@ namespace DotNetNuke.Entities.Tabs
                                  includeDeleted,
                                  includeURL,
                                  checkViewPermisison,
-                                 checkEditPermission);
+                                 checkEditPermission,
+                                 true);
         }
 
         /// <summary>
@@ -2544,6 +2547,45 @@ namespace DotNetNuke.Entities.Tabs
         public static List<TabInfo> GetPortalTabs(List<TabInfo> tabs, int excludeTabId, bool includeNoneSpecified,
                                                   string noneSpecifiedText, bool includeHidden, bool includeDeleted, bool includeURL,
                                                   bool checkViewPermisison, bool checkEditPermission)
+        {
+            return GetPortalTabs(
+                tabs,
+                excludeTabId,
+                includeNoneSpecified,
+                noneSpecifiedText,
+                includeHidden,
+                includeDeleted,
+                includeURL,
+                checkViewPermisison,
+                checkEditPermission,
+                true);
+        }
+
+        /// <summary>
+        /// Gets the portal tabs.
+        /// </summary>
+        /// <param name="tabs">The tabs.</param>
+        /// <param name="excludeTabId">The exclude tab id.</param>
+        /// <param name="includeNoneSpecified">if set to <c>true</c> [include none specified].</param>
+        /// <param name="noneSpecifiedText">The none specified text.</param>
+        /// <param name="includeHidden">if set to <c>true</c> [include hidden].</param>
+        /// <param name="includeDeleted">if set to <c>true</c> [include deleted].</param>
+        /// <param name="includeURL">if set to <c>true</c> [include URL].</param>
+        /// <param name="checkViewPermisison">if set to <c>true</c> [check view permisison].</param>
+        /// <param name="checkEditPermission">if set to <c>true</c> [check edit permission].</param>
+        /// <param name="includeDeletedChildren">The value of this parameter affects <see cref="TabInfo.HasChildren"></see> property.</param>
+        /// <returns></returns>
+        public static List<TabInfo> GetPortalTabs(
+            List<TabInfo> tabs,
+            int excludeTabId,
+            bool includeNoneSpecified,
+            string noneSpecifiedText,
+            bool includeHidden,
+            bool includeDeleted,
+            bool includeURL,
+            bool checkViewPermisison,
+            bool checkEditPermission,
+            bool includeDeletedChildren)
         {
             var listTabs = new List<TabInfo>();
             if (includeNoneSpecified)
@@ -2583,8 +2625,8 @@ namespace DotNetNuke.Entities.Tabs
 
                     // HasChildren should be true in case there is at least one not deleted child
                     tab.HasChildren &=
-                        includeDeleted || (
-                            !includeDeleted &&
+                        includeDeletedChildren || (
+                            !includeDeletedChildren &&
                             GetTabsByParent(tab.TabID, tab.PortalID)
                                 .Any(a => !a.IsDeleted));
                 }

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -2580,6 +2580,13 @@ namespace DotNetNuke.Entities.Tabs
                             listTabs.Add(tab);
                         }
                     }
+
+                    // HasChildren should be true in case there is at least one not deleted child
+                    tab.HasChildren &=
+                        includeDeleted || (
+                            !includeDeleted &&
+                            GetTabsByParent(tab.TabID, tab.PortalID)
+                                .Any(a => !a.IsDeleted));
                 }
             }
             return listTabs;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Partially Fixes #2919 (There are total 2 PRs; for the other PR, you can check: https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1082 ).

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
A new overload which accepts an additional parameter named as "includeDeletedChildren" is added.

Demo: https://drive.google.com/open?id=1yg6OuVuLMbwCbBlFHXDqQa8Abd3WPIn_

Note: This PR should be merged BEFORE https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1082