### PR TITLE
Adjust version numbers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -41,8 +41,9 @@ Provide any additional context that may be helpful in understanding and/or resol
 Please add X in at least one of the boxes as appropriate. In order for an issue to be accepted, a developer needs to be able to reproduce the issue on a currently supported version. If you are looking for a workaround for an issue with an older version, please visit the forums at https://dnncommunity.org/forums
 -->
 * [ ] 10.0.0 alpha build
-* [ ] 9.5.0 alpha build
-* [ ] 9.4.4 latest supported release
+* [ ]  9.5.1 alpha build
+* [ ]  9.5.0 latest supported release
+* [ ]  9.4.4 
 
 ## Affected browser
 <!-- 


### PR DESCRIPTION
## Summary
trivial adjustment without Issue.
I removed "Alpha build" from 9.5.0, added 9.5.1
I left 9.4.4 for the moment. We won't benefit from reports stating wrong number.