### PR TITLE
DNN-26060 fix sitemap settings display develop

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/sitemapSettings/providerRow/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/sitemapSettings/providerRow/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Collapsible as Collapse, SvgIcons } from "@dnnsoftware/dnn-react-common";
+import resx from "../../../resources";
 import "./style.less";
 
 class ProviderRow extends Component {
@@ -56,7 +57,7 @@ class ProviderRow extends Component {
                                 {this.getEnabledDisplay()}
                             </div>
                             <div className="provider-item item-row-priority">
-                                {props.priority}
+                                {props.overridePriority ? props.priority : resx.get("None")}
                             </div>
                             <div className="provider-item item-row-editButton">
                                 <div className={opened ? "edit-icon-active" : "edit-icon"} dangerouslySetInnerHTML={{ __html: SvgIcons.EditIcon }} onClick={this.toggle.bind(this)} />

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/sitemapSettings/providerRow/style.less
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/sitemapSettings/providerRow/style.less
@@ -32,7 +32,7 @@
                     .enabled-icon {
                         > svg {
                             padding: 0 15px 0 15px;
-                            width: 16px;
+                            width: 46px;
                             float: left;
                             height: 16px;
                             fill: @mountainMist;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3425

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Fix enabled-icon to display properly

Increase the width to 46px = 16px (height size) + 30 px (padding left
and right)
Fix to display priority as None if override priority is false

Confirmation video - https://drive.google.com/open?id=1G4jDqp_pM3CZrMqgaNWM42hUDctygqNr

Notes: This PR is migrated from https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1066
