### PR TITLE
Adds the IServiceProvider to the Container

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web/Startup.cs
@@ -23,6 +23,7 @@ namespace DotNetNuke.Web
             var services = new ServiceCollection();
             ConfigureServices(services);
             DependencyProvider = services.BuildServiceProvider();
+            services.AddSingleton(DependencyProvider);
         }
 
         public IServiceProvider DependencyProvider { get; private set; }


### PR DESCRIPTION

fixes: #3028

## Summary
The `IServiceProvider` is now added to the Dependency Injection Container so it can be resolved using constructor injection. See original work-item for more details on problem