### PR TITLE
<DIV> Wrap Registration Buttons with css class

### DIFF
--- a/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx
@@ -18,19 +18,18 @@
                 </ul>
             </div>
         </div>
-    </div>
-    <div id="captchaRow" runat="server" visible="false" class="dnnFormItem dnnCaptcha">
-        <dnn:label id="captchaLabel" controlname="ctlCaptcha" runat="server" />
-        <dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" ErrorStyle-CssClass="dnnFormMessage dnnFormError dnnCaptcha" runat="server" />
-    </div>
-    <input runat="server" id="gotcha" type="text" name="gotcha" style="display: none;" autocomplete="off" aria-label="gotcha" />
+	</div>
+	<div id="captchaRow" runat="server" visible="false" class="dnnFormItem dnnCaptcha">
+		<dnn:label id="captchaLabel" controlname="ctlCaptcha" runat="server" />
+		<dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" ErrorStyle-CssClass="dnnFormMessage dnnFormError dnnCaptcha" runat="server" />
+	</div>
+	<input runat="server" id="gotcha" type="text" name="gotcha" style="display: none;" autocomplete="off" aria-label="gotcha" />
 	<div class="registerButtonGroup">    
 		<ul id="actionsRow" runat="server" class="dnnActions dnnClear">
 			<li><asp:LinkButton id="registerButton" runat="server" CssClass="dnnPrimaryAction" resourcekey="cmdRegister" /></li>
 			<li><asp:HyperLink ID="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" /></li>
 		</ul>
 	</div>
-</div>
 </div>
 <asp:HyperLink ID="closeLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="Close" CausesValidation="false" Visible="False" />
 <script type="text/javascript">

--- a/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx
@@ -24,10 +24,13 @@
         <dnn:captchacontrol id="ctlCaptcha" captchawidth="130" captchaheight="40" ErrorStyle-CssClass="dnnFormMessage dnnFormError dnnCaptcha" runat="server" />
     </div>
     <input runat="server" id="gotcha" type="text" name="gotcha" style="display: none;" autocomplete="off" aria-label="gotcha" />
-    <ul id="actionsRow" runat="server" class="dnnActions dnnClear">
-        <li><asp:LinkButton id="registerButton" runat="server" CssClass="dnnPrimaryAction" resourcekey="cmdRegister" /></li>
-        <li><asp:HyperLink ID="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" /></li>
-    </ul>
+	<div class="registerButtonGroup">    
+		<ul id="actionsRow" runat="server" class="dnnActions dnnClear">
+			<li><asp:LinkButton id="registerButton" runat="server" CssClass="dnnPrimaryAction" resourcekey="cmdRegister" /></li>
+			<li><asp:HyperLink ID="cancelLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="cmdCancel" CausesValidation="false" /></li>
+		</ul>
+	</div>
+</div>
 </div>
 <asp:HyperLink ID="closeLink" runat="server" CssClass="dnnSecondaryAction" resourcekey="Close" CausesValidation="false" Visible="False" />
 <script type="text/javascript">


### PR DESCRIPTION
adds a div around the register button list along with a css class "registerButtonGroup"

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

issue #3390


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
adds a missing DIV around the registration button group to allow the buttons to go below the other form fields instead of to the right of the security code div.