### PR TITLE
Updates .gitignore to include files in 'src' folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@
 *.dotCover
 *.ldf
 Artifacts/
-[Ss]rc
 [Tt]emp
 [Bb]uild/**/*.zip
 


### PR DESCRIPTION
Closes #3571

.gitignore was ignoring all files in 'src' folders, this was probably not noticed since it only affects new files and most PRs that came in since this change did not have new files.