### PR TITLE
Make white-space visible in log viewer

### DIFF
--- a/Dnn.AdminExperience/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Servers.Web/src/components/Tabs/tabs.less
+++ b/Dnn.AdminExperience/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Servers.Web/src/components/Tabs/tabs.less
@@ -135,6 +135,7 @@
         .log-file-display {
             height:500px;
             padding-right: 50px;
+            white-space: pre-wrap;
         }
 
         .track-horizontal {


### PR DESCRIPTION
Fixes #3197 