### PR TITLE
Issues/3455 lerna build

### DIFF
--- a/Build/BuildScripts/AEModule.build
+++ b/Build/BuildScripts/AEModule.build
@@ -46,6 +46,6 @@
     <Message Importance="high" Text="Running Yarn for $(WorkingDirectory)" />
 
     <Yarn Command="install" WorkingDirectory="$(WorkingDirectory)" IgnoreExitCode="false" Condition="$(WorkingDirectory.Length) > 0" />
-    <Yarn Command="lerna run build --parallel" WorkingDirectory="$(WorkingDirectory)" IgnoreExitCode="false" Condition="$(WorkingDirectory.Length) > 0" />
+    <Yarn Command="build" WorkingDirectory="$(WorkingDirectory)" IgnoreExitCode="false" Condition="$(WorkingDirectory.Length) > 0" />
   </Target>
 </Project>

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/.eslintignore
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/.eslintignore
@@ -1,3 +1,4 @@
 src/components/contentTypeModal/fieldDefinitions/FileUpload/Dropzone.jsx
 /src/vendor/**
 /src/utils/masker.js
+*dnn-react-common.min.js

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -12,7 +12,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "@dnnsoftware/dnn-react-common": "^2.1.2",
     "array.prototype.find": "2.0.4",
     "array.prototype.findindex": "2.0.2",
     "babel-loader": "^8.0.6",
@@ -63,5 +62,8 @@
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "3.1.14"
+  },
+  "dependencies": {
+    "@dnnsoftware/dnn-react-common": "^2.1.2"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -64,6 +64,6 @@
     "webpack-dev-server": "3.1.14"
   },
   "dependencies": {
-    "@dnnsoftware/dnn-react-common": "^2.1.2"
+    "@dnnsoftware/dnn-react-common": "2.1.2"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
     resolve: {
         extensions: [".js", ".json", ".jsx"],
         modules: [
-            "node_modules",
+            path.resolve("./node_modules"), // Try local node_modules
             path.resolve("../../../node_modules"),
             path.resolve(__dirname, "src")
         ]

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/dist.webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/dist.webpack.config.js
@@ -28,7 +28,6 @@ module.exports = {
             { test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/, loader: "file-loader?name=[name].[ext]" }
         ]
     },
-    target: "node", // in order to ignore built-in modules like path, fs, etc.
     externals: ["react", "prop-types", nodeExternals()], // in order to ignore all modules in node_modules folder
     resolve: {
         extensions: [".js", ".json", ".jsx"],

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dnnsoftware/dnn-react-common",
-  "version": "2.0.9",
+  "version": "2.1.2",
   "private": false,
   "description": "DNN React Component Library",
   "main": "dist/dnn-react-common.min.js",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,25 @@
 {
   "packages": [
-    "src/*"
+    "Dnn.AdminExperience/ClientSide/Dnn.React.Common",
+    "Dnn.AdminExperience/ClientSide/AdminLogs.Web",
+    "Dnn.AdminExperience/ClientSide/Bundle.Web",
+    "Dnn.AdminExperience/ClientSide/Extensions.Web",
+    "Dnn.AdminExperience/ClientSide/Licensing.Web",
+    "Dnn.AdminExperience/ClientSide/Pages.Web",
+    "Dnn.AdminExperience/ClientSide/Prompt.Web",
+    "Dnn.AdminExperience/ClientSide/Roles.Web",
+    "Dnn.AdminExperience/ClientSide/Security.Web",
+    "Dnn.AdminExperience/ClientSide/Seo.Web",
+    "Dnn.AdminExperience/ClientSide/Servers.Web",
+    "Dnn.AdminExperience/ClientSide/SiteImportExport.Web",
+    "Dnn.AdminExperience/ClientSide/Sites.Web",
+    "Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables",
+    "Dnn.AdminExperience/ClientSide/SiteSettings.Web",
+    "Dnn.AdminExperience/ClientSide/TaskScheduler.Web",
+    "Dnn.AdminExperience/ClientSide/Themes.Web",
+    "Dnn.AdminExperience/ClientSide/Users.Web",
+    "Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables",
+    "Dnn.AdminExperience/ClientSide/Vocabularies.Web"
   ],
   "version": "independent",
   "npmClient": "yarn",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "workspaces": [
+    "Dnn.AdminExperience/ClientSide/Dnn.React.Common",
     "Dnn.AdminExperience/ClientSide/AdminLogs.Web",
     "Dnn.AdminExperience/ClientSide/Bundle.Web",
-    "Dnn.AdminExperience/ClientSide/Dnn.React.Common",
     "Dnn.AdminExperience/ClientSide/Extensions.Web",
     "Dnn.AdminExperience/ClientSide/Licensing.Web",
     "Dnn.AdminExperience/ClientSide/Pages.Web",
@@ -26,5 +26,13 @@
   ],
   "devDependencies": {
     "lerna": "^3.16.4"
+  },
+  "scripts": {
+    "start": "gulp debug",
+    "build": "lerna run build",
+    "package": "lerna run package",
+    "clean": "lerna run clean",
+    "lint": "lerna run lint",
+    "test": "lerna run test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "lerna": "^3.16.4"
   },
   "scripts": {
-    "start": "gulp debug",
     "build": "lerna run build",
     "package": "lerna run package",
     "clean": "lerna run clean",


### PR DESCRIPTION
Fixes #3455 

## Summary
Made sure that lerna knew about the workspace packages configured for yarn. Had to move React Common to the top to make sure it was built first. Also added scripts to the main package.json for a cleaner interface instead of calling lerna directly from msbuild.