### PR TITLE
Relaxed nuget.cake wildcard to include all packages in folder

### DIFF
--- a/Build/Cake/nuget.cake
+++ b/Build/Cake/nuget.cake
@@ -3,7 +3,7 @@ Task("CreateNugetPackages")
 	.Does(() =>
 	{
 		//look for solutions and start building them
-		var nuspecFiles = GetFiles("./Build/Tools/NuGet/DotNetNuke.*.nuspec");
+		var nuspecFiles = GetFiles("./Build/Tools/NuGet/*.nuspec");
 	
 		Information("Found {0} nuspec files.", nuspecFiles.Count);
 


### PR DESCRIPTION
Fixes #3330

## Summary
Relaxes the GetFiles filter so that it also includes **Dnn.PersonaBar.Library.nuspec** file.