### PR TITLE
Fixes #3671

### DIFF
--- a/DNN Platform/Website/Install/Config/09.06.00.config
+++ b/DNN Platform/Website/Install/Config/09.06.00.config
@@ -1,0 +1,12 @@
+<configuration>
+  <nodes configfile="Web.config">
+    <node path="/configuration/system.web/httpHandlers/add[@name='Telerik.Web.UI.ChartHttpHandler']" action="remove" />
+    <node path="/configuration/system.webServer/handlers/add[@name='Telerik.Web.UI.ChartHttpHandler']" action="remove" />
+    <node path="/configuration/system.web/httpModules/add[@name='RadUploadModule']" action="remove" />
+    <node path="/configuration/system.webServer/modules/add[@name='RadUploadModule']" action="remove" />
+    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
+      <add key="Telerik.Upload.AllowedCustomMetaDataTypes" value="Telerik.Web.UI.AsyncUploadConfiguration" />
+      <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+    </node>
+  </nodes>
+</configuration>

--- a/DNN Platform/Website/Install/Config/09.06.00.config
+++ b/DNN Platform/Website/Install/Config/09.06.00.config
@@ -1,12 +1,6 @@
 <configuration>
-  <nodes configfile="Web.config">
-    <node path="/configuration/system.web/httpHandlers/add[@name='Telerik.Web.UI.ChartHttpHandler']" action="remove" />
-    <node path="/configuration/system.webServer/handlers/add[@name='Telerik.Web.UI.ChartHttpHandler']" action="remove" />
-    <node path="/configuration/system.web/httpModules/add[@name='RadUploadModule']" action="remove" />
-    <node path="/configuration/system.webServer/modules/add[@name='RadUploadModule']" action="remove" />
-    <node path="/configuration/appSettings" action="update" key="key" collision="overwrite">
-      <add key="Telerik.Upload.AllowedCustomMetaDataTypes" value="Telerik.Web.UI.AsyncUploadConfiguration" />
-      <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
-    </node>
+  <nodes configfile="Web.config">  
+    <node path="/configuration/system.webServer/handlers/add[@name='Telerik.Web.UI.WebResource']" action="remove" />
+    <node path="/configuration/system.web/httpHandlers/add[@name='Telerik.Web.UI.WebResource']" action="remove" />
   </nodes>
 </configuration>


### PR DESCRIPTION
This PR fixes an incomplete push from #3671 disables additional Telerik features that are not used by DNN Platform.

This is a potential breaking change for anyone with third-party modules that are using Telerik functionality, however, it is NOT a breaking change for a base DNN Platform installation. 