### PR TITLE
Increase pagesize for site management

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/reducers/pagination.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/reducers/pagination.js
@@ -16,7 +16,7 @@ const switchCase = [{
 export default function getReducer(initialState, additionalCases) {
     return function common(state = Object.assign({
         pageIndex: 0,
-        pageSize: 10,
+        pageSize: 100,
         portalGroupId: -1,
         filter: ""
     }, initialState), action) {


### PR DESCRIPTION
This PR improves Site Management (#3085) for setups with a lot of portals (>>50). 

### Summary
Change is trivial as it just increases  the pagesize from 10 to 100. The  request will take now aout 100ms instead of about 30ms, which is still reasonable.

This should **not** close the linked issue. But it impoves the handling until a PR with pagination like in Eventlog is provided.  

### Risk
Smaller setups with just a few portals will see a longer list. 