### PR TITLE
Adds sqldataprovider for 9.4.4 upgrades

### DIFF
--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.04.04.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.04.04.SqlDataProvider
@@ -1,0 +1,9 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/


### PR DESCRIPTION
Adds the required 09.04.04.SqlDataProvider file to allow upgrades to 9.4.4 to work. This is a release management task and we are self-approving it for that reason.