### PR TITLE
Fix bug #3583 for double Html decoding when using custom portal templates

### DIFF
--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -497,8 +497,6 @@ namespace DotNetNuke.Entities.Modules
                 {
                     var portal = PortalController.Instance.GetPortal(PortalId);
 
-                    content = HttpContext.Current.Server.HtmlDecode(content);
-
                     //Determine if the Module is copmpletely installed 
                     //(ie are we running in the same request that installed the module).
                     if (module.DesktopModule.SupportedFeatures == Null.NullInteger)
@@ -518,7 +516,8 @@ namespace DotNetNuke.Entities.Modules
                                 var controller = businessController as IPortable;
                                 if (controller != null)
                                 {
-                                    controller.ImportModule(module.ModuleID, content, version, portal.AdministratorId);
+                                    var decodedContent = HttpContext.Current.Server.HtmlDecode(content);
+                                    controller.ImportModule(module.ModuleID, decodedContent, version, portal.AdministratorId);
                                 }
                             }
                             catch


### PR DESCRIPTION
Fixes #3583 

The proposed solution ensures content is only decoded and sent to `IPortable.ImportModule` implementation of the bussiness controller. 

The rest of the `GetModuleContent` method schedules the non-decoded html content of the module for the next app start so that the static method `EventMessageProcessor.ImportModule` will decode it and import the module
