### PR TITLE
Fixed hierarchical terms import

### DIFF
--- a/DNN Platform/Modules/DnnExportImport/Components/Services/VocabularyService.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Services/VocabularyService.cs
@@ -214,6 +214,7 @@ namespace Dnn.ExportImport.Components.Services
 
                 var vocabulary = otherVocabularies.FirstOrDefault(v => v.VocabularyID == other.VocabularyID);
                 var vocabularyId = vocabulary?.LocalId ?? 0;
+                var isHierarchical = vocabulary != null && vocabulary.VocabularyTypeID == (int)VocabularyType.Hierarchy;
                 var local = localTaxonomyTerms.FirstOrDefault(t => t.Name == other.Name && t.VocabularyID == vocabularyId);
 
                 if (local != null)
@@ -235,7 +236,7 @@ namespace Dnn.ExportImport.Components.Services
                                 Weight = other.Weight,
                             };
 
-                            if (term.ParentTermId.HasValue)
+                            if (isHierarchical)
                             {
                                 dataService.UpdateHeirarchicalTerm(term, modifiedBy);
                             }
@@ -262,7 +263,7 @@ namespace Dnn.ExportImport.Components.Services
                     };
 
 
-                    other.LocalId = term.ParentTermId.HasValue
+                    other.LocalId = isHierarchical
                         ? dataService.AddHeirarchicalTerm(term, createdBy)
                         : dataService.AddSimpleTerm(term, createdBy);
                     Result.AddLogEntry("Added taxonomy", other.Name);


### PR DESCRIPTION
Fixes #3567

## Summary
The terms import process was identifying hierarchical vocabularies by checking on the `ParentTermId` property of the `TaxonomyTerm` items. This is not correct because the root element of a hierarchical vocabulary doesn't have a parent element and yet it's a hierarchical item. So the root element was being imported as a simple term which affected the rest of the hierarchy.
