### PR TITLE
Fixed MVC dependency injection.

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcDependencyResolver.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcDependencyResolver.cs
@@ -5,7 +5,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.Web;
 using System.Web.Mvc;
+using DotNetNuke.Common.Extensions;
 
 namespace DotNetNuke.Web.Mvc
 {
@@ -15,20 +17,6 @@ namespace DotNetNuke.Web.Mvc
     /// </summary>
     internal class DnnMvcDependencyResolver : IDependencyResolver
     {
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IDependencyResolver _resolver;
-
-        /// <summary>
-        /// Instantiate a new instance of the <see cref="DnnDependencyResolver"/>.
-        /// </summary>
-        /// <param name="serviceProvider">
-        /// The <see cref="IServiceProvider"/> to be used in the <see cref="DnnDependencyResolver"/>
-        /// </param>
-        public DnnMvcDependencyResolver(IServiceProvider serviceProvider, IDependencyResolver resolver)
-        {
-            _serviceProvider = serviceProvider;
-            _resolver = resolver;
-        }
 
         /// <summary>
         /// Returns the specified service from the scope
@@ -41,14 +29,11 @@ namespace DotNetNuke.Web.Mvc
         /// </returns>
         public object GetService(Type serviceType)
         {
-            try
-            {
-                return _serviceProvider.GetService(serviceType);
-            }
-            catch
-            {
-                return _resolver.GetService(serviceType);
-            }
+            var scope = HttpContext.Current?.GetScope();
+            if (scope != null)
+                return scope.ServiceProvider.GetService(serviceType);
+
+            throw new InvalidOperationException("IServiceScope not provided");
         }
 
         /// <summary>
@@ -62,14 +47,11 @@ namespace DotNetNuke.Web.Mvc
         /// </returns>
         public IEnumerable<object> GetServices(Type serviceType)
         {
-            try
-            {
-                return _serviceProvider.GetServices(serviceType);
-            }
-            catch
-            {
-                return _resolver.GetServices(serviceType);
-            }
+            var scope = HttpContext.Current?.GetScope();
+            if (scope != null)
+                return scope.ServiceProvider.GetServices(serviceType);
+
+            throw new InvalidOperationException("IServiceScope not provided");
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcDependencyResolver.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcDependencyResolver.cs
@@ -5,9 +5,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using System.Web;
 using System.Web.Mvc;
-using DotNetNuke.Common.Extensions;
+using DotNetNuke.Services.DependencyInjection;
 
 namespace DotNetNuke.Web.Mvc
 {
@@ -17,6 +16,12 @@ namespace DotNetNuke.Web.Mvc
     /// </summary>
     internal class DnnMvcDependencyResolver : IDependencyResolver
     {
+        private readonly IServiceProvider _serviceProvider;
+
+        public DnnMvcDependencyResolver(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        }
 
         /// <summary>
         /// Returns the specified service from the scope
@@ -29,7 +34,8 @@ namespace DotNetNuke.Web.Mvc
         /// </returns>
         public object GetService(Type serviceType)
         {
-            var scope = HttpContext.Current?.GetScope();
+            var accessor = _serviceProvider.GetRequiredService<IScopeAccessor>();
+            var scope = accessor.GetScope();
             if (scope != null)
                 return scope.ServiceProvider.GetService(serviceType);
 
@@ -47,7 +53,8 @@ namespace DotNetNuke.Web.Mvc
         /// </returns>
         public IEnumerable<object> GetServices(Type serviceType)
         {
-            var scope = HttpContext.Current?.GetScope();
+            var accessor = _serviceProvider.GetRequiredService<IScopeAccessor>();
+            var scope = accessor.GetScope();
             if (scope != null)
                 return scope.ServiceProvider.GetServices(serviceType);
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Common\PropertyHelper.cs" />
     <Compile Include="Common\TypeHelper.cs" />
     <Compile Include="DnnMvcDependencyResolver.cs" />
+    <Compile Include="Extensions\StartupExtensions.cs" />
     <Compile Include="Framework\ActionFilters\AuthFilterContext.cs" />
     <Compile Include="Framework\ActionFilters\AuthorizeAttributeBase.cs" />
     <Compile Include="Framework\ActionFilters\DnnAuthorizeAttribute.cs" />

--- a/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
@@ -1,0 +1,28 @@
+﻿using DotNetNuke.DependencyInjection.Extensions;
+using DotNetNuke.Web.Mvc.Framework.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetNuke.Web.Mvc.Extensions
+{
+    public static class StartupExtensions
+    {
+        public static void AddWebApiControllers(this IServiceCollection services)
+        {
+            var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(TypeExtensions.SafeGetTypes)
+                .Where(x => typeof(IDnnController).IsAssignableFrom(x)
+                    && x.IsClass
+                    && !x.IsAbstract
+                );
+            foreach (var controller in controllerTypes)
+            {
+                services.AddScoped(controller);
+            }
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
@@ -2,9 +2,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // 
-using DotNetNuke.Common;
 using DotNetNuke.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using DotNetNuke.Web.Mvc.Extensions;
 using System.Web.Mvc;
 
 namespace DotNetNuke.Web.Mvc
@@ -13,11 +13,12 @@ namespace DotNetNuke.Web.Mvc
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton(serviceProvider => ControllerBuilder.Current.GetControllerFactory());
+            services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
             services.AddSingleton<MvcModuleControlFactory>();
 
-            IDependencyResolver resolver = new DnnMvcDependencyResolver(Globals.DependencyProvider, DependencyResolver.Current);
-            DependencyResolver.SetResolver(resolver);
+            services.AddWebApiControllers();
+
+            DependencyResolver.SetResolver(new DnnMvcDependencyResolver());
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
@@ -6,6 +6,7 @@ using DotNetNuke.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using DotNetNuke.Web.Mvc.Extensions;
 using System.Web.Mvc;
+using DotNetNuke.Common;
 
 namespace DotNetNuke.Web.Mvc
 {
@@ -18,7 +19,7 @@ namespace DotNetNuke.Web.Mvc
 
             services.AddWebApiControllers();
 
-            DependencyResolver.SetResolver(new DnnMvcDependencyResolver());
+            DependencyResolver.SetResolver(new DnnMvcDependencyResolver(Globals.DependencyProvider));
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
@@ -25,14 +25,14 @@ namespace DotNetNuke.Web.Extensions
         /// </param>
         public static void AddWebApi(this IServiceCollection services)
         {
-            var startuptypes = AppDomain.CurrentDomain.GetAssemblies()
+            var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(x => x.SafeGetTypes())
                 .Where(x => typeof(DnnApiController).IsAssignableFrom(x) &&
                             x.IsClass &&
                             !x.IsAbstract);
-            foreach (var controller in startuptypes)
+            foreach (var controller in controllerTypes)
             {
-                services.AddTransient(controller);
+                services.AddScoped(controller);
             }
         }
     }

--- a/DNN Platform/DotNetNuke.Web/Api/Internal/DnnDependencyResolver.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Internal/DnnDependencyResolver.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Web.Http.Dependencies;
+using DotNetNuke.Common.Extensions;
 
 namespace DotNetNuke.Web.Api.Internal
 {
@@ -25,7 +26,7 @@ namespace DotNetNuke.Web.Api.Internal
         /// </param>
         public DnnDependencyResolver(IServiceProvider serviceProvider)
         {
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         }
 
         /// <summary>
@@ -36,7 +37,8 @@ namespace DotNetNuke.Web.Api.Internal
         /// </returns>
         public IDependencyScope BeginScope()
         {
-            return new DnnDependencyResolver(_serviceProvider.CreateScope().ServiceProvider);
+            var scope = System.Web.HttpContext.Current.GetScope();
+            return new DnnDependencyResolver(scope.ServiceProvider);
         }
 
         /// <summary>

--- a/DNN Platform/DotNetNuke.Web/Api/Internal/DnnDependencyResolver.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Internal/DnnDependencyResolver.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Web.Http.Dependencies;
 using DotNetNuke.Common.Extensions;
+using DotNetNuke.Services.DependencyInjection;
 
 namespace DotNetNuke.Web.Api.Internal
 {
@@ -37,7 +38,8 @@ namespace DotNetNuke.Web.Api.Internal
         /// </returns>
         public IDependencyScope BeginScope()
         {
-            var scope = System.Web.HttpContext.Current.GetScope();
+            var accessor = _serviceProvider.GetRequiredService<IScopeAccessor>();
+            var scope = accessor.GetScope();
             return new DnnDependencyResolver(scope.ServiceProvider);
         }
 

--- a/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
@@ -67,8 +67,9 @@ namespace DotNetNuke.Web.Common.Internal
             var name = Config.GetSetting("ServerName");
             Globals.ServerName = String.IsNullOrEmpty(name) ? Dns.GetHostName() : name;
 
+            Globals.DependencyProvider = new LazyServiceProvider();
             var startup = new Startup();
-            Globals.DependencyProvider = startup.DependencyProvider;
+            (Globals.DependencyProvider as LazyServiceProvider).SetProvider(startup.DependencyProvider);
             ServiceRequestScopeModule.SetServiceProvider(Globals.DependencyProvider);
 
             ComponentFactory.Container = new SimpleContainer();

--- a/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
@@ -35,7 +35,7 @@ using DotNetNuke.Services.Url.FriendlyUrl;
 using DotNetNuke.Instrumentation;
 using DotNetNuke.Security.Cookies;
 using DotNetNuke.Services.Installer.Blocker;
-using Microsoft.Extensions.DependencyInjection;
+using DotNetNuke.HttpModules.DependencyInjection;
 
 #endregion
 
@@ -69,6 +69,7 @@ namespace DotNetNuke.Web.Common.Internal
 
             var startup = new Startup();
             Globals.DependencyProvider = startup.DependencyProvider;
+            ServiceRequestScopeModule.SetServiceProvider(Globals.DependencyProvider);
 
             ComponentFactory.Container = new SimpleContainer();
 

--- a/DNN Platform/DotNetNuke.Web/Common/LazyServiceProvider.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/LazyServiceProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetNuke.Web.Common
+{
+    public class LazyServiceProvider : IServiceProvider
+    {
+        private IServiceProvider _serviceProvider;
+
+        public object GetService(Type serviceType)
+        {
+            if (_serviceProvider is null)
+                throw new Exception("Cannot resolve services until the service provider is built.");
+
+            return _serviceProvider.GetService(serviceType);
+        }
+
+        internal void SetProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Common\DynamicSharedConstants.cs" />
     <Compile Include="Common\DotNetNukeHttpApplication.cs" />
     <Compile Include="Api\WebApiException.cs" />
+    <Compile Include="Common\LazyServiceProvider.cs" />
     <Compile Include="Components\Controllers\ControlBarController.cs" />
     <Compile Include="Components\Controllers\IControlBarController.cs" />
     <Compile Include="Components\Controllers\Models\MenuItemViewModel.cs" />

--- a/DNN Platform/DotNetNuke.Web/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web/Startup.cs
@@ -5,6 +5,7 @@
 using DotNetNuke.DependencyInjection;
 using DotNetNuke.DependencyInjection.Extensions;
 using DotNetNuke.Instrumentation;
+using DotNetNuke.Services.DependencyInjection;
 using DotNetNuke.Web.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -25,6 +26,7 @@ namespace DotNetNuke.Web
         private void Configure()
         {
             var services = new ServiceCollection();
+            services.AddSingleton<IScopeAccessor, ScopeAccessor>();
             ConfigureServices(services);
             DependencyProvider = services.BuildServiceProvider();
         }

--- a/DNN Platform/HttpModules/DependencyInjection/ServiceRequestScopeModule.cs
+++ b/DNN Platform/HttpModules/DependencyInjection/ServiceRequestScopeModule.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Web;
+using DotNetNuke.Common.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Web.Infrastructure.DynamicModuleHelper;
+
+[assembly: PreApplicationStartMethod(typeof(DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule), nameof(DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule.InitModule))]
+
+namespace DotNetNuke.HttpModules.DependencyInjection
+{
+    public class ServiceRequestScopeModule : IHttpModule
+    {
+        public static void InitModule()
+        {
+            DynamicModuleUtility.RegisterModule(typeof(ServiceRequestScopeModule));
+        }
+
+        private static IServiceProvider _serviceProvider;
+
+        public void Init(HttpApplication context)
+        {
+            context.BeginRequest += Context_BeginRequest;
+            context.EndRequest += Context_EndRequest;
+        }
+
+        public static void SetServiceProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        private void Context_BeginRequest(object sender, EventArgs e)
+        {
+            var context = ((HttpApplication)sender).Context;
+            context.SetScope(_serviceProvider.CreateScope());
+        }
+
+        private void Context_EndRequest(object sender, EventArgs e)
+        {
+            var context = ((HttpApplication)sender).Context;
+            context.GetScope()?.Dispose();
+            context.ClearScope();
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, 
+        /// releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, 
+        /// releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// true if the object is currently disposing.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // left empty by design
+        }
+    }
+}

--- a/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
+++ b/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
@@ -56,6 +56,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DotNetNuke.Instrumentation\bin\DotNetNuke.Instrumentation.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
@@ -67,6 +71,7 @@
     <Compile Include="..\..\SolutionInfo.cs">
       <Link>SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="DependencyInjection\ServiceRequestScopeModule.cs" />
     <Compile Include="MobileRedirect\MobileRedirectModule.cs" />
     <Compile Include="OutputCaching\OutputCacheModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
@@ -113,6 +118,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="UrlRewrite\Config\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/DNN Platform/HttpModules/packages.config
+++ b/DNN Platform/HttpModules/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+</packages>

--- a/DNN Platform/Library/Common/Extensions/HttpContextDependencyInjectionExtensions.cs
+++ b/DNN Platform/Library/Common/Extensions/HttpContextDependencyInjectionExtensions.cs
@@ -30,7 +30,7 @@ namespace DotNetNuke.Common.Extensions
             return GetScope(httpContext.Items);
         }
 
-        private static IServiceScope GetScope(System.Collections.IDictionary contextItems)
+        internal static IServiceScope GetScope(System.Collections.IDictionary contextItems)
         {
             if (!contextItems.Contains(typeof(IServiceScope)))
                 return null;

--- a/DNN Platform/Library/Common/Extensions/HttpContextDependencyInjectionExtensions.cs
+++ b/DNN Platform/Library/Common/Extensions/HttpContextDependencyInjectionExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System.Web;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotNetNuke.Common.Extensions
+{
+    public static class HttpContextDependencyInjectionExtensions
+    {
+        public static void SetScope(this HttpContextBase httpContext, IServiceScope scope)
+        {
+            httpContext.Items[typeof(IServiceScope)] = scope;
+        }
+
+        public static void SetScope(this HttpContext httpContext, IServiceScope scope)
+        {
+            httpContext.Items[typeof(IServiceScope)] = scope;
+        }
+
+        public static void ClearScope(this HttpContext httpContext)
+        {
+            httpContext.Items.Remove(typeof(IServiceScope));
+        }
+
+        public static IServiceScope GetScope(this HttpContextBase httpContext)
+        {
+            return GetScope(httpContext.Items);
+        }
+
+        public static IServiceScope GetScope(this HttpContext httpContext)
+        {
+            return GetScope(httpContext.Items);
+        }
+
+        private static IServiceScope GetScope(System.Collections.IDictionary contextItems)
+        {
+            if (!contextItems.Contains(typeof(IServiceScope)))
+                return null;
+
+            return contextItems[typeof(IServiceScope)] is IServiceScope scope ? scope : null;
+        }
+    }
+}

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Application\Application.cs" />
     <Compile Include="Application\AssemblyStatusAttribute.cs" />
     <Compile Include="Application\DotNetNukeContext.cs" />
+    <Compile Include="Common\Extensions\HttpContextDependencyInjectionExtensions.cs" />
     <Compile Include="Common\NavigationManager.cs" />
     <Compile Include="Common\Utilities\CryptographyUtils.cs" />
     <Compile Include="Common\Utilities\RegexUtils.cs" />

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -701,6 +701,7 @@
     <Compile Include="Services\Cryptography\CryptographyProvider.cs" />
     <Compile Include="Services\Cryptography\ICryptographyProvider.cs" />
     <Compile Include="Services\Authentication\UserAuthenticationInfo.cs" />
+    <Compile Include="Services\DependencyInjection\IScopeAccessor.cs" />
     <Compile Include="Services\Exceptions\ExceptionExtensions.cs" />
     <Compile Include="Services\Exceptions\SearchIndexEmptyException.cs" />
     <Compile Include="Services\Assets\AssetManager.cs" />

--- a/DNN Platform/Library/Services/DependencyInjection/IScopeAccessor.cs
+++ b/DNN Platform/Library/Services/DependencyInjection/IScopeAccessor.cs
@@ -1,0 +1,35 @@
+﻿using DotNetNuke.Common.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections;
+using System.Web;
+
+namespace DotNetNuke.Services.DependencyInjection
+{
+    public interface IScopeAccessor
+    {
+        IServiceScope GetScope();
+    }
+
+    public class ScopeAccessor : IScopeAccessor
+    {
+        private static Func<IDictionary> fallbackGetContextItems = () => HttpContext.Current?.Items;
+
+        private Func<IDictionary> _getContextItems;
+
+        public ScopeAccessor()
+        {
+            _getContextItems = fallbackGetContextItems;
+        }
+
+        public IServiceScope GetScope()
+        {
+            return HttpContextDependencyInjectionExtensions.GetScope(_getContextItems());
+        }
+
+        internal void SetContextItemsFunc(Func<IDictionary> getContextItems)
+        {
+            _getContextItems = getContextItems ?? fallbackGetContextItems;
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/DnnDependencyResolverTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/DnnDependencyResolverTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // 
+using DotNetNuke.Services.DependencyInjection;
 using DotNetNuke.Web.Api.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -21,6 +22,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         public void FixtureSetUp()
         {
             var services = new ServiceCollection();
+            services.AddSingleton<IScopeAccessor>(sp => new FakeScopeAccessor(sp.CreateScope()));
             services.AddScoped(typeof(ITestService), typeof(TestService));
 
             _serviceProvider = services.BuildServiceProvider();
@@ -107,5 +109,20 @@ namespace DotNetNuke.Tests.Web.Api.Internals
 
         private interface ITestService { }
         private class TestService : ITestService { }
+
+        private class FakeScopeAccessor : IScopeAccessor
+        {
+            private IServiceScope fakeScope;
+
+            public FakeScopeAccessor(IServiceScope fakeScope)
+            {
+                this.fakeScope = fakeScope;
+            }
+
+            public IServiceScope GetScope()
+            {
+                return fakeScope;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #3513 

## Summary
* Added a HttpModule (ServiceRequestScopeModule) that handles DI's request scope lifetime.
  * This enables scoped service resolutions for WebForms, MVC and WebApi.
  * It also stores the created scope inside the HttpContext.Items for easy access. This can be useful for vendors to access the request scope.

* Setup the ServiceRequestScopeModule as part of the Application_Start initialization.
* Register the WebApi controllers in the DI container.

Used example from https://github.com/dotnet/aspnetcore/issues/3172 as inspiration.

TODOs: 
* Properly include the `ServiceRequestScopeModule` HttpModule through the web.config, get rid of `PreApplicationStartMethod` assembly attribute in `ServiceRequestScopeModule` and the `Microsoft.Web.Infrastructure` package. The module should be the first in the pipeline for BeginRequest and the last for EndRequest, so that as much of the request as possible is covered.
* Improve naming and placement for some of the classes created.
