### PR TITLE
Fixes to build process

### DIFF
--- a/Build/Cake/devsite.cake
+++ b/Build/Cake/devsite.cake
@@ -2,6 +2,7 @@
 // Note these tasks depend on the correct settings in your settings file.
 
 Task("ResetDevSite")
+    .IsDependentOn("SetVersion")
     .IsDependentOn("ResetDatabase")
     .IsDependentOn("PreparePackaging")
 	.IsDependentOn("OtherPackages")

--- a/Build/Cake/devsite.cake
+++ b/Build/Cake/devsite.cake
@@ -3,6 +3,7 @@
 
 Task("ResetDevSite")
     .IsDependentOn("SetVersion")
+    .IsDependentOn("UpdateDnnManifests")
     .IsDependentOn("ResetDatabase")
     .IsDependentOn("PreparePackaging")
 	.IsDependentOn("OtherPackages")

--- a/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.csproj
+++ b/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -21,6 +20,9 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Providers\DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.xml</DocumentationFile>
+    <NoWarn>1591,0618</NoWarn>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Providers\DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.xml</DocumentationFile>
+    <NoWarn>1591,0618</NoWarn>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -47,6 +52,9 @@
     <Compile Include="SimpleWebFarmSynchronizationHandler.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\..\SolutionInfo.cs">
+      <Link>Properties\SolutionInfo.cs</Link>
+    </Compile>
     <None Include="SimpleWebFarmCachingProvider.dnn" />
   </ItemGroup>
   <ItemGroup>

--- a/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/Properties/AssemblyInfo.cs
@@ -1,36 +1,15 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿// 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// 
+#region Usings
+
+using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
+#endregion
+
 [assembly: AssemblyTitle("DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: AssemblyDescription("Open Source Web Application Framework")]
 [assembly: Guid("2c25580c-a971-4f0b-9f70-436a35c2473e")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/SimpleWebFarmCachingProvider.dnn
+++ b/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/SimpleWebFarmCachingProvider.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider" type="Provider" isSystem="true">
+    <package name="DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider" type="Provider" isSystem="true" version="09.04.04">
       <friendlyName>DotNetNuke Simple Web Farm Caching Provider</friendlyName>
       <description>DotNetNuke Simple Web Farm Caching Provider</description>
       <dependencies />
@@ -14,7 +14,6 @@
       <releaseNotes src="releaseNotes.txt" /> 
       <azureCompatible>true</azureCompatible>
       <components>
-        <component type="Provider" />
         <component type="Assembly">
           <assemblies>
             <assembly>

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p --progress",
     "debug": "set NODE_ENV=debug&&webpack -p --progress",
+    "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "webpack": "webpack-dev-server -d --port 8070 --hot --inline --content-base dist/ --history-api-fallback",
     "analyze": "set NODE_ENV=production&&webpack --config webpack.config.js --profile --json > stats.json&&webpack-bundle-analyzer stats.json"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "build": "lerna run build --stream",
     "debug": "lerna run debug --stream",
+    "watch": "lerna run watch --stream",
     "package": "lerna run package",
     "clean": "lerna run clean",
     "lint": "lerna run lint",


### PR DESCRIPTION
This PR addresses these issues:

1. The new SimpleWebCachingProvider project wasn't pulling in the solutioninfo for versioning
2. The cake ResetDevSite task wasn't adjusting the version on items according to the settings
3. Add the missing watch task to the root package json