### PR TITLE
Moves Remember Login above Login Button:  referenced in issue #2471 #3255

### DIFF
--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
@@ -32,10 +32,10 @@
 	<div class="dnnFormItem">
         <span class="dnnFormLabel">&nbsp;</span>
         <div class="dnnLoginActions">
-			<ul class="dnnActions dnnClear">
-				<li id="liRegister" runat="server"><asp:HyperLink ID="registerLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdRegister" ViewStateMode="Disabled" /></li>                
-				<li id="liPassword" runat="server"><asp:HyperLink ID="passwordLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdPassword" ViewStateMode="Disabled" /></li>
-			</ul>
+		<ul class="dnnActions dnnClear">
+			<li id="liRegister" runat="server"><asp:HyperLink ID="registerLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdRegister" ViewStateMode="Disabled" /></li>                
+			<li id="liPassword" runat="server"><asp:HyperLink ID="passwordLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdPassword" ViewStateMode="Disabled" /></li>
+		</ul>
         </div>
     </div>
 </div>

--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
@@ -2,41 +2,40 @@
 <%@ Register TagPrefix="dnn" Assembly="DotNetNuke" Namespace="DotNetNuke.UI.WebControls"%>
 <%@ Register TagPrefix="dnn" Namespace="DotNetNuke.Web.UI.WebControls.Internal" Assembly="DotNetNuke.Web" %>
 <div class="dnnForm dnnLoginService dnnClear">
-    <div class="dnnFormItem">
+	<div class="dnnFormItem">
 		<div class="dnnLabel">
 			<asp:label id="plUsername" AssociatedControlID="txtUsername" runat="server" CssClass="dnnFormLabel" />
 		</div>        
-        <asp:textbox id="txtUsername" runat="server" />
-    </div>
-    <div class="dnnFormItem">
+        	<asp:textbox id="txtUsername" runat="server" />
+	</div>
+	<div class="dnnFormItem">
 		<div class="dnnLabel">
 			<asp:label id="plPassword" AssociatedControlID="txtPassword" runat="server" resourcekey="Password" CssClass="dnnFormLabel" ViewStateMode="Disabled" />
 		</div>
-        <asp:textbox id="txtPassword" textmode="Password" runat="server" />
-    </div>
-    <div class="dnnFormItem" id="divCaptcha1" runat="server" visible="false">		
-        <asp:label id="plCaptcha" AssociatedControlID="ctlCaptcha" runat="server" resourcekey="Captcha" CssClass="dnnFormLabel" />
-    </div>
-    <div class="dnnFormItem dnnCaptcha" id="divCaptcha2" runat="server" visible="false">
-        <dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" runat="server" errorstyle-cssclass="dnnFormMessage dnnFormError dnnCaptcha" ViewStateMode="Disabled" />
-    </div>
-    <div class="dnnFormItem">
-        <asp:label id="lblLogin" runat="server" AssociatedControlID="cmdLogin" CssClass="dnnFormLabel" ViewStateMode="Disabled" />
-        <asp:LinkButton id="cmdLogin" resourcekey="cmdLogin" cssclass="dnnPrimaryAction" text="Login" runat="server" CausesValidation="false" />
-		<asp:HyperLink id="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" />
-        
-    </div>
+        	<asp:textbox id="txtPassword" textmode="Password" runat="server" />
+    	</div>
+    	<div class="dnnFormItem" id="divCaptcha1" runat="server" visible="false">		
+        	<asp:label id="plCaptcha" AssociatedControlID="ctlCaptcha" runat="server" resourcekey="Captcha" CssClass="dnnFormLabel" />
+    	</div>
+    	<div class="dnnFormItem dnnCaptcha" id="divCaptcha2" runat="server" visible="false">
+        	<dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" runat="server" errorstyle-cssclass="dnnFormMessage dnnFormError dnnCaptcha" ViewStateMode="Disabled" />
+    	</div>
 	<div class="dnnFormItem">
 		<asp:label id="lblLoginRememberMe" runat="server" CssClass="dnnFormLabel" />
 		<span class="dnnLoginRememberMe"><asp:checkbox id="chkCookie" resourcekey="Remember" runat="server" /></span>
+	</div>    
+	<div class="dnnFormItem">
+        <asp:label id="lblLogin" runat="server" AssociatedControlID="cmdLogin" CssClass="dnnFormLabel" ViewStateMode="Disabled" />
+		<asp:LinkButton id="cmdLogin" resourcekey="cmdLogin" cssclass="dnnPrimaryAction" text="Login" runat="server" CausesValidation="false" />
+		<asp:HyperLink id="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" />
 	</div>
-    <div class="dnnFormItem">
+	<div class="dnnFormItem">
         <span class="dnnFormLabel">&nbsp;</span>
         <div class="dnnLoginActions">
