### PR TITLE
DNN-32474 - Not able to delete custom roles if their associated social group folder isn't empty

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -190,7 +190,7 @@ namespace DotNetNuke.Services.FileSystem
 
             if (DirectoryWrapper.Instance.Exists(folder.PhysicalPath))
             {
-                DirectoryWrapper.Instance.Delete(folder.PhysicalPath, false);
+                DirectoryWrapper.Instance.Delete(folder.PhysicalPath, true);
             }
             DeleteFolder(folder.PortalID, folder.FolderPath);
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FolderManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FolderManagerTests.cs
@@ -443,7 +443,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             _mockFolder.Setup(mf => mf.DeleteFolder(_folderInfo.Object));
 
             _directory.Setup(d => d.Exists(Constants.FOLDER_ValidFolderPath)).Returns(true);
-            _directory.Setup(d => d.Delete(Constants.FOLDER_ValidFolderPath, false)).Verifiable();
+            _directory.Setup(d => d.Delete(Constants.FOLDER_ValidFolderPath, true)).Verifiable();
 
             _mockFolderManager.Setup(mfm => mfm.DeleteFolder(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath));
 


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3248 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
I added the recursive delete option for the nested folders too.
Demo: https://drive.google.com/open?id=1lMUHbr2-tcj8vVMXPZvhucO0eMuvqEQI