### PR TITLE
Make sure TimeZone doesn't store to database just by setting the prop

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -583,7 +583,7 @@ namespace DotNetNuke.Entities.Portals
             get { return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false); }
         }
 
-        public TimeZoneInfo TimeZone { get; set; }
+        public TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Local;
 
         public string PageHeadText
         {

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -92,8 +92,6 @@ namespace DotNetNuke.Entities.Portals
         }
         #endregion
 
-        private TimeZoneInfo _timeZone = TimeZoneInfo.Local;
-
         #region Constructors
 
         public PortalSettings()
@@ -585,16 +583,7 @@ namespace DotNetNuke.Entities.Portals
             get { return PortalController.GetPortalSettingAsBoolean("IsLocked", PortalId, false); }
         }
 
-        public TimeZoneInfo TimeZone
-        {
-            get { return _timeZone; }
-            set
-            {
-                _timeZone = value;
-                PortalController.UpdatePortalSetting(PortalId, "TimeZone", value.Id, true);
-            }
-        }
-
+        public TimeZoneInfo TimeZone { get; set; }
 
         public string PageHeadText
         {


### PR DESCRIPTION
Currently when setting the TimeZone property on the PortalSettings object it will persist to the database and clears the cache. This is obviously not a good idea. The front end already sets the TimeZone when an admin changes the value in the site settings personabar module.