### PR TITLE
Ensure UpdateDnnManifests doesn't run for building dev site

### DIFF
--- a/Build/Cake/thirdparty.cake
+++ b/Build/Cake/thirdparty.cake
@@ -11,7 +11,6 @@ public class OtherPackage {
 }
 
 Task("OtherPackages")
-    .IsDependentOn("UpdateDnnManifests")
     .IsDependentOn("Newtonsoft")
     .Does(() =>
 	{


### PR DESCRIPTION
Small fix to scripts. The main CI logic goes through UpdateDnnManifests. The local dev stuff should not do this. Only if specifically requested by developer.