### PR TITLE
Journal Links + Comments Word-Break and Resizing

### DIFF
--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -87,6 +87,9 @@
 .journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
 .journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
+.journalrow div.journalitem ul.jcmt li p a{display: inline-flex;}
+.journalrow div.journalitem .jlink a{display: inline-flex;}
+.journalrow div.journalitem .authorname{display: inline-flex;}
 .journalrow div.author{overflow:hidden;float:left;}
 .journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
 .journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -1,4 +1,4 @@
-﻿@charset "utf-8";
+@charset "utf-8";
 /* CSS Document */
 
 
@@ -135,6 +135,233 @@ border-bottom-left-radius: 3px;
                                               padding-left: 5px;
                                               padding-top: 4px;}
 .journalrow div.journalitem .journalfooter abbr {border-style:none;}
+.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;padding:5px;border:1px #ccc solid;}
+.journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
+.journalrow div.journalitem .jlink div{max-width: 67%;word-break:break-word;}   
+.journalrow div.journalitem .likes{padding:2px;}                                              
+.jcmt .cmteditor{max-width:445px;display:none;resize:none;outline:none;}
+.jcmt .cmteditarea{margin: 2px 4px 4px 2px;}
+.jcmt .cmteditarea .editorPlaceholder{height:18px;font-size:11px;line-height:18px;}
+div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;word-break:break-word;}
+.journalrow .juser{ cursor: pointer;}
+/* Visibility and Security */
+.securityMenu{
+	position: absolute;
+	right:-7px;
+	display:none;
+	min-width:200px; height:300px;
+	margin-top: 24px;
+	background-color:#fff;
+	z-index:1000;
+}
+.securityMenu .handle{
+	z-index:1000;
+	position:absolute; right:2px; top:-28px;
+	width:26px; height:22px;
+	border:1px solid #ccc;
+	border-bottom:1px solid #fff;
+	
+	/*CSS3*/
+	-moz-border-radius-topright: 	3px;
+	-moz-border-radius-topleft: 	3px;
+	-webkit-border-radius: 		3px 3px 0px 0px;
+	border-radius: 			3px 3px 0px 0px; 
+}
+.DnnModule .securityMenu ul{
+	position:absolute; top:-5px; right:2px;
+	padding:15px;
+	border:1px solid #ccc;
+	list-style:none;
+	background:#fff;
+	
+	-webkit-border-radius: 3px 0px 3px 3px;
+    	border-radius: 3px 0px 3px 3px;
+	
+	-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
+	-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
+	box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
+        
+}
+.securityMenu ul li{list-style:none; margin-bottom: 4px;}
+
+.journalitem p{
+	margin-bottom: 5px;
+	word-break: break-word;
+}
+
+/* File Upload */
+.progress_bar_wrapper{ width: 500px;overflow: hidden;}
+.progress-bar div{ background-image: url('Images/progress.gif');position:relative;padding:0 !important;}
+
+#tbar-attach-Area input:not([type=file]){cursor:pointer; left: 0;top: 0;width: 150px;position:absolute; opacity:0; display:inline;height:18px;padding:4px;margin-bottom:9px;font-size:13px;line-height:18px;color:#555555;border:1px solid #ccc;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+
+.journalTools #journalOptionArea div span.browser-upload-btn{position:relative; font-weight: bold; padding-left:0px; cursor:pointer;display: block; }
+    .browser-upload-btn:hover{cursor:pointer;}
+div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.filePreviewArea {padding:0;margin:0}
+div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.progress_bar_wrapper{padding:0;margin:0;}
+
+.journalTools #journalOptionArea #itemUpload .filePreviewArea img {
+    background: none repeat scroll 0 0 #FFFFFF;
+    border: 1px solid #E0EFF7;
+    border-radius: 3px 3px 3px 3px;
+    margin: 0 0 12px 12px;
+    padding: 6px;
+}
+
+div#journalOptionArea > div.fileUploadArea {
+    background: #eff8ff; /* blue */		
+}
+
+div#journalOptionArea div.journal_onlineFileShare,
+div#journalOptionArea div.journal_localFileShare {
+    width: 50%;
+    float: left;
+    padding: 0;
+}
+
+div#journalOptionArea div.journal_onlineFileShare {
+    border-right: 1px solid #cce8ff;
+    margin-right: 25px;
+}
+div#journalOptionArea div.journal_localFileShare {
+    width: 40%;
+}
+
+div#journalOptionArea div.journal_onlineFileShare div {
+    margin: 0;
+    padding: 0;
+}
+div#journalOptionArea div.journal_onlineFileShare a.dnnSecondaryAction {
+    display: inline-block;
+    margin: 15px 0 0 15px;
+}
+
+div#journalOptionArea div.journal_localFileShare .dnnInputFileWrapper {
+    display: inline-block;
+    margin: 15px 0 0 0;
+}
+/* Search Suggest */
+ul.ui-autocomplete, 
+ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
+	ul.ui-autocomplete{
+		display:none;
+		position:absolute;top:46px;left:0;
+		width:auto;
+		border:1px solid #ccc; background:#fff;
+		z-index:5;
+		
+		/*CSS3*/
+		-moz-border-radius-bottomright: 3px;
+		-moz-border-radius-bottomleft:	3px;
+		-webkit-border-radius: 		0px 0px 3px 3px;
+		border-radius: 			0px 0px 3px 3px; 
+		
+		-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
+		-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
+		box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
+	}
+	ul.ui-autocomplete li{display:block;clear:both;overflow:hidden}
+	ul.ui-autocomplete li a{
+		display:block;
+		padding:10px;
+		border-bottom:1px #e8e8e8 solid;
+		clear:both;overflow:hidden
+	}
+	ul.ui-autocomplete li a:hover, ul.ui-autocomplete li a.ui-state-focus{
+		background:#FEFDDE;
+		cursor:pointer
+	}
+	ul.ui-autocomplete .ui-menu-item a img{ width: 24px;height: 24px;}
+	ul.ui-autocomplete .ui-menu-item a span.dn{ font-weight: bold;color: #000;margin: 0 4px;}
+	ul.ui-autocomplete .ui-menu-item a span.un{ color: #ccc;margin: 0 4px;}
+.ui-helper-hidden-accessible { display:none; }
+}
+#journalEditor #tbar > span{display:block;height:16px;width:24px;float:right;background-image:url('images/journal-tools.png'); border:1px solid transparent}
+.securityMenu > ul > li > span {display: inline-block; margin-right: 3px;}
+#journalEditor #tbar span#tbar-photo{background-position:0 0;}
+#journalEditor #tbar span#tbar-attach{background-position:-24px 0;}
+#journalEditor #tbar span#tbar-perm{background-position:-81px 0;}
+#journalEditor #tbar span#tbar-photo:hover,#journalEditor #tbar span#tbar-photo.selected{background-position:0 -16px;}
+#journalEditor #tbar span#tbar-attach:hover,#journalEditor #tbar span#tbar-attach.selected{background-position:-24px -16px;}
+#journalEditor #tbar span#tbar-attach:hover{background-position:-24px -16px;}
+#journalEditor #tbar span#tbar-perm:hover{background-position:-81px -16px;}
+.journalTools #journalOptionArea{background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
+                                 -webkit-border-bottom-right-radius: 3px;
+-webkit-border-bottom-left-radius: 3px;
+-moz-border-radius-bottomright: 3px;
+-moz-border-radius-bottomleft: 3px;
+border-bottom-right-radius: 3px;
+border-bottom-left-radius: 3px;
+    top: -10px;
+    position:relative;
+    width: 96%;
+}
+
+.journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
+.journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}
+
+.journalTools #journalOptionArea #itemUpload{margin:0;padding:0;}
+
+
+
+.journalTools #journalOptionArea .jpa{display:none;}
+.journalTools #journalOptionArea #linkArea #imagePreviewer{width:150px; float:left;margin-right:12px;}
+.journalTools #journalOptionArea #linkArea #imagePreviewer #image{width:140px; height:100px; overflow:hidden;}
+.journalTools #journalOptionArea #linkArea #imagePreviewer #imgPrev,.journalTools #journalOptionArea #linkArea #imagePreviewer #imgNext{cursor:pointer;}
+.journalTools #btnShare,.jcmt li.cmtbtn a{display: inline-block;display:none;outline: none;cursor: pointer;text-align: center;text-decoration: none;
+	padding: .7em 1.5em .77em;text-shadow: 0 1px 1px rgba(0,0,0,.3);-webkit-border-radius: .3em; -moz-border-radius: .3em;border-radius:.3em;-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.2);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,.2);	box-shadow: 0 1px 2px rgba(0,0,0,.2);   color: #fef4e9;cursor:pointer;float:left;background: #005cb2;
+	background: -webkit-gradient(linear, left top, left bottom, from(#298fd0), to(#005cb2));
+	background: -moz-linear-gradient(top,  #298fd0,  #005cb2);
+	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#298fd0', endColorstr='#005cb2');}
+
+    .journalTools #btnShare:hover,.jcmt li.cmtbtn a:hover {text-decoration: none;background: #003465;
+	    background: -webkit-gradient(linear, left top, left bottom, from(#156292), to(#003465));
+	    background: -moz-linear-gradient(top,  #156292,  #003465);
+	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#156292', endColorstr='#003465');}
+	    
+    .journalTools #btnShare:active,.jcmt li.cmtbtn a:active {position: relative;top: 1px;color: #fff;
+	    background: -webkit-gradient(linear, left top, left bottom, from(#005cb2), to(#298fd0));
+	    background: -moz-linear-gradient(top,  #005cb2,  #298fd0);
+	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#005cb2', endColorstr='#298fd0');}		
+	    
+.journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
+.journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
+
+
+.journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
+.journalrow div.author{overflow:hidden;float:left;}
+.journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;border:1px #ccc solid;padding:4px;}
+.journalrow div.journalitem{margin-left:65px;overflow: hidden;word-break: break-all;}
+
+.journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
+.journalrow div.journalitem .authorname{padding-right:6px;}
+.journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
+
+/*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
+    .journalrow div.journalitem ul.jcmt {
+        margin-left: 0px;
+        margin-bottom: 0px;
+    }
+.journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
+.journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
+.journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
+.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel{display:block;}
+.journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
+.journalrow div.journalitem ul.jcmt li img{ float: left;
+    left: 0;
+    padding: 4px;
+    position: relative;
+    top: 0;}
+.journalrow div.journalitem ul.jcmt li p{padding:4px 0px 4px 5px; margin:3px 0px 5px 42px;}
+.journalrow div.journalitem ul.jcmt li p a{padding-right:6px;}                                         
+.journalrow div.journalitem ul.jcmt li p abbr{border-style: none;
+                                              display: block;
+                                              margin-bottom: 3px;
+                                              margin-top: 4px;
+                                              padding-left: 5px;
+                                              padding-top: 4px;}
+.journalrow div.journalitem .journalfooter abbr {border-style:none;}
 .journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;}
 .journalrow div.journalitem .jlink div{max-width:450px;}
 .journalrow div.journalitem .likes{padding:2px;}                                              
@@ -172,8 +399,8 @@ border-bottom-left-radius: 3px;
 	list-style:none;
 	background:#fff;
 	
-	-webkit-border-radius: 3px 0px 3px 3px;
-    	border-radius: 3px 0px 3px 3px;
+	-webkit-border-radius: 	3px 0px 3px 3px;
+    	border-radius: 		3px 0px 3px 3px;
 	
 	-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
 	-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -127,7 +127,7 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
 .journalrow div.journalitem .jlink div{max-width: 100%;word-break:break-word;}   
 .journalrow div.journalitem .likes{padding:2px;}                                              
-.jcmt .cmteditor{max-width:445px;display:none;resize:none;outline:none;}
+.jcmt .cmteditor{max-width:100%;display:none;resize:none;outline:none;}
 .jcmt .cmteditarea{margin: 2px 4px 4px 2px;}
 .jcmt .cmteditarea .editorPlaceholder{height:18px;font-size:11px;line-height:18px;}
 div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;word-break:break-word;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -1,5 +1,7 @@
 @charset "utf-8";
 /* CSS Document */
+
+
 #journalEditor, .jcmt .cmteditarea
 {
         display:inline-block;
@@ -19,16 +21,13 @@
 		overflow:visible;
 		zoom:1;
 }
- .jcmt .cmteditarea{z-index:0;}
 .journalTools ul.jacmenu{display:none; position: absolute;z-index: 4; list-style-type:none;border:solid 1px #dcdcdc;background-color:#f5f5f5;}
 .journalTools ul.jacmenu li{padding:2px;list-style-type:none;border-bottom:1px solid #dcdcdc;background-color:#f3f3f3;}
 
-#journalEditor {width:100%;}
 #journalEditor #journalContent{overflow:auto;outline:none;}
 #journalEditor #journalContent span{padding:0 2px 0 2px;border-radius:3px;-moz-border-radius:3px;-webkit-border-radius:3px;}
 #journalEditor #journalContent .juser, .journalrow .juser{color:#000;border:1px solid #ccd5e4; background-color:#eff2f7;}
 #journalEditor #journalContent .jtag, .journalrow .jtag{border:1px solid #ccc; background-color:#f5f5f5}
-
 #journalEditor #journalClose, #linkClose, .miniclose, .minidel{float:right;visibility:hidden;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
 #journalEditor .minidel{position:absolute;right:0px;}
 #journalEditor #journalClose{position:absolute; right:6px; top:6px;}
@@ -36,6 +35,7 @@
 #journalEditor #journalClose{position:absolute;right:2px;}
 #journalEditor #journalPlaceholder,.jcmt .cmteditarea .editorPlaceholder{font-size:14px;color:#999;height:24px;line-height:24px;padding-left:7px;}
 #journalEditor #journalContent{font-family:Arial, Helvetica; float:left; display:none;height:1px;margin-bottom:4px;padding: 2px 4px 6px 4px;font-size:14px; border: none; -webkit-box-shadow: none; box-shadow: none; line-height:1.3em;width:99%;resize:none;}
+
 
 #journalEditor .journalPlaceholder {width:100%;}
 #journalEditor .dnnClear{height:0;}
@@ -56,7 +56,7 @@
 #journalEditor #tbar span#tbar-attach:hover,#journalEditor #tbar span#tbar-attach.selected{background-position:-24px -16px;}
 #journalEditor #tbar span#tbar-attach:hover{background-position:-24px -16px;}
 #journalEditor #tbar span#tbar-perm:hover{background-position:-81px -16px;}
-.journalTools #journalOptionArea{width:100%;background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
+.journalTools #journalOptionArea{background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
                                  -webkit-border-bottom-right-radius: 3px;
 -webkit-border-bottom-left-radius: 3px;
 -moz-border-radius-bottomright: 3px;
@@ -67,6 +67,7 @@ border-bottom-left-radius: 3px;
     position:relative;
     width: 100%;
 }
+
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
 .journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}
 .journalTools #journalOptionArea #itemUpload{margin:0;padding:0;}
@@ -96,14 +97,18 @@ border-bottom-left-radius: 3px;
 
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
-.journalrow div.author img{width:32px;max-width:100%;height:auto;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
-.journalrow div.journalitem{margin-left:50px;overflow: hidden;word-break: break-all;}
+.journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+.journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}
+.journalitem p{margin-bottom: 5px;word-break: break-word;}
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
 .journalrow div.journalitem .authorname{padding-right:6px;}
 .journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
 
 /*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
-.journalrow div.journalitem ul.jcmt {margin-left: 0px;margin-bottom: 0px;}
+    .journalrow div.journalitem ul.jcmt {
+        margin-left: 0px;
+        margin-bottom: 0px;
+    }
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
@@ -123,15 +128,12 @@ border-bottom-left-radius: 3px;
                                               padding-left: 5px;
                                               padding-top: 4px;}
 .journalrow div.journalitem .journalfooter abbr {border-style:none;}
+.journalrow div.journalitem .jlink a{font-weight:bold;display:block}
 .journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;height:auto;padding:5px;}
-.journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
-.journalrow div.journalitem .jlink div{max-width: 100%;word-break:break-word;}   
+.journalrow div.journalitem .jlink div{max-width:100%;}
 .journalrow div.journalitem .likes{padding:2px;}                                              
 .jcmt .cmteditor{max-width:100%;display:none;resize:none;outline:none;}
-.jcmt .cmteditarea{margin: 2px 4px 4px 2px;}
-.jcmt .cmteditarea .editorPlaceholder{height:18px;font-size:11px;line-height:18px;}
-div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;word-break:break-word;}
-.journalrow .juser{ cursor: pointer;}
+.jcmt .cmteditarea{margin: 2px 4px 4px 2px;z-index:0;}
 /* Visibility and Security */
 .securityMenu{
 	position: absolute;
@@ -150,10 +152,10 @@ div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:n
 	border-bottom:1px solid #fff;
 	
 	/*CSS3*/
-	-moz-border-radius-topright: 	3px;
-	-moz-border-radius-topleft: 	3px;
-	-webkit-border-radius: 		3px 3px 0px 0px;
-	border-radius: 			3px 3px 0px 0px; 
+	-moz-border-radius-topright:    3px;
+	-moz-border-radius-topleft:	    3px;
+	-webkit-border-radius: 			3px 3px 0px 0px;
+	border-radius: 					3px 3px 0px 0px; 
 }
 .DnnModule .securityMenu ul{
 	position:absolute; top:-5px; right:2px;
@@ -162,238 +164,16 @@ div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:n
 	list-style:none;
 	background:#fff;
 	
-	-webkit-border-radius: 	3px 0px 3px 3px;
-    	border-radius: 		3px 0px 3px 3px;
+	-webkit-border-radius:  3px 0px 3px 3px;
+    border-radius:          3px 0px 3px 3px;
 	
 	-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-	-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-	box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
+	-moz-box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5);
+	box-shadow: 			0px 2px 0px 0px rgba(0, 0, 0, .5); 
         
 }
 .securityMenu ul li{list-style:none; margin-bottom: 4px;}
 
-.journalitem p{
-	margin-bottom: 5px;
-	word-break: break-word;
-}
-/* File Upload */
-.progress_bar_wrapper{ width: 500px;overflow: hidden;}
-.progress-bar div{ background-image: url('Images/progress.gif');position:relative;padding:0 !important;}
-
-#tbar-attach-Area input:not([type=file]){cursor:pointer; left: 0;top: 0;width: 150px;position:absolute; opacity:0; display:inline;height:18px;padding:4px;margin-bottom:9px;font-size:13px;line-height:18px;color:#555555;border:1px solid #ccc;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
-
-.journalTools #journalOptionArea div span.browser-upload-btn{position:relative; font-weight: bold; padding-left:0px; cursor:pointer;display: block; }
-	.browser-upload-btn:hover{cursor:pointer;}
-div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.filePreviewArea {padding:0;margin:0}
-div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.progress_bar_wrapper{padding:0;margin:0;}
-
-.journalTools #journalOptionArea #itemUpload .filePreviewArea img {
-    background: none repeat scroll 0 0 #FFFFFF;
-    border: 1px solid #E0EFF7;
-    border-radius: 3px 3px 3px 3px;
-    margin: 0 0 12px 12px;
-    padding: 6px;
-}
-
-div#journalOptionArea > div.fileUploadArea {
-    background: #eff8ff; /* blue */		
-}
-
-div#journalOptionArea div.journal_onlineFileShare,
-div#journalOptionArea div.journal_localFileShare {
-    width: 50%;
-    float: left;
-    padding: 0;
-}
-
-div#journalOptionArea div.journal_onlineFileShare {
-    border-right: 1px solid #cce8ff;
-    margin-right: 25px;
-}
-div#journalOptionArea div.journal_localFileShare {
-    width: 40%;
-}
-
-div#journalOptionArea div.journal_onlineFileShare div {
-    margin: 0;
-    padding: 0;
-}
-div#journalOptionArea div.journal_onlineFileShare a.dnnSecondaryAction {
-    display: inline-block;
-    margin: 15px 0 0 15px;
-}
-
-div#journalOptionArea div.journal_localFileShare .dnnInputFileWrapper {
-    display: inline-block;
-    margin: 15px 0 0 0;
-}
-/* Search Suggest */
-ul.ui-autocomplete, 
-ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
-	ul.ui-autocomplete{
-		display:none;
-		position:absolute;top:46px;left:0;
-		width:auto;
-		border:1px solid #ccc; background:#fff;
-		z-index:5;
-		
-		/*CSS3*/
-		-moz-border-radius-bottomright: 3px;
-		-moz-border-radius-bottomleft:	3px;
-		-webkit-border-radius: 		0px 0px 3px 3px;
-		border-radius: 			0px 0px 3px 3px; 
-		
-		-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-		-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-		box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
-	}
-	ul.ui-autocomplete li{display:block;clear:both;overflow:hidden}
-	ul.ui-autocomplete li a{
-		display:block;
-		padding:10px;
-		border-bottom:1px #e8e8e8 solid;
-		clear:both;overflow:hidden
-	}
-	ul.ui-autocomplete li a:hover, ul.ui-autocomplete li a.ui-state-focus{
-		background:#FEFDDE;
-		cursor:pointer
-	}
-	ul.ui-autocomplete .ui-menu-item a img{ width: 24px;height: 24px;}
-	ul.ui-autocomplete .ui-menu-item a span.dn{ font-weight: bold;color: #000;margin: 0 4px;}
-	ul.ui-autocomplete .ui-menu-item a span.un{ color: #ccc;margin: 0 4px;}
-.ui-helper-hidden-accessible { display:none; }
-}
-#journalEditor #tbar > span{display:block;height:16px;width:24px;float:right;background-image:url('images/journal-tools.png'); border:1px solid transparent}
-.securityMenu > ul > li > span {display: inline-block; margin-right: 3px;}
-#journalEditor #tbar span#tbar-photo{background-position:0 0;}
-#journalEditor #tbar span#tbar-attach{background-position:-24px 0;}
-#journalEditor #tbar span#tbar-perm{background-position:-81px 0;}
-#journalEditor #tbar span#tbar-photo:hover,#journalEditor #tbar span#tbar-photo.selected{background-position:0 -16px;}
-#journalEditor #tbar span#tbar-attach:hover,#journalEditor #tbar span#tbar-attach.selected{background-position:-24px -16px;}
-#journalEditor #tbar span#tbar-attach:hover{background-position:-24px -16px;}
-#journalEditor #tbar span#tbar-perm:hover{background-position:-81px -16px;}
-.journalTools #journalOptionArea{background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
-				-webkit-border-bottom-right-radius: 3px;
-				-webkit-border-bottom-left-radius: 3px;
-				-moz-border-radius-bottomright: 3px;
-				-moz-border-radius-bottomleft: 3px;
-				border-bottom-right-radius: 3px;
-				border-bottom-left-radius: 3px;
-					top: -10px;
-					position:relative;
-					width: 100%;
-}
-
-.journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
-.journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}
-.journalTools #journalOptionArea #itemUpload{margin:0;padding:0;}
-.journalTools #journalOptionArea .jpa{display:none;}
-.journalTools #journalOptionArea #linkArea #imagePreviewer{width:150px; float:left;margin-right:12px;}
-.journalTools #journalOptionArea #linkArea #imagePreviewer #image{width:140px; height:100px; overflow:hidden;}
-.journalTools #journalOptionArea #linkArea #imagePreviewer #imgPrev,.journalTools #journalOptionArea #linkArea #imagePreviewer #imgNext{cursor:pointer;}
-.journalTools #btnShare,.jcmt li.cmtbtn a{display: inline-block;display:none;outline: none;cursor: pointer;text-align: center;text-decoration: none;
-	padding: .7em 1.5em .77em;text-shadow: 0 1px 1px rgba(0,0,0,.3);-webkit-border-radius: .3em; -moz-border-radius: .3em;border-radius:.3em;-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.2);
-	-moz-box-shadow: 0 1px 2px rgba(0,0,0,.2);	box-shadow: 0 1px 2px rgba(0,0,0,.2);   color: #fef4e9;cursor:pointer;float:left;background: #005cb2;
-	background: -webkit-gradient(linear, left top, left bottom, from(#298fd0), to(#005cb2));
-	background: -moz-linear-gradient(top,  #298fd0,  #005cb2);
-	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#298fd0', endColorstr='#005cb2');}
-
-    .journalTools #btnShare:hover,.jcmt li.cmtbtn a:hover {text-decoration: none;background: #003465;
-	    background: -webkit-gradient(linear, left top, left bottom, from(#156292), to(#003465));
-	    background: -moz-linear-gradient(top,  #156292,  #003465);
-	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#156292', endColorstr='#003465');}
-	    
-    .journalTools #btnShare:active,.jcmt li.cmtbtn a:active {position: relative;top: 1px;color: #fff;
-	    background: -webkit-gradient(linear, left top, left bottom, from(#005cb2), to(#298fd0));
-	    background: -moz-linear-gradient(top,  #005cb2,  #298fd0);
-	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#005cb2', endColorstr='#298fd0');}		
-	    
-.journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
-.journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
-
-.journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
-.journalrow div.author{overflow:hidden;float:left;}
-.journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;}
-.journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}
-
-.journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
-.journalrow div.journalitem .authorname{padding-right:6px;}
-.journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
-
-/*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
-    .journalrow div.journalitem ul.jcmt {
-        margin-left: 0px;
-        margin-bottom: 0px;
-    }
-.journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
-.journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
-.journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
-.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel{display:block;}
-.journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
-.journalrow div.journalitem ul.jcmt li img{ float: left;
-    left: 0;
-    padding: 4px;
-    position: relative;
-    top: 0;}
-.journalrow div.journalitem ul.jcmt li p{padding:4px 0px 4px 5px; margin:3px 0px 5px 42px;}
-.journalrow div.journalitem ul.jcmt li p a{padding-right:6px;}                                         
-.journalrow div.journalitem ul.jcmt li p abbr{border-style: none;
-                                              display: block;
-                                              margin-bottom: 3px;
-                                              margin-top: 4px;
-                                              padding-left: 5px;
-                                              padding-top: 4px;}
-.journalrow div.journalitem .journalfooter abbr {border-style:none;}
-.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;}
-.journalrow div.journalitem .jlink div{max-width:450px;}
-.journalrow div.journalitem .likes{padding:2px;}                                              
-.jcmt .cmteditor{max-width:445px;display:none;resize:none;outline:none;}
-.jcmt .cmteditarea{margin: 2px 4px 4px 2px;}
-.jcmt .cmteditarea .editorPlaceholder{height:18px;font-size:11px;line-height:18px;}
-/* Visibility and Security */
-.securityMenu{
-	position: absolute;
-	right:-7px;
-	display:none;
-	min-width:200px; height:300px;
-	margin-top: 24px;
-	background-color:#fff;
-	z-index:1000;
-}
-.securityMenu .handle{
-	z-index:1000;
-	position:absolute; right:2px; top:-28px;
-	width:26px; height:22px;
-	border:1px solid #ccc;
-	border-bottom:1px solid #fff;
-	
-	/*CSS3*/
-	-moz-border-radius-topright: 	3px;
-	-moz-border-radius-topleft: 	3px;
-	-webkit-border-radius: 		3px 3px 0px 0px;
-	border-radius: 			3px 3px 0px 0px; 
-}
-.DnnModule .securityMenu ul{
-	position:absolute; top:-5px; right:2px;
-	padding:15px;
-	border:1px solid #ccc;
-	list-style:none;
-	background:#fff;
-	
-	-webkit-border-radius: 	3px 0px 3px 3px;
-    	border-radius: 		3px 0px 3px 3px;
-	
-	-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-	-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-	box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
-        
-}
-.securityMenu ul li{list-style:none; margin-bottom: 4px;}
-
-.journalitem p{
-	margin-bottom: 5px;
-	word-break: break-word;
-}
 /* File Upload */
 .progress_bar_wrapper{ width: 500px;overflow: hidden;}
 .progress-bar div{ background-image: url('Images/progress.gif');position:relative;padding:0 !important;}
@@ -413,9 +193,8 @@ div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.pro
     padding: 6px;
 }
 
-.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;height:auto;padding:5px;}
-.journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
-.journalrow div.journalitem .jlink div{max-width: 100%;word-break:break-word;}   
+
+    
 div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;}
 .journalrow .juser{ cursor: pointer;}
 
@@ -465,12 +244,12 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 		/*CSS3*/
 		-moz-border-radius-bottomright: 3px;
 		-moz-border-radius-bottomleft:	3px;
-		-webkit-border-radius: 		0px 0px 3px 3px;
-		border-radius: 			0px 0px 3px 3px; 
+		-webkit-border-radius: 			0px 0px 3px 3px;
+		border-radius: 					0px 0px 3px 3px; 
 		
 		-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-		-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-		box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
+		-moz-box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5);
+		box-shadow: 			0px 2px 0px 0px rgba(0, 0, 0, .5); 
 	}
 	ul.ui-autocomplete li{display:block;clear:both;overflow:hidden}
 	ul.ui-autocomplete li a{

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -64,7 +64,7 @@ border-bottom-right-radius: 3px;
 border-bottom-left-radius: 3px;
     top: -10px;
     position:relative;
-    width: 96%;
+    width: 100%;
 }
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
 .journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -414,7 +414,7 @@ div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.pro
 
 .journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;height:auto;padding:5px;}
 .journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
-.journalrow div.journalitem .jlink div{max-width: 67%;word-break:break-word;}   
+.journalrow div.journalitem .jlink div{max-width: 100%;word-break:break-word;}   
 div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;}
 .journalrow .juser{ cursor: pointer;}
 

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -178,7 +178,7 @@ div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.pro
     margin: 0 0 12px 12px;
     padding: 6px;
 }   
