### PR TITLE
Ensures we can use 09.05.00.SqlDataProvider scripts

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,4 +1,4 @@
-next-version: 9.4.2
+next-version: 9.5.0
 commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment


### PR DESCRIPTION
Right now gitVersion will default to 9.4.5 because we bump the last digit (patch) since the last tagged release (9.4.4) on the develop branch. Since we know the next version we will release is 9.5.0, if we need to have sql scripts in that release, they will be 9.5.0 versioned and will not run during install or upgrade since everything else would be versioned 9.4.5. 

This PR sets next-version to 9.5.0 for that reason.

What this means is that CI will default to 9.5.0 for the develop branch until we actually release and tag 9.5.0, after that time it will go back to it's normal behaviour of bumping the patch number as it does now. This affectes only CI and if the local settings for version is set to "auto".