### PR TITLE
Fixes DDRMenu Razor Bug with Dependency Injection

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
@@ -63,7 +63,7 @@ namespace DotNetNuke.Web.Razor
         public DotNetNukeWebPage()
         {
             var model = Globals.DependencyProvider.GetService<TModel>();
-            Model = model ?? Activator.CreateInstance<TModel>();
+            Model = model;
         }
 
         [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]

--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage.cs
@@ -63,13 +63,13 @@ namespace DotNetNuke.Web.Razor
         public DotNetNukeWebPage()
         {
             var model = Globals.DependencyProvider.GetService<TModel>();
-            Model = model;
+            Model = model ?? Activator.CreateInstance<TModel>();
         }
 
         [Obsolete("Deprecated in 9.3.2, will be removed in 11.0.0, use Razor Pages instead")]
         public new TModel Model
         {
-            get { return _model ?? (_model = PageContext.Model as TModel); }
+            get { return PageContext?.Model as TModel ?? _model; }
             set { _model = value; }
         }
     }


### PR DESCRIPTION
Fixes: #2997 

## Summary
The DDRMenu supports multiple types of rendering engines. The razor engine which uses `.cshtml` files leverages the DNN Razor3 Module Platform. When we implemented Dependency Injection for 9.4.0 this was added to every module platform including the Razor3 Module Pattern (which is used by DDRMenu Razor).

## The problem
When running a page that uses DNN 9.4.0 the Razor Menu would completely disappear, which is documented in #2997. This was discovered when installing the default theme for nvQuickTheme.

### Screenshot
Copied screenshot from #2997 for convenience
![image](https://user-images.githubusercontent.com/17751436/65003386-586a5a80-d8c6-11e9-92bb-1b35b4cdeccb.png)


## The Fix
In DNN 9.4.0 we updated the constructor of any Razor3 module's `DotNetNukeWebPage<T>` to resolve the model if it is included in the IoC DependencyProvider. This provides simple DependencyInjection for this deprecated module pattern. 

**As part of this change, we decided to create a default instantiation of the Model if it isn't registered in the DependencyProvider.** This default instantiation causes the crash.

```c#
public abstract class DotNetNukeWebPage<TModel> :DotNetNukeWebPage where TModel : class
{
    // unchanged code

    public DotNetNukeWebPage()
    {
        var model = Globals.DependencyProvider.GetService<TModel>();
        Model = model ?? Activator.CreateInstance<TModel>();
    }
}
``` 

Removing the default instantiation appears to fix the problem
```c#
Model = model; // Removing 'Activator.CreateInstance<TModel>();`
```

## Testing
I have followed the exact same testing steps highlighted in #2997.  **I do not have any other Razor3 modules to test**. We should really test a non DDRMenu Razor3 module to validate it still works

My List of Modules to Test
- [x] DDRMenu Razor3
- [x] Razor3 Module (Using Dependency Injection)
- [x] Razor3 Module (Not Using Dependency Injection)