### PR TITLE
Fix to installer and the dependencies of the HTML and DA modules

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -4920,7 +4920,7 @@ namespace DotNetNuke.Services.Upgrade
         /// <returns></returns>
         public static IDictionary<string, PackageInfo> GetInstallPackages()
         {
-            var packageTypes = new string[] { "Module", "Skin", "Container", "JavaScriptLibrary", "Language", "Provider", "AuthSystem", "Package" };
+            var packageTypes = new string[] { "Library", "Module", "Skin", "Container", "JavaScriptLibrary", "Language", "Provider", "AuthSystem", "Package" };
             var invalidPackages = new List<string>();
 
             var packages = new Dictionary<string, PackageInfo>();

--- a/DNN Platform/Modules/DigitalAssets/dnn_DigitalAssets.dnn
+++ b/DNN Platform/Modules/DigitalAssets/dnn_DigitalAssets.dnn
@@ -15,7 +15,7 @@
       <azureCompatible>true</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.01.00</dependency>
-        <dependency type="package" version="09.01.00">DotNetNuke.Web.Deprecated</dependency>
+        <dependency type="ManagedPackage" version="09.01.00">DotNetNuke.Web.Deprecated</dependency>
       </dependencies>
       <components>
         <component type="Module">

--- a/DNN Platform/Modules/HTML/dnn_HTML.dnn
+++ b/DNN Platform/Modules/HTML/dnn_HTML.dnn
@@ -15,7 +15,7 @@
       <azureCompatible>true</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.01.00</dependency>
-        <dependency type="package" version="09.01.00">DotNetNuke.Web.Deprecated</dependency>
+        <dependency type="ManagedPackage" version="09.01.00">DotNetNuke.Web.Deprecated</dependency>
       </dependencies>
       <components>
         <component type="Script">


### PR DESCRIPTION
Two issues are being addressed in this PR:

1. When installing the installer skips the Install/Library folder. No packages in there are currently being installed when first installing DNN.

2. The HTML and DA modules have a dependency on the Web.Deprecated package. The current type of "Package" means they don't actually get checked during install and will therefore not get sorted after that dependency has been installed. Changing this to "ManagedPackage" solves the issue and DNN correctly installs them towards the end.