### PR TITLE
Fixes an issue with backup/restore in build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -58,7 +58,7 @@ Setup(context =>
 	if(Settings.Version == "auto" && !isRunningInCI){
 		// Temporarelly commit all changes to prevent checking in scripted changes like versioning.
 		StartPowershellScript("git add .");
-		StartPowershellScript("git commit -m 'backup'");	
+		StartPowershellScript("git commit --allow-empty -m 'backup'");	
 	}
 });
 


### PR DESCRIPTION
Closes #3613

As part of the build process we do a backup commit when the build starts
then we revert 1 commit up to bring back the files at excatly the point
they where before the build. This works nice when there are any files
to commit but not when there is nothing to commit.
This PR resolves that by adding the --allow-empty flag to the backup
commit.