### PR TITLE
DNN-31029 - Set ModuleInfo.IsDeleted to ExportModule.IsDeleted when

### DIFF
--- a/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
@@ -897,7 +897,7 @@ namespace Dnn.ExportImport.Components.Services
                                 local.DisplayTitle = other.DisplayTitle;
                                 local.DisplayPrint = other.DisplayPrint;
                                 local.DisplaySyndicate = other.DisplaySyndicate;
-                                local.IsDeleted = other.IsDeleted;
+                                //local.IsDeleted = other.IsDeleted;
                                 local.IsShareable = otherModule.IsShareable;
                                 local.IsShareableViewOnly = otherModule.IsShareableViewOnly;
                                 local.IsWebSlice = other.IsWebSlice;
@@ -915,7 +915,7 @@ namespace Dnn.ExportImport.Components.Services
                                 }
 
                                 // updates both module and tab module db records
-                                _moduleController.UpdateModule(local);
+                                UpdateModuleWithIsDeletedHandling(other, otherModule, local);
                                 other.LocalId = local.TabModuleID;
                                 otherModule.LocalId = localExpModule.ModuleID;
                                 Repository.UpdateItem(otherModule);
@@ -978,6 +978,18 @@ namespace Dnn.ExportImport.Components.Services
             }
 
             return count;
+        }
+        /*
+            Update Modules.IsDeleted with ExportModule.IsDeleted and not ExportTabModule.IsDeleted. 
+            ExportTabModule.IsDeleted may different from ExportModule.IsDeleted when Module is deleted.
+            Change ModuleInfo.IsDeleted to ExportModule.IsDeleted and reverting to ExportMabModule.IsDeleted after 
+            updating Modules.
+        */
+        private void UpdateModuleWithIsDeletedHandling(ExportTabModule other, ExportModule otherModule, ModuleInfo local)
+        {
+            local.IsDeleted = otherModule.IsDeleted;
+            _moduleController.UpdateModule(local);
+            local.IsDeleted = other.IsDeleted;
         }
 
         private int ImportModuleSettings(ModuleInfo localModule, ExportModule otherModule, bool isNew)

--- a/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
@@ -897,7 +897,6 @@ namespace Dnn.ExportImport.Components.Services
                                 local.DisplayTitle = other.DisplayTitle;
                                 local.DisplayPrint = other.DisplayPrint;
                                 local.DisplaySyndicate = other.DisplaySyndicate;
-                                //local.IsDeleted = other.IsDeleted;
                                 local.IsShareable = otherModule.IsShareable;
                                 local.IsShareableViewOnly = otherModule.IsShareableViewOnly;
                                 local.IsWebSlice = other.IsWebSlice;
@@ -985,11 +984,11 @@ namespace Dnn.ExportImport.Components.Services
             Change ModuleInfo.IsDeleted to ExportModule.IsDeleted and reverting to ExportMabModule.IsDeleted after 
             updating Modules.
         */
-        private void UpdateModuleWithIsDeletedHandling(ExportTabModule other, ExportModule otherModule, ModuleInfo local)
+        private void UpdateModuleWithIsDeletedHandling(ExportTabModule exportTabModule, ExportModule exportModule, ModuleInfo importModule)
         {
-            local.IsDeleted = otherModule.IsDeleted;
-            _moduleController.UpdateModule(local);
-            local.IsDeleted = other.IsDeleted;
+            importModule.IsDeleted = exportModule.IsDeleted;
+            _moduleController.UpdateModule(importModule);
+            importModule.IsDeleted = exportTabModule.IsDeleted;
         }
 
         private int ImportModuleSettings(ModuleInfo localModule, ExportModule otherModule, bool isNew)


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #2910

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
--> 
Root cause: 
ModuleInfo.IsDeleted is shared by both TabModules and Modules table. Modules.IsDeleted should based on ExportModule.IsDeleted and TabModules.IsDeleted should based on ExportTabModule.isDeleted. However, ModuleInfo.IsDeleted is only set to ExportTabModule.isDeleted value.

When import data to the same site, Modules.IsDeleted value is updated to be same as 
ExportModule.IsDeleted. After restored the TabModules, TabModules.IsDeleted is changed to false but Modules.IsDeleted is remains as true. When exporting the site without included deletions, Modules is not exported because Modules.IsDeleted is remains as true.

Solution: 
Set ModuleInfo.IsDeleted to ExportModule.IsDeleted when updating Modules
- This is to handle scenario when ExportTabModule.IsDeleted and ExportModule.IsDeleted are having different value.

Confirmation video - https://drive.google.com/open?id=1uhmOT31yk9zKAqk7eULNS9Q8uUdLr5wA