### PR TITLE
Fix for DisplayUserName

### DIFF
--- a/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx.cs
@@ -591,12 +591,14 @@ namespace DotNetNuke.Modules.Admin.Users
                 {
                     CreateStatus = UserCreateStatus.InvalidLastName;
                 }
-
-                var cleanDisplayName = PortalSecurity.Instance.InputFilter(User.DisplayName, filterFlags);
-                if (!cleanDisplayName.Equals(User.DisplayName))
-                {
-                    CreateStatus = UserCreateStatus.InvalidDisplayName;
-                }
+				if (string.IsNullOrEmpty(PortalSettings.Registration.DisplayNameFormat))
+				{
+					var cleanDisplayName = PortalSecurity.Instance.InputFilter(User.DisplayName, filterFlags);
+					if (!cleanDisplayName.Equals(User.DisplayName))
+					{
+						CreateStatus = UserCreateStatus.InvalidDisplayName;
+					}
+				}
             }
 
             if (PortalSettings.Registration.RegistrationFormType == 0)


### PR DESCRIPTION
Fixes  #3157
Change is minor - if no displayname can be set directly, is must not be checked if it is valid.