### PR TITLE
Fixed alias of added language

### DIFF
--- a/DNN Platform/Library/Services/Localization/Localization.cs
+++ b/DNN Platform/Library/Services/Localization/Localization.cs
@@ -459,7 +459,13 @@ namespace DotNetNuke.Services.Localization
                 var portalAliasInfos = portalAliasses as IList<PortalAliasInfo> ?? portalAliasses.ToList();
                 if (portalAliasses != null && portalAliasInfos.Any())
                 {
-                    currentAlias = portalAliasInfos.First();
+                    currentAlias = currentAlias
+                        ?? portalAliasInfos
+                            .Where(a => string.IsNullOrWhiteSpace(a.CultureCode))
+                            .OrderByDescending(a => a.IsPrimary)
+                            .FirstOrDefault()
+                        ?? portalAliasInfos.First();
+
                     httpAlias = currentAlias.HTTPAlias;
                 }
 


### PR DESCRIPTION
Fixes #3444

## Summary
When adding new languages, I'm adding following fallback logic to select the base URL for the new aliases:
1) pick first culture-neutral, primary alias
2) pick first culture-neutral, non-primary alias
3) just pick the first one (the strategy before this change)