### PR TITLE
Registered IPersonaBarContainer with DI

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
@@ -58,7 +58,7 @@ namespace Dnn.PersonaBar.Library.Containers
             {
                 if (_instance == null)
                 {
-                    _instance = new PersonaBarContainer(Globals.DependencyProvider.GetRequiredService<INavigationManager>());
+                    _instance = Globals.DependencyProvider.GetRequiredService<IPersonaBarContainer>();
                 }
 
                 return _instance;

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
@@ -109,11 +109,16 @@
     <Compile Include="Security\ISecurityService.cs" />
     <Compile Include="Security\SecurityService.cs" />
     <Compile Include="ServiceScope.cs" />
+    <Compile Include="Startup.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\DNN Platform\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
       <Project>{6928A9B1-F88A-4581-A132-D3EB38669BB0}</Project>
       <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\DNN Platform\DotNetNuke.DependencyInjection\DotNetNuke.DependencyInjection.csproj">
+      <Project>{0fca217a-5f9a-4f5b-a31b-86d64ae65198}</Project>
+      <Name>DotNetNuke.DependencyInjection</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\DNN Platform\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
       <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Startup.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Startup.cs
@@ -1,0 +1,14 @@
+﻿using Dnn.PersonaBar.Library.Containers;
+using DotNetNuke.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dnn.PersonaBar.Library
+{
+    class Startup : IDnnStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<IPersonaBarContainer, PersonaBarContainer>();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3328 

## Summary
This makes `PersonaBarContainer.Instance` property use DI to build the returned object instead of simply newing up a `PersonaBarContainer` instance.
This allows third-party apps to register PB container derived classes with DI and override the default PB container.