### PR TITLE
Move email above username field.

### DIFF
--- a/Website/controls/user.ascx
+++ b/Website/controls/user.ascx
@@ -3,9 +3,9 @@
 <%@ Register TagPrefix="dnn" TagName="label" Src="~/controls/labelControl.ascx" %>
 <table cellSpacing="0" cellPadding="1" border="0" summary="User Design Table">
 	<tr>
-		<td class="SubHead" width="175">
+	    <td class="SubHead" width="175">
 			<dnn:label id="plFirstName" runat="server" controlname="txtFirstName" text="First Name:"></dnn:label></td>
-		<td class="NormalBold" noWrap>
+	    <td class="NormalBold" noWrap>
 			<asp:textbox id="txtFirstName" tabIndex="1" runat="server" cssclass="NormalTextBox" size="25"
 				maxlength="50"></asp:textbox>&nbsp;*
 			<asp:requiredfieldvalidator id="valFirstName" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>First Name Is Required."
@@ -20,6 +20,17 @@
 			<asp:requiredfieldvalidator id="valLastName" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Last Name Is Required."
 				controltovalidate="txtLastName" resourcekey="valLastName"></asp:requiredfieldvalidator></td>
 	</tr>
+	</tr>
+        <tr>
+	    <td class="SubHead" width="175">
+			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>
+		<td class="NormalBold" noWrap>
+			<asp:textbox id="txtEmail" tabIndex="6" runat="server" cssclass="NormalTextBox" size="25" maxlength="175"></asp:textbox>&nbsp;*
+			<asp:requiredfieldvalidator id="valEmail1" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Is Required."
+				controltovalidate="txtEmail" resourcekey="valEmail1"></asp:requiredfieldvalidator>
+			<asp:regularexpressionvalidator id="valEmail2" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Must be Valid."
+				controltovalidate="txtEmail" resourcekey="valEmail2" validationexpression="[\w\.-]+(\+[\w-]*)?@([\w-]+\.)+[\w-]+"></asp:regularexpressionvalidator></td>
+	</tr>	
 	<tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plUserName" runat="server" controlname="txtUsername" text="User Name:"></dnn:label></td>
@@ -30,20 +41,10 @@
 			<asp:label id="lblUsername" runat="server"></asp:label>
 			<asp:requiredfieldvalidator id="valUsername" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Username Is Required."
 				controltovalidate="txtUsername" resourcekey="valUsername"></asp:requiredfieldvalidator></td>
-	</tr>
-        <tr>
-		<td class="SubHead" width="175">
-			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>
-		<td class="NormalBold" noWrap>
-			<asp:textbox id="txtEmail" tabIndex="6" runat="server" cssclass="NormalTextBox" size="25" maxlength="175"></asp:textbox>&nbsp;*
-			<asp:requiredfieldvalidator id="valEmail1" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Is Required."
-				controltovalidate="txtEmail" resourcekey="valEmail1"></asp:requiredfieldvalidator>
-			<asp:regularexpressionvalidator id="valEmail2" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Must be Valid."
-				controltovalidate="txtEmail" resourcekey="valEmail2" validationexpression="[\w\.-]+(\+[\w-]*)?@([\w-]+\.)+[\w-]+"></asp:regularexpressionvalidator></td>
-	</tr>
+
 	<tr id="PasswordRow" runat="server">
 		<td class="SubHead" width="175">
-			<dnn:label id="plPassword" runat="server" controlname="txtPassword" text="Password:"></dnn:label></td>
+		    <dnn:label id="plPassword" runat="server" controlname="txtPassword" text="Password:"></dnn:label></td>
 		<td class="NormalBold" noWrap>
 			<asp:textbox id="txtPassword" tabIndex="4" runat="server" cssclass="NormalTextBox" size="25"
 				maxlength="20" textmode="Password"></asp:textbox>&nbsp;*

--- a/Website/controls/user.ascx
+++ b/Website/controls/user.ascx
@@ -41,7 +41,7 @@
 			<asp:label id="lblUsername" runat="server"></asp:label>
 			<asp:requiredfieldvalidator id="valUsername" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Username Is Required."
 				controltovalidate="txtUsername" resourcekey="valUsername"></asp:requiredfieldvalidator></td>
-
+	</tr>
 	<tr id="PasswordRow" runat="server">
 		<td class="SubHead" width="175">
 		    <dnn:label id="plPassword" runat="server" controlname="txtPassword" text="Password:"></dnn:label></td>

--- a/Website/controls/user.ascx
+++ b/Website/controls/user.ascx
@@ -31,7 +31,7 @@
 			<asp:requiredfieldvalidator id="valUsername" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Username Is Required."
 				controltovalidate="txtUsername" resourcekey="valUsername"></asp:requiredfieldvalidator></td>
 	</tr>
-    <tr>
+        <tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>
 		<td class="NormalBold" noWrap>

--- a/Website/controls/user.ascx
+++ b/Website/controls/user.ascx
@@ -19,7 +19,8 @@
 				maxlength="50"></asp:textbox>&nbsp;*
 			<asp:requiredfieldvalidator id="valLastName" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Last Name Is Required."
 				controltovalidate="txtLastName" resourcekey="valLastName"></asp:requiredfieldvalidator></td>
