### PR TITLE
DNN-35360 - Azure Storage connector changes its name on disconnect

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Connectors/scripts/Connectors.js
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Connectors/scripts/Connectors.js
@@ -362,7 +362,7 @@ define(['jquery', 'knockout', 'main/pager', 'main/validator', 'main/config', 'ma
                     newConfigurations[key] = "";
                 }
             });
-            var displayName = e === true ? item.name : getNewName(item);
+            var displayName = e === true ? item.displayName : getNewName(item);
             closeAllSubConnectors();
             var newConnection = Object.assign(connections[0].initialObject, { id: null, configurations: newConfigurations, displayName: displayName, open: true });
             var newConn = wrapConnection(newConnection);
@@ -377,9 +377,9 @@ define(['jquery', 'knockout', 'main/pager', 'main/validator', 'main/config', 'ma
         var getNewName = function (item) {
             var connections = item.connections();
             var index = connections.length;
-            var newName = item.name + " - " + index;
+            var newName = item.displayName + " - " + index;
             while (connections.some(function (conn) { return conn.displayName() === newName })) {
-                newName = item.name + " - " + ++index;
+                newName = item.displayName + " - " + ++index;
             }
             return newName;
         }
@@ -491,6 +491,7 @@ define(['jquery', 'knockout', 'main/pager', 'main/validator', 'main/config', 'ma
                     connections: ko.observable(_connections),
                     supportsMultiple: ko.observable(_connections[0].supportsMultiple),
                     name: _connections[0].name,
+                    displayName: _connections[0].displayName(),
                     isOpen: ko.observable(false),
                     height: ko.observable(0),
 


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3448 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Since the other connector names are in single word (except Amazon S3), this situation is specific to the connector names with multiple words because it was resetting the displayName property by the name property which can be different from the displayName (like "Azure" and "Azure Storage") so that it's bound to the correct property now.

Demo: https://drive.google.com/file/d/1ArAiSShbeg6cd5chSysR2RPxLYrX3kvy/view