### PR TITLE
DI: Register MVC/WebApi Controllers using TryAddScoped.

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using DotNetNuke.DependencyInjection.Extensions;
 using DotNetNuke.Web.Mvc.Framework.Controllers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace DotNetNuke.Web.Mvc.Extensions
 {
     public static class StartupExtensions
     {
-        public static void AddWebApiControllers(this IServiceCollection services)
+        public static void AddMvcControllers(this IServiceCollection services)
         {
             var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(TypeExtensions.SafeGetTypes)
@@ -21,7 +22,7 @@ namespace DotNetNuke.Web.Mvc.Extensions
                 );
             foreach (var controller in controllerTypes)
             {
-                services.AddScoped(controller);
+                services.TryAddScoped(controller);
             }
         }
     }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using DotNetNuke.Web.Mvc.Extensions;
 using System.Web.Mvc;
 using DotNetNuke.Common;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace DotNetNuke.Web.Mvc
 {
@@ -14,10 +15,10 @@ namespace DotNetNuke.Web.Mvc
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+            services.TryAddSingleton<IControllerFactory, DefaultControllerFactory>();
             services.AddSingleton<MvcModuleControlFactory>();
 
-            services.AddWebApiControllers();
+            services.AddMvcControllers();
 
             DependencyResolver.SetResolver(new DnnMvcDependencyResolver(Globals.DependencyProvider));
         }

--- a/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
@@ -5,6 +5,7 @@
 using DotNetNuke.DependencyInjection.Extensions;
 using DotNetNuke.Web.Api;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Linq;
 
@@ -32,7 +33,7 @@ namespace DotNetNuke.Web.Extensions
                             !x.IsAbstract);
             foreach (var controller in controllerTypes)
             {
-                services.AddScoped(controller);
+                services.TryAddScoped(controller);
             }
         }
     }


### PR DESCRIPTION
Fixes #3543 

## Summary
This is a quick fix for the assigned issue.
This will allow vendors to add/replace controller registrations with their own.
The DefaultControllerFactory is also added to the ServiceCollection using the `TryAddSingleton` for the same reasons.

Fix AddWebApiControllers typo for AddMvcControllers.
