### PR TITLE
DNN-29164 - Open page settings can't display data for correct page

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/App.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/App.jsx
@@ -93,7 +93,7 @@ class App extends Component {
         window.dnn.utility.setConfirmationDialogPosition();
         window.dnn.utility.closeSocialTasks();
         this.props.getPageList().then(() => {
-            const selectedPageId = utils.getCurrentPageId();
+            const selectedPageId = utils.getSelectedPageId() || utils.getCurrentPageId();
             selectedPageId && !utils.getIsAdminHostSystemPage() && this.onLoadPage(selectedPageId);
         
             if (viewName === "edit") {

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
@@ -99,6 +99,11 @@ function getCurrentPageId() {
     return parseInt(config.tabId);
 }
 
+function getSelectedPageId() {
+    checkInit();
+    return viewParams && viewParams.pageId ? parseInt(viewParams.pageId) : null;
+}
+
 function getViewName() {
     checkInit();
     return viewName;
@@ -211,6 +216,7 @@ const utils = {
     getUtilities,
     getModuleName,
     getCurrentPageId,
+    getSelectedPageId,
     getViewName,
     closePersonaBar,
     getViewParams,


### PR DESCRIPTION
Fixes #1116

Summary
When the script got loaded the first time, a wrong page id was getting sent in the XHR request which caused this issue (there were multiple page requests being sent and the order of responses for that requests play an important role in this bug's intermittent occurrence).

Demo: https://drive.google.com/open?id=1RvwR04B8iPrDdqrMAInCK3N0kN1cWMe2

Note: This is the copy of the PR in https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1117