### PR TITLE
DNN-29110 Site Assets > Select All is not working

### DIFF
--- a/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
+++ b/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
@@ -2193,6 +2193,7 @@ dnnModule.digitalAssets = function ($, $find, $telerik, dnnModal) {
             if (totalItems == totalSelectedItems) {
                 $("#dnnModuleDigitalAssetsListViewToolbar input[type=checkbox]", "#" + controls.scopeWrapperId).attr('checked', true);
                 $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnModuleDigitalAssetsListViewToolbarTitle', "#" + controls.scopeWrapperId).text(resources.unselectAll);
+                $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnCheckbox').addClass('dnnCheckbox-checke');
             }
             updateSelectionToolBar();
         }, 2);
@@ -2220,6 +2221,7 @@ dnnModule.digitalAssets = function ($, $find, $telerik, dnnModal) {
         updateSelectionToolBarTimeout = setTimeout(function () {
             $("#dnnModuleDigitalAssetsListViewToolbar input[type=checkbox]", "#" + controls.scopeWrapperId).attr('checked', false);
             $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnModuleDigitalAssetsListViewToolbarTitle', "#" + controls.scopeWrapperId).text(resources.selectAll);
+            $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnCheckbox').removeClass('dnnCheckbox-checked');
             updateSelectionToolBar();
         }, 2);
     }

--- a/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
+++ b/DNN Platform/Modules/DigitalAssets/ClientScripts/dnn.DigitalAssets.js
@@ -2193,7 +2193,7 @@ dnnModule.digitalAssets = function ($, $find, $telerik, dnnModal) {
             if (totalItems == totalSelectedItems) {
                 $("#dnnModuleDigitalAssetsListViewToolbar input[type=checkbox]", "#" + controls.scopeWrapperId).attr('checked', true);
                 $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnModuleDigitalAssetsListViewToolbarTitle', "#" + controls.scopeWrapperId).text(resources.unselectAll);
-                $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnCheckbox').addClass('dnnCheckbox-checke');
+                $('#dnnModuleDigitalAssetsListViewToolbar>span.dnnCheckbox').addClass('dnnCheckbox-checked');
             }
             updateSelectionToolBar();
         }, 2);


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/3250

Summary: 

There is a dnnCheckbox control that needs to be updated according to the selected items. If no one item is selected, we should remove `dnnCheckbox` class, otherwise , if all items selected, add this class. 

Confirmation video: [DEMO](https://drive.google.com/file/d/1qXSI2pNX0mQNrlT2j6B5wX9Oaf7TXTUO/view?usp=sharing)