### PR TITLE
Updated to Version Properly for 9.4.1

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,4 +1,4 @@
-next-version: 9.4.0
+next-version: 9.4.1
 commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment


### PR DESCRIPTION
Updating GitVersion to properly set up the build for 9.4.1 versioning.

Per the published policies, this is in support of continuous development and will be self merged.