### PR TITLE
Fixes #3651 — UI/UX Dropdown page picker within Personabar 

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/RoleGroupFilter/style.less
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/RoleGroupFilter/style.less
@@ -89,7 +89,7 @@
                     .page-value {
                         >div {
                             font-size: 15px;
-                            text-indent: 20px;
+                            margin-left: 20px;
                             line-height: 16px;
                             svg {
                                 width: 16px;
@@ -104,10 +104,10 @@
                                 }
                             }
                             &.text-with-page-icon {
-                                text-indent: 40px;
+                                margin-left: 40px;
                             }
                             &.no-icon {
-                                text-indent: 0px;
+                                margin-left: 0px;
                             }
                             &:hover {
                                 color: @curiousBlue;


### PR DESCRIPTION
Replacing text-indent css property with margin-left, to insure wrapping text will all start at the same left position.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
[Issue #3651](https://github.com/dnnsoftware/Dnn.Platform/issues/3651)


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

I've replaced the text-indent property in /Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/RoleGroupFilter/style.less to utilize the margin-left property to insure wrapping text will all start at the same left position.

I am unable to compile and test the code locally, but all in-browser tests on a production environment show this to be a successful modification.

When editing the file, I noticed two additional css modifiers (.text-with-page-icon, and .no-icon) that utilize the text-indent property. These appear to be conditional based on line 298 in /Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PagePicker/index.jsx, but the same adjustment should not cause any problem.