### PR TITLE
Remove reference to empty fs npm package

### DIFF
--- a/Dnn.AdminExperience/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/package.json
@@ -27,7 +27,6 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-spellcheck": "0.0.11",
-    "fs": "^0.0.1-security",
     "less": "3.9.0",
     "less-loader": "5.0.0",
     "localization": "^1.0.2",

--- a/Dnn.AdminExperience/yarn.lock
+++ b/Dnn.AdminExperience/yarn.lock
@@ -7505,11 +7505,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
-
 fsevents@^1.2.7:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"


### PR DESCRIPTION
fs is a core package, and the version on the npm registry is just an
empty package; this was almost certainly added accidentally

Fixes #3091