### PR TITLE
DNN-30135 - Issue when loading the Persona Bar: Not Thread Safe

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Repository/PersonaBarRepository.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Repository/PersonaBarRepository.cs
@@ -50,12 +50,12 @@ namespace Dnn.PersonaBar.Library.Repository
 
         public MenuItem GetMenuItem(string identifier)
         {
-            return GetMenu().AllItems.FirstOrDefault(m => m.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase));
+            return GetMenu().AllItems.ToList().FirstOrDefault(m => m.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public MenuItem GetMenuItem(int menuId)
         {
-            return GetMenu().AllItems.FirstOrDefault(m => m.MenuId == menuId);
+            return GetMenu().AllItems.ToList().FirstOrDefault(m => m.MenuId == menuId);
         }
 
         public void SaveMenuItem(MenuItem item)


### PR DESCRIPTION
Note: This is the duplicate PR of https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1126 . I do it again now since it wasn't merged here after Dnn.AdminExperience is migrated here.

Fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/1125

Summary
The problem lies in "Dnn.PersonaBar.Library.Repository.PersonaBarRepository.GetMenuItem(string identifier)" method which is called from "Evoq.PersonaBar.UI.Controllers.EvoqPersonaBarContainer.Initialize(UserControl personaBarControl)". GetMenuItem method doesn't exist in the StackTrace because JIT (Just-In-Time) Compiler does Inline Code Optimizations for release builds which basically means that some methods (especially like the ones that are only a few lines) get inlined into the previous method chain for performance reasons. Therefore, if you have a method call chain like A -> B -> C, it might become A -> B if C is inlined (you might think of it as method C's code gets copied under method B).

Using a list instance which might change state in loops (FirstOrDefault method iterates the elements one by one which behaves like a loop) will raise that error when the list gets updated while iterating. The solution is to use ToList method to copy the list's current state into another list and then use it instead for iteration. You can watch the following video I shot a demo video which demonstrates the issue: https://drive.google.com/open?id=13bneeDRu2aqicSvJ-QtV2okoPUivkHh4