### PR TITLE
Separate out CI from local package build

### DIFF
--- a/Build/Cake/ci.cake
+++ b/Build/Cake/ci.cake
@@ -1,6 +1,7 @@
 Task("BuildAll")
     .IsDependentOn("CleanArtifacts")
-    .IsDependentOn("UpdateDnnManifests")
+    .IsDependentOn("GenerateChecksum")
+    .IsDependentOn("SetPackageVersions")
 	.IsDependentOn("CreateInstall")
 	.IsDependentOn("CreateUpgrade")
     .IsDependentOn("CreateDeploy")

--- a/Build/Cake/ci.cake
+++ b/Build/Cake/ci.cake
@@ -1,3 +1,5 @@
+// This is the task CI will use to build release packages
+
 Task("BuildAll")
     .IsDependentOn("CleanArtifacts")
     .IsDependentOn("GenerateChecksum")

--- a/Build/Cake/ci.cake
+++ b/Build/Cake/ci.cake
@@ -2,6 +2,7 @@
 
 Task("BuildAll")
     .IsDependentOn("CleanArtifacts")
+    .IsDependentOn("UpdateDnnManifests")
     .IsDependentOn("GenerateChecksum")
     .IsDependentOn("SetPackageVersions")
 	.IsDependentOn("CreateInstall")

--- a/Build/Cake/compiling.cake
+++ b/Build/Cake/compiling.cake
@@ -1,4 +1,5 @@
-// Main solution
+// This tasks kicks off MS Build (just as in Visual Studio)
+
 var dnnSolutionPath = "./DNN_Platform.sln";
 
 Task("Build")

--- a/Build/Cake/database.cake
+++ b/Build/Cake/database.cake
@@ -1,3 +1,5 @@
+// Database tasks for your local DNN development site
+
 Task("ResetDatabase")
   .Does(() => 
     {

--- a/Build/Cake/devsite.cake
+++ b/Build/Cake/devsite.cake
@@ -1,3 +1,6 @@
+// Tasks to help you create and maintain a local DNN development site.
+// Note these tasks depend on the correct settings in your settings file.
+
 Task("ResetDevSite")
     .IsDependentOn("ResetDatabase")
     .IsDependentOn("PreparePackaging")

--- a/Build/Cake/packaging.cake
+++ b/Build/Cake/packaging.cake
@@ -1,3 +1,5 @@
+// The tasks create the various DNN release packages (Install, Upgrade, Deploy and Symbols)
+
 using Dnn.CakeUtils;
 
 public class PackagingPatterns {

--- a/Build/Cake/settings.cake
+++ b/Build/Cake/settings.cake
@@ -1,3 +1,6 @@
+// This file loads or creates the local settings file you can use to influence the build process
+// and/or maintain a local DNN development site
+
 public class LocalSettings {
     public string WebsitePath {get; set;} = "";
     public string WebsiteUrl {get; set;} = "";

--- a/Build/Cake/version.cake
+++ b/Build/Cake/version.cake
@@ -1,4 +1,5 @@
-// These tasks are meant for our CI build process. They set the versions of the assemblies and manifests to the version found on Github.
+// These tasks will set the right version for manifests and assemblies. Note you can
+// control this by using custom settings
 
 GitVersion version;
 var buildId = EnvironmentVariable("BUILD_BUILDID") ?? "0";

--- a/Build/Cake/version.cake
+++ b/Build/Cake/version.cake
@@ -49,7 +49,6 @@ Task("SetVersion")
 
 Task("UpdateDnnManifests")
   .IsDependentOn("SetVersion")
-  .IsDependentOn("GenerateChecksum")
   .IsDependentOn("SetPackageVersions")
   .DoesForEach(GetFilesByPatterns(".", new string[] {"**/*.dnn"}, unversionedManifests), (file) => 
   { 

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+// Main Cake Build entry points. Note most Cake scripts are located under Build/Cake.
+
 #addin nuget:?package=Cake.XdtTransform&version=0.18.1&loaddependencies=true
 #addin nuget:?package=Cake.FileHelpers&version=3.2.0
 #addin nuget:?package=Cake.Powershell&version=0.4.8

--- a/build.cake
+++ b/build.cake
@@ -98,7 +98,12 @@ Task("CleanArtifacts")
 //////////////////////////////////////////////////////////////////////
 
 Task("Default")
-    .IsDependentOn("BuildAll");
+    .IsDependentOn("CleanArtifacts")
+    .IsDependentOn("UpdateDnnManifests")
+	.IsDependentOn("CreateInstall")
+	.IsDependentOn("CreateUpgrade")
+    .IsDependentOn("CreateDeploy")
+    .IsDependentOn("CreateSymbols");
 
 //////////////////////////////////////////////////////////////////////
 // EXECUTION


### PR DESCRIPTION
This PR will make the default cake build avoid:
1. Creating NuGet packages
2. Tweak the checksum of default.aspx

The advantage is that this avoids unnecessary work and avoids potential mishaps for people building locally. You can still call the CI build using the target BuildAll.