-            <ul class="dnnActions dnnClear">
-                <li id="liRegister" runat="server"><asp:HyperLink ID="registerLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdRegister" ViewStateMode="Disabled" /></li>                
-                <li id="liPassword" runat="server"><asp:HyperLink ID="passwordLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdPassword" ViewStateMode="Disabled" /></li>
-            </ul>
+			<ul class="dnnActions dnnClear">
+				<li id="liRegister" runat="server"><asp:HyperLink ID="registerLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdRegister" ViewStateMode="Disabled" /></li>                
+				<li id="liPassword" runat="server"><asp:HyperLink ID="passwordLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdPassword" ViewStateMode="Disabled" /></li>
+			</ul>
         </div>
     </div>
 </div>

--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
@@ -2,40 +2,40 @@
 <%@ Register TagPrefix="dnn" Assembly="DotNetNuke" Namespace="DotNetNuke.UI.WebControls"%>
 <%@ Register TagPrefix="dnn" Namespace="DotNetNuke.Web.UI.WebControls.Internal" Assembly="DotNetNuke.Web" %>
 <div class="dnnForm dnnLoginService dnnClear">
-	<div class="dnnFormItem">
+    <div class="dnnFormItem">
 		<div class="dnnLabel">
 			<asp:label id="plUsername" AssociatedControlID="txtUsername" runat="server" CssClass="dnnFormLabel" />
 		</div>        
-        	<asp:textbox id="txtUsername" runat="server" />
-	</div>
-	<div class="dnnFormItem">
+        <asp:textbox id="txtUsername" runat="server" />
+    </div>
+    <div class="dnnFormItem">
 		<div class="dnnLabel">
 			<asp:label id="plPassword" AssociatedControlID="txtPassword" runat="server" resourcekey="Password" CssClass="dnnFormLabel" ViewStateMode="Disabled" />
 		</div>
-        	<asp:textbox id="txtPassword" textmode="Password" runat="server" />
-    	</div>
-    	<div class="dnnFormItem" id="divCaptcha1" runat="server" visible="false">		
-        	<asp:label id="plCaptcha" AssociatedControlID="ctlCaptcha" runat="server" resourcekey="Captcha" CssClass="dnnFormLabel" />
-    	</div>
-    	<div class="dnnFormItem dnnCaptcha" id="divCaptcha2" runat="server" visible="false">
-        	<dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" runat="server" errorstyle-cssclass="dnnFormMessage dnnFormError dnnCaptcha" ViewStateMode="Disabled" />
-    	</div>
-	<div class="dnnFormItem">
+        <asp:textbox id="txtPassword" textmode="Password" runat="server" />
+    </div>
+    <div class="dnnFormItem" id="divCaptcha1" runat="server" visible="false">		
+        <asp:label id="plCaptcha" AssociatedControlID="ctlCaptcha" runat="server" resourcekey="Captcha" CssClass="dnnFormLabel" />
+    </div>
+    <div class="dnnFormItem dnnCaptcha" id="divCaptcha2" runat="server" visible="false">
+        <dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" runat="server" errorstyle-cssclass="dnnFormMessage dnnFormError dnnCaptcha" ViewStateMode="Disabled" />
+    </div>
+    	<div class="dnnFormItem">
 		<asp:label id="lblLoginRememberMe" runat="server" CssClass="dnnFormLabel" />
 		<span class="dnnLoginRememberMe"><asp:checkbox id="chkCookie" resourcekey="Remember" runat="server" /></span>
-	</div>    
-	<div class="dnnFormItem">
-        <asp:label id="lblLogin" runat="server" AssociatedControlID="cmdLogin" CssClass="dnnFormLabel" ViewStateMode="Disabled" />
-		<asp:LinkButton id="cmdLogin" resourcekey="cmdLogin" cssclass="dnnPrimaryAction" text="Login" runat="server" CausesValidation="false" />
-		<asp:HyperLink id="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" />
 	</div>
-	<div class="dnnFormItem">
+    <div class="dnnFormItem">
+        <asp:label id="lblLogin" runat="server" AssociatedControlID="cmdLogin" CssClass="dnnFormLabel" ViewStateMode="Disabled" />
+        <asp:LinkButton id="cmdLogin" resourcekey="cmdLogin" cssclass="dnnPrimaryAction" text="Login" runat="server" CausesValidation="false" />
+		<asp:HyperLink id="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" />        
+    </div>
+    <div class="dnnFormItem">
         <span class="dnnFormLabel">&nbsp;</span>
         <div class="dnnLoginActions">
-		<ul class="dnnActions dnnClear">
-			<li id="liRegister" runat="server"><asp:HyperLink ID="registerLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdRegister" ViewStateMode="Disabled" /></li>                
-			<li id="liPassword" runat="server"><asp:HyperLink ID="passwordLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdPassword" ViewStateMode="Disabled" /></li>
-		</ul>
+            <ul class="dnnActions dnnClear">
+                <li id="liRegister" runat="server"><asp:HyperLink ID="registerLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdRegister" ViewStateMode="Disabled" /></li>                
+                <li id="liPassword" runat="server"><asp:HyperLink ID="passwordLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdPassword" ViewStateMode="Disabled" /></li>
+            </ul>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Moves Remember Login above Login and Cancel buttons on the login form.

Fixes issue #2471 and part 4 in #3255

## Summary
moved UI for setting the Remember Login checkbox above Login Cancel buttons
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
