### PR TITLE
Don't expose file last modifed date/time via cachebusted URLs

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -616,12 +616,9 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /*
-         * add a cachebuster parameter to generated file URI's
-         * 
-         * of the form ver=[file timestame] ie ver=2015-02-17-162255-735
-         * 
-         */
+        /// <summary>
+        /// If true then add a cachebuster parameter to generated file URI's.
+        /// </summary>
         public bool AddCachebusterToResourceUris
         {
             get

--- a/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
@@ -199,7 +199,9 @@ namespace DotNetNuke.Services.FileSystem
             // Does site management want the cachebuster parameter?
             if (portalSettings.AddCachebusterToResourceUris)
             {
-                return TestableGlobals.Instance.ResolveUrl(fullPath + "?ver=" + file.LastModificationTime.ToString("yyyy-MM-dd-HHmmss-fff"));
+                var cachebusterToken = UrlUtils.EncryptParameter(file.LastModificationTime.GetHashCode().ToString());
+
+                return TestableGlobals.Instance.ResolveUrl(fullPath + "?ver=" + cachebusterToken);
             }
 
             return TestableGlobals.Instance.ResolveUrl(fullPath);


### PR DESCRIPTION
This is a duplicate of @roman-yagodin's #3528 which was merged into `development` instead of `develop`.

Closes #2850

(cherry picked from commit 143b1879cccc222e3a1b39f676d4676b4598ee7a)