-div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;}
+div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;max-width:99%;}
 .journalrow .juser{ cursor: pointer;}
 
 div#journalOptionArea > div.fileUploadArea {

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -280,7 +280,7 @@ border-bottom-right-radius: 3px;
 border-bottom-left-radius: 3px;
     top: -10px;
     position:relative;
-    width: 96%;
+    width: 100%;
 }
 
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -107,7 +107,7 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
-.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, div:hover #linkClose{visibility:visible;}
+.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, div:hover #linkClose,div:hover #journalEditor #journalClose{visibility:visible;}
 .journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
 .journalrow div.journalitem ul.jcmt li img{ float: left;
     left: 0;

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -107,7 +107,7 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
-.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel{visibility:visible;}
+.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, div:hover #linkClose{visibility:visible;}
 .journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
 .journalrow div.journalitem ul.jcmt li img{ float: left;
     left: 0;

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -117,7 +117,7 @@ border-bottom-left-radius: 3px;
         margin-bottom: 0px;
     }
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
-.journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;}
+.journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
 .journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel{display:block;}
 .journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
@@ -160,10 +160,10 @@ border-bottom-left-radius: 3px;
 	border-bottom:1px solid #fff;
 	
 	/*CSS3*/
-	-moz-border-radius-topright: 3px;
-	-moz-border-radius-topleft:	3px;
-	-webkit-border-radius: 			3px 3px 0px 0px;
-	border-radius: 					3px 3px 0px 0px; 
+	-moz-border-radius-topright: 	3px;
+	-moz-border-radius-topleft: 	3px;
+	-webkit-border-radius: 		3px 3px 0px 0px;
+	border-radius: 			3px 3px 0px 0px; 
 }
 .DnnModule .securityMenu ul{
 	position:absolute; top:-5px; right:2px;
@@ -173,11 +173,11 @@ border-bottom-left-radius: 3px;
 	background:#fff;
 	
 	-webkit-border-radius: 3px 0px 3px 3px;
-    border-radius: 3px 0px 3px 3px;
+    	border-radius: 3px 0px 3px 3px;
 	
 	-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-	-moz-box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5);
