### PR TITLE
Fix error running unit tests

### DIFF
--- a/Build/Cake/unit-tests.cake
+++ b/Build/Cake/unit-tests.cake
@@ -2,7 +2,7 @@
 Task("EnsureAllProjectsBuilt")
   .IsDependentOn("UpdateDnnManifests")
   .IsDependentOn("Restore-NuGet-Packages")
-  .Does(() => 
+  .Does(() =>
   {
     MSBuild("DNN_Platform.sln", new MSBuildSettings {
       Verbosity = Verbosity.Minimal,
@@ -13,21 +13,31 @@ Task("EnsureAllProjectsBuilt")
 
 Task("UnitTests")
   .IsDependentOn("EnsureAllProjectsBuilt")
-  .Does(() => 
+  .Does(() =>
   {
     var testAssemblies = GetFiles($@"**\bin\{configuration}\DotNetNuke.Tests.*.dll");
     testAssemblies -= GetFiles(@"**\DotNetNuke.Tests.Data.dll");
     testAssemblies -= GetFiles(@"**\DotNetNuke.Tests.Integration.dll");
     testAssemblies -= GetFiles(@"**\DotNetNuke.Tests.Utilities.dll");
     testAssemblies -= GetFiles(@"**\DotNetNuke.Tests.Urls.dll");
-  
-    foreach(var file in testAssemblies) {
-        VSTest(file.FullPath, new VSTestSettings() { 
-          Logger = $"trx;LogFileName={file.GetFilename()}.xml",
-          Parallel = true,
-          EnableCodeCoverage = true,
-          FrameworkVersion = VSTestFrameworkVersion.NET45,
-          TestAdapterPath = @"tools\NUnitTestAdapter.2.1.1\tools"
-        });
+
+    foreach (var file in testAssemblies) {
+      VSTest(file.FullPath, FixToolPath(new VSTestSettings() {
+        Logger = $"trx;LogFileName={file.GetFilename()}.xml",
+        Parallel = true,
+        EnableCodeCoverage = true,
+        FrameworkVersion = VSTestFrameworkVersion.NET45,
+        TestAdapterPath = @"tools\NUnitTestAdapter.2.1.1\tools"
+      }));
     }
   });
+
+// https://github.com/cake-build/cake/issues/1522
+VSTestSettings FixToolPath(VSTestSettings settings)
+{
+    #tool vswhere
+    settings.ToolPath =
+        VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.VisualStudio.PackageGroup.TestTools.Core" })
+        .CombineWithFilePath(File(@"Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"));
+    return settings;
+}


### PR DESCRIPTION
When running tests, the following error occurs:
>VSTest: Could not locate executable.

https://github.com/cake-build/cake/issues/1522#issuecomment-341612194 indicates that there's an issue using VS 2019, and presents a workaround to find the correct path