### PR TITLE
Correction to DotNetNuke.Core NuGet Package

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Core.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Core.nuspec
@@ -14,6 +14,9 @@
       Provides basic references to the DotNetNuke.dll to develop extensions for the DNN Platform.  For MVC or WebAPI please see other packages available as well
     </description>
     <copyright>DNN and DotNetNuke are copyright 2002-2019 by DNN Corp. All Rights Reserved.</copyright>
+	<dependencies>
+      <dependency id="DotNetNuke.DependencyInjection" version="$version$" />
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\Website\bin\DotNetNuke.dll" target="lib\net45\" />


### PR DESCRIPTION
With the introduction of Dependency Injection with the DNN 9.4.0 release, a reference to the DependencyInjection package should be added