### PR TITLE
DNN-32978 Copying pro html module don't modify the permission

### DIFF
--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -296,9 +296,9 @@ namespace DotNetNuke.Entities.Modules
                 HostController.Instance.GetString(translatorSettingKey, null);
 
             var translatorRoles =
-                translatorSettingValue?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Enumerable.Empty<string>();
+                translatorSettingValue?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
-            return translatorRoles.Any(r => r.Equals(permission.RoleName, StringComparison.OrdinalIgnoreCase));
+            return translatorRoles?.Any(r => r.Equals(permission.RoleName, StringComparison.OrdinalIgnoreCase)) == true;
         }
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -270,10 +270,8 @@ namespace DotNetNuke.Entities.Modules
             }
 
             var tabPermissions = TabPermissionController.GetTabPermissions(module.TabID, module.PortalID);
-
-            return tabPermissions
-                .ToList()
-                .Find(x => x.RoleID == permission.RoleID && x.PermissionKey == permissionViewKey) != null;
+            
+            return tabPermissions?.Where(x => x.RoleID == permission.RoleID && x.PermissionKey == permissionViewKey).Any() == true;
         }
 
         /// <summary>
@@ -300,8 +298,7 @@ namespace DotNetNuke.Entities.Modules
             var translatorRoles =
                 translatorSettingValue?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Enumerable.Empty<string>();
 
-            return translatorRoles.Any() &&
-                    translatorRoles.Select(x => x.ToLower()).Contains(permission.RoleName.ToLower());
+            return translatorRoles.Any(r => r.Equals(permission.RoleName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -38,6 +38,7 @@ using DotNetNuke.Data;
 using DotNetNuke.Entities.Content;
 using DotNetNuke.Entities.Content.Common;
 using DotNetNuke.Entities.Content.Taxonomy;
+using DotNetNuke.Entities.Controllers;
 using DotNetNuke.Entities.Modules.Actions;
 using DotNetNuke.Entities.Modules.Definitions;
 using DotNetNuke.Entities.Portals;
@@ -247,6 +248,93 @@ namespace DotNetNuke.Entities.Modules
             foreach (DictionaryEntry setting in fromModule.TabModuleSettings)
             {
                 UpdateTabModuleSetting(toModule.TabModuleID, Convert.ToString(setting.Key), Convert.ToString(setting.Value));
+            }
+        }
+
+        /// <summary>
+        /// Checks whether module VIEW permission is inherited from its tab
+        /// </summary> 
+        /// <param name="module">The module</param>
+        /// <param name="permission">The module permission.</param>
+        private bool IsModuleViewPermissionInherited(ModuleInfo module, ModulePermissionInfo permission)
+        {
+            Requires.NotNull(module);
+
+            Requires.NotNull(permission);
+
+            var permissionViewKey = "VIEW";
+
+            if (!module.InheritViewPermissions || permission.PermissionKey != permissionViewKey)
+            {
+                return false;
+            }
+
+            var tabPermissions = TabPermissionController.GetTabPermissions(module.TabID, module.PortalID);
+
+            return tabPermissions
+                .ToList()
+                .Find(x => x.RoleID == permission.RoleID && x.PermissionKey == permissionViewKey) != null;
+        }
+
+        /// <summary>
+        /// Checks whether given permission is granted for translator role
+        /// </summary>
+        /// <param name="permission">The module permission.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="culture">The culture code.</param>
+        private bool IsTranslatorRolePermission(ModulePermissionInfo permission, int portalId, string culture)
+        {
+            Requires.NotNull(permission);
+
+            if (string.IsNullOrWhiteSpace(culture) || portalId == Null.NullInteger)
+            {
+                return false;
+            }
+
+            var translatorSettingKey = $"DefaultTranslatorRoles-{ culture }";
+
+            var translatorSettingValue = 
+                PortalController.GetPortalSetting(translatorSettingKey, portalId, null) ?? 
+                HostController.Instance.GetString(translatorSettingKey, null);
+
+            var translatorRoles =
+                translatorSettingValue?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Enumerable.Empty<string>();
+
+            return translatorRoles.Any() &&
+                    translatorRoles.Select(x => x.ToLower()).Contains(permission.RoleName.ToLower());
+        }
+
+        /// <summary>
+        /// Copies permissions from source to new tab
+        /// </summary>
+        /// <param name="sourceModule">Source module.</param>
+        /// <param name="newModule">New module.</param>
+        private void CopyModulePermisions(ModuleInfo sourceModule, ModuleInfo newModule)
+        {
+            Requires.NotNull(sourceModule);
+
+            Requires.NotNull(newModule);
+
+            foreach (ModulePermissionInfo permission in sourceModule.ModulePermissions)
+            {
+                // skip inherited view and translator permissions
+                if (IsModuleViewPermissionInherited(newModule, permission) ||
+                    IsTranslatorRolePermission(permission, sourceModule.PortalID, sourceModule.CultureCode))
+                {
+                    continue;
+                }
+
+                // need to force vew permission to be copied 
+                permission.PermissionKey = newModule.InheritViewPermissions && permission.PermissionKey == "VIEW" ?
+                    null :
+                    permission.PermissionKey;
+
+                AddModulePermission(
+                    newModule,
+                    permission,
+                    permission.RoleID,
+                    permission.UserID,
+                    permission.AllowAccess);
             }
         }
 
@@ -614,6 +702,9 @@ namespace DotNetNuke.Entities.Modules
                         AddModulePermission(ref newModule, sourceModule.PortalID, translatorRole, editPermisison, "EDIT");
                     }
                 }
+
+                // copy permisions from source to new module
+                CopyModulePermisions(sourceModule, newModule);
 
                 //Add Module
                 AddModuleInternal(newModule);


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/3122

Summary:
On copying modules between different locales, we also need to copy permissions that we granted for the original module. Having that we also need to make sure we are not explicitly adding inherited VIEW permissions from the tab and permissions for the source module translator.  Any other permission should be copied to the destination module to avoid users to compare and re-add missing roles. 

See demo: [DEMO](https://drive.google.com/file/d/1LDfsP0P0diRV-GJKLoe8Ax30kULWTIyv/view?usp=sharing)