### PR TITLE
DNN-30542 - Asset Manager activity wheel constantly spins

### DIFF
--- a/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
+++ b/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
@@ -1813,7 +1813,7 @@ dnnModule.digitalAssets = function ($, $find, $telerik, dnnModal) {
         var node = treeView.get_nodes().getItem(0);
         node.expand();
         var p = path.split('/');
-        for (var i = 0; i < p.length; i++) {
+        for (var i = 1; i < p.length; i++) {
             var name = p[i];
             if (name != '') {
                 var nodes = node.get_nodes();


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #2958 
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
For loop should start at the second element since the first element (root) is already expanded and handled before. This is the original PR, you can reach the retargeted PR from https://github.com/dnnsoftware/Dnn.Platform/pull/2970

Demo: https://drive.google.com/open?id=199i4weckQqh4odCwyU8KThuQoflIZ7kP