### PR TITLE
Add safe access to UrlReferrer in Log404

### DIFF
--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -814,30 +814,28 @@ namespace DotNetNuke.Entities.Modules
                 var currentUser = UserController.Instance.GetCurrentUserInfo();
                 dr = dataProvider.GetModuleSetting(moduleId, settingName);
 
-	            var settingExist = false;
 	            string existValue = null;
                 if (dr.Read())
                 {
-					settingExist = true;
-	                existValue = dr.GetString(1);
+                    existValue = dr.GetString(1);
                 }
 
 				dr.Close();
 
-				if (existValue != settingValue)
-	            {
-					dataProvider.UpdateModuleSetting(moduleId, settingName, settingValue, currentUser.UserID);
-					EventLogController.AddSettingLog(EventLogController.EventLogType.MODULE_SETTING_UPDATED,
-														"ModuleId", moduleId, settingName, settingValue,
-														currentUser.UserID);
-				}
-				else if (!settingExist)
-				{
-					dataProvider.UpdateModuleSetting(moduleId, settingName, settingValue, currentUser.UserID);
-					EventLogController.AddSettingLog(EventLogController.EventLogType.MODULE_SETTING_CREATED,
-													"ModuleId", moduleId, settingName, settingValue,
-													currentUser.UserID);
-				}
+                if (existValue == null)
+                {
+                    dataProvider.UpdateModuleSetting(moduleId, settingName, settingValue, currentUser.UserID);
+                    EventLogController.AddSettingLog(EventLogController.EventLogType.MODULE_SETTING_CREATED,
+                        "ModuleId", moduleId, settingName, settingValue,
+                        currentUser.UserID);
+                } 
+                else if (existValue != settingValue)
+                {
+                    dataProvider.UpdateModuleSetting(moduleId, settingName, settingValue, currentUser.UserID);
+                    EventLogController.AddSettingLog(EventLogController.EventLogType.MODULE_SETTING_UPDATED,
+                                                        "ModuleId", moduleId, settingName, settingValue,
+                                                        currentUser.UserID);
+                }
 
                 if (updateVersion)
                 {

--- a/DNN Platform/Library/Entities/Urls/UrlRewriterUtils.cs
+++ b/DNN Platform/Library/Entities/Urls/UrlRewriterUtils.cs
@@ -111,9 +111,16 @@ namespace DotNetNuke.Entities.Urls
 
             if (request != null)
             {
-                if (request.UrlReferrer != null)
+                try
                 {
-                    log.LogProperties.Add(new LogDetailInfo("Referer", request.UrlReferrer.AbsoluteUri));
+                    if (request.UrlReferrer != null)
+                    {
+                        log.LogProperties.Add(new LogDetailInfo("Referer", request.UrlReferrer.AbsoluteUri));
+                    }
+                }
+                catch (Exception)
+                {
+                    log.LogProperties.Add(new LogDetailInfo("Referer", request.Headers["Referer"]));
                 }
                 log.LogProperties.Add(new LogDetailInfo("Url", request.Url.AbsoluteUri));
                 log.LogProperties.Add(new LogDetailInfo("UserAgent", request.UserAgent));

--- a/DNN Platform/Library/Entities/Urls/UrlRewriterUtils.cs
+++ b/DNN Platform/Library/Entities/Urls/UrlRewriterUtils.cs
@@ -118,7 +118,7 @@ namespace DotNetNuke.Entities.Urls
                         log.LogProperties.Add(new LogDetailInfo("Referer", request.UrlReferrer.AbsoluteUri));
                     }
                 }
-                catch (Exception)
+                catch (UriFormatException)
                 {
                     log.LogProperties.Add(new LogDetailInfo("Referer", request.Headers["Referer"]));
                 }


### PR DESCRIPTION
Allow safe access to the UrlReferrer property in Log404 in case of bad format UrlReferrer property.
Issue #3339

## Summary
We intercept the error in Log404 method and get the missing information from the header.