-	box-shadow: 			0px 2px 0px 0px rgba(0, 0, 0, .5); 
+	-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
+	box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
         
 }
 .securityMenu ul li{list-style:none; margin-bottom: 4px;}
@@ -207,8 +207,8 @@ div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.pro
 }
 
 .journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;padding:5px;border:1px #ccc solid;}
-    .journalrow div.journalitem .jlink a{font-weight:bold;display:block}
-    
+.journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
+.journalrow div.journalitem .jlink div{max-width: 67%;word-break:break-word;}   
 div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;}
 .journalrow .juser{ cursor: pointer;}
 
@@ -258,12 +258,12 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 		/*CSS3*/
 		-moz-border-radius-bottomright: 3px;
 		-moz-border-radius-bottomleft:	3px;
-		-webkit-border-radius: 			0px 0px 3px 3px;
-		border-radius: 					0px 0px 3px 3px; 
+		-webkit-border-radius: 		0px 0px 3px 3px;
+		border-radius: 			0px 0px 3px 3px; 
 		
 		-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
-		-moz-box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5);
-		box-shadow: 			0px 2px 0px 0px rgba(0, 0, 0, .5); 
+		-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
+		box-shadow: 		0px 2px 0px 0px rgba(0, 0, 0, .5); 
 	}
 	ul.ui-autocomplete li{display:block;clear:both;overflow:hidden}
 	ul.ui-autocomplete li a{

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -1,7 +1,6 @@
 @charset "utf-8";
 /* CSS Document */
 
-
 #journalEditor, .jcmt .cmteditarea
 {
         display:inline-block;
@@ -23,7 +22,6 @@
 }
 .journalTools ul.jacmenu{display:none; position: absolute;z-index: 4; list-style-type:none;border:solid 1px #dcdcdc;background-color:#f5f5f5;}
 .journalTools ul.jacmenu li{padding:2px;list-style-type:none;border-bottom:1px solid #dcdcdc;background-color:#f3f3f3;}
-
 #journalEditor #journalContent{overflow:auto;outline:none;}
 #journalEditor #journalContent span{padding:0 2px 0 2px;border-radius:3px;-moz-border-radius:3px;-webkit-border-radius:3px;}
 #journalEditor #journalContent .juser, .journalrow .juser{color:#000;border:1px solid #ccd5e4; background-color:#eff2f7;}
@@ -31,15 +29,10 @@
 #journalEditor #journalClose, #linkClose, .miniclose, .minidel{float:right;visibility:hidden;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
 #journalEditor .minidel{position:absolute;right:0px;}
 #journalEditor #journalClose{position:absolute; right:6px; top:6px;}
-
-#journalEditor #journalClose{position:absolute;right:2px;}
 #journalEditor #journalPlaceholder,.jcmt .cmteditarea .editorPlaceholder{font-size:14px;color:#999;height:24px;line-height:24px;padding-left:7px;}
 #journalEditor #journalContent{font-family:Arial, Helvetica; float:left; display:none;height:1px;margin-bottom:4px;padding: 2px 4px 6px 4px;font-size:14px; border: none; -webkit-box-shadow: none; box-shadow: none; line-height:1.3em;width:99%;resize:none;}
-
-
 #journalEditor .journalPlaceholder {width:100%;}
 #journalEditor .dnnClear{height:0;}
-
 #journalEditor #tbar{
 		position:absolute;
 		right:6px; bottom: 5px;
@@ -57,17 +50,16 @@
 #journalEditor #tbar span#tbar-attach:hover{background-position:-24px -16px;}
 #journalEditor #tbar span#tbar-perm:hover{background-position:-81px -16px;}
 .journalTools #journalOptionArea{background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
-                                 -webkit-border-bottom-right-radius: 3px;
--webkit-border-bottom-left-radius: 3px;
--moz-border-radius-bottomright: 3px;
--moz-border-radius-bottomleft: 3px;
-border-bottom-right-radius: 3px;
-border-bottom-left-radius: 3px;
-    top: -10px;
-    position:relative;
-    width: 100%;
+								-webkit-border-bottom-right-radius: 3px;
+								-webkit-border-bottom-left-radius: 3px;
+								-moz-border-radius-bottomright: 3px;
+								-moz-border-radius-bottomleft: 3px;
+								border-bottom-right-radius: 3px;
+								border-bottom-left-radius: 3px;
+									top: -10px;
+									position:relative;
+									width: 100%;
 }
-
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
 .journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}
 .journalTools #journalOptionArea #itemUpload{margin:0;padding:0;}
@@ -82,7 +74,7 @@ border-bottom-left-radius: 3px;
 	background: -moz-linear-gradient(top,  #298fd0,  #005cb2);
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#298fd0', endColorstr='#005cb2');}
 
-    .journalTools #btnShare:hover,.jcmt li.cmtbtn a:hover {text-decoration: none;background: #003465;
+   	.journalTools #btnShare:hover,.jcmt li.cmtbtn a:hover {text-decoration: none;background: #003465;
 	    background: -webkit-gradient(linear, left top, left bottom, from(#156292), to(#003465));
 	    background: -moz-linear-gradient(top,  #156292,  #003465);
 	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#156292', endColorstr='#003465');}
@@ -90,11 +82,9 @@ border-bottom-left-radius: 3px;
     .journalTools #btnShare:active,.jcmt li.cmtbtn a:active {position: relative;top: 1px;color: #fff;
 	    background: -webkit-gradient(linear, left top, left bottom, from(#005cb2), to(#298fd0));
 	    background: -moz-linear-gradient(top,  #005cb2,  #298fd0);
-	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#005cb2', endColorstr='#298fd0');}		
-	    
+	    filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#005cb2', endColorstr='#298fd0');}			    
 .journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
 .journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
-
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
 .journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
@@ -103,7 +93,6 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
 .journalrow div.journalitem .authorname{padding-right:6px;}
 .journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
-
 /*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
     .journalrow div.journalitem ul.jcmt {
         margin-left: 0px;
@@ -173,43 +162,33 @@ border-bottom-left-radius: 3px;
         
 }
 .securityMenu ul li{list-style:none; margin-bottom: 4px;}
-
 /* File Upload */
 .progress_bar_wrapper{ width: 500px;overflow: hidden;}
 .progress-bar div{ background-image: url('Images/progress.gif');position:relative;padding:0 !important;}
-
 #tbar-attach-Area input:not([type=file]){cursor:pointer; left: 0;top: 0;width: 150px;position:absolute; opacity:0; display:inline;height:18px;padding:4px;margin-bottom:9px;font-size:13px;line-height:18px;color:#555555;border:1px solid #ccc;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
-
 .journalTools #journalOptionArea div span.browser-upload-btn{position:relative; font-weight: bold; padding-left:0px; cursor:pointer;display: block; }
     .browser-upload-btn:hover{cursor:pointer;}
 div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.filePreviewArea {padding:0;margin:0}
 div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.progress_bar_wrapper{padding:0;margin:0;}
-
 .journalTools #journalOptionArea #itemUpload .filePreviewArea img {
     background: none repeat scroll 0 0 #FFFFFF;
     border: 1px solid #E0EFF7;
     border-radius: 3px 3px 3px 3px;
     margin: 0 0 12px 12px;
     padding: 6px;
-}
-
-
-    
+}   
 div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;}
 .journalrow .juser{ cursor: pointer;}
-
 
 div#journalOptionArea > div.fileUploadArea {
     background: #eff8ff; /* blue */		
 }
-
 div#journalOptionArea div.journal_onlineFileShare,
 div#journalOptionArea div.journal_localFileShare {
     width: 50%;
     float: left;
     padding: 0;
 }
-
 div#journalOptionArea div.journal_onlineFileShare {
     border-right: 1px solid #cce8ff;
     margin-right: 25px;
@@ -217,7 +196,6 @@ div#journalOptionArea div.journal_onlineFileShare {
 div#journalOptionArea div.journal_localFileShare {
     width: 40%;
 }
-
 div#journalOptionArea div.journal_onlineFileShare div {
     margin: 0;
     padding: 0;
@@ -226,7 +204,6 @@ div#journalOptionArea div.journal_onlineFileShare a.dnnSecondaryAction {
     display: inline-block;
     margin: 15px 0 0 15px;
 }
-
 div#journalOptionArea div.journal_localFileShare .dnnInputFileWrapper {
     display: inline-block;
     margin: 15px 0 0 0;
@@ -240,7 +217,6 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 		width:auto;
 		border:1px solid #ccc; background:#fff;
 		z-index:5;
-		
 		/*CSS3*/
 		-moz-border-radius-bottomright: 3px;
 		-moz-border-radius-bottomleft:	3px;
@@ -262,7 +238,7 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 		background:#FEFDDE;
 		cursor:pointer
 	}
