### PR TITLE
change change.me to changeme.invalid

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
@@ -232,7 +232,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const int homePage = 1;
             table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null,
                 "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website", "DotNetNuke, DNN, Content, Management, CMS", null,
-                "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0",
+                "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0",
                 null, homePage.ToString("D"), null, null, "57", "56", "-1", "-1", "7", null, null, "-1", "2011-08-25 07:34:11", "-1", "2011-08-25 07:34:29", culture);
 
             return table.CreateDataReader();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchControllerTests.cs
@@ -276,7 +276,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const int homePage = 1;
             table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null,
                     "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website", "DotNetNuke, DNN, Content, Management, CMS", null,
-                    "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0",
+                    "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0",
                     null, homePage.ToString("D"), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11", "-1", "2011-08-25 07:34:29", culture);
 
             return table.CreateDataReader();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
@@ -134,7 +134,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             }
 
             var homePage = 1;
-            table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null, "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website", "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0", null, homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11", "-1", "2011-08-25 07:34:29", culture);
+            table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null, "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website", "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0", null, homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11", "-1", "2011-08-25 07:34:29", culture);
 
             return table.CreateDataReader();
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mobile/RedirectionControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mobile/RedirectionControllerTests.cs
@@ -731,7 +731,7 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
             else if (portalId == Portal1)
                 homePage = HomePageOnPortal1;
 
-            table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null, "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website", "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0", null, homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11", "-1", "2011-08-25 07:34:29", culture);
+            table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null, "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website", "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020", null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0", null, homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11", "-1", "2011-08-25 07:34:29", culture);
 
 			return table.CreateDataReader();
 		}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/TestUtil.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/TestUtil.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Tests.Urls
                 {
                     PortalID = portalId,
                     Username = userName,
-                    Email = userName + "@change.me",
+                    Email = userName + "@changeme.invalid",
                     VanityUrl = vanityUrl,
                     Membership = { Password = password, Approved = true }
                 };

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/JwtAuthMessageHandlerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/JwtAuthMessageHandlerTests.cs
@@ -102,7 +102,7 @@ namespace DotNetNuke.Tests.Web.Api
             table.Columns.Add("LastModifiedByUserID", typeof(int));
             table.Columns.Add("LastModifiedOnDate", typeof(DateTime));
 
-            table.Rows.Add(1, null, "host", "host", "host", "host", 1, "host@change.me", null, null, 0, null,
+            table.Rows.Add(1, null, "host", "host", "host", "host", 1, "host@changeme.invalid", null, null, 0, null,
                            "127.0.0.1", 0, "8D3C800F-7A40-45D6-BA4D-E59A393F9800", DateTime.Now, null, -1, DateTime.Now,
                            -1, DateTime.Now);
             return table.CreateDataReader();
@@ -158,7 +158,7 @@ namespace DotNetNuke.Tests.Web.Api
             table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright (c) 2018 DNN Corp.", null,
                 "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website",
                 "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020",
-                null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0", null,
+                null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0", null,
                 homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11",
                 "-1", "2011-08-25 07:34:29", culture);
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/StandardTabAndModuleInfoProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/StandardTabAndModuleInfoProviderTests.cs
@@ -99,7 +99,7 @@ namespace DotNetNuke.Tests.Web.Api
             table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright (c) 2018 DNN Corp.", null,
                 "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website",
                 "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020",
-                null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0", null,
+                null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0", null,
                 homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11",
                 "-1", "2011-08-25 07:34:29", culture);
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/SearchServiceControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/SearchServiceControllerTests.cs
@@ -273,7 +273,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
             table.Columns.Add("LastModifiedByUserID", typeof(int));
             table.Columns.Add("LastModifiedOnDate", typeof(DateTime));
 
-            table.Rows.Add(1, null, UserName1, UserName1, UserName1, UserName1, 1, "host@change.me", null, null, 0, null,
+            table.Rows.Add(1, null, UserName1, UserName1, UserName1, UserName1, 1, "host@changeme.invalid", null, null, 0, null,
                            "127.0.0.1", 0, "8D3C800F-7A40-45D6-BA4D-E59A393F9800", DateTime.Now, null, -1, DateTime.Now,
                            -1, DateTime.Now);
             return table.CreateDataReader();
@@ -515,7 +515,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
             table.Rows.Add(portalId, null, "My Website", "Logo.png", "Copyright 2011 by DotNetNuke Corporation", null,
                            "2", "0", "2", "USD", "0", "0", "0", "0", "0", "1", "My Website",
                            "DotNetNuke, DNN, Content, Management, CMS", null, "1057AC7A-3C08-4849-A3A6-3D2AB4662020",
-                           null, null, null, "0", "admin@change.me", "en-US", "-8", "58", "Portals/0", null,
+                           null, null, null, "0", "admin@changeme.invalid", "en-US", "-8", "58", "Portals/0", null,
                            homePage.ToString(), null, null, "57", "56", "-1", "-1", null, null, "7", "-1", "2011-08-25 07:34:11",
                            "-1", "2011-08-25 07:34:29", culture);
 

--- a/DNN Platform/Website/Install/DotNetNuke.install.config.resources
+++ b/DNN Platform/Website/Install/DotNetNuke.install.config.resources
@@ -12,7 +12,7 @@
     <lastname>Account</lastname>
     <username>host</username>
     <password>dnnhost</password>
-    <email>host@change.me</email>
+    <email>host@changeme.invalid</email>
     <locale>en-US</locale>
     <updatepassword>false</updatepassword>
   </superuser>
@@ -89,7 +89,7 @@
         <lastname>Account</lastname>
         <username>admin</username>
         <password>dnnadmin</password>
-        <email>admin@change.me</email>
+        <email>admin@changeme.invalid</email>
       </administrator>
       <description>My Website</description>
       <keywords>DotNetNuke, DNN, Content, Management, CMS</keywords>

--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/src/__tests__/prompt/ui.test.js
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/src/__tests__/prompt/ui.test.js
@@ -125,14 +125,14 @@ describe("UI snapshots for state change", () => {
 
         const rows = [
             {
-                Email: "host@change.me",
+                Email: "host@changeme.invalid",
                 IsAuthorized: true,
                 IsDeleted: false,
                 IsLockedOut: false,
                 LastLogin: "2018-01-04",
                 UserId: 1,
                 Username: "host",
-                __Email: "get-user 'host@change.me'",
+                __Email: "get-user 'host@changeme.invalid'",
                 __UserId: "get-user 1",
                 __Username: "get-user 'host'"
             }


### PR DESCRIPTION
According to descriptions in the blog, I have changed default mail change.me to changeme.invalid due to security issues.
https://medium.com/@SajjadPourali/do-not-use-internet-valid-domain-names-as-default-users-email-e-g-host-change-me-309213dffb8a