### PR TITLE
Change Css Priority File Order + Add PageCss Priority #3578

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/FileOrder.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/FileOrder.cs
@@ -92,9 +92,10 @@ namespace DotNetNuke.Web.Client
         public enum Css
         {
             /// <summary>
-            /// The default priority (100) indicates that the ordering will be done based on the order in which the registrations are made
+            /// The default priority (90) indicates that the ordering will be done based on the order in which the registrations are made.  
+			/// PortalCss then PageCss load after DefaultPriority has loaded all assigned css pages.
             /// </summary>
-            DefaultPriority = 100,
+            DefaultPriority = 90,
 
             /// <summary>
             /// The default.css file has a priority of 5
@@ -147,9 +148,14 @@ namespace DotNetNuke.Web.Client
             SpecificContainerCss = 30,
 
             /// <summary>
-            /// The portal.css file has a priority of 35
+            /// The portal.css file has a priority of 95
             /// </summary>
-            PortalCss = 35,
+            PortalCss = 95,
+			
+			/// <summary>
+            /// The Page.css file has a priority of 100 and will load last.
+            /// </summary>
+            PageCss = 100,
         }
     }
 }

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -411,13 +411,6 @@ namespace DotNetNuke.Framework
                 Title += versionString;
             }
 
-			//register the custom stylesheet of current page
-			if (PortalSettings.ActiveTab.TabSettings.ContainsKey("CustomStylesheet") && !string.IsNullOrEmpty(PortalSettings.ActiveTab.TabSettings["CustomStylesheet"].ToString()))
-			{
-				var customStylesheet = Path.Combine(PortalSettings.HomeDirectory, PortalSettings.ActiveTab.TabSettings["CustomStylesheet"].ToString());
-				ClientResourceManager.RegisterStyleSheet(this, customStylesheet);
-			}
-
             // Cookie Consent
             if (PortalSettings.ShowCookieConsent)
             {
@@ -674,6 +667,13 @@ namespace DotNetNuke.Framework
             SkinPlaceHolder.Controls.Add(ctlSkin);
 
             ClientResourceManager.RegisterStyleSheet(this, string.Concat(PortalSettings.HomeDirectory, "portal.css"), FileOrder.Css.PortalCss);
+
+			//register the custom stylesheet of current page
+			if (PortalSettings.ActiveTab.TabSettings.ContainsKey("CustomStylesheet") && !string.IsNullOrEmpty(PortalSettings.ActiveTab.TabSettings["CustomStylesheet"].ToString()))
+			{
+				var customStylesheet = Path.Combine(PortalSettings.HomeDirectory, PortalSettings.ActiveTab.TabSettings["CustomStylesheet"].ToString());
+				ClientResourceManager.RegisterStyleSheet(this, customStylesheet, FileOrder.Css.PageCss);
+			}
 
             //add Favicon
             ManageFavicon();


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
https://github.com/dnnsoftware/Dnn.Platform/issues/3578

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
What was done:

2 files changed
FileOrder.cs
modifies the DefaultPriority for all other CSS to 90
Sets PortalCss priority to 95
Creates and Sets PageCss priority to 100

Default.aspx.cs
Moves CustomStylesheet (Page.css) to load after all other stylesheets both programmatically in page source and using the new stylesheet file load order PageCss  priority.

This should be labeled "Fixing Change" but it is in fact probably going to break someones CSS.  I almost dont thing it will because the files are custom page and portal css files getting priority like everyone expects.  Most CSS Styles on these files will have !important.

Everytime module vendors support using Portal.css file to fix anything they always say use !Important.

I think this discussion may have started in the DNN Events module github issues and after talking to you and getting the same from others in the past I had to do some due diligence because I didn't believe things loaded in proper order.

Do you want this in version 9 for 9.6?

Steps to reproduce on of the issues a developer would deal with:

> try to change logo size using Page.css.
> 
>     create a page
>     upload a pagename.css to the root site directory
>     include the following in the pagename.css file
> 
>     .navbar .brand {max-width:50px;}
> 
>     Add pagename.css as Page Stylesheet in PersonaBar Page Settings editor
>     Refresh the page notice nothing happens
>     put the same code in Portal.css and it works however other CSS stylesheets load after Portal.css taking priority. I had to really dig to find where "CustomStylesheet" or Page Stylesheet was located. Funny part is Portal.css is called "Custom CSS" while Page.css files are "CustomStylesheet" and load way before default CSS loads with NO priority it just loads.
