### PR TITLE
Google Analytics TrackingID is stored in lowercase #3318

### DIFF
--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -189,7 +189,7 @@ namespace DNN.Connectors.GoogleAnalytics
                 }
                 else
                 {
-                    trackingID = values["TrackingID"] != null ? values["TrackingID"].ToLowerInvariant().Trim() : string.Empty;
+                    trackingID = values["TrackingID"] != null ? values["TrackingID"].ToUpperInvariant().Trim() : string.Empty;
                     urlParameter = values["UrlParameter"]?.Trim() ?? string.Empty;
                     trackForAdmin = values["TrackAdministrators"] != null ? values["TrackAdministrators"].ToLowerInvariant().Trim() : string.Empty;
                     anonymizeIp = values["AnonymizeIp"] != null ? values["AnonymizeIp"].ToLowerInvariant().Trim() : string.Empty;


### PR DESCRIPTION
Closes #3318 
Supersedes #3319 

## Summary
The TrackingId should be uppercase to work with Google Analytics.