### PR TITLE
Fixed NuGet package specification

### DIFF
--- a/Build/Tools/NuGet/Dnn.PersonaBar.Library.nuspec
+++ b/Build/Tools/NuGet/Dnn.PersonaBar.Library.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>DNN PersonaBar Common Library</description>
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>

--- a/Build/Tools/NuGet/DotNetNuke.Abstractions.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Abstractions.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides common abstraction API references for the DNN Platform.

--- a/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Bundle.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       This package is a metapackage that automatically includes all other available DNN Packages, this should only be used in situations where support for ALL types of development are truly needed.

--- a/Build/Tools/NuGet/DotNetNuke.Core.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Core.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides basic references to the DotNetNuke.dll to develop extensions for the DNN Platform.  For MVC or WebAPI please see other packages available as well

--- a/Build/Tools/NuGet/DotNetNuke.DependencyInjection.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.DependencyInjection.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides API references needed to use Dependency Injection for the DNN Platform.

--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides references to enhanced logging and instrumentation available within DNN Platform for extension developers. Including access to Log4Net

--- a/Build/Tools/NuGet/DotNetNuke.Providers.FolderProviders.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Providers.FolderProviders.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides API references needed to develop custom folder providers, or to consume folder providers

--- a/Build/Tools/NuGet/DotNetNuke.SiteExportImport.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.SiteExportImport.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       This package contains components required for developing extensiong to utilize site export/import features.

--- a/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Client.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides API references for usage of the Client Dependency Framework (CDF) for the inclusion of CSS and JS files within DNN Platform

--- a/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Deprecated.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       	Provides API references for deprecated items removed from the primary API's, such as DNN's Telerik component.  These elements may not be distributed with DNN in the future

--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides API references needed to develop ASP.MVC extensions for DNN Platform

--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       Provides references to core components such as Caching, Security and other security-related items for DNN Platform

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -9,7 +9,6 @@
     <license type="expression">MIT</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <icon>images\logo-for-nuget.png</icon>
-    <iconUrl>https://dnncommunity.org/favicon.ico</iconUrl>
     <projectUrl>https://github.com/dnnsoftware/Dnn.Platform</projectUrl>
     <description>
       This package contains components required for developing WebAPI based services for DNN Platform.


### PR DESCRIPTION
Fixes #3411 by removing the <iconUrl> node from all NuGet specifications to match documentation
