### PR TITLE
Automates generation of .sqlDataProvider file

### DIFF
--- a/Build/Cake/ci.cake
+++ b/Build/Cake/ci.cake
@@ -8,4 +8,5 @@ Task("BuildAll")
     .IsDependentOn("CreateNugetPackages")
     .Does(() =>
 	{
+        RevertSqlDataProvider();
 	});

--- a/Build/Cake/compiling.cake
+++ b/Build/Cake/compiling.cake
@@ -8,7 +8,6 @@ Task("Build")
 	{
 		var buildSettings = new MSBuildSettings()
 			.SetConfiguration(configuration)
-			.UseToolVersion(MSBuildToolVersion.VS2017)
 			.SetPlatformTarget(PlatformTarget.MSIL)
 			.WithTarget("Rebuild")
 			.SetMaxCpuCount(4);

--- a/Build/Cake/packaging.cake
+++ b/Build/Cake/packaging.cake
@@ -113,7 +113,6 @@ Task("CreateSymbols")
 
 Task("GenerateSqlDataProvider")
 	.IsDependentOn("SetVersion")
-	.IsDependentOn("CopyWebsite")
 	.Does(() => {
 		var fileName = GetTwoDigitsVersionNumber() + ".SqlDataProvider";
 		var filePath = "./Dnn Platform/Website/Providers/DataProviders/SqlDataProvider/" + fileName;

--- a/Build/Cake/version.cake
+++ b/Build/Cake/version.cake
@@ -60,6 +60,19 @@ public string GetBuildNumber()
     return buildNumber;
 }
 
+public string GetTwoDigitsVersionNumber(){
+    var fullVer = GetBuildNumber().Split('-')[0]; // Gets rid of the -unstable, -beta, etc.
+    var numbers = fullVer.Split('.');
+    for (int i=0; i < numbers.Length; i++)
+    {
+      if (numbers[i].Length < 2)
+      {
+        numbers[i] = "0" + numbers[i];
+      }
+    }
+    return String.Join(".", numbers);
+  }
+
 public string GetProductVersion()
 {
     return productVersion;


### PR DESCRIPTION

## Summary
* Removes the hardcoded tools version 2017 which prevented building if you only have Visual Studio 2019 and never had 2017
* Automates the generation of the xx.xx.xx.sqlDataProvider file to prevent and upgrade loop if we forget to create that file.

Closes #3296 