### PR TITLE
Fixed Canonical and None mapping redirects

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalAliasExtensions.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasExtensions.cs
@@ -95,10 +95,6 @@ namespace DotNetNuke.Entities.Portals
         {
             var aliasList = aliases.ToList();
 
-            var defaultAlias = aliasList.ToList().Where(a => a.PortalID == portalId)
-                                        .OrderByDescending(a => a.IsPrimary)
-                                        .FirstOrDefault();
-
             //First check if our current alias is already a perfect match.
             PortalAliasInfo foundAlias = null;
             if (result != null && !string.IsNullOrEmpty(result.HttpAlias))
@@ -107,7 +103,6 @@ namespace DotNetNuke.Entities.Portals
                 foundAlias = aliasList.FirstOrDefault(a => a.BrowserType == browserType &&
                                                          (String.Compare(a.CultureCode, cultureCode,
                                                              StringComparison.OrdinalIgnoreCase) == 0)
-                                                         && a.IsPrimary
                                                          && a.PortalID == portalId
                                                          && a.HTTPAlias == result.HttpAlias);
                 if (foundAlias == null) //let us try again using Startswith() to find matching Hosts
@@ -115,7 +110,6 @@ namespace DotNetNuke.Entities.Portals
                     foundAlias = aliasList.FirstOrDefault(a => a.BrowserType == browserType &&
                                                          (String.Compare(a.CultureCode, cultureCode,
                                                              StringComparison.OrdinalIgnoreCase) == 0)
-                                                         && a.IsPrimary
                                                          && a.PortalID == portalId
                                                          && a.HTTPAlias.StartsWith(result.HttpAlias.Split('/')[0]));
                 }
@@ -164,10 +158,15 @@ namespace DotNetNuke.Entities.Portals
             }
             else
             {
+                // if we didn't find a specific match, return the default, which is the closest match
+                var defaultAlias = aliasList
+                    .Where(a => a.PortalID == portalId)
+                    .OrderByDescending(a => a.IsPrimary)
+                    .FirstOrDefault();
+
                 foundAlias = defaultAlias;
             }
 
-            //if we didn't find a specific match, return the default, which is the closest match
             return foundAlias;
         }
 

--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -1700,7 +1700,9 @@ namespace DotNetNuke.Entities.Urls
                                     //var cpa = portalAliases.GetAliasByPortalIdAndSettings(result);
                                     string url = requestUri.ToString();
                                     RewriteController.CheckLanguageMatch(ref url, result);
-                                    var cpa = portalAliases.GetAliasByPortalIdAndSettings(result.PortalId, result, result.CultureCode, result.BrowserType);
+                                    var cpa = portalAliases
+                                        .Where(a => a.IsPrimary || result.PortalAliasMapping != PortalSettings.PortalAliasMapping.Redirect)
+                                        .GetAliasByPortalIdAndSettings(result.PortalId, result, result.CultureCode, result.BrowserType);
 
                                     if (cpa != null)
                                     {


### PR DESCRIPTION
Fixes #3395
Fixes #3017 
Fixes #2841 

## Summary
This pull request fixes wrong redirections that occur on Canonical and None URL mappings.
I have tested this as much as I could. I created following spreadsheet to track my tests and make sure this change does not introduce new regressions:
https://docs.google.com/spreadsheets/d/1c9DyWfLAG5qrAnPDZsvAg5VBJkSRWBciWtPxHARxWUA/edit?usp=sharing
Above spreadsheet contains:

Tab | Description
-- | --
DNN943 | A set of test URLs along with the expected and the actual responses when executed on DNN 9.4.3. Red colors on the right show cases where the response is not correct, as per my understanding. In such cases the Severity column shows 1 (minor issue) or 3 (big issue).
Patched | Same set of test URLs but with responses after applying this fix. Green colors in Severity column show how each test case improved with respect to original.
Bindings | IIS bindings I used in the test environment
Portals | How I set up the portals in the test environment. Main portal is localized, child portal is not localized
Tabs | Which pages I created in the test environment
Aliases | How aliases were configured.

I used following Powershell script to automate requesting each test URL:
```powershell
$domain = "platform-9-4-3.dnndev.me"
@(
	"en-$domain"
	"en.$domain"
	"fr-$domain"
	"fr.$domain"
	"$domain"
	"$domain/en-us"
	"$domain/fr-fr"
	"www-$domain"
	"www-$domain/en-us"
	"www-$domain/fr-fr"
	"www.$domain"
	"www.$domain/en-us"
	"www.$domain/fr-fr"
    "$domain/child"
    "www.$domain/child"
    "www-$domain/child"
) | % { @( $_, "$_/" ) | % {
    $response = Invoke-WebRequest "http://$_" -MaximumRedirection 0 -ErrorAction Ignore -UseBasicParsing
    $output = $_, $response.StatusCode
    If ($response.StatusCode -eq 301) {
        $output += $response.Headers['Location'], $response.Headers['X-Redirect-Reason']
    }
    $output -join "`t"
}}
```

This PR is currently targetting 9.4.4 instead of develop, but I know it needs to be re-targeted. I did this on purpose to test if it's easier to re-target from 9.4.4 than from develop.