-	</tr>
+	</tr>	
+
 	<tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plUserName" runat="server" controlname="txtUsername" text="User Name:"></dnn:label></td>
@@ -30,6 +31,16 @@
 			<asp:label id="lblUsername" runat="server"></asp:label>
 			<asp:requiredfieldvalidator id="valUsername" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Username Is Required."
 				controltovalidate="txtUsername" resourcekey="valUsername"></asp:requiredfieldvalidator></td>
+	</tr>    
+    <tr>
+		<td class="SubHead" width="175">
+			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>
+		<td class="NormalBold" noWrap>
+			<asp:textbox id="txtEmail" tabIndex="6" runat="server" cssclass="NormalTextBox" size="25" maxlength="175"></asp:textbox>&nbsp;*
+			<asp:requiredfieldvalidator id="valEmail1" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Is Required."
+				controltovalidate="txtEmail" resourcekey="valEmail1"></asp:requiredfieldvalidator>
+			<asp:regularexpressionvalidator id="valEmail2" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Must be Valid."
+				controltovalidate="txtEmail" resourcekey="valEmail2" validationexpression="[\w\.-]+(\+[\w-]*)?@([\w-]+\.)+[\w-]+"></asp:regularexpressionvalidator></td>
 	</tr>
 	<tr id="PasswordRow" runat="server">
 		<td class="SubHead" width="175">
@@ -51,16 +62,7 @@
 			<asp:comparevalidator id="valConfirm2" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Password Values Entered Do Not Match."
 				controltovalidate="txtConfirm" resourcekey="valConfirm2" controltocompare="txtPassword"></asp:comparevalidator></td>
 	</tr>
-	<tr>
-		<td class="SubHead" width="175">
-			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>
-		<td class="NormalBold" noWrap>
-			<asp:textbox id="txtEmail" tabIndex="6" runat="server" cssclass="NormalTextBox" size="25" maxlength="175"></asp:textbox>&nbsp;*
-			<asp:requiredfieldvalidator id="valEmail1" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Is Required."
-				controltovalidate="txtEmail" resourcekey="valEmail1"></asp:requiredfieldvalidator>
-			<asp:regularexpressionvalidator id="valEmail2" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Email Must be Valid."
-				controltovalidate="txtEmail" resourcekey="valEmail2" validationexpression="[\w\.-]+(\+[\w-]*)?@([\w-]+\.)+[\w-]+"></asp:regularexpressionvalidator></td>
-	</tr>
+
 	<tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plWebsite" runat="server" controlname="txtWebsite" text="Website:"></dnn:label></td>

--- a/Website/controls/user.ascx
+++ b/Website/controls/user.ascx
@@ -20,7 +20,6 @@
 			<asp:requiredfieldvalidator id="valLastName" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Last Name Is Required."
 				controltovalidate="txtLastName" resourcekey="valLastName"></asp:requiredfieldvalidator></td>
 	</tr>
-	</tr>
         <tr>
 	    <td class="SubHead" width="175">
 			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>

--- a/Website/controls/user.ascx
+++ b/Website/controls/user.ascx
@@ -19,8 +19,7 @@
 				maxlength="50"></asp:textbox>&nbsp;*
 			<asp:requiredfieldvalidator id="valLastName" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Last Name Is Required."
 				controltovalidate="txtLastName" resourcekey="valLastName"></asp:requiredfieldvalidator></td>
-	</tr>	
-
+	</tr>
 	<tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plUserName" runat="server" controlname="txtUsername" text="User Name:"></dnn:label></td>
@@ -31,7 +30,7 @@
 			<asp:label id="lblUsername" runat="server"></asp:label>
 			<asp:requiredfieldvalidator id="valUsername" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Username Is Required."
 				controltovalidate="txtUsername" resourcekey="valUsername"></asp:requiredfieldvalidator></td>
-	</tr>    
+	</tr>
     <tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plEmail" runat="server" controlname="txtEmail" text="Email Address:"></dnn:label></td>
@@ -62,7 +61,6 @@
 			<asp:comparevalidator id="valConfirm2" runat="server" cssclass="NormalRed" display="Dynamic" errormessage="<br>Password Values Entered Do Not Match."
 				controltovalidate="txtConfirm" resourcekey="valConfirm2" controltocompare="txtPassword"></asp:comparevalidator></td>
 	</tr>
-
 	<tr>
 		<td class="SubHead" width="175">
 			<dnn:label id="plWebsite" runat="server" controlname="txtWebsite" text="Website:"></dnn:label></td>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
Email address is at the bottom below password.  when you have to enter in the captcha code you have to scroll up to get to enter password again.  would be nice not to have to re-enter passwords as this is an issue as well but at least the email address is below the username field with this pull request if accepted.

![image](https://user-images.githubusercontent.com/13577556/67624847-21536700-f7eb-11e9-9b62-2fd848dc4169.png)

NOTE:  I wish I could move "Display Name"  below User Name but this is where the bio registration fields go so no way to really move this easily.

If you have Email as Username set the email address is at the bottom making a user enter passwords first and I can't find any other website that does this.  However email address under Username is more industry standard I believe for a registration form.


