### PR TITLE
deleting_themes_from_Extensions_doesnt_remove_it_from_themes

### DIFF
--- a/DNN Platform/Library/Common/Utilities/FileSystemUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/FileSystemUtils.cs
@@ -200,7 +200,7 @@ namespace DotNetNuke.Common.Utilities
             try
             {
 				//Open File Stream
-                fs = File.OpenRead(filePath.Replace("/", "\\"));
+                fs = File.OpenRead(FixPath(filePath));
 				
 				//Read file into byte array buffer
                 var buffer = new byte[fs.Length];
@@ -234,7 +234,7 @@ namespace DotNetNuke.Common.Utilities
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Trys to copy a file in the file system
+        /// Tries to copy a file in the file system
         /// </summary>
         /// <param name="sourceFileName">The name of the source file</param>
         /// <param name="destFileName">The name of the destination file</param>
@@ -253,16 +253,17 @@ namespace DotNetNuke.Common.Utilities
         /// Deletes file in areas with a high degree of concurrent file access (i.e. caching, logging) 
         /// This solves file concurrency issues under heavy load.
         /// </summary>
-        /// <param name="filename">String</param>
+        /// <param name="fileName">String</param>
         /// <param name="waitInMilliseconds">Int16</param>
         /// <param name="maxAttempts">Int16</param>
         /// <returns>Boolean</returns>
         /// <remarks>
         /// </remarks>
         /// -----------------------------------------------------------------------------
-        public static bool DeleteFileWithWait(string filename, Int16 waitInMilliseconds, Int16 maxAttempts)
+        public static bool DeleteFileWithWait(string fileName, Int16 waitInMilliseconds, Int16 maxAttempts)
         {
-            if (!File.Exists(filename))
+            fileName = FixPath(fileName);
+            if (!File.Exists(fileName))
             {
                 return true;
             }
@@ -277,9 +278,9 @@ namespace DotNetNuke.Common.Utilities
                 i = i + 1;
                 try
                 {
-                    if (File.Exists(filename))
+                    if (File.Exists(fileName))
                     {
-                        File.Delete(filename);
+                        File.Delete(fileName);
                     }
                     fileDeleted = true; //we don't care if it didn't exist...the operation didn't fail, that's what we care about
                 }
@@ -298,15 +299,15 @@ namespace DotNetNuke.Common.Utilities
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Trys to delete a file from the file system
+        /// Tries to delete a file from the file system
         /// </summary>
 		/// <param name="fileName">The name of the file</param>
         /// -----------------------------------------------------------------------------
         public static void DeleteFile(string fileName)
         {
+            fileName = FixPath(fileName);
             if (File.Exists(fileName))
             {
-                fileName = fileName.Replace('/', '\\');
                 File.SetAttributes(fileName, FileAttributes.Normal);
                 File.Delete(fileName);
             }
@@ -348,7 +349,7 @@ namespace DotNetNuke.Common.Utilities
                     }
                     if (!zipEntry.IsDirectory && (!string.IsNullOrEmpty(localFileName)))
                     {
-                        var fileNamePath = Path.Combine(destPath, localFileName).Replace("/", "\\");
+                        var fileNamePath = FixPath(Path.Combine(destPath, localFileName));
                         try
                         {
                             if (File.Exists(fileNamePath))
@@ -410,7 +411,7 @@ namespace DotNetNuke.Common.Utilities
                     strPath = strPath.Substring(0, pos);
                 }
 
-                strPath = strPath.Trim().Replace("/", "\\").TrimStart('\\');
+                strPath = FixPath(strPath).TrimStart('\\');
                 if (!string.IsNullOrEmpty(strPath))
                 {
                     strPath = Path.Combine(Globals.ApplicationMapPath, strPath);
@@ -457,6 +458,7 @@ namespace DotNetNuke.Common.Utilities
         {
             if (!String.IsNullOrEmpty(strRoot))
             {
+                strRoot = FixPath(strRoot);
                 if (Directory.Exists(strRoot))
                 {
                     foreach (string strFolder in Directory.EnumerateDirectoryPaths(strRoot))
@@ -467,7 +469,7 @@ namespace DotNetNuke.Common.Utilities
                             DeleteFilesRecursive(strFolder, filter);
                         }
                     }
-                    foreach (string strFile in Directory.EnumerateFilePaths(strRoot).Where(f => f.Contains(filter)))
+                    foreach (string strFile in Directory.EnumerateFilePaths(new DirectoryInfo(strRoot)).Where(f => f.Contains(filter)))
                     {
                         try
                         {
@@ -484,8 +486,8 @@ namespace DotNetNuke.Common.Utilities
 
         public static void DeleteFolderRecursive(string strRoot)
         {
-            strRoot = strRoot.Replace("/", "\\");
-            if (string.IsNullOrEmpty(strRoot) || !Directory.Exists(strRoot.Trim()))
+            strRoot = FixPath(strRoot);
+            if (string.IsNullOrEmpty(strRoot) || !Directory.Exists(strRoot))
             {   Logger.Info(strRoot + " does not exist. ");
                 return;
             }
@@ -520,5 +522,14 @@ namespace DotNetNuke.Common.Utilities
             }
         }
 
+        public static string FixPath(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            return input.Trim().Replace("/", "\\");
+        }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
@@ -119,6 +119,50 @@ namespace DotNetNuke.Tests.Core
             }
         }
 
+        [Test]
+        public void DeleteFile_Should_Delete_File()
+        {
+            //Action
+            var testPath = Globals.ApplicationMapPath + $"/Test{Guid.NewGuid().ToString().Substring(0, 8)}.txt";
+            using (StreamWriter sw = File.CreateText(testPath))
+            {
+                sw.WriteLine("48");
+            }
+            
+            FileSystemUtils.DeleteFile(testPath);
+
+            //Assert
+            bool res = File.Exists(testPath.Replace("/", "\\"));
+            Assert.IsFalse(res);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("/")]
+        [TestCase("Test/Test ")]
+        public void FixPath_Should_Change_Slashes_And_Trim(string input)
+        {
+            //Action
+            var result = FileSystemUtils.FixPath(input);
+
+            //Assert
+            if (string.IsNullOrEmpty(input))
+            {
+                Assert.IsTrue(input == result);
+            }
+            else if(string.IsNullOrWhiteSpace(input))
+            {
+                Assert.IsTrue(result == string.Empty);
+            }
+            else
+            {
+                Assert.IsFalse(result.Contains(" "));
+                Assert.IsFalse(result.Contains("/"));
+            }
+
+        }
+
         private void PrepareRootPath(string rootPath)
         {
             if (!Directory.Exists(rootPath))


### PR DESCRIPTION
https://github.com/dnnsoftware/Dnn.Platform/issues/2943

## Summary
Fixed issue with incorrect slash and trimmed whitespaces for validation File.Exists for all cases it checkes file names. UT's are added. 
Also fixed to remove Theme from Extentions without removing it from Theme additionally

fix for DNN-17149 , DNN-32014