### PR TITLE
Ability to entirely switch off the versioning mechanism.

### DIFF
--- a/Build/Cake/version.cake
+++ b/Build/Cake/version.cake
@@ -25,7 +25,10 @@ Task("SetVersion")
       buildNumber = version.LegacySemVerPadded;
     } else {
       version = new GitVersion();
-      var requestedVersion = new System.Version(Settings.Version);
+      var assemblyInfo = new AssemblyInfo("SolutionInfo.cs");
+      var requestedVersion = Settings.Version == "off" ? 
+        assemblyInfo.GetVersion():
+        new System.Version(Settings.Version);
       version.Major = requestedVersion.Major;
       version.Minor = requestedVersion.Minor;
       version.Patch = requestedVersion.Build;
@@ -36,10 +39,11 @@ Task("SetVersion")
         version.CommitsSinceVersionSource = requestedVersion.Revision;
         version.InformationalVersion = requestedVersion.ToString(4) + " Custom build";
       }
-      buildNumber = Settings.Version;
+      buildNumber = requestedVersion.ToString(3);
     }
     Information(Newtonsoft.Json.JsonConvert.SerializeObject(version));
-    Dnn.CakeUtils.Utilities.UpdateAssemblyInfoVersion(new System.Version(version.Major, version.Minor, version.Patch, version.CommitsSinceVersionSource != null ? (int)version.CommitsSinceVersionSource : 0), version.InformationalVersion, "SolutionInfo.cs");
+    if (Settings.Version != "off")
+      Dnn.CakeUtils.Utilities.UpdateAssemblyInfoVersion(new System.Version(version.Major, version.Minor, version.Patch, version.CommitsSinceVersionSource != null ? (int)version.CommitsSinceVersionSource : 0), version.InformationalVersion, "SolutionInfo.cs");
     Information("Informational Version : " + version.InformationalVersion);
     productVersion = version.MajorMinorPatch;
     Information("Product Version : " + productVersion);
@@ -53,6 +57,7 @@ Task("UpdateDnnManifests")
   .IsDependentOn("SetPackageVersions")
   .DoesForEach(GetFilesByPatterns(".", new string[] {"**/*.dnn"}, unversionedManifests), (file) => 
   { 
+    if (Settings.Version == "off") return;
     Information("Transforming: " + file);
     var transformFile = File(System.IO.Path.GetTempFileName());
     FileAppendText(transformFile, GetXdtTransformation());
@@ -62,6 +67,7 @@ Task("UpdateDnnManifests")
 Task("SetPackageVersions")
   .IsDependentOn("SetVersion")
   .Does(() => {
+    if (Settings.Version == "off") return;
     var packages = GetFiles("./Dnn.AdminExperience/ClientSide/*.Web/package.json");
     packages.Add(GetFiles("./Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json"));
     packages.Add(GetFiles("./Dnn.AdminExperience/ClientSide/*.Web/**/_exportables/package.json"));

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@
 #addin nuget:?package=Cake.FileHelpers&version=3.2.0
 #addin nuget:?package=Cake.Powershell&version=0.4.8
 
-#addin nuget:?package=Dnn.CakeUtils&version=1.1.1
+#addin nuget:?package=Dnn.CakeUtils&version=1.1.6
 #tool "nuget:?package=GitVersion.CommandLine&version=5.0.1"
 #tool "nuget:?package=Microsoft.TestPlatform&version=15.7.0"
 #tool "nuget:?package=NUnitTestAdapter&version=2.1.1"


### PR DESCRIPTION
The version used will be parsed from the solutioninfo.cs. This is done using a new method in the CakeUtils library.

