### PR TITLE
Load DefaultPriority Css prior to PortalCss Priority Load Order

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/FileOrder.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/FileOrder.cs
@@ -92,9 +92,9 @@ namespace DotNetNuke.Web.Client
         public enum Css
         {
             /// <summary>
-            /// The default priority (100) indicates that the ordering will be done based on the order in which the registrations are made
+            /// The default priority (99) indicates that the ordering will be done based on the order in which the registrations are made
             /// </summary>
-            DefaultPriority = 100,
+            DefaultPriority = 99,
 
             /// <summary>
             /// The default.css file has a priority of 5
@@ -147,9 +147,9 @@ namespace DotNetNuke.Web.Client
             SpecificContainerCss = 30,
 
             /// <summary>
-            /// The portal.css file has a priority of 35
+            /// The portal.css file has a priority of 100 and loads last
             /// </summary>
-            PortalCss = 35,
+            PortalCss = 100,
         }
     }
 }


### PR DESCRIPTION
Portal CSS seems to load after modules and other things load causing issues when modifying a portal CSS.   Loading portalcss last will ensure these styles override all other previous css stylesheets loaded.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes https://github.com/dnnsoftware/Dnn.Platform/issues/3578

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Moves DefaultPriority CSS (not to be confused with default.css which loads priority first 5) to 99 and PortalCss to 100 so it loads last no matter how many stylesheets get loaded first.