### PR TITLE
Allow (super)users to log in to portals that have email as username

### DIFF
--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -259,7 +259,7 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
                 if (emailUsedAsUsername)
                 {
                     // one additonal call to db to see if an account with that email actually exists
-                    userByEmail = UserController.GetUserByEmail(PortalId, userName);                     
+                    userByEmail = UserController.GetUserByEmail(PortalController.GetEffectivePortalId(PortalId), userName);                     
 
                     if (userByEmail != null)
                     {

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -3325,6 +3325,7 @@
     <Content Include="Providers\DataProviders\SqlDataProvider\09.03.02.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.04.02.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.04.03.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.06.00.SqlDataProvider" />
     <None Include="Providers\DataProviders\SqlDataProvider\09.05.00.SqlDataProvider" />
     <None Include="Providers\DataProviders\SqlDataProvider\DotNetNuke.Data.SqlDataProvider" />
     <None Include="Providers\DataProviders\SqlDataProvider\DotNetNuke.Schema.SqlDataProvider" />

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.06.00.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.06.00.SqlDataProvider
@@ -1,0 +1,28 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}GetSingleUserByEmail') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}{objectQualifier}GetSingleUserByEmail
+GO
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE PROCEDURE {databaseOwner}{objectQualifier}GetSingleUserByEmail
+@PortalId INT,
+	@Email nvarchar(255)
+AS 
+	SELECT ISNULL((SELECT TOP 1 U.UserId from {databaseOwner}{objectQualifier}Users U LEFT JOIN {databaseOwner}{objectQualifier}UserPortals UP on UP.[UserId] = U.[UserId] AND UP.[PortalId] = @PortalId WHERE U.Email = @Email AND (UP.[PortalId] = @PortalId OR U.IsSuperUser=1)), -1)
+GO
+
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/************************************************************/


### PR DESCRIPTION
## Summary
This fixes issues #3658 and #3660 by 

1. allowing a superuser to also be returned from the GetSingleUserByEmail SPROC even though they might not ba a member of the portal.
2. Ensuring we user EffectivePortalId when looking up a user by email in the login logic