### PR TITLE
Add debug build to lerna

### DIFF
--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p --progress",
+    "debug": "set NODE_ENV=debug&&webpack -p --progress",
     "webpack": "webpack-dev-server -d --port 8070 --hot --inline --content-base dist/ --history-api-fallback",
     "analyze": "set NODE_ENV=production&&webpack --config webpack.config.js --profile --json > stats.json&&webpack-bundle-analyzer stats.json"
   },

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -20,6 +20,7 @@
     "eslint": "eslint ./src/**/*.jsx --fix",
     "test": "echo \"No tests script specified to run.\"",
     "build": "set NODE_ENV=production && webpack -p --config dist.webpack.config.js",
+    "debug": "set NODE_ENV=debug && webpack -p --config dist.webpack.config.js",
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Extensions.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Extensions.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Licensing.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Licensing.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server --host localhost -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=analyze&&webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Security.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --host localhost --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8085 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Users.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/package.json
@@ -6,6 +6,7 @@
     "start": "npm run webpack",
     "test": "jest",
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
+    "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "build": "lerna run build --stream",
+    "debug": "lerna run debug --stream",
     "package": "lerna run package",
     "clean": "lerna run clean",
     "lint": "lerna run lint",


### PR DESCRIPTION
This was overlooked in the last Lerna/Yarn overhaul. The user must be able to target a local dev site with the Lerna build. It is currently missing as it only runs in production mode.