### PR TITLE
Do not show "No Search results" message when no search is performed.

### DIFF
--- a/Website/DesktopModules/Admin/SearchResults/dnn.searchResult.js
+++ b/Website/DesktopModules/Admin/SearchResults/dnn.searchResult.js
@@ -389,7 +389,6 @@
         var sterm = dnn.searchResult.queryOptions.searchTerm;
         var advancedTerm = dnn.searchResult.queryOptions.advancedTerm;
         if ((!sterm || $.trim(sterm).length <= 1) && (!advancedTerm || $.trim(advancedTerm).length <= 1)) {
-            dnn.searchResult.renderResults(null);
             return;
         }
 


### PR DESCRIPTION
Fixes #3184 

## Summary
Code change was the removal of showing the message when no search operation was a actually performed. Previously the code showed the message and stopped further processing. As of now it just does not show the message if no search is performed and also does no further processing.

[Demo Video](https://drive.google.com/file/d/1pxE-Cx1u_K3-zduZdqgIwo-KeyF1Vj8f/view?usp=sharing)

Created after **closing #3185** which was approved but closed because it was opened against "develop" branch and not "release/9.4.x".