-	ul.ui-autocomplete .ui-menu-item a img{ width: 24px;height: 24px;}
-	ul.ui-autocomplete .ui-menu-item a span.dn{ font-weight: bold;color: #000;margin: 0 4px;}
-	ul.ui-autocomplete .ui-menu-item a span.un{ color: #ccc;margin: 0 4px;}
-.ui-helper-hidden-accessible { display:none; }
+	ul.ui-autocomplete .ui-menu-item a img{width:24px;height:24px;}
+	ul.ui-autocomplete .ui-menu-item a span.dn{font-weight:bold;color: #000;margin: 0 4px;}
+	ul.ui-autocomplete .ui-menu-item a span.un{color: #ccc;margin: 0 4px;}
+.ui-helper-hidden-accessible{display:none;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -93,7 +93,7 @@
 .journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}
 .journalitem p{margin-bottom: 5px;word-break: break-word;}
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
-.journalrow div.journalitem .authorname{padding-right:6px;display:flex;}
+.journalrow div.journalitem .authorname{padding-right:6px;display:inline-flex;}
 .journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
 /*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
     .journalrow div.journalitem ul.jcmt {
@@ -111,7 +111,7 @@
     position: relative;
     top: 0;}
 .journalrow div.journalitem ul.jcmt li p{padding:4px 0px 4px 5px; margin:3px 0px 5px 42px;}
-.journalrow div.journalitem ul.jcmt li p a{padding-right:6px;display:flex;}                                         
+.journalrow div.journalitem ul.jcmt li p a{padding-right:6px;display:inline-flex;}                                         
 .journalrow div.journalitem ul.jcmt li p abbr{border-style: none;
                                               display: block;
                                               margin-bottom: 3px;

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -29,7 +29,7 @@
 #journalEditor #journalContent .juser, .journalrow .juser{color:#000;border:1px solid #ccd5e4; background-color:#eff2f7;}
 #journalEditor #journalContent .jtag, .journalrow .jtag{border:1px solid #ccc; background-color:#f5f5f5}
 
-#journalEditor #journalClose, #linkClose, .miniclose, .minidel{float:right;display:none;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
+#journalEditor #journalClose, #linkClose, .miniclose, .minidel{float:right;visibility:hidden;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
 #journalEditor .minidel{position:absolute;right:0px;}
 #journalEditor #journalClose{position:absolute; right:6px; top:6px;}
 
@@ -107,7 +107,7 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
-.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel{display:block;}
+.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel{visibility:visible;}
 .journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
 .journalrow div.journalitem ul.jcmt li img{ float: left;
     left: 0;

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -1,11 +1,9 @@
 @charset "utf-8";
 /* CSS Document */
-
-
 #journalEditor, .jcmt .cmteditarea
 {
         display:inline-block;
-		width:96%;
+		width:100%;
 		position:relative;
 		background: #fff url('Images/input-bg.png') left top no-repeat;
         margin:10px 0 0; 
@@ -38,7 +36,6 @@
 #journalEditor #journalPlaceholder,.jcmt .cmteditarea .editorPlaceholder{font-size:14px;color:#999;height:24px;line-height:24px;padding-left:7px;}
 #journalEditor #journalContent{font-family:Arial, Helvetica; float:left; display:none;height:1px;margin-bottom:4px;padding: 2px 4px 6px 4px;font-size:14px; border: none; -webkit-box-shadow: none; box-shadow: none; line-height:1.3em;width:99%;resize:none;}
 
-
 #journalEditor .journalPlaceholder {width:100%;}
 #journalEditor .dnnClear{height:0;}
 
@@ -58,7 +55,7 @@
 #journalEditor #tbar span#tbar-attach:hover,#journalEditor #tbar span#tbar-attach.selected{background-position:-24px -16px;}
 #journalEditor #tbar span#tbar-attach:hover{background-position:-24px -16px;}
 #journalEditor #tbar span#tbar-perm:hover{background-position:-81px -16px;}
-.journalTools #journalOptionArea{background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
+.journalTools #journalOptionArea{width:100%;background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
                                  -webkit-border-bottom-right-radius: 3px;
 -webkit-border-bottom-left-radius: 3px;
 -moz-border-radius-bottomright: 3px;
@@ -69,14 +66,9 @@ border-bottom-left-radius: 3px;
     position:relative;
     width: 96%;
 }
-
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
 .journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}
-
 .journalTools #journalOptionArea #itemUpload{margin:0;padding:0;}
-
-
-
 .journalTools #journalOptionArea .jpa{display:none;}
 .journalTools #journalOptionArea #linkArea #imagePreviewer{width:150px; float:left;margin-right:12px;}
 .journalTools #journalOptionArea #linkArea #imagePreviewer #image{width:140px; height:100px; overflow:hidden;}
@@ -103,18 +95,14 @@ border-bottom-left-radius: 3px;
 
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
-.journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;border:1px #ccc solid;padding:4px;}
-
-.journalrow div.journalitem{margin-left:65px;overflow: hidden;word-break: break-all;}
+.journalrow div.author img{width:32px;max-width:100%;height:auto;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+.journalrow div.journalitem{margin-left:50px;overflow: hidden;word-break: break-all;}
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
 .journalrow div.journalitem .authorname{padding-right:6px;}
 .journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
 
 /*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
-    .journalrow div.journalitem ul.jcmt {
-        margin-left: 0px;
-        margin-bottom: 0px;
-    }
+.journalrow div.journalitem ul.jcmt {margin-left: 0px;margin-bottom: 0px;}
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
@@ -134,7 +122,7 @@ border-bottom-left-radius: 3px;
                                               padding-left: 5px;
                                               padding-top: 4px;}
 .journalrow div.journalitem .journalfooter abbr {border-style:none;}
-.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;padding:5px;border:1px #ccc solid;}
+.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;height:auto;padding:5px;}
 .journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
 .journalrow div.journalitem .jlink div{max-width: 100%;word-break:break-word;}   
 .journalrow div.journalitem .likes{padding:2px;}                                              
@@ -187,7 +175,6 @@ div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:n
 	margin-bottom: 5px;
 	word-break: break-word;
 }
-
 /* File Upload */
 .progress_bar_wrapper{ width: 500px;overflow: hidden;}
 .progress-bar div{ background-image: url('Images/progress.gif');position:relative;padding:0 !important;}
@@ -195,7 +182,7 @@ div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:n
 #tbar-attach-Area input:not([type=file]){cursor:pointer; left: 0;top: 0;width: 150px;position:absolute; opacity:0; display:inline;height:18px;padding:4px;margin-bottom:9px;font-size:13px;line-height:18px;color:#555555;border:1px solid #ccc;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
 
 .journalTools #journalOptionArea div span.browser-upload-btn{position:relative; font-weight: bold; padding-left:0px; cursor:pointer;display: block; }
-    .browser-upload-btn:hover{cursor:pointer;}
+	.browser-upload-btn:hover{cursor:pointer;}
 div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.filePreviewArea {padding:0;margin:0}
 div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.progress_bar_wrapper{padding:0;margin:0;}
 
@@ -298,11 +285,7 @@ border-bottom-left-radius: 3px;
 
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}
 .journalTools #journalOptionArea div span{font-weight:bold;color:#333;padding-right:12px;padding-left:12px;}
-
 .journalTools #journalOptionArea #itemUpload{margin:0;padding:0;}
-
-
-
 .journalTools #journalOptionArea .jpa{display:none;}
 .journalTools #journalOptionArea #linkArea #imagePreviewer{width:150px; float:left;margin-right:12px;}
 .journalTools #journalOptionArea #linkArea #imagePreviewer #image{width:140px; height:100px; overflow:hidden;}
@@ -326,7 +309,6 @@ border-bottom-left-radius: 3px;
 	    
 .journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
 .journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
-
 
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
@@ -367,7 +349,6 @@ border-bottom-left-radius: 3px;
 .jcmt .cmteditor{max-width:445px;display:none;resize:none;outline:none;}
 .jcmt .cmteditarea{margin: 2px 4px 4px 2px;}
 .jcmt .cmteditarea .editorPlaceholder{height:18px;font-size:11px;line-height:18px;}
-
 /* Visibility and Security */
 .securityMenu{
 	position: absolute;
@@ -412,7 +393,6 @@ border-bottom-left-radius: 3px;
 	margin-bottom: 5px;
 	word-break: break-word;
 }
-
 /* File Upload */
 .progress_bar_wrapper{ width: 500px;overflow: hidden;}
 .progress-bar div{ background-image: url('Images/progress.gif');position:relative;padding:0 !important;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -89,6 +89,7 @@
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
 .journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
+.journalrow div.journalitem .jlink img {max-width: 25%;width: auto;}
 .journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}
 .journalitem p{margin-bottom: 5px;word-break: break-word;}
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -102,7 +102,7 @@
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
-.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, .journalTools #journalOptionArea:hover #linkClose, #journalEditor:hover #journalClose{visibility:visible;}
+.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, .journalTools #journalOptionArea:hover #linkClose{visibility:visible;}
 .journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
 .journalrow div.journalitem ul.jcmt li img{ float: left;
     left: 0;

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -101,12 +101,11 @@ border-bottom-left-radius: 3px;
 .journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
 .journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
 
-
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
 .journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;border:1px #ccc solid;padding:4px;}
-.journalrow div.journalitem{margin-left:65px;overflow: hidden;word-break: break-all;}
 
+.journalrow div.journalitem{margin-left:65px;overflow: hidden;word-break: break-all;}
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
 .journalrow div.journalitem .authorname{padding-right:6px;}
 .journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
@@ -137,7 +136,7 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem .journalfooter abbr {border-style:none;}
 .journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;padding:5px;border:1px #ccc solid;}
 .journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
-.journalrow div.journalitem .jlink div{max-width: 67%;word-break:break-word;}   
+.journalrow div.journalitem .jlink div{max-width: 100%;word-break:break-word;}   
 .journalrow div.journalitem .likes{padding:2px;}                                              
 .jcmt .cmteditor{max-width:445px;display:none;resize:none;outline:none;}
 .jcmt .cmteditarea{margin: 2px 4px 4px 2px;}
@@ -174,8 +173,8 @@ div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:n
 	list-style:none;
 	background:#fff;
 	
-	-webkit-border-radius: 3px 0px 3px 3px;
-    	border-radius: 3px 0px 3px 3px;
+	-webkit-border-radius: 	3px 0px 3px 3px;
+    	border-radius: 		3px 0px 3px 3px;
 	
 	-webkit-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);
 	-moz-box-shadow: 	0px 2px 0px 0px rgba(0, 0, 0, .5);

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -312,8 +312,8 @@ border-bottom-left-radius: 3px;
 
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
 .journalrow div.author{overflow:hidden;float:left;}
-.journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;border:1px #ccc solid;padding:4px;}
-.journalrow div.journalitem{margin-left:65px;overflow: hidden;word-break: break-all;}
+.journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;background:#fff;}
+.journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}
 
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
 .journalrow div.journalitem .authorname{padding-right:6px;}
@@ -412,7 +412,7 @@ div.journalTools div#journalOptionArea div.fileUploadArea div#itemUpload div.pro
     padding: 6px;
 }
 
-.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;padding:5px;border:1px #ccc solid;}
+.journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;height:auto;padding:5px;}
 .journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
 .journalrow div.journalitem .jlink div{max-width: 67%;word-break:break-word;}   
 div#journalItems div.journalrow div.journalitem ul.jcmt li.cmteditarea{display:none;overflow:auto;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -87,15 +87,12 @@
 .journalTools #btnShare.disabled,.jcmt li.cmtbtn a.disabled{background:#cdcdcd;color:#999;cursor:text;}
 .journalTools ul.jacmenu li.liselected{background-color:#ffffcc;}
 .journalrow {border-bottom:1px solid #e4e1e1;margin-bottom:20px;padding-bottom:10px;}
-.journalrow div.journalitem ul.jcmt li p a{display: inline-flex;}
-.journalrow div.journalitem .jlink a{display: inline-flex;}
-.journalrow div.journalitem .authorname{display: inline-flex;}
 .journalrow div.author{overflow:hidden;float:left;}
 .journalrow div.author img{width:32px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px;}
 .journalrow div.journalitem{margin-left:44px;overflow: hidden;word-break: break-all;}
 .journalitem p{margin-bottom: 5px;word-break: break-word;}
 .journalrow div.journalitem p.journalfooter span{padding:0px 4px 0px 4px; font-weight:bold;}
-.journalrow div.journalitem .authorname{padding-right:6px;}
+.journalrow div.journalitem .authorname{padding-right:6px;display:flex;}
 .journalrow div.journalitem ul.jcmt,.journalrow div.journalitem .likes{width:100%;padding:0px;font-size:11px;}
 /*.journalrow div.journalitem ul.jcmt li{border-bottom: solid 1px #fff;}*/
     .journalrow div.journalitem ul.jcmt {
@@ -113,7 +110,7 @@
     position: relative;
     top: 0;}
 .journalrow div.journalitem ul.jcmt li p{padding:4px 0px 4px 5px; margin:3px 0px 5px 42px;}
-.journalrow div.journalitem ul.jcmt li p a{padding-right:6px;}                                         
+.journalrow div.journalitem ul.jcmt li p a{padding-right:6px;display:flex;}                                         
 .journalrow div.journalitem ul.jcmt li p abbr{border-style: none;
                                               display: block;
                                               margin-bottom: 3px;
@@ -121,9 +118,9 @@
                                               padding-left: 5px;
                                               padding-top: 4px;}
 .journalrow div.journalitem .journalfooter abbr {border-style:none;}
-.journalrow div.journalitem .jlink a{font-weight:bold;display:block}
+.journalrow div.journalitem .jlink a{font-weight:bold;display:block;word-break:break-word;}
 .journalrow div.journalitem .jlink img{float:left; margin-right:12px;max-width:150px;width:100%;height:auto;padding:5px;}
-.journalrow div.journalitem .jlink div{max-width:100%;}
+.journalrow div.journalitem .jlink div{max-width:100%;word-break:break-word;}
 .journalrow div.journalitem .likes{padding:2px;}                                              
 .jcmt .cmteditor{max-width:100%;display:none;resize:none;outline:none;}
 .jcmt .cmteditarea{margin: 2px 4px 4px 2px;z-index:0;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -26,7 +26,8 @@
 #journalEditor #journalContent span{padding:0 2px 0 2px;border-radius:3px;-moz-border-radius:3px;-webkit-border-radius:3px;}
 #journalEditor #journalContent .juser, .journalrow .juser{color:#000;border:1px solid #ccd5e4; background-color:#eff2f7;}
 #journalEditor #journalContent .jtag, .journalrow .jtag{border:1px solid #ccc; background-color:#f5f5f5}
-#journalEditor #journalClose, #linkClose, .miniclose, .minidel{float:right;visibility:hidden;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
+#journalEditor #journalClose{float:right;display:none;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
+#linkClose, .miniclose, .minidel{float:right;visibility:hidden;width:18px !important; height:18px !important; cursor:pointer; background-image:url('images/mini_del.gif'); background-repeat:no-repeat;}
 #journalEditor .minidel{position:absolute;right:0px;}
 #journalEditor #journalClose{position:absolute; right:6px; top:6px;}
 #journalEditor #journalPlaceholder,.jcmt .cmteditarea .editorPlaceholder{font-size:14px;color:#999;height:24px;line-height:24px;padding-left:7px;}

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -107,7 +107,7 @@ border-bottom-left-radius: 3px;
 .journalrow div.journalitem ul.jcmt, .journalrow div.journalitem ul.jcmt li{list-style-type:none;}
 .journalrow div.journalitem ul.jcmt li textarea{border:solid 0px #ccc;font-family:tahoma,verdana,arial,sans-serif;font-size:12px;padding:0px;height:20px;margin-left:0px;margin-right:0px;width:100%;max-width:100%;word-break:break-word;}
 .journalrow div.journalitem ul.jcmt li .miniclose{margin:2px;}
-.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, div:hover #linkClose,div:hover #journalEditor #journalClose{visibility:visible;}
+.journalrow div.journalitem ul.jcmt li:hover .miniclose, .journalrow:hover .minidel, .journalTools #journalOptionArea:hover #linkClose, #journalEditor:hover #journalClose{visibility:visible;}
 .journalrow div.journalitem ul.jcmt li.cmtbtn a{display:none;} 
 .journalrow div.journalitem ul.jcmt li img{ float: left;
     left: 0;

--- a/DNN Platform/Modules/Journal/module.css
+++ b/DNN Platform/Modules/Journal/module.css
@@ -23,6 +23,7 @@
 .journalTools ul.jacmenu{display:none; position: absolute;z-index: 4; list-style-type:none;border:solid 1px #dcdcdc;background-color:#f5f5f5;}
 .journalTools ul.jacmenu li{padding:2px;list-style-type:none;border-bottom:1px solid #dcdcdc;background-color:#f3f3f3;}
 
+#journalEditor {width:100%;}
 #journalEditor #journalContent{overflow:auto;outline:none;}
 #journalEditor #journalContent span{padding:0 2px 0 2px;border-radius:3px;-moz-border-radius:3px;-webkit-border-radius:3px;}
 #journalEditor #journalContent .juser, .journalrow .juser{color:#000;border:1px solid #ccd5e4; background-color:#eff2f7;}
@@ -272,15 +273,15 @@ ul.ui-autocomplete li{margin:0;padding:0;list-style:none;}
 #journalEditor #tbar span#tbar-attach:hover{background-position:-24px -16px;}
 #journalEditor #tbar span#tbar-perm:hover{background-position:-81px -16px;}
 .journalTools #journalOptionArea{background-color:#f5f5f5;display:none; border: 1px solid #bbb; border-top:0px none transparent;
-                                 -webkit-border-bottom-right-radius: 3px;
--webkit-border-bottom-left-radius: 3px;
--moz-border-radius-bottomright: 3px;
--moz-border-radius-bottomleft: 3px;
-border-bottom-right-radius: 3px;
-border-bottom-left-radius: 3px;
-    top: -10px;
-    position:relative;
-    width: 100%;
+				-webkit-border-bottom-right-radius: 3px;
+				-webkit-border-bottom-left-radius: 3px;
+				-moz-border-radius-bottomright: 3px;
+				-moz-border-radius-bottomleft: 3px;
+				border-bottom-right-radius: 3px;
+				border-bottom-left-radius: 3px;
+					top: -10px;
+					position:relative;
+					width: 100%;
 }
 
 .journalTools #journalOptionArea div{font-size:12px;padding:6px;padding-top:12px;padding-bottom:12px;}


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->
To resolve Issue #2225 plus issue #2981 
<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Dedicated to enhance the Journal Module Styles for the Journal UI.
- This PR Expands Journal Editor and Comment Areas to use 100% Width of Site Theme Module Container Width.
- This PR Adds Visibility Setting to Save Space for for Closing Items Replacing Display Setting for Journal Close Items as Needed to Keep Text from Shifting When Hovering Mouse Pointer Over a Journal Item.
- This PR Adds Word Break Feature in the Journal  and Link Author, Titles, Description and Comment Areas.
- This PR Adds Inline-Flex to Author Links
- This PR adjusts author image area margin allowing more screen use.
- This PR Removes Border and Padding from Author Images.
- This PR Removes borders from Journal Link Images.
- This PR Adds Responsive Effect to Journal Link Images Allowing up to 25% Screen Width Size.
