### PR TITLE
Remove Thread Cancellation from OAuthClientBase Implementation

### DIFF
--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -241,7 +241,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
                                             new QueryParameter("response_type", "code")
                                         };
 
-                HttpContext.Current.Response.Redirect(AuthorizationEndpoint + "?" + parameters.ToNormalizedString(), true);
+                HttpContext.Current.Response.Redirect(AuthorizationEndpoint + "?" + parameters.ToNormalizedString(), false);
                 return AuthorisationResult.RequestingCode;
             }
 


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes: #2687 

## Summary
Adjusts OAuthClientBase implementation to prevent thread abortion code. This allows the OAuthClientBase to properly return the status code to the caller and adds additional extension points to custom Auth Providers.

I checked the history on this change and it dates prior to the migration to git so I can't find the reason why we were aborting the thread. This was discussed awhile back in #2687 and we agreed this change would be a good thing to do for the Auth Provider