### PR TITLE
Fix potential XML namespace bug

### DIFF
--- a/DNN Platform/Library/Services/Installer/XmlMerge.cs
+++ b/DNN Platform/Library/Services/Installer/XmlMerge.cs
@@ -558,8 +558,10 @@ namespace DotNetNuke.Services.Installer
 
 		                    var targetNodeContent = GetNodeContentWithoutComment(targetNode);
 							XmlComment commentNode = TargetConfig.CreateComment(targetNodeContent);
-                            rootNode.RemoveChild(targetNode);
-                            rootNode.InnerXml = rootNode.InnerXml + commentHeader.OuterXml + commentNode.OuterXml + child.OuterXml;
+                            var newChild = this.TargetConfig.ImportNode(child, true);
+                            rootNode.ReplaceChild(newChild, targetNode);
+                            rootNode.InsertBefore(commentHeader, newChild);
+                            rootNode.InsertBefore(commentNode, newChild);
                             changedNode = true;
                             break;
                         case "ignore":

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/DotNetNuke.Tests.Integration.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/DotNetNuke.Tests.Integration.csproj
@@ -215,6 +215,8 @@
     <Content Include="Files\Test.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Services\Installer\MergeFiles\ShouldPreserveEmptyNamespaceOnSaveTarget.xml" />
+    <EmbeddedResource Include="Services\Installer\MergeFiles\ShouldPreserveEmptyNamespaceOnSaveMerge.xml" />
     <EmbeddedResource Include="Services\Installer\MergeFiles\ShouldChangeOnOverwriteMerge.xml" />
     <EmbeddedResource Include="Services\Installer\MergeFiles\ShouldChangeOnOverwriteTarget.xml" />
     <EmbeddedResource Include="Services\Installer\MergeFiles\NoChangeOnOverwriteTarget.xml" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldPreserveEmptyNamespaceOnSaveMerge.xml
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldPreserveEmptyNamespaceOnSaveMerge.xml
@@ -1,0 +1,17 @@
+﻿<configuration>
+  <nodes configfile="Web.config">
+    <!-- NOTE: dependentAssembly _should_ have xmlns="urn:schemas-microsoft-com:asm.v1" on it. -->
+    <!-- NOTE: this is a test to verify that an incorrect merge file is correctly treated as incorrect. -->
+    <node path="/configuration/runtime/ab:assemblyBinding"
+          action="update"
+          collision="save"
+          targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='System.Web.Extensions'][ab:assemblyIdentity/@publicKeyToken='31bf3856ad364e35'][ab:bindingRedirect]"
+          nameSpace="urn:schemas-microsoft-com:asm.v1"
+          nameSpacePrefix="ab">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Extensions" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-32767.32767.32767.32767" newVersion="4.1.0.0"/>
+      </dependentAssembly>
+    </node>
+  </nodes>
+</configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldPreserveEmptyNamespaceOnSaveTarget.xml
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/MergeFiles/ShouldPreserveEmptyNamespaceOnSaveTarget.xml
@@ -1,0 +1,11 @@
+﻿<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="bin;bin\HttpModules;bin\Providers;bin\Modules;bin\Support;" />
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Extensions" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/XmlMergeTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Services/Installer/XmlMergeTests.cs
@@ -485,6 +485,28 @@ namespace DotNetNuke.Tests.Integration.Services.Installer
             Assert.True(merge.ConfigUpdateChangedNodes);
         }
 
+        [Test]
+        public void ShouldPreserveEmptyNamespaceOnSave()
+        {
+            var targetDoc = ExecuteMerge();
+
+            var ns = new XmlNamespaceManager(targetDoc.NameTable);
+            ns.AddNamespace("ab", "urn:schemas-microsoft-com:asm.v1");
+
+            // removed the existing node, since it matched targetpath attribute
+            var nodesWithNamespace = targetDoc.SelectNodes("/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly", ns);
+            Assert.AreEqual(0, nodesWithNamespace.Count);
+
+            // added a new node with xmlns=""
+            var nodesWithoutNamespace = targetDoc.SelectNodes("/configuration/runtime/ab:assemblyBinding/dependentAssembly", ns);
+            Assert.AreEqual(1, nodesWithoutNamespace.Count);
+
+            // non-namespaced node has newVersion from merge
+            var dependentAssembly = nodesWithoutNamespace[0];
+            var bindingRedirect = dependentAssembly.SelectSingleNode("bindingRedirect", ns);
+            Assert.AreEqual("4.1.0.0", bindingRedirect.Attributes["newVersion"].Value);
+        }
+
 // ReSharper restore PossibleNullReferenceException
     }
 

--- a/DNN Platform/Website/Install/Config/08.00.00.22.config
+++ b/DNN Platform/Website/Install/Config/08.00.00.22.config
@@ -6,7 +6,7 @@
     <node path="/configuration/runtime/ab:assemblyBinding" action="update"
           targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='System.Web.WebPages.Razor']"
           collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
-      <dependentAssembly>
+      <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Website/Install/Config/08.00.00.30.config
+++ b/DNN Platform/Website/Install/Config/08.00.00.30.config
@@ -3,7 +3,7 @@
     <node path="/configuration/runtime/ab:assemblyBinding" action="update"
           targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='Newtonsoft.Json']"
           collision="ignore" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
-      <dependentAssembly>
+      <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
@@ -11,7 +11,7 @@
     <node path="/configuration/runtime/ab:assemblyBinding" action="update"
         targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='System.Web.Http']"
         collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
-      <dependentAssembly>
+      <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
@@ -19,7 +19,7 @@
     <node path="/configuration/runtime/ab:assemblyBinding" action="update"
         targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='System.Net.Http.Formatting']"
         collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
-      <dependentAssembly>
+      <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
@@ -27,7 +27,7 @@
     <node path="/configuration/runtime/ab:assemblyBinding" action="update"
         targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='System.Web.Http.WebHost']"
         collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab">
-      <dependentAssembly>
+      <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
         <assemblyIdentity name="System.Web.Http.WebHost" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>


### PR DESCRIPTION
The background for this issue is documented in #2971.  This PR fixes a bug that can be introduced when using `collision="save"` with an incorrectly created XML Merge file.  This can result in an element with a namespace being replaced by an element that has the namespace reset (e.g. `<dependentAssembly xmlns="">`), resulting in that element being ignored.