### PR TITLE
Fixed widget.js 404 error

### DIFF
--- a/DNN Platform/Website/Resources/Shared/scripts/jquery/jquery.fileupload.js
+++ b/DNN Platform/Website/Resources/Shared/scripts/jquery/jquery.fileupload.js
@@ -16,7 +16,7 @@
   'use strict';
   if (typeof define === 'function' && define.amd) {
     // Register as an anonymous AMD module:
-    define(['jquery', 'jquery-ui/ui/widget'], factory);
+    define(['jquery', 'jquery.ui.widget'], factory);
   } else if (typeof exports === 'object') {
     // Node/CommonJS:
     factory(require('jquery'), require('./vendor/jquery.ui.widget'));


### PR DESCRIPTION
Fixes #3630

## Summary
The updated `jquery.fileupload.js` file changed the way it references the widget factory from this:
```javascript
if (typeof define === 'function' && define.amd) {
  // Register as an anonymous AMD module:
  define([
    'jquery',
    'jquery.ui.widget'
  ], factory);
} else ...
```
to this:
```javascript
if (typeof define === 'function' && define.amd) {
  // Register as an anonymous AMD module:
  define([
    'jquery',
    'jquery-ui/ui/widget'
  ], factory);
} else ...
```
and since this standalone `jquery-ui/ui/widget.js` file doesn't exist, it returns a 404, causing dependent modules to fail. The needed widget factory is actually included in the `jquery-ui.min.js` file.
After reverting this path, the module loads fine again:

![DNN-37504-4](https://user-images.githubusercontent.com/30123437/76912719-9bb47e80-6893-11ea-8752-78fd03633f14.png)
