### PR TITLE
Updates version to 9.6.0

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,4 +1,4 @@
-next-version: 9.5.0
+next-version: 9.6.0
 commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment


### PR DESCRIPTION
This updates gitversion.yml so that CI builds version 9.6.0
as we decided this would be the next version.

This is a release management task and we are self-approving
it for that reason