### PR TITLE
Fixed "Allow Indexing" module setting

### DIFF
--- a/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
@@ -113,7 +113,7 @@ namespace DotNetNuke.Modules.Admin.Modules
                 chkAllTabs.Checked = Module.AllTabs;
                 trnewPages.Visible = chkAllTabs.Checked;
                 allowIndexRow.Visible = desktopModule.IsSearchable;
-                chkAllowIndex.Checked = Settings["AllowIndex"] == null || Settings["AllowIndex"] != null && bool.Parse(Settings["AllowIndex"].ToString());
+                chkAllowIndex.Checked = GetBooleanSetting("AllowIndex", true);
                 txtMoniker.Text = (string)Settings["Moniker"] ?? "";
 
                 cboVisibility.SelectedIndex = (int)Module.Visibility;
@@ -237,6 +237,15 @@ namespace DotNetNuke.Modules.Admin.Modules
         private void ShowCacheRows()
         {
             divCacheDuration.Visible = !string.IsNullOrEmpty(cboCacheProvider.SelectedValue);
+        }
+
+        private bool GetBooleanSetting(string settingName, bool defaultValue)
+        {
+            var value = Settings[settingName];
+
+            return value == null
+                ? defaultValue
+                : bool.Parse(value.ToString());
         }
 
         #endregion
@@ -555,7 +564,7 @@ namespace DotNetNuke.Modules.Admin.Modules
 
                     // collect these first as any settings update will clear the cache
                     var originalChecked = Settings["hideadminborder"] != null && bool.Parse(Settings["hideadminborder"].ToString());
-                    var allowIndex = Settings.ContainsKey("AllowIndex") && Convert.ToBoolean(Settings["AllowIndex"]);
+                    var allowIndex = GetBooleanSetting("AllowIndex", true);
                     var oldMoniker = ((string)Settings["Moniker"] ?? "").TrimToLength(100);
                     var newMoniker = txtMoniker.Text.TrimToLength(100);
                     if (!oldMoniker.Equals(txtMoniker.Text))


### PR DESCRIPTION
Fixes #3656

## Summary
After installation, some modules have no entries in `TabModuleSettings` or `ModuleSettings`. This is the case for instance of the "CONNECT and PARTICIPATE" module in the home page. In such cases, a default value is calculated in `DNN Platform\Website\admin\Modules\Modulesettings.ascx.cs`.

The default value of "Allow Indexing" setting is `True`, as calculated at line 116 (`BindData` method):
```
chkAllowIndex.Checked = Settings["AllowIndex"] == null || Settings["AllowIndex"] != null && bool.Parse(Settings["AllowIndex"].ToString());
```
but at line 558 (`OnUpdateClick` method) the expression is different and generates a `False` default value:
```
var allowIndex = Settings.ContainsKey("AllowIndex") && Convert.ToBoolean(Settings["AllowIndex"]);
```
This bug then affects the decision on whether to update the setting or not:
```
//check whether allow index value is changed
if (allowIndex != chkAllowIndex.Checked)
{
    ModuleController.Instance.UpdateTabModuleSetting(Module.TabModuleID, "AllowIndex", chkAllowIndex.Checked.ToString());
}
```
resulting in inability to turn it off.