### PR TITLE
DNN-32726: avoid null reference exception when call to Globals.LinkClick method.

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
@@ -203,7 +203,14 @@ namespace DotNetNuke.Services.FileSystem
             //check if a filename has a character that is not valid for urls
             if (fullPath.IndexOfAny(InvalidFileUrlChars) >= 0)
             {
-                return Globals.LinkClick(String.Format("fileid={0}", file.FileId), Null.NullInteger, Null.NullInteger);
+                return Globals.LinkClick($"fileid={file.FileId}", 
+                    Null.NullInteger, 
+                    Null.NullInteger, 
+                    true, 
+                    false, 
+                    portalSettings.PortalId, 
+                    portalSettings.EnableUrlLanguage, 
+                    portalSettings.GUID.ToString());
             }
 
             // Does site management want the cachebuster parameter?


### PR DESCRIPTION
Fix #2967 