### PR TITLE
dnnFormMessage 100% width fix

### DIFF
--- a/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/7.0.0/default.css
+++ b/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/7.0.0/default.css
@@ -374,7 +374,7 @@ li p {
     background: rgba(2,139,255,0.15); /* blue */
     -webkit-border-radius: 3px;
     border-radius: 3px;
-    max-width: 980px;
+    max-width: 100%;
 }
 
     .dnnFormMessage.dnnFormError,

--- a/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/8.0.0/default.css
+++ b/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/8.0.0/default.css
@@ -108,7 +108,7 @@ img {
     background: rgba(2,139,255,0.15); /* blue */
     -webkit-border-radius: 3px;
     border-radius: 3px;
-    max-width: 980px;
+    max-width: 100%;
 }
 
     .dnnFormMessage.dnnFormError,


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

#3387
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
allows a form message to use 100% of the area it is presented in.

![image](https://user-images.githubusercontent.com/13577556/70355770-cf5d2280-1827-11ea-91c1-294c84994a91.png)

will now look like 
![image](https://user-images.githubusercontent.com/13577556/70355808-e00d9880-1827-11ea-8fcb-2ae4fc9b7398.png)

if accepted as a solution.

