### PR TITLE
Fix missing parsing of AllowUserUICulture and EnableBrowserLanguage settings from portal templates #3558

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1472,6 +1472,14 @@ namespace DotNetNuke.Entities.Portals
             {
                 UpdatePortalSetting(portalId, "AddCompatibleHttpHeader", XmlUtils.GetNodeValue(nodeSettings, "addcompatiblehttpheader", ""));
             }
+            if (!String.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "allowuseruiculture", "")))
+            {
+                UpdatePortalSetting(portalId, "AllowUserUICulture", XmlUtils.GetNodeValue(nodeSettings, "allowuseruiculture", ""));
+            }
+            if (!String.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "enablebrowserlanguage", "")))
+            {
+                UpdatePortalSetting(portalId, "EnableBrowserLanguage", XmlUtils.GetNodeValue(nodeSettings, "enablebrowserlanguage", ""));
+            }
         }
 
         private void ParseRoleGroups(XPathNavigator nav, int portalID, int administratorId)

--- a/DNN Platform/Website/DesktopModules/Admin/Portals/portal.template.xsd
+++ b/DNN Platform/Website/DesktopModules/Admin/Portals/portal.template.xsd
@@ -42,6 +42,8 @@
               <xs:element name="pageheadtext" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="injectmodulehyperlink" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="addcompatiblehttpheader" type="xs:string" minOccurs="0" maxOccurs="1" />
+			  <xs:element name="allowuseruiculture" type="xs:string" minOccurs="0" maxOccurs="1" />
+			  <xs:element name="enablebrowserlanguage" type="xs:string" minOccurs="0" maxOccurs="1" />			  
             </xs:all>
             <xs:attribute name="sku" type="xs:string"/>
           </xs:complexType>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
Fix missing parsing of AllowUserUICulture and EnableBrowserLanguage settings from portal templates