### PR TITLE
Warns before install/upgrade about needing .Net Framework 4.7.2

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Internals/Steps/IISVerificationStep.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/Steps/IISVerificationStep.cs
@@ -38,18 +38,20 @@ namespace DotNetNuke.Services.Upgrade.Internals.Steps
 
             Details = Localization.Localization.GetString("CheckingIIS", LocalInstallResourceFile);
 
-            // Checks for integrate pipiline mode.
+            // Checks for integrated pipeline mode.
             if (!HttpRuntime.UsingIntegratedPipeline)
             {
                 Errors.Add(Localization.Localization.GetString("IISVerificationFail", LocalInstallResourceFile));
                 Status = StepStatus.Abort;
+                return;
             }
 
             // Check for .Net Framework 4.7.2
-            if (!IsDotNetVersionAtLeast(999999)) // 461808
+            if (!IsDotNetVersionAtLeast(461808))
             {
                 Errors.Add(Localization.Localization.GetString("DotNetVersion472Required", LocalInstallResourceFile));
                 Status = StepStatus.Abort;
+                return;
             }
 
             Status = StepStatus.Done;

--- a/DNN Platform/Library/Services/Upgrade/Internals/Steps/IISVerificationStep.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/Steps/IISVerificationStep.cs
@@ -18,28 +18,57 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
+using Microsoft.Win32;
 using System;
 using System.Web;
 
 namespace DotNetNuke.Services.Upgrade.Internals.Steps
 {
+    /// <summary>
+    /// Performs verifications about the IIS environment.
+    /// </summary>
     public class IISVerificationStep : BaseInstallationStep
     {
+        /// <summary>
+        /// Executes verifications on the IIS environment.
+        /// </summary>
         public override void Execute()
         {
             Status = StepStatus.Running;
 
             Details = Localization.Localization.GetString("CheckingIIS", LocalInstallResourceFile);
 
-            if (HttpRuntime.UsingIntegratedPipeline)
-            {
-                Status = StepStatus.Done;
-            }
-            else
+            // Checks for integrate pipiline mode.
+            if (!HttpRuntime.UsingIntegratedPipeline)
             {
                 Errors.Add(Localization.Localization.GetString("IISVerificationFail", LocalInstallResourceFile));
                 Status = StepStatus.Abort;
             }
+
+            // Check for .Net Framework 4.7.2
+            if (!IsDotNetVersionAtLeast(999999)) // 461808
+            {
+                Errors.Add(Localization.Localization.GetString("DotNetVersion472Required", LocalInstallResourceFile));
+                Status = StepStatus.Abort;
+            }
+
+            Status = StepStatus.Done;
+        }
+
+        private static bool IsDotNetVersionAtLeast(int version)
+        {
+            return GetVersion() >= version;
+        }
+
+        private static int GetVersion()
+        {
+            int release = 0;
+            using (RegistryKey key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey("SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\"))
+            {
+                release = Convert.ToInt32(key.GetValue("Release"));
+            }
+
+            return release;
         }
     }
 }

--- a/Website/Install/App_LocalResources/Installwizard.aspx.de-DE.resx
+++ b/Website/Install/App_LocalResources/Installwizard.aspx.de-DE.resx
@@ -538,4 +538,7 @@ Gehen Sie im Windows Explorer zum Basisverzeichnis Ihrer Website ({0}). Klicken 
   <data name="AcceptTerms.Text" xml:space="preserve">
     <value>I accept the terms of the &lt;a href="../Licenses/Dnn_Corp_License.pdf" target="_blank"&gt;license agreement&lt;/a&gt;</value>
   </data>
+  <data name="DotNetVersion472Required.Text" xml:space="preserve">
+    <value>.Net Framework 4.7.2 ist erforderlich. Suchen Sie nach Windows-Updates, bevor Sie fortfahren.</value>
+  </data>
 </root>

--- a/Website/Install/App_LocalResources/Installwizard.aspx.es-ES.resx
+++ b/Website/Install/App_LocalResources/Installwizard.aspx.es-ES.resx
@@ -1,5 +1,110 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -7,181 +112,181 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AcceptTerms.Required" lastModified="2018-06-01 13:29:22">
-    <value xml:space="preserve">Acepte los términos del acuerdo de licencia para continuar.</value>
+  <data name="AcceptTerms.Required" xml:space="preserve">
+    <value>Acepte los términos del acuerdo de licencia para continuar.</value>
   </data>
-  <data name="AcceptTerms.Text" lastModified="2018-06-01 13:29:22">
-    <value xml:space="preserve">Acepto los términos del &lt;a href="../Licenses/Dnn_Corp_License.pdf" target="_blank"&gt;acuerdo de licencia&lt;/a&gt;</value>
+  <data name="AcceptTerms.Text" xml:space="preserve">
+    <value>Acepto los términos del &lt;a href="../Licenses/Dnn_Corp_License.pdf" target="_blank"&gt;acuerdo de licencia&lt;/a&gt;</value>
   </data>
-  <data name="AccountInfo.Text">
-    <value xml:space="preserve">Información de cuenta de acceso</value>
+  <data name="AccountInfo.Text" xml:space="preserve">
+    <value>Información de cuenta de acceso</value>
   </data>
-  <data name="AccountInfoIntro.Text">
-    <value xml:space="preserve">Introduzca la siguiente información para realizar la configuración de la instalación.</value>
+  <data name="AccountInfoIntro.Text" xml:space="preserve">
+    <value>Introduzca la siguiente información para realizar la configuración de la instalación.</value>
   </data>
-  <data name="AdminInfo.Text">
-    <value xml:space="preserve">Información de administración</value>
+  <data name="AdminInfo.Text" xml:space="preserve">
+    <value>Información de administración</value>
   </data>
-  <data name="CheckingIIS.Text">
-    <value xml:space="preserve">Verificando configuración IIS</value>
+  <data name="CheckingIIS.Text" xml:space="preserve">
+    <value>Verificando configuración IIS</value>
   </data>
-  <data name="ChooseDbError.Text">
-    <value xml:space="preserve">Tiene que elegir la base de datos</value>
+  <data name="ChooseDbError.Text" xml:space="preserve">
+    <value>Tiene que elegir la base de datos</value>
   </data>
-  <data name="cmdContinue.Text">
-    <value xml:space="preserve">Continuar</value>
+  <data name="cmdContinue.Text" xml:space="preserve">
+    <value>Continuar</value>
   </data>
-  <data name="Confirm.Help">
-    <value xml:space="preserve">Confirme la contraseña introducida en la caja inferior.</value>
+  <data name="Confirm.Help" xml:space="preserve">
+    <value>Confirme la contraseña introducida en la caja inferior.</value>
   </data>
-  <data name="Confirm.Required">
-    <value xml:space="preserve">La confirmación de la contraseña es obligatoria</value>
+  <data name="Confirm.Required" xml:space="preserve">
+    <value>La confirmación de la contraseña es obligatoria</value>
   </data>
-  <data name="Confirm.Text">
-    <value xml:space="preserve">Confirme la contraseña:</value>
+  <data name="Confirm.Text" xml:space="preserve">
+    <value>Confirme la contraseña:</value>
   </data>
-  <data name="CreateSuperUser.Text">
-    <value xml:space="preserve">Crear el superusuario</value>
+  <data name="CreateSuperUser.Text" xml:space="preserve">
+    <value>Crear el superusuario</value>
   </data>
-  <data name="CreatingSite.Text">
-    <value xml:space="preserve">Creando el sitio [{0}]</value>
+  <data name="CreatingSite.Text" xml:space="preserve">
+    <value>Creando el sitio [{0}]</value>
   </data>
-  <data name="CreatingSuperUser.Text">
-    <value xml:space="preserve">Creando el superusuario</value>
+  <data name="CreatingSuperUser.Text" xml:space="preserve">
+    <value>Creando el superusuario</value>
   </data>
-  <data name="DatabaseAdvanced.Text">
-    <value xml:space="preserve">Personalizada</value>
+  <data name="DatabaseAdvanced.Text" xml:space="preserve">
+    <value>Personalizada</value>
   </data>
-  <data name="DatabaseConnectionError.Text">
-    <value xml:space="preserve">Error de conexión a la base de datos</value>
+  <data name="DatabaseConnectionError.Text" xml:space="preserve">
+    <value>Error de conexión a la base de datos</value>
   </data>
-  <data name="DatabaseError.Text">
-    <value xml:space="preserve">No se puede establecer una conexión con la base de datos.</value>
+  <data name="DatabaseError.Text" xml:space="preserve">
+    <value>No se puede establecer una conexión con la base de datos.</value>
   </data>
-  <data name="DatabaseFilename.Help">
-    <value xml:space="preserve">Nombre del archivo de la base de datos.</value>
+  <data name="DatabaseFilename.Help" xml:space="preserve">
+    <value>Nombre del archivo de la base de datos.</value>
   </data>
-  <data name="DatabaseFilename.Required">
-    <value xml:space="preserve">El nombre del archivo de base de datos es obligatorio.</value>
+  <data name="DatabaseFilename.Required" xml:space="preserve">
+    <value>El nombre del archivo de base de datos es obligatorio.</value>
   </data>
-  <data name="DatabaseFilename.Text">
-    <value xml:space="preserve">Archivo</value>
+  <data name="DatabaseFilename.Text" xml:space="preserve">
+    <value>Archivo</value>
   </data>
-  <data name="DatabaseInfo.Text">
-    <value xml:space="preserve">Información de la base de datos</value>
+  <data name="DatabaseInfo.Text" xml:space="preserve">
+    <value>Información de la base de datos</value>
   </data>
-  <data name="DatabaseInstallation.Text">
-    <value xml:space="preserve">Instalación de la base de datos</value>
+  <data name="DatabaseInstallation.Text" xml:space="preserve">
+    <value>Instalación de la base de datos</value>
   </data>
-  <data name="DatabaseName.Help">
-    <value xml:space="preserve">Nombre de la base de datos</value>
+  <data name="DatabaseName.Help" xml:space="preserve">
+    <value>Nombre de la base de datos</value>
   </data>
-  <data name="DatabaseName.Required">
-    <value xml:space="preserve">El nombre de la base de datos es obligatorio.</value>
+  <data name="DatabaseName.Required" xml:space="preserve">
+    <value>El nombre de la base de datos es obligatorio.</value>
   </data>
-  <data name="DatabaseName.Text">
-    <value xml:space="preserve">Nombre de la base de datos</value>
+  <data name="DatabaseName.Text" xml:space="preserve">
+    <value>Nombre de la base de datos</value>
   </data>
-  <data name="DatabaseOwner.Text">
-    <value xml:space="preserve">Propietario base de datos</value>
+  <data name="DatabaseOwner.Text" xml:space="preserve">
+    <value>Propietario base de datos</value>
   </data>
-  <data name="DatabasePassword.Help">
-    <value xml:space="preserve">Introduzca el usuario propietario de la base de datos.</value>
+  <data name="DatabasePassword.Help" xml:space="preserve">
+    <value>Introduzca el usuario propietario de la base de datos.</value>
   </data>
-  <data name="DatabasePassword.Required">
-    <value xml:space="preserve">La contraseña de acceso a la base de datos es obligatoria.</value>
+  <data name="DatabasePassword.Required" xml:space="preserve">
+    <value>La contraseña de acceso a la base de datos es obligatoria.</value>
   </data>
-  <data name="DatabasePassword.Text">
-    <value xml:space="preserve">Contraseña</value>
+  <data name="DatabasePassword.Text" xml:space="preserve">
+    <value>Contraseña</value>
   </data>
-  <data name="DatabaseRunAs.Help">
-    <value xml:space="preserve">Ejecutar base de datos como tipo de usuario indicado.</value>
+  <data name="DatabaseRunAs.Help" xml:space="preserve">
+    <value>Ejecutar base de datos como tipo de usuario indicado.</value>
   </data>
-  <data name="DatabaseRunAs.Text">
-    <value xml:space="preserve">Ejecutar base de datos como</value>
+  <data name="DatabaseRunAs.Text" xml:space="preserve">
+    <value>Ejecutar base de datos como</value>
   </data>
-  <data name="DatabaseSecurity.Help">
-    <value xml:space="preserve">Seleccione el tipo de seguridad utilizada por la base de datos.</value>
+  <data name="DatabaseSecurity.Help" xml:space="preserve">
+    <value>Seleccione el tipo de seguridad utilizada por la base de datos.</value>
   </data>
-  <data name="DatabaseSecurity.Text">
-    <value xml:space="preserve">Seguridad</value>
+  <data name="DatabaseSecurity.Text" xml:space="preserve">
+    <value>Seguridad</value>
   </data>
-  <data name="DatabaseServer.Help">
-    <value xml:space="preserve">Nombre del servidor de base de datos.</value>
+  <data name="DatabaseServer.Help" xml:space="preserve">
+    <value>Nombre del servidor de base de datos.</value>
   </data>
-  <data name="DatabaseServer.Required">
-    <value xml:space="preserve">El nombre del servidor de base de datos es obligatorio.</value>
+  <data name="DatabaseServer.Required" xml:space="preserve">
+    <value>El nombre del servidor de base de datos es obligatorio.</value>
   </data>
-  <data name="DatabaseServer.Text">
-    <value xml:space="preserve">Servidor</value>
+  <data name="DatabaseServer.Text" xml:space="preserve">
+    <value>Servidor</value>
   </data>
-  <data name="DatabaseSetup.Help">
-    <value xml:space="preserve">Seleccione si quiere ver la configuración estándar o avanzada.</value>
+  <data name="DatabaseSetup.Help" xml:space="preserve">
+    <value>Seleccione si quiere ver la configuración estándar o avanzada.</value>
   </data>
-  <data name="DatabaseSetup.Text">
-    <value xml:space="preserve">Configuración base de datos</value>
+  <data name="DatabaseSetup.Text" xml:space="preserve">
+    <value>Configuración base de datos</value>
   </data>
-  <data name="DatabaseStandard.Text">
-    <value xml:space="preserve">Predeterminada</value>
+  <data name="DatabaseStandard.Text" xml:space="preserve">
+    <value>Predeterminada</value>
   </data>
-  <data name="DatabaseType.Help">
-    <value xml:space="preserve">Indique el tipo de base de datos que quiere utilizar para la instalación.</value>
+  <data name="DatabaseType.Help" xml:space="preserve">
+    <value>Indique el tipo de base de datos que quiere utilizar para la instalación.</value>
   </data>
-  <data name="DatabaseType.Text">
-    <value xml:space="preserve">Tipo de base de datos</value>
+  <data name="DatabaseType.Text" xml:space="preserve">
+    <value>Tipo de base de datos</value>
   </data>
-  <data name="DatabaseUsername.Help">
-    <value xml:space="preserve">Indique el usuario para conectarse a la base de datos.</value>
+  <data name="DatabaseUsername.Help" xml:space="preserve">
+    <value>Indique el usuario para conectarse a la base de datos.</value>
   </data>
-  <data name="DatabaseUsername.Required">
-    <value xml:space="preserve">El usuario de la base de datos es obligatorio</value>
+  <data name="DatabaseUsername.Required" xml:space="preserve">
+    <value>El usuario de la base de datos es obligatorio</value>
   </data>
-  <data name="DatabaseUsername.Text">
-    <value xml:space="preserve">Usuario</value>
+  <data name="DatabaseUsername.Text" xml:space="preserve">
+    <value>Usuario</value>
   </data>
-  <data name="DbSecurityIntegrated.Text">
-    <value xml:space="preserve">Integrada</value>
+  <data name="DbSecurityIntegrated.Text" xml:space="preserve">
+    <value>Integrada</value>
   </data>
-  <data name="DbSecurityUserDefined.Text">
-    <value xml:space="preserve">Usuario</value>
+  <data name="DbSecurityUserDefined.Text" xml:space="preserve">
+    <value>Usuario</value>
   </data>
-  <data name="DeletingOldFiles.Text">
-    <value xml:space="preserve">Borrando archivos anteriores de </value>
+  <data name="DeletingOldFiles.Text" xml:space="preserve">
+    <value>Borrando archivos anteriores de </value>
   </data>
-  <data name="Email.Help">
-    <value xml:space="preserve">Introduzca el email de este usuario.</value>
+  <data name="Email.Help" xml:space="preserve">
+    <value>Introduzca el email de este usuario.</value>
   </data>
-  <data name="Email.Invalid">
-    <value xml:space="preserve">El email no es válido</value>
+  <data name="Email.Invalid" xml:space="preserve">
+    <value>El email no es válido</value>
   </data>
-  <data name="Email.Required" lastModified="2018-06-01 15:32:59">
-    <value xml:space="preserve">La dirección de correo electrónico es obligatoria</value>
+  <data name="Email.Required" xml:space="preserve">
+    <value>La dirección de correo electrónico es obligatoria</value>
   </data>
-  <data name="Email.Text" lastModified="2018-06-01 15:32:59">
-    <value xml:space="preserve">Correo electrónico:</value>
+  <data name="Email.Text" xml:space="preserve">
+    <value>Correo electrónico:</value>
   </data>
-  <data name="Error.Text">
-    <value xml:space="preserve">Error</value>
+  <data name="Error.Text" xml:space="preserve">
+    <value>Error</value>
   </data>
-  <data name="ErrorInStep.Text">
-    <value xml:space="preserve">Ha ocurrido un ERROR - {0}</value>
+  <data name="ErrorInStep.Text" xml:space="preserve">
+    <value>Ha ocurrido un ERROR - {0}</value>
   </data>
-  <data name="ExtensionsInstallation.Text">
-    <value xml:space="preserve">Instalación de extensiones </value>
+  <data name="ExtensionsInstallation.Text" xml:space="preserve">
+    <value>Instalación de extensiones </value>
   </data>
-  <data name="FcnMode.Text">
-    <value xml:space="preserve">Añadiendo FcnMode</value>
+  <data name="FcnMode.Text" xml:space="preserve">
+    <value>Añadiendo FcnMode</value>
   </data>
-  <data name="FileAndFolderPermissionCheck.Text">
-    <value xml:space="preserve">Verificación de permisos de archivo y carpeta</value>
+  <data name="FileAndFolderPermissionCheck.Text" xml:space="preserve">
+    <value>Verificación de permisos de archivo y carpeta</value>
   </data>
-  <data name="FileAndFolderPermissionCheckFailed.Text">
-    <value xml:space="preserve">&lt;div class="permission"&gt;&lt;img alt="Imagen que muestra la configuración de seguridad de la carpeta raíz del web: Leer, Escribir y Modificar, para la cuenta ASPNET o NT AUTHORITY/SERVICIO DE RED." src="..\403-3.gif" align="right" hspace="10"/&gt;
+  <data name="FileAndFolderPermissionCheckFailed.Text" xml:space="preserve">
+    <value>&lt;div class="permission"&gt;&lt;img alt="Imagen que muestra la configuración de seguridad de la carpeta raíz del web: Leer, Escribir y Modificar, para la cuenta ASPNET o NT AUTHORITY/SERVICIO DE RED." src="..\403-3.gif" align="right" hspace="10"/&gt;
 &lt;p&gt;&lt;strong&gt;&lt;font color='red'&gt;Su sitio ha fallado las verificaciones de permisos.&lt;/font&gt;&lt;/strong&gt;&lt;/p&gt;
 Utilice el Explorador de Windows para ver las carpetas de su sitio web ( {0} ). Vaya a las propiedades de la carpeta, y seleccione la pestaña Seguridad. Añada las cuentas y permisos necesarios.
 &lt;br/&gt;&lt;br/&gt;
@@ -192,250 +297,253 @@ Utilice el Explorador de Windows para ver las carpetas de su sitio web ( {0} ). 
 &lt;h3&gt;Si utiliza Windows 7 o Windows Server 2008 R2 y  IIS7.5&lt;/h3&gt;
 &lt;p&gt;La cuenta IIS AppPool\DefaultAppPool tiene que tener permisos de Lectura, Escritura y Modificación en la carpeta raíz de la web.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Verificar de nuevo&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
-  <data name="FileAndFolderPermissionCheckTitle.Text">
-    <value xml:space="preserve">Verificando los permisos de archivo y carpeta </value>
+  <data name="FileAndFolderPermissionCheckTitle.Text" xml:space="preserve">
+    <value>Verificando los permisos de archivo y carpeta </value>
   </data>
-  <data name="FileCreateCheck.Text">
-    <value xml:space="preserve">Verificación de creación de archivos </value>
+  <data name="FileCreateCheck.Text" xml:space="preserve">
+    <value>Verificación de creación de archivos </value>
   </data>
-  <data name="FileDeleteCheck.Text">
-    <value xml:space="preserve">Verificación de borrado de archivos </value>
+  <data name="FileDeleteCheck.Text" xml:space="preserve">
+    <value>Verificación de borrado de archivos </value>
   </data>
-  <data name="FolderCreateCheck.Text">
-    <value xml:space="preserve">Verificación de creación de carpetas </value>
+  <data name="FolderCreateCheck.Text" xml:space="preserve">
+    <value>Verificación de creación de carpetas </value>
   </data>
-  <data name="FolderDeleteCheck.Text">
-    <value xml:space="preserve">Verificación de borrado de carpetas </value>
+  <data name="FolderDeleteCheck.Text" xml:space="preserve">
+    <value>Verificación de borrado de carpetas </value>
   </data>
-  <data name="HostWarning.Text">
-    <value xml:space="preserve">El nombre contiene caracteres no válidos (solo se permite a-Z, 0-9, - y . ).  Modifique el nombre que ha introducido.</value>
+  <data name="HostWarning.Text" xml:space="preserve">
+    <value>El nombre contiene caracteres no válidos (solo se permite a-Z, 0-9, - y . ).  Modifique el nombre que ha introducido.</value>
   </data>
-  <data name="IISVerificationFail.Text">
-    <value xml:space="preserve">El grupo de aplicaciones de IIS tiene que ejecutarse en Modo Integrado</value>
+  <data name="IISVerificationFail.Text" xml:space="preserve">
+    <value>El grupo de aplicaciones de IIS tiene que ejecutarse en Modo Integrado</value>
   </data>
-  <data name="ImprovementProgramExplain.Text" lastModified="2016-11-29 16:18:45">
-    <value xml:space="preserve">El programa de mejoras del producto nos permite entender mejor como mejorar DNN para usted. Los datos enviados nos ayudarán a analizar el uso y lo que es más importante para los usuarios del producto. Todos los datos enviados son anónimos y para uso interno. Ver más información sobre el &lt;a href="http://www.dnnsoftware.com/dnn-improvement-program" target="_blank"&gt;Programa de Mejoras del Producto&lt;/a&gt;.</value>
+  <data name="ImprovementProgramExplain.Text" xml:space="preserve">
+    <value>El programa de mejoras del producto nos permite entender mejor como mejorar DNN para usted. Los datos enviados nos ayudarán a analizar el uso y lo que es más importante para los usuarios del producto. Todos los datos enviados son anónimos y para uso interno. Ver más información sobre el &lt;a href="http://www.dnnsoftware.com/dnn-improvement-program" target="_blank"&gt;Programa de Mejoras del Producto&lt;/a&gt;.</value>
   </data>
-  <data name="ImprovementProgramLabel.Text" lastModified="2016-11-29 16:18:45">
-    <value xml:space="preserve">Enviar información anónima de uso a DNN</value>
+  <data name="ImprovementProgramLabel.Text" xml:space="preserve">
+    <value>Enviar información anónima de uso a DNN</value>
   </data>
-  <data name="ImprovementsProgramTitle.Text" lastModified="2016-11-29 16:18:45">
-    <value xml:space="preserve">Programa de mejoras del producto</value>
+  <data name="ImprovementsProgramTitle.Text" xml:space="preserve">
+    <value>Programa de mejoras del producto</value>
   </data>
-  <data name="InitHostSetting.Text">
-    <value xml:space="preserve">Inicializando configuración del sistema </value>
+  <data name="InitHostSetting.Text" xml:space="preserve">
+    <value>Inicializando configuración del sistema </value>
   </data>
-  <data name="InputErrorInvalidPassword.Text" lastModified="2018-06-01 15:32:59">
-    <value xml:space="preserve">La contraseña introducida no cumple los requisitos mínimos de seguridad.</value>
+  <data name="InputErrorInvalidPassword.Text" xml:space="preserve">
+    <value>La contraseña introducida no cumple los requisitos mínimos de seguridad.</value>
   </data>
-  <data name="InputErrorMissingRequiredFields.Text">
-    <value xml:space="preserve">Faltan campos obligatorios</value>
+  <data name="InputErrorMissingRequiredFields.Text" xml:space="preserve">
+    <value>Faltan campos obligatorios</value>
   </data>
-  <data name="Installation.Text">
-    <value xml:space="preserve">Iniciar la instalación</value>
+  <data name="Installation.Text" xml:space="preserve">
+    <value>Iniciar la instalación</value>
   </data>
-  <data name="InstallationComplete.Text">
-    <value xml:space="preserve">Instalación completa</value>
+  <data name="InstallationComplete.Text" xml:space="preserve">
+    <value>Instalación completa</value>
   </data>
-  <data name="InstallationDone.Text">
-    <value xml:space="preserve">Finalizado</value>
+  <data name="InstallationDone.Text" xml:space="preserve">
+    <value>Finalizado</value>
   </data>
-  <data name="InstallationIntroInfo.Text">
-    <value xml:space="preserve">El sistema se está instalando. Gracias por su espera...</value>
+  <data name="InstallationIntroInfo.Text" xml:space="preserve">
+    <value>El sistema se está instalando. Gracias por su espera...</value>
   </data>
-  <data name="InstallingDataBaseScriptStep.Text">
-    <value xml:space="preserve">Instalando el script de base de datos </value>
+  <data name="InstallingDataBaseScriptStep.Text" xml:space="preserve">
+    <value>Instalando el script de base de datos </value>
   </data>
-  <data name="InstallingExtension.Text">
-    <value xml:space="preserve">Instalando {0} - {1}</value>
+  <data name="InstallingExtension.Text" xml:space="preserve">
+    <value>Instalando {0} - {1}</value>
   </data>
-  <data name="InstallingExtensionType.Text">
-    <value xml:space="preserve">Instalando paquetes del tipo - {0}</value>
+  <data name="InstallingExtensionType.Text" xml:space="preserve">
+    <value>Instalando paquetes del tipo - {0}</value>
   </data>
-  <data name="InstallingLanguagesTitle.Text">
-    <value xml:space="preserve">Instalando idiomas </value>
+  <data name="InstallingLanguagesTitle.Text" xml:space="preserve">
+    <value>Instalando idiomas </value>
   </data>
-  <data name="InstallingMembershipDatabaseScriptStep.Text">
-    <value xml:space="preserve">Instalando scripts de base de datos de Membership </value>
+  <data name="InstallingMembershipDatabaseScriptStep.Text" xml:space="preserve">
+    <value>Instalando scripts de base de datos de Membership </value>
   </data>
-  <data name="InstallTitle.Text">
-    <value xml:space="preserve">Instalación</value>
+  <data name="InstallTitle.Text" xml:space="preserve">
+    <value>Instalación</value>
   </data>
-  <data name="InstallVersion.Text">
-    <value xml:space="preserve">Añadiendo versión de instalación</value>
+  <data name="InstallVersion.Text" xml:space="preserve">
+    <value>Añadiendo versión de instalación</value>
   </data>
-  <data name="IntroDetail.Text">
-    <value xml:space="preserve">&lt;a class="videoLink" href="http://www.dotnetnuke.com/Resources/Training/Training-Videos/Installation.aspx" target="new"&gt;Ver el vídeo de instalación&lt;/a&gt;</value>
+  <data name="IntroDetail.Text" xml:space="preserve">
+    <value>&lt;a class="videoLink" href="http://www.dotnetnuke.com/Resources/Training/Training-Videos/Installation.aspx" target="new"&gt;Ver el vídeo de instalación&lt;/a&gt;</value>
   </data>
-  <data name="InvalidQualifier.Text">
-    <value xml:space="preserve">El prefijo de objetos tiene que empezar con una letra y no puede tener más de 20 caracteres.</value>
+  <data name="InvalidQualifier.Text" xml:space="preserve">
+    <value>El prefijo de objetos tiene que empezar con una letra y no puede tener más de 20 caracteres.</value>
   </data>
-  <data name="IsAbleToPerformDatabaseActions.Text">
-    <value xml:space="preserve">El usuario de base de datos no tiene suficientes permisos para la instalación (dbo)</value>
+  <data name="IsAbleToPerformDatabaseActions.Text" xml:space="preserve">
+    <value>El usuario de base de datos no tiene suficientes permisos para la instalación (dbo)</value>
   </data>
-  <data name="IsAbleToPerformDatabaseActionsCheck.Text">
-    <value xml:space="preserve">Verificando si el usuario tiene suficientes permisos para realizar las acciones necesarias</value>
+  <data name="IsAbleToPerformDatabaseActionsCheck.Text" xml:space="preserve">
+    <value>Verificando si el usuario tiene suficientes permisos para realizar las acciones necesarias</value>
   </data>
-  <data name="IsSqlServerDbo.Text">
-    <value xml:space="preserve">El usuario de base de datos no tiene permisos de dbo</value>
+  <data name="IsSqlServerDbo.Text" xml:space="preserve">
+    <value>El usuario de base de datos no tiene permisos de dbo</value>
   </data>
-  <data name="IsValidDotNetVersion.Text">
-    <value xml:space="preserve">DotNetNuke necesita la versión .NET 4.0 o superior</value>
+  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
+    <value>DotNetNuke necesita la versión .NET 4.0 o superior</value>
   </data>
-  <data name="IsValidSqlServerVersion.Text">
-    <value xml:space="preserve">DotNetNuke necesita la versión SQL Server 2008 (Express o normal)</value>
+  <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
+    <value>DotNetNuke necesita la versión SQL Server 2008 (Express o normal)</value>
   </data>
-  <data name="IsValidSqlServerVersionCheck.Text">
-    <value xml:space="preserve">Verificando si la base de datos es SQL Server 2008</value>
+  <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
+    <value>Verificando si la base de datos es SQL Server 2008</value>
   </data>
-  <data name="Language.Help">
-    <value xml:space="preserve">Seleccione el idioma que quiere utilizar para su sitio web.</value>
+  <data name="Language.Help" xml:space="preserve">
+    <value>Seleccione el idioma que quiere utilizar para su sitio web.</value>
   </data>
-  <data name="Language.Text">
-    <value xml:space="preserve">Idioma</value>
+  <data name="Language.Text" xml:space="preserve">
+    <value>Idioma</value>
   </data>
-  <data name="LanguageDutch.Text">
-    <value xml:space="preserve">Holandés</value>
+  <data name="LanguageDutch.Text" xml:space="preserve">
+    <value>Holandés</value>
   </data>
-  <data name="LanguageEnglish.Text">
-    <value xml:space="preserve">Inglés</value>
+  <data name="LanguageEnglish.Text" xml:space="preserve">
+    <value>Inglés</value>
   </data>
-  <data name="LanguageFrench.Text">
-    <value xml:space="preserve">Francés</value>
+  <data name="LanguageFrench.Text" xml:space="preserve">
+    <value>Francés</value>
   </data>
-  <data name="LanguageGerman.Text">
-    <value xml:space="preserve">Alemán</value>
+  <data name="LanguageGerman.Text" xml:space="preserve">
+    <value>Alemán</value>
   </data>
-  <data name="LanguageItalian.Text">
-    <value xml:space="preserve">Italiano</value>
+  <data name="LanguageItalian.Text" xml:space="preserve">
+    <value>Italiano</value>
   </data>
-  <data name="LanguageSpanish.Text">
-    <value xml:space="preserve">Español</value>
+  <data name="LanguageSpanish.Text" xml:space="preserve">
+    <value>Español</value>
   </data>
-  <data name="LaunchInstall.Text">
-    <value xml:space="preserve">Iniciar la instalación</value>
+  <data name="LaunchInstall.Text" xml:space="preserve">
+    <value>Iniciar la instalación</value>
   </data>
-  <data name="LegacyLangaugePack.Text">
-    <value xml:space="preserve">Este paquete de idioma es anterior a la versión actual de la aplicación:</value>
+  <data name="LegacyLangaugePack.Text" xml:space="preserve">
+    <value>Este paquete de idioma es anterior a la versión actual de la aplicación:</value>
   </data>
-  <data name="LicenseActivation.Text">
-    <value xml:space="preserve">Activando licencia</value>
+  <data name="LicenseActivation.Text" xml:space="preserve">
+    <value>Activando licencia</value>
   </data>
-  <data name="NoErrorsLogged.Text">
-    <value xml:space="preserve">No se han registrado errores de instalación</value>
+  <data name="NoErrorsLogged.Text" xml:space="preserve">
+    <value>No se han registrado errores de instalación</value>
   </data>
-  <data name="NoInstallationLog.Text">
-    <value xml:space="preserve">No hay registro de instalación</value>
+  <data name="NoInstallationLog.Text" xml:space="preserve">
+    <value>No hay registro de instalación</value>
   </data>
-  <data name="PageTitle.Text">
-    <value xml:space="preserve">Instalación</value>
+  <data name="PageTitle.Text" xml:space="preserve">
+    <value>Instalación</value>
   </data>
-  <data name="Password.Help">
-    <value xml:space="preserve">Indique la contraseña del superusuario.</value>
+  <data name="Password.Help" xml:space="preserve">
+    <value>Indique la contraseña del superusuario.</value>
   </data>
-  <data name="Password.Required">
-    <value xml:space="preserve">La contraseña es obligatoria.</value>
+  <data name="Password.Required" xml:space="preserve">
+    <value>La contraseña es obligatoria.</value>
   </data>
-  <data name="Password.Text">
-    <value xml:space="preserve">Contraseña:</value>
+  <data name="Password.Text" xml:space="preserve">
+    <value>Contraseña:</value>
   </data>
-  <data name="PasswordMismatch.Text">
-    <value xml:space="preserve">Las contraseñas no coinciden.</value>
+  <data name="PasswordMismatch.Text" xml:space="preserve">
+    <value>Las contraseñas no coinciden.</value>
   </data>
-  <data name="ProcessingUpgradeScript.Text">
-    <value xml:space="preserve">Aplicando script de actualización</value>
+  <data name="ProcessingUpgradeScript.Text" xml:space="preserve">
+    <value>Aplicando script de actualización</value>
   </data>
-  <data name="RequiresFileOrDatabase.Text">
-    <value xml:space="preserve">El archivo o nombre de base de datos tiene que estar informado en el nodo connection en el archivo DotNetNuke.Install.Config</value>
+  <data name="RequiresFileOrDatabase.Text" xml:space="preserve">
+    <value>El archivo o nombre de base de datos tiene que estar informado en el nodo connection en el archivo DotNetNuke.Install.Config</value>
   </data>
-  <data name="Retry.Text">
-    <value xml:space="preserve">Volver a intentar</value>
+  <data name="Retry.Text" xml:space="preserve">
+    <value>Volver a intentar</value>
   </data>
-  <data name="SeeLogs.Text">
-    <value xml:space="preserve">Ver registro</value>
+  <data name="SeeLogs.Text" xml:space="preserve">
+    <value>Ver registro</value>
   </data>
-  <data name="SkipCreatingSite.Text" lastModified="2018-06-01 15:32:59">
-    <value xml:space="preserve">El alias de portal [{0}] ya existe. Omitiendo este paso.</value>
+  <data name="SkipCreatingSite.Text" xml:space="preserve">
+    <value>El alias de portal [{0}] ya existe. Omitiendo este paso.</value>
   </data>
-  <data name="SqlTypeExpress.Text" lastModified="2018-06-01 15:32:59">
-    <value xml:space="preserve">Archivo SQL Server Express</value>
+  <data name="SqlTypeExpress.Text" xml:space="preserve">
+    <value>Archivo SQL Server Express</value>
   </data>
-  <data name="SqlTypeServer.Text">
-    <value xml:space="preserve">SQL Server/Base de datos SQL Server Express</value>
+  <data name="SqlTypeServer.Text" xml:space="preserve">
+    <value>SQL Server/Base de datos SQL Server Express</value>
   </data>
-  <data name="StandardDatabaseMsg.Text">
-    <value xml:space="preserve">No se ha encontrado ninguna conexión por omisión válida. La configuración estándar no está disponible.</value>
+  <data name="StandardDatabaseMsg.Text" xml:space="preserve">
+    <value>No se ha encontrado ninguna conexión por omisión válida. La configuración estándar no está disponible.</value>
   </data>
-  <data name="StepFailed.Text">
-    <value xml:space="preserve">Error en el paso - {0}</value>
+  <data name="StepFailed.Text" xml:space="preserve">
+    <value>Error en el paso - {0}</value>
   </data>
-  <data name="SuperUserCreation.Text">
-    <value xml:space="preserve">Creación del superusuario</value>
+  <data name="SuperUserCreation.Text" xml:space="preserve">
+    <value>Creación del superusuario</value>
   </data>
-  <data name="TemplateBlank.Text">
-    <value xml:space="preserve">Plantilla en blanco</value>
+  <data name="TemplateBlank.Text" xml:space="preserve">
+    <value>Plantilla en blanco</value>
   </data>
-  <data name="TemplateDefault.Text">
-    <value xml:space="preserve">Plantilla predeterminada</value>
+  <data name="TemplateDefault.Text" xml:space="preserve">
+    <value>Plantilla predeterminada</value>
   </data>
-  <data name="TemplateMobile.Text">
-    <value xml:space="preserve">Plantilla móvil</value>
+  <data name="TemplateMobile.Text" xml:space="preserve">
+    <value>Plantilla móvil</value>
   </data>
-  <data name="TemplateSolutions.Text">
-    <value xml:space="preserve">Plantilla de soluciones</value>
+  <data name="TemplateSolutions.Text" xml:space="preserve">
+    <value>Plantilla de soluciones</value>
   </data>
-  <data name="TestingDatabase.Text">
-    <value xml:space="preserve">Verificando conexión a base de datos</value>
+  <data name="TestingDatabase.Text" xml:space="preserve">
+    <value>Verificando conexión a base de datos</value>
   </data>
-  <data name="TimerMinutes.Text">
-    <value xml:space="preserve">Minutos</value>
+  <data name="TimerMinutes.Text" xml:space="preserve">
+    <value>Minutos</value>
   </data>
-  <data name="TimerSeconds.Text">
-    <value xml:space="preserve">segundos</value>
+  <data name="TimerSeconds.Text" xml:space="preserve">
+    <value>segundos</value>
   </data>
-  <data name="UpdatingConfigFile.Text" lastModified="2018-06-01 13:29:22">
-    <value xml:space="preserve">Actualizando la configuración para </value>
+  <data name="UpdatingConfigFile.Text" xml:space="preserve">
+    <value>Actualizando la configuración para </value>
   </data>
-  <data name="UpgradingNormalApplication.Text">
-    <value xml:space="preserve">Actualizando aplicación</value>
+  <data name="UpgradingNormalApplication.Text" xml:space="preserve">
+    <value>Actualizando aplicación</value>
   </data>
-  <data name="UpgradingVersionApplication.Text" lastModified="2018-06-01 13:29:22">
-    <value xml:space="preserve">Actualizando aplicación a </value>
+  <data name="UpgradingVersionApplication.Text" xml:space="preserve">
+    <value>Actualizando aplicación a </value>
   </data>
-  <data name="UserName.Help">
-    <value xml:space="preserve">Nombre de usuario del superusuario.</value>
+  <data name="UserName.Help" xml:space="preserve">
+    <value>Nombre de usuario del superusuario.</value>
   </data>
-  <data name="UserName.Required">
-    <value xml:space="preserve">El usuario es obligatorio.</value>
+  <data name="UserName.Required" xml:space="preserve">
+    <value>El usuario es obligatorio.</value>
   </data>
-  <data name="UserName.Text">
-    <value xml:space="preserve">Usuario:</value>
+  <data name="UserName.Text" xml:space="preserve">
+    <value>Usuario:</value>
   </data>
-  <data name="ViewWebsite.Text">
-    <value xml:space="preserve">Ver el sitio web</value>
+  <data name="ViewWebsite.Text" xml:space="preserve">
+    <value>Ver el sitio web</value>
   </data>
-  <data name="VisitWebsite.Text">
-    <value xml:space="preserve">Ver el sitio web</value>
+  <data name="VisitWebsite.Text" xml:space="preserve">
+    <value>Ver el sitio web</value>
   </data>
-  <data name="WebsiteCreation.Text" lastModified="2018-06-01 15:32:59">
-    <value xml:space="preserve">Creación del sitio web</value>
+  <data name="WebsiteCreation.Text" xml:space="preserve">
+    <value>Creación del sitio web</value>
   </data>
-  <data name="WebsiteInfo.Text">
-    <value xml:space="preserve">Información del sitio web</value>
+  <data name="WebsiteInfo.Text" xml:space="preserve">
+    <value>Información del sitio web</value>
   </data>
-  <data name="WebsiteName.Help">
-    <value xml:space="preserve">Introduzca el nombre que quiere utilizar para su sitio web.</value>
+  <data name="WebsiteName.Help" xml:space="preserve">
+    <value>Introduzca el nombre que quiere utilizar para su sitio web.</value>
   </data>
-  <data name="WebsiteName.Required">
-    <value xml:space="preserve">El nombre del sitio web es obligatorio.</value>
+  <data name="WebsiteName.Required" xml:space="preserve">
+    <value>El nombre del sitio web es obligatorio.</value>
   </data>
-  <data name="WebsiteName.Text">
-    <value xml:space="preserve">Nombre del sitio web</value>
+  <data name="WebsiteName.Text" xml:space="preserve">
+    <value>Nombre del sitio web</value>
   </data>
-  <data name="WebsiteTemplate.Help">
-    <value xml:space="preserve">Seleccione el tipo de sitio web que quiere configurar.</value>
+  <data name="WebsiteTemplate.Help" xml:space="preserve">
+    <value>Seleccione el tipo de sitio web que quiere configurar.</value>
   </data>
-  <data name="WebsiteTemplate.Text">
-    <value xml:space="preserve">Plantilla</value>
+  <data name="WebsiteTemplate.Text" xml:space="preserve">
+    <value>Plantilla</value>
+  </data>
+  <data name="DotNetVersion472Required.Text" xml:space="preserve">
+    <value>Se requiere .Net Framework 4.7.2. Verifique las actualizaciones de Windows antes de continuar.</value>
   </data>
 </root>

--- a/Website/Install/App_LocalResources/Installwizard.aspx.fr-FR.resx
+++ b/Website/Install/App_LocalResources/Installwizard.aspx.fr-FR.resx
@@ -532,4 +532,7 @@
   <data name="AcceptTerms.Text" xml:space="preserve">
     <value>I accept the terms of the &lt;a href="../Licenses/Dnn_Corp_License.pdf" target="_blank"&gt;license agreement&lt;/a&gt;</value>
   </data>
+  <data name="DotNetVersion472Required.Text" xml:space="preserve">
+    <value>.Net Framework 4.7.2 est requis. Vérifiez les mises à jour Windows avant de continuer.</value>
+  </data>
 </root>

--- a/Website/Install/App_LocalResources/Installwizard.aspx.it-IT.resx
+++ b/Website/Install/App_LocalResources/Installwizard.aspx.it-IT.resx
@@ -532,4 +532,7 @@ L'opzione per impostare il Database Standard  non è disponibile</value>
   <data name="AcceptTerms.Text" xml:space="preserve">
     <value>I accept the terms of the &lt;a href="../Licenses/Dnn_Corp_License.pdf" target="_blank"&gt;license agreement&lt;/a&gt;</value>
   </data>
+  <data name="DotNetVersion472Required.Text" xml:space="preserve">
+    <value>È richiesto .Net Framework 4.7.2. Controlla gli aggiornamenti di Windows prima di procedere.</value>
+  </data>
 </root>

--- a/Website/Install/App_LocalResources/Installwizard.aspx.nl-NL.resx
+++ b/Website/Install/App_LocalResources/Installwizard.aspx.nl-NL.resx
@@ -541,4 +541,7 @@ Standaard database installatie opties niet beschikbaar</value>
   <data name="AcceptTerms.Text" xml:space="preserve">
     <value>I accept the terms of the &lt;a href="../Licenses/Dnn_Corp_License.pdf" target="_blank"&gt;license agreement&lt;/a&gt;</value>
   </data>
+  <data name="DotNetVersion472Required.Text" xml:space="preserve">
+    <value>.Net Framework 4.7.2 is vereist. Controleer op Windows-updates voordat u doorgaat.</value>
+  </data>
 </root>

--- a/Website/Install/App_LocalResources/Installwizard.aspx.resx
+++ b/Website/Install/App_LocalResources/Installwizard.aspx.resx
@@ -293,7 +293,6 @@ for people using the product. All of the data is anonymous and for internal use 
   <data name="DatabaseName.Help" xml:space="preserve">
     <value>The name of your database.</value>
   </data>
-
   <data name="DatabaseOwner.Text" xml:space="preserve">
     <value>Database Owner</value>
   </data>
@@ -546,5 +545,8 @@ Using Windows Explorer, browse to the folders of your website ( {0} ). Right-cli
   </data>
   <data name="AcceptTerms.Required" xml:space="preserve">
     <value>Accept the terms of the license agreement to continue.</value>
+  </data>
+  <data name="DotNetVersion472Required.Text" xml:space="preserve">
+    <value>.Net Framework 4.7.2 is required. Check for Windows updates before proceeding.</value>
   </data>
 </root>

--- a/Website/Install/UpgradeWizard.aspx.cs
+++ b/Website/Install/UpgradeWizard.aspx.cs
@@ -411,15 +411,17 @@ namespace DotNetNuke.Services.Install
         //steps shown in UI
         static IInstallationStep upgradeDatabase = new InstallDatabaseStep();
         static IInstallationStep upgradeExtensions = new InstallExtensionsStep();
+        static IInstallationStep iisVerification = new IISVerificationStep();
 
         //Ordered List of Steps (and weight in percentage) to be executed
         private static IDictionary<IInstallationStep, int> _steps = new Dictionary<IInstallationStep, int>
-                                {
-                                    //{new AddFcnModeStep(), 1},
-                                    {upgradeDatabase, 50}, 
-                                    {upgradeExtensions, 49}, 
-                                    {new InstallVersionStep(), 1}
-                                };
+            {
+            //{new AddFcnModeStep(), 1},
+                {iisVerification, 1 },
+                {upgradeDatabase, 49}, 
+                {upgradeExtensions, 49}, 
+                {new InstallVersionStep(), 1}
+            };
 
         static UpgradeWizard()
         {


### PR DESCRIPTION
Closes #2990 

Adds a check in the existing IIS configuration step to make sure that .Net Framework 4.7.2 at least is installed. This is the first step for both installs and upgrades so that the upgrade does not continue if that condition is not met and users can just re-fire the upgrade after doing windows updates without needing to restore and all that...