### PR TITLE
Performance improvement PersonaBar tree view node selection change

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
@@ -134,12 +134,16 @@ class PersonaBarPageTreeviewInteractor extends Component {
     }
 
     onSelection({ id }) {
+        let listPageItems = undefined;
+        let updateReduxStore = null;
         this.props._traverse((item, listItem, updateStore) => {
             (item.id === id && item.canManagePage) ? item.selected = true : item.selected = false;
             item.selected ? this.props.onSelection(id) : null;
             delete item.showInContextMenu;
-            updateStore(listItem);
+            updateReduxStore = updateStore;
+            listPageItems = listItem;
         });
+        updateReduxStore ? updateReduxStore(listPageItems) : null;
     }
 
     onNoPermissionSelection({ id }) {


### PR DESCRIPTION
Fix bug #3534 
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
- UpdateStore method was repeating called for each tree view node with the same parameters.
- Optimize call to this update store method once per process as parameters remains constant.

**Measurements**

Action | Baseline (ms) | Baseline avg. | Improve (ms) | Improve avg. | Improvement
-- | -- | -- | -- | -- | --
on selection change | 54,622 | 53,314.60 | 456 | 349.00 | 152.76
-- | 53,091 | | 334
-- | 52,230 | | 309
-- | 54,076 | | 307
-- | 52,554 | | 339

