### PR TITLE
Remove disposal of MemoryStream for email attachments sent using SendTokenizedBuilkEmail

### DIFF
--- a/DNN Platform/Library/Services/Mail/SendTokenizedBulkEmail.cs
+++ b/DNN Platform/Library/Services/Mail/SendTokenizedBulkEmail.cs
@@ -347,24 +347,22 @@ namespace DotNetNuke.Services.Mail
 			foreach (var attachment in _attachments)
 			{
 				var buffer = new byte[4096];
-                using (var memoryStream = new MemoryStream())
+                var memoryStream = new MemoryStream();
+                while (true)
                 {
-                    while (true)
+                    var read = attachment.ContentStream.Read(buffer, 0, 4096);
+                    if (read <= 0)
                     {
-                        var read = attachment.ContentStream.Read(buffer, 0, 4096);
-                        if (read <= 0)
-                        {
-                            break;
-                        }
-                        memoryStream.Write(buffer, 0, read);
+                        break;
                     }
-
-                    var newAttachment = new Attachment(memoryStream, attachment.ContentType);
-                    newAttachment.ContentStream.Position = 0;
-                    attachments.Add(newAttachment);
-                    //reset original position
-                    attachment.ContentStream.Position = 0;
+                    memoryStream.Write(buffer, 0, read);
                 }
+
+                var newAttachment = new Attachment(memoryStream, attachment.ContentType);
+                newAttachment.ContentStream.Position = 0;
+                attachments.Add(newAttachment);
+                //reset original position
+                attachment.ContentStream.Position = 0;
 			}
 
 			return attachments;


### PR DESCRIPTION
Resolves #3036 

## Summary
The `using` statement has been removed to avoid disposal of the MemoryStream prior to sending of email.