### PR TITLE
Fixed the issue that caused all modules to be relocated to same pane

### DIFF
--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ContentEditor.js
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ContentEditor.js
@@ -321,11 +321,13 @@ dnn.ContentEditorManager = $.extend({}, dnn.ContentEditorManager, {
             var cookieModuleId = moduleDialog._getCookie('CEM_CallbackData');
             if (cookieModuleId && cookieModuleId.indexOf('module-') > -1) {
                 var moduleId = cookieModuleId.substr(7);
+                var existingModule = moduleDialog._getCookie('CEM_ExistingModule');
+                if (!existingModule) existingModule = false;
 
                 var module = $('div.DnnModule-' + moduleId);
                 var moduleManager = module.parent().data('dnnModuleManager');
 
-                moduleDialog.apply(moduleManager);
+                moduleDialog.apply(moduleManager, existingModule);
                 moduleDialog._processModuleForDrag(module);
                 $('#moduleActions-' + moduleId).addClass('floating');
                 moduleDialog._removeCookie('CEM_CallbackData');

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ModuleDialog.js
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ModuleDialog.js
@@ -224,8 +224,10 @@ if (typeof dnn.ContentEditorManager === "undefined" || dnn.ContentEditorManager 
         setModuleId: function (moduleId) {
             if (moduleId <= 0) {
                 this._removeCookie('CEM_NewModuleId');
+                this._removeCookie('CEM_ExistingModule');
             } else {
                 this._setCookie('CEM_NewModuleId', moduleId);
+                this._setCookie('CEM_ExistingModule', this._callFromExistingModule);
             }
         },
 


### PR DESCRIPTION
Closes #2289

## Summary
Changed dnnModuleDialog setModuleId function so that it saves the property _callFromExistingModule to cookie. In contentEditorManager, it's then possible to load that property back from cookie and use it to call apply function of dnnModuleDialog so that existing modules are not relocated.

## How to test
Add a new page to an existing web site. Then add an existing module to that page and make sure to link it to original (no copy). Finally, add a new module to the page and put it in another pane (not the one where you put the existing module). Once the page as reloaded, all modules should remain in their pane. Without the fix, all the modules a relocated to the pane where you put the last module.