### PR TITLE
Performance improvement PersonaBar pages treeview on Expand/Collapse

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
@@ -124,12 +124,14 @@ class PersonaBarPageTreeviewInteractor extends Component {
             initialCollapse: false
         });
         let listPageItems = undefined;
+        let updateReduxStore = null;
         this.props._traverse((item, listItem, updateStore) => {
             (item.id === id) ? item.isOpen = !item.isOpen : null;
-            updateStore(listItem);
+            updateReduxStore = updateStore;
             listPageItems = listItem;
         });
 
+        updateReduxStore ? updateReduxStore(listPageItems) : null;
         this._countTreeOpenDeepParent(listPageItems);
     }
 


### PR DESCRIPTION
Fix bug #3532 

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
- Update store method was repeating called for each tree view node with the same parameters.
- Optimize call to this update store method once per process as parameters remains constant.


**Measurements**

Action | Baseline (ms) | Baseline avg. | Improve (ms) | Improve avg. | Improvement
-- | -- | -- | -- | -- | --
Expand node | 59,358 | 59,227.80 | 6,032 | 5,685.60 | 10.42 X
 -- | 59,573 | | 5,512 | | 
 -- | 61,184 | | 5,631 | | 
 -- | 58,579 | | 5,775 | | 
 -- | 57,445 | | 5,478 | | 
Collapse node | 55,476 | 53,868.40 | 825 | 754.20 | 71.42 X
 -- | 52,227 | | 695 | | 
 -- | 54,076 | | 716 | | 
 -- | 54,947 | | 794 | | 
 -- | 52,616 | | 741 | | 

