### PR TITLE
Persona bar: Show page title on hover, show more of long page titles

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -13,23 +13,6 @@ export class PersonaBarPageTreeview extends Component {
         this.state = {};
     }
 
-    trimName(item) {
-        if (item.name){
-            let tabPath = "";
-            if (item.tabpath) {
-                tabPath = item.tabpath;
-            }
-            let maxLength = 18;
-            let { name } = item;
-            let newLength = tabPath.split(/\//).length * 2 + 1;
-            newLength--;
-            let depth = (newLength < maxLength) ? newLength : 1;
-            return (name.length > maxLength - depth) ? `${item.name.slice(0, maxLength - depth)}...` : item.name;
-        } else {
-            return item.name;
-        }
-    }
-
     render_tree(item, childListItems) {
         const {
             draggedItem,
@@ -148,7 +131,6 @@ export class PersonaBarPageTreeview extends Component {
         let index = 0;
         let total = listItems.length;
         return listItems.map((item) => {
-            const name = this.trimName(item);
             const canManagePage = (e, item, fn) => {
                 const whenCanManage = () => e ? fn(e, item) : fn(item);
                 const whenCannotManage = () => this.props.setEmptyPageMessage(Localization.get("NoPermissionManagePage"));
@@ -190,9 +172,9 @@ export class PersonaBarPageTreeview extends Component {
                                         <SingleLineInput 
                                             style={{ marginBottom: "0px", width:"80%", height:"100%"}}
                                             onChange={() => void(0)}
-                                            value={name}/>
+                                            value={item.name}/>
                                     ):
-                                    name
+                                    item.name
                                 }
                             </span>
                             <div className="draft-pencil">

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -140,7 +140,7 @@ export class PersonaBarPageTreeview extends Component {
             const onDragLeave = e => e.target.classList.remove("list-item-dragover");
             index++;
 
-            const style = item.canManagePage ? { "whiteSpace": "nowrap", height: "28px", lineHeight: "35px", marginLeft: "15px" } : { height: "28px", marginLeft: "15px" };
+            const style = item.canManagePage ? { "whiteSpace": "nowrap", height: "28px", lineHeight: "35px" } : { height: "28px" };
             const itemNameHidden = item.status === "Hidden" ? "item-name-hidden" : "";
             return (
                 <li key={"list-item-key-" + index} id={`list-item-${item.name}-${item.id}`} title={item.name}>

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -143,7 +143,7 @@ export class PersonaBarPageTreeview extends Component {
             const style = item.canManagePage ? { "whiteSpace": "nowrap", height: "28px", lineHeight: "35px", marginLeft: "15px" } : { height: "28px", marginLeft: "15px" };
             const itemNameHidden = item.status === "Hidden" ? "item-name-hidden" : "";
             return (
-                <li key={"list-item-key-" + index} id={`list-item-${item.name}-${item.id}`}>
+                <li key={"list-item-key-" + index} id={`list-item-${item.name}-${item.id}`} title={item.name}>
                     <div className={item.onDragOverState && item.id !== draggedItem.id ? "dropZoneActive" : "dropZoneInactive"} >
                         {this.renderDropZone("before", item)}
                         <div
@@ -166,7 +166,8 @@ export class PersonaBarPageTreeview extends Component {
                             <PersonaBarPageIcon iconType={item.pageType} selected={item.selected || false} />
                             <span
                                 className={`item-name ${itemNameHidden}`}
-                                onClick={() => item.canManagePage ? onSelection(item) : onNoPermissionSelection(item)}>
+                                onClick={() => item.canManagePage ? onSelection(item) : onNoPermissionSelection(item)}
+                            >
                                 { (item.tabId === 0) || (item.selected && selectedPageDirty) ? 
                                     (
                                         <SingleLineInput 

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
@@ -68,6 +68,13 @@
         top: -5px;
         font-weight: bold;
         margin-left: 5px;
+        
+        display: inline-block;
+        width: 140px;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+
         p {
             display: inline;
         }

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
@@ -70,7 +70,7 @@
         margin-left: 5px;
         
         display: inline-block;
-        width: 140px;
+        width: 150px;
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -226,7 +226,7 @@
         margin: 0;
     }
     ul {
-        margin-left: 20px;
+        margin-left: 5px;
         padding: 0 0;
     }
     ul:first-child {


### PR DESCRIPTION
Fixes #3090.

1. No longer truncates the page name. This means screen readers should be able to read the entire page name.
1. Handles the text-overflow using CSS.
1. Adds the page name to the `title` attribute of the list item. Most desktop browsers will show this when hovering over the page name.
1. Tightens up the spacing a little, so slightly longer page titles fit. I'm pretty sure there's more we can do here, but I think this is a decent start.

I've tested in latest Chrome, Edge (Chromium) and Firefox. Could do with testing in a wider variety of browsers.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
