### PR TITLE
DNN-29557 - Infinite loop occurs in vocabularies

### DIFF
--- a/DNN Platform/Library/Entities/Content/Taxonomy/Term.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/Term.cs
@@ -176,9 +176,9 @@ namespace DotNetNuke.Entities.Content.Taxonomy
             }
             set
             {
-                while (HtmlUtils.IsUrlEncoded(value))
+                if (HtmlUtils.IsUrlEncoded(value))
                     value = System.Net.WebUtility.UrlDecode(value);
-                while (HtmlUtils.ContainsEntity(value))
+                if (HtmlUtils.ContainsEntity(value))
                     value = System.Net.WebUtility.HtmlDecode(value);
                 _name = Security.InputFilter(value, PortalSecurity.FilterFlag.NoMarkup);
             }


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #2955 
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
If "System.Net.WebUtility.HtmlDecode" returns the same value as the input, it will cause an infinite loop because of the while loop. There are no needs for a while loop here since it's enough for "System.Net.WebUtility.HtmlDecode" to work only once.

Demo: https://drive.google.com/open?id=1nG5P1_drh8Ncx-AvwNcSDI1MANxAz9Ve

Note: The retargeted PR (for release/9.4.x) can be found in #2956 