### PR TITLE
Bring back Export Portal Template

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ExportPortal/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ExportPortal/index.jsx
@@ -1,7 +1,21 @@
-import PropTypes from 'prop-types';
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { PagePicker, Switch, Dropdown, Checkbox as CheckBox, Label, PersonaBarPageHeader, PersonaBarPageBody, GridCell, GridSystem, Tooltip as ToolTip, SingleLineInputWithError, MultiLineInputWithError, Button  } from "@dnnsoftware/dnn-react-common";
+import {
+  PagePicker,
+  Switch,
+  Dropdown,
+  Checkbox as CheckBox,
+  Label,
+  PersonaBarPageHeader,
+  PersonaBarPageBody,
+  GridCell,
+  GridSystem,
+  Tooltip as ToolTip,
+  SingleLineInputWithError,
+  MultiLineInputWithError,
+  Button
+} from "@dnnsoftware/dnn-react-common";
 import { CommonExportPortalActions } from "../../actions";
 import utilities from "utils";
 import stringUtils from "utils/string";
@@ -9,333 +23,392 @@ import Localization from "localization";
 import "./style.less";
 
 const emptyExport = {
-    fileName: "",
-    description: "",
-    portalId: -1,
-    pages: [],
-    locales: [],
-    isMultiLanguage: false,
-    includeContent: false,
-    includeFiles: false,
-    includeRoles: true,
-    includeProfile: true,
-    includeModules: true,
-    localizationCulture: "en-US"
+  fileName: "",
+  description: "",
+  portalId: -1,
+  pages: [],
+  locales: [],
+  isMultiLanguage: false,
+  includeContent: false,
+  includeFiles: false,
+  includeRoles: true,
+  includeProfile: true,
+  includeModules: true,
+  localizationCulture: "en-US"
 };
 const scrollAreaStyle = {
-    width: "100%",
-    height: 200,
-    marginTop: 0,
-    border: "1px solid #c8c8c8"
+  width: "100%",
+  height: 200,
+  marginTop: 0,
+  border: "1px solid #c8c8c8"
 };
 const keysToValidate = ["fileName", "description"];
 
 /* eslint-disable eqeqeq */
 class ExportPortal extends Component {
-    constructor() {
-        super();
-        this.state = {
-            localData: {
-                locales: [],
-                errors: {
-                    fileName: false,
-                    description: false
-                }
-            },
-            portalBeingExported: emptyExport,
-            reloadPages: false
-        };
-    }
+  constructor() {
+    super();
+    this.state = {
+      localData: {
+        locales: [],
+        errors: {
+          fileName: false,
+          description: false
+        }
+      },
+      portalBeingExported: emptyExport,
+      reloadPages: false
+    };
+  }
 
-    componentWillMount() {
-        const { props } = this;
-        props.dispatch(CommonExportPortalActions.getPortalLocales(props.portalBeingExported.PortalID, (data) => {
-            const {portalBeingExported} = this.state;
-            const {localData} = this.state;
-            portalBeingExported.portalId = props.portalBeingExported.PortalID;
-            portalBeingExported.portalName = props.portalBeingExported.PortalName;
-            localData.locales = data.Results;
-            portalBeingExported.locales = data.Results.map(locale => { return locale.Code; });
-            portalBeingExported.isMultiLanguage = props.portalBeingExported.contentLocalizable;
-            portalBeingExported.localizationCulture = props.portalBeingExported.DefaultLanguage;
+  componentWillMount() {
+    const { props } = this;
+    props.dispatch(
+      CommonExportPortalActions.getPortalLocales(
+        props.portalBeingExported.PortalID,
+        data => {
+          const { portalBeingExported } = this.state;
+          const { localData } = this.state;
+          portalBeingExported.portalId = props.portalBeingExported.PortalID;
+          portalBeingExported.portalName = props.portalBeingExported.PortalName;
+          localData.locales = data.Results;
+          portalBeingExported.locales = data.Results.map(locale => {
+            return locale.Code;
+          });
+          portalBeingExported.isMultiLanguage =
+            props.portalBeingExported.contentLocalizable;
+          portalBeingExported.localizationCulture =
+            props.portalBeingExported.DefaultLanguage;
+          this.setState({
+            portalBeingExported,
+            localData
+          });
+        }
+      )
+    );
+  }
+
+  onChange(key, event) {
+    const value = typeof event === "object" ? event.target.value : event;
+    let { portalBeingExported } = this.state;
+    portalBeingExported[key] = value;
+    this.setState(
+      {
+        portalBeingExported
+      },
+      () => {
+        if (key == "isMultiLanguage")
+          this.setState({ reloadPages: true }, () => {
             this.setState({
-                portalBeingExported,
-                localData
+              reloadPages: false
             });
-        }));
-    }
+          });
+      }
+    );
+    if (keysToValidate.some(vkey => vkey == key)) this.ValidateTexts(key);
+  }
 
-    onChange(key, event) {
-        const value = typeof event === "object" ? event.target.value : event;
-        let {portalBeingExported} = this.state;
-        portalBeingExported[key] = value;
-        this.setState({
-            portalBeingExported
-        });
-        if (keysToValidate.some(vkey => vkey == key))
-            this.ValidateTexts(key);
-    }
-
-    onExportPortal() {
-        const { props, state } = this;
-        if (this.Validate()) {
-            props.dispatch(CommonExportPortalActions.exportPortal(state.portalBeingExported, (data) => {
-                utilities.notify(data.Message);
-                let {portalBeingExported} = state;
-                portalBeingExported.fileName = "";
-                portalBeingExported.description = "";
-                this.setState({ portalBeingExported }, () => {
-                    props.onCancel();
-                });
-            }));
-        }
-    }
-    Validate() {
-        let success = true;
-        const {portalBeingExported} = this.state;
-        success = this.ValidateTexts();
-        // if (success && this.props.portalBeingExported.contentLocalizable && portalBeingExported.isMultiLanguage && portalBeingExported.locales.length <= 0) {
-        //     success = false;
-        //     util.utilities.notify("At least one language must be selected.");//This error shouldn't happen because the default locale is disabled.
-        // }
-        if (success && portalBeingExported.pages.length <= 0) {
-            success = false;
-            utilities.notify(Localization.get("ErrorPages"));
-        }
-        return success;
-    }
-    ValidateTexts(key) {
-        let success = true;
-        const {portalBeingExported} = this.state;
-        const {localData} = this.state;
-        keysToValidate.map(vkey => {
-            if (key === undefined || key == vkey) {
-                if (portalBeingExported[vkey] === "") {
-                    success = false;
-                    localData.errors[vkey] = true;
-                } else {
-                    localData.errors[vkey] = false;
-                }
-            }
-            this.setState({});
-        });
-
-        return success;
-    }
-    onLanguageSelectionChange(option) {
-        let {portalBeingExported} = this.state;
-        let {reloadPages} = this.state;
-        reloadPages = true;
-        portalBeingExported.localizationCulture = option.value;
-        this.setState({ portalBeingExported, reloadPages }, () => {
-            this.setState({
-                reloadPages: false
+  onExportPortal() {
+    const { props, state } = this;
+    if (this.Validate()) {
+      props.dispatch(
+        CommonExportPortalActions.exportPortal(
+          state.portalBeingExported,
+          data => {
+            utilities.notify(data.Message);
+            let { portalBeingExported } = state;
+            portalBeingExported.fileName = "";
+            portalBeingExported.description = "";
+            this.setState({ portalBeingExported }, () => {
+              props.onCancel();
             });
-        });
+          }
+        )
+      );
     }
-    createLocaleOptions(native) {
-        let localeOptions = [];
-        localeOptions = this.state.localData.locales.map(locale => {
-            if (native)//There is need of mechanism to get native name
-                return { label: locale.EnglishName, value: locale.Code };
-            else
-                return { label: locale.EnglishName, value: locale.Code };
-        });
-        return localeOptions;
+  }
+  Validate() {
+    let success = true;
+    const { portalBeingExported } = this.state;
+    success = this.ValidateTexts();
+    if (success && portalBeingExported.pages.length <= 0) {
+      success = false;
+      utilities.notify(Localization.get("ErrorPages"));
     }
-    onLanguageCheckBoxChange(Code, event) {
-        let {portalBeingExported} = this.state;
-        if (event && !portalBeingExported.locales.some(sl => sl === Code)) {
-            portalBeingExported.locales = portalBeingExported.locales.concat([Code]);
-        } else if (!event && portalBeingExported.locales.some(sl => sl === Code)) {
-            portalBeingExported.locales = portalBeingExported.locales.filter(sl => sl !== Code);
+    return success;
+  }
+  ValidateTexts(key) {
+    let success = true;
+    const { portalBeingExported } = this.state;
+    const { localData } = this.state;
+    keysToValidate.map(vkey => {
+      if (key === undefined || key == vkey) {
+        if (portalBeingExported[vkey] === "") {
+          success = false;
+          localData.errors[vkey] = true;
+        } else {
+          localData.errors[vkey] = false;
         }
-        this.setState({ portalBeingExported });
+      }
+      this.setState({});
+    });
+
+    return success;
+  }
+  onLanguageSelectionChange(option) {
+    let { portalBeingExported } = this.state;
+    let { reloadPages } = this.state;
+    reloadPages = true;
+    portalBeingExported.localizationCulture = option.value;
+    this.setState({ portalBeingExported, reloadPages }, () => {
+      this.setState({
+        reloadPages: false
+      });
+    });
+  }
+  createLocaleOptions(native) {
+    let localeOptions = [];
+    localeOptions = this.state.localData.locales.map(locale => {
+      if (native)
+        //There is need of mechanism to get native name
+        return { label: locale.EnglishName, value: locale.Code };
+      else return { label: locale.EnglishName, value: locale.Code };
+    });
+    return localeOptions;
+  }
+  onLanguageCheckBoxChange(Code, event) {
+    let { portalBeingExported } = this.state;
+    if (event && !portalBeingExported.locales.some(sl => sl === Code)) {
+      portalBeingExported.locales = portalBeingExported.locales.concat([Code]);
+    } else if (!event && portalBeingExported.locales.some(sl => sl === Code)) {
+      portalBeingExported.locales = portalBeingExported.locales.filter(
+        sl => sl !== Code
+      );
     }
-    createLanguageDropDownOptions() {
-        let {state} = this;
-        return state.localData.locales.map(locale => {
-            return {
-                label: <div><CheckBox
-                    label={locale.EnglishName}
-                    value={state.portalBeingExported.locales.some(sl => sl === locale.Code)}
-                    onChange={this.onLanguageCheckBoxChange.bind(this, locale.Code)}
-                    enabled={this.props.portalBeingExported.DefaultLanguage !== locale.Code}
+    this.setState({ portalBeingExported });
+  }
+  createLanguageDropDownOptions() {
+    let { state } = this;
+    return state.localData.locales.map(locale => {
+      return {
+        label: (
+          <div>
+            <CheckBox
+              label={locale.EnglishName}
+              value={state.portalBeingExported.locales.some(
+                sl => sl === locale.Code
+              )}
+              onChange={this.onLanguageCheckBoxChange.bind(this, locale.Code)}
+              enabled={
+                this.props.portalBeingExported.DefaultLanguage !== locale.Code
+              }
+            />
+            {locale.Code === state.portalBeingExported.localizationCulture && (
+              <ToolTip
+                messages={[
+                  stringUtils.format(
+                    Localization.get("lblNote"),
+                    locale.EnglishName
+                  )
+                ]}
+              />
+            )}
+          </div>
+        ),
+        value: locale.Code
+      };
+    });
+  }
+  updatePagesToExport(selectedPages) {
+    let { portalBeingExported } = this.state;
+    portalBeingExported.pages = selectedPages;
+    this.setState({ portalBeingExported });
+  }
+
+  render() {
+    const { props, state } = this;
+    const localeOptions = this.createLocaleOptions();
+    const dropdownOptions = this.createLanguageDropDownOptions();
+    const PortalTabsParameters = {
+      portalId: props.portalBeingExported.PortalID,
+      cultureCode: state.portalBeingExported.localizationCulture,
+      isMultiLanguage: state.portalBeingExported.isMultiLanguage,
+      excludeAdminTabs: true,
+      disabledNotSelectable: false,
+      roles: "",
+      sortOrder: 0
+    };
+    return (
+      <GridCell className="export-portal-container">
+        <PersonaBarPageHeader
+          title={Localization.get("ControlTitle_template")}
+        />
+        <PersonaBarPageBody
+          backToLinkProps={{
+            text: Localization.get("BackToSites"),
+            onClick: props.onCancel.bind(this)
+          }}
+        >
+          <div className="export-portal">
+            <GridCell className="export-site-container">
+              <h3 className="site-template-info-title">
+                {Localization.get("titleTemplateInfo")}
+              </h3>
+              <GridCell>
+                <SingleLineInputWithError
+                  label={Localization.get("plPortals")}
+                  tooltipMessage={Localization.get("plPortals.Help")}
+                  enabled={false}
+                  value={state.portalBeingExported.portalName}
+                  error={false}
+                />
+              </GridCell>
+              <GridCell>
+                <SingleLineInputWithError
+                  label={Localization.get("plTemplateName") + "*"}
+                  tooltipMessage={Localization.get("plTemplateName.Help")}
+                  onChange={this.onChange.bind(this, "fileName")}
+                  error={state.localData.errors.fileName}
+                  errorMessage={Localization.get("valFileName.ErrorMessage")}
+                  value={state.portalBeingExported.fileName}
+                />
+              </GridCell>
+              <GridCell>
+                <MultiLineInputWithError
+                  label={Localization.get("plDescription") + "*"}
+                  tooltipMessage={Localization.get("plDescription.Help")}
+                  className="portal-description"
+                  onChange={this.onChange.bind(this, "description")}
+                  error={state.localData.errors.description}
+                  errorMessage={Localization.get("valDescription.ErrorMessage")}
+                  value={state.portalBeingExported.description}
+                />
+                <hr />
+              </GridCell>
+              <GridSystem>
+                <div className="export-switches">
+                  <Switch
+                    label={Localization.get("plContent")}
+                    onText={Localization.get("SwitchOn")}
+                    offText={Localization.get("SwitchOff")}
+                    tooltipMessage={Localization.get("plContent.Help")}
+                    value={state.portalBeingExported.includeContent}
+                    onChange={this.onChange.bind(this, "includeContent")}
+                  />
+                  <Switch
+                    label={Localization.get("lblFiles")}
+                    onText={Localization.get("SwitchOn")}
+                    offText={Localization.get("SwitchOff")}
+                    tooltipMessage={Localization.get("lblFiles.Help")}
+                    value={state.portalBeingExported.includeFiles}
+                    onChange={this.onChange.bind(this, "includeFiles")}
+                  />
+                  <Switch
+                    label={Localization.get("lblRoles")}
+                    onText={Localization.get("SwitchOn")}
+                    offText={Localization.get("SwitchOff")}
+                    tooltipMessage={Localization.get("lblRoles.Help")}
+                    value={state.portalBeingExported.includeRoles}
+                    onChange={this.onChange.bind(this, "includeRoles")}
+                  />
+                  <Switch
+                    label={Localization.get("lblProfile")}
+                    onText={Localization.get("SwitchOn")}
+                    offText={Localization.get("SwitchOff")}
+                    tooltipMessage={Localization.get("lblProfile.Help")}
+                    value={state.portalBeingExported.includeProfile}
+                    onChange={this.onChange.bind(this, "includeProfile")}
+                  />
+                  <Switch
+                    label={Localization.get("lblModules")}
+                    onText={Localization.get("SwitchOn")}
+                    offText={Localization.get("SwitchOff")}
+                    tooltipMessage={Localization.get("lblModules.Help")}
+                    value={state.portalBeingExported.includeModules}
+                    onChange={this.onChange.bind(this, "includeModules")}
+                  />
+                  {props.portalBeingExported.contentLocalizable && (
+                    <Switch
+                      label={Localization.get("lblMultilanguage")}
+                      onText={Localization.get("SwitchOn")}
+                      offText={Localization.get("SwitchOff")}
+                      tooltipMessage={Localization.get("lblMultilanguage.Help")}
+                      value={state.portalBeingExported.isMultiLanguage}
+                      onChange={this.onChange.bind(this, "isMultiLanguage")}
                     />
-                    {locale.Code === state.portalBeingExported.localizationCulture
-                        && <ToolTip messages={[stringUtils.format(Localization.get("lblNote"), locale.EnglishName)]} />
-                    }
-                </div>,
-                value: locale.Code
-            };
-        });
-    }
-    updatePagesToExport(selectedPages) {
-        let {portalBeingExported} = this.state;
-        portalBeingExported.pages = selectedPages;
-        this.setState({ portalBeingExported });
-    }
-
-    render() {
-        const {props, state} = this;
-        const localeOptions = this.createLocaleOptions();
-        const dropdownOptions = this.createLanguageDropDownOptions();
-        const PortalTabsParameters = {
-            portalId: props.portalBeingExported.PortalID,
-            cultureCode: state.portalBeingExported.localizationCulture,
-            isMultiLanguage: state.portalBeingExported.isMultiLanguage,
-            excludeAdminTabs: true,
-            disabledNotSelectable: false,
-            roles: "",
-            sortOrder: 0
-        };
-        return (
-            <GridCell className="export-portal-container">
-                <PersonaBarPageHeader title={Localization.get("ControlTitle_template")} />
-                <PersonaBarPageBody backToLinkProps={{
-                    text: Localization.get("BackToSites"),
-                    onClick: props.onCancel.bind(this)
-                }}>
-                    <div className="export-portal">
-                        <GridCell className="export-site-container">
-                            <h3 className="site-template-info-title">{Localization.get("titleTemplateInfo")}</h3>
-                            <GridCell>
-                                <SingleLineInputWithError
-                                    label={Localization.get("plPortals")}
-                                    tooltipMessage={Localization.get("plPortals.Help")}
-                                    enabled={false}
-                                    value={state.portalBeingExported.portalName}
-                                    error={false}
-                                    />
-                            </GridCell>
-                            <GridCell>
-                                <SingleLineInputWithError
-                                    label={Localization.get("plTemplateName") + "*"}
-                                    tooltipMessage={Localization.get("plTemplateName.Help")}
-                                    onChange={this.onChange.bind(this, "fileName")}
-                                    error={state.localData.errors.fileName}
-                                    errorMessage={Localization.get("valFileName.ErrorMessage")}
-                                    value={state.portalBeingExported.fileName}
-                                    />
-                            </GridCell>
-                            <GridCell>
-                                <MultiLineInputWithError
-                                    label={Localization.get("plDescription") + "*"}
-                                    tooltipMessage={Localization.get("plDescription.Help")}
-                                    className="portal-description"
-                                    onChange={this.onChange.bind(this, "description")}
-                                    error={state.localData.errors.description}
-                                    errorMessage={Localization.get("valDescription.ErrorMessage")}
-                                    value={state.portalBeingExported.description}
-                                    />
-                                <hr />
-                            </GridCell>
-                            <GridSystem>
-                                <div className="export-switches">
-                                    <Switch
-                                        label={Localization.get("plContent")}
-                                        onText={Localization.get("SwitchOn")}
-                                        offText={Localization.get("SwitchOff")}
-                                        tooltipMessage={Localization.get("plContent.Help")}
-                                        value={state.portalBeingExported.includeContent}
-                                        onChange={this.onChange.bind(this, "includeContent")}
-                                        />
-                                    <Switch
-                                        label={Localization.get("lblFiles")}
-                                        onText={Localization.get("SwitchOn")}
-                                        offText={Localization.get("SwitchOff")}
-                                        tooltipMessage={Localization.get("lblFiles.Help")}
-                                        value={state.portalBeingExported.includeFiles}
-                                        onChange={this.onChange.bind(this, "includeFiles")}
-                                        />
-                                    <Switch
-                                        label={Localization.get("lblRoles")}
-                                        onText={Localization.get("SwitchOn")}
-                                        offText={Localization.get("SwitchOff")}
-                                        tooltipMessage={Localization.get("lblRoles.Help")}
-                                        value={state.portalBeingExported.includeRoles}
-                                        onChange={this.onChange.bind(this, "includeRoles")}
-                                        />
-                                    <Switch
-                                        label={Localization.get("lblProfile")}
-                                        onText={Localization.get("SwitchOn")}
-                                        offText={Localization.get("SwitchOff")}
-                                        tooltipMessage={Localization.get("lblProfile.Help")}
-                                        value={state.portalBeingExported.includeProfile}
-                                        onChange={this.onChange.bind(this, "includeProfile")}
-                                        />
-                                    <Switch
-                                        label={Localization.get("lblModules")}
-                                        onText={Localization.get("SwitchOn")}
-                                        offText={Localization.get("SwitchOff")}
-                                        tooltipMessage={Localization.get("lblModules.Help")}
-                                        value={state.portalBeingExported.includeModules}
-                                        onChange={this.onChange.bind(this, "includeModules")}
-                                        />
-                                    {props.portalBeingExported.contentLocalizable &&
-                                        <Switch
-                                            label={Localization.get("lblMultilanguage")}
-                                            onText={Localization.get("SwitchOn")}
-                                            offText={Localization.get("SwitchOff")}
-                                            tooltipMessage={Localization.get("lblMultilanguage.Help")}
-                                            value={state.portalBeingExported.isMultiLanguage}
-                                            onChange={this.onChange.bind(this, "isMultiLanguage")}
-                                            />
-                                    }
-                                </div>
-                                {state.portalBeingExported.portalId >= 0 &&
-                                    <div className="export-pages">
-                                        {props.portalBeingExported.contentLocalizable &&
-                                            <div className="language-box">
-                                                <Label label={Localization.get("lblLanguages")} tooltipMessage={Localization.get("lblLanguages.Help")} />
-                                                {!state.portalBeingExported.isMultiLanguage && <Dropdown options={localeOptions} value={state.portalBeingExported.localizationCulture}
-                                                    onSelect={this.onLanguageSelectionChange.bind(this)} />}
-                                                {state.portalBeingExported.isMultiLanguage &&
-                                                    <Dropdown options={dropdownOptions} label={Localization.get("lblSelectLanguages")}
-                                                        closeOnClick={false} />
-                                                }
-                                            </div>
-                                        }
-                                        <Label label={Localization.get("lblPages")} tooltipMessage={Localization.get("lblPages.Help")} />
-                                        <PagePicker
-                                            serviceFramework={utilities && utilities.sf}
-                                            PortalTabsParameters={PortalTabsParameters}
-                                            scrollAreaStyle={scrollAreaStyle}
-                                            OnSelect={this.updatePagesToExport.bind(this)}
-                                            allSelected={true}
-                                            IsMultiSelect={true}
-                                            IsInDropDown={false}
-                                            ShowCount={false}
-                                            Reload={this.state.reloadPages}
-                                            ShowIcon={false}
-                                            />
-                                    </div>
-                                }
-                            </GridSystem>
-                            <GridCell className="site-action-buttons">
-                                <Button type="secondary" onClick={props.onCancel.bind(this)}>{Localization.get("cmdCancel")}</Button>
-                                <Button type="primary" onClick={this.onExportPortal.bind(this)}>{Localization.get("cmdExport")}</Button>
-                            </GridCell>
-                        </GridCell>
-                    </div>
-                </PersonaBarPageBody>
+                  )}
+                </div>
+                {state.portalBeingExported.portalId >= 0 && (
+                  <div className="export-pages">
+                    {props.portalBeingExported.contentLocalizable && (
+                      <div className="language-box">
+                        <Label
+                          label={Localization.get("lblLanguages")}
+                          tooltipMessage={Localization.get("lblLanguages.Help")}
+                        />
+                        {!state.portalBeingExported.isMultiLanguage && (
+                          <Dropdown
+                            options={localeOptions}
+                            value={
+                              state.portalBeingExported.localizationCulture
+                            }
+                            onSelect={this.onLanguageSelectionChange.bind(this)}
+                          />
+                        )}
+                        {state.portalBeingExported.isMultiLanguage && (
+                          <Dropdown
+                            options={dropdownOptions}
+                            label={Localization.get("lblSelectLanguages")}
+                            closeOnClick={false}
+                          />
+                        )}
+                      </div>
+                    )}
+                    <Label
+                      label={Localization.get("lblPages")}
+                      tooltipMessage={Localization.get("lblPages.Help")}
+                    />
+                    <PagePicker
+                      serviceFramework={utilities && utilities.sf}
+                      PortalTabsParameters={PortalTabsParameters}
+                      scrollAreaStyle={scrollAreaStyle}
+                      OnSelect={this.updatePagesToExport.bind(this)}
+                      allSelected={true}
+                      IsMultiSelect={true}
+                      IsInDropDown={false}
+                      ShowCount={false}
+                      Reload={this.state.reloadPages}
+                      ShowIcon={false}
+                    />
+                  </div>
+                )}
+              </GridSystem>
+              <GridCell className="site-action-buttons">
+                <Button type="secondary" onClick={props.onCancel.bind(this)}>
+                  {Localization.get("cmdCancel")}
+                </Button>
+                <Button type="primary" onClick={this.onExportPortal.bind(this)}>
+                  {Localization.get("cmdExport")}
+                </Button>
+              </GridCell>
             </GridCell>
-        );
-    }
+          </div>
+        </PersonaBarPageBody>
+      </GridCell>
+    );
+  }
 }
 
 ExportPortal.propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    onCancel: PropTypes.func,
-    portalBeingExported: PropTypes.object
+  dispatch: PropTypes.func.isRequired,
+  onCancel: PropTypes.func,
+  portalBeingExported: PropTypes.object
 };
 
-
 function mapStateToProps(state) {
-    return {
-        portalBeingExported: state.exportPortal.portalBeingExported
-    };
+  return {
+    portalBeingExported: state.exportPortal.portalBeingExported
+  };
 }
-
 
 export default connect(mapStateToProps)(ExportPortal);

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ExportPortal/style.less
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ExportPortal/style.less
@@ -59,10 +59,15 @@
             .dnn-switch-container {
                 width: 100%;
                 margin-top: 15px;
+                display: flex;
                 .switch-label {
-                    width: calc(100% - 45px);
+                    flex: 1;
+                }
+                .dnn-ui-common-tooltip {
+                    flex-basis: 32px;
                 }
                 .dnn-switch {
+                    flex: 1;
                     float: right;
                 }
             }

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ListView/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ListView/index.jsx
@@ -112,6 +112,11 @@ class ListView extends Component {
                 icon: SvgIcons.DownloadIcon,
                 onClick: this.onImportExport.bind(this, portal, "Import", index),
                 title: Localization.get("SiteImport")
+            },
+            {
+                icon: SvgIcons.TreeCopy,
+                onClick: this.props.onExportPortal.bind(this, portal),
+                title: Localization.get("ExportTemplate")
             }
         ];
         if (portal.allowDelete) {

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/components/App.jsx
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/components/App.jsx
@@ -1,84 +1,93 @@
-import PropTypes from 'prop-types';
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PortalList from "./PortalList";
-import { CommonVisiblePanelActions, CommonExportPortalActions } from "dnn-sites-common-actions";
+import {
+  CommonVisiblePanelActions,
+  CommonExportPortalActions
+} from "dnn-sites-common-actions";
 import { PersonaBarPage } from "@dnnsoftware/dnn-react-common";
-import {ExportPortal} from "dnn-sites-common-components";
+import { ExportPortal } from "dnn-sites-common-components";
 import CreatePortal from "./CreatePortal";
 
 class App extends Component {
-    constructor() {
-        super();
-        this.state = {
-            editMode: false,
-            portalBeingExported: {}
-        };
-    }
+  constructor() {
+    super();
+    this.state = {
+      editMode: false,
+      portalBeingExported: {}
+    };
+  }
 
-    onAddNewSite(event) {
-        event.preventDefault();
-        this.navigateMap(1);
-    }
+  onAddNewSite(event) {
+    event.preventDefault();
+    this.navigateMap(1);
+  }
 
-    onEditSite() { }
+  onEditSite() {}
 
-    onExportPortal(portalBeingExported) {
-        const { props } = this;
-        props.dispatch(CommonExportPortalActions.setPortalBeingExported(portalBeingExported, this.navigateMap.bind(this, 2)));
-    }
+  onExportPortal(portalBeingExported) {
+    const { props } = this;
+    props.dispatch(
+      CommonExportPortalActions.setPortalBeingExported(
+        portalBeingExported,
+        this.navigateMap.bind(this, 2)
+      )
+    );
+  }
 
-    navigateMap(page) {
-        const {props} = this;
-        props.dispatch(CommonVisiblePanelActions.selectPanel(page));
-    }
+  navigateMap(page) {
+    const { props } = this;
+    props.dispatch(CommonVisiblePanelActions.selectPanel(page));
+  }
 
-    cancelExport(event) {
-        if (event !== undefined)
-            event.preventDefault();
-        this.setState({
-            portalBeingExported: {}
-        });
-        this.navigateMap(0);
-    }
+  cancelExport(event) {
+    if (event !== undefined) event.preventDefault();
+    this.setState({
+      portalBeingExported: {}
+    });
+    this.navigateMap(0);
+  }
 
-    render() {
-        const {props} = this;
-        return (
-            <div className="sites-Root">
-                <PersonaBarPage isOpen={props.selectedPage === 0 || props.selectedPage === 2}>
-                    <PortalList
-                        onAddNewSite={this.onAddNewSite.bind(this)}
-                        onExportPortal={this.onExportPortal.bind(this)} />
-                </PersonaBarPage>
-                {props.selectedPage === 1 && <PersonaBarPage isOpen={props.selectedPage === 1}>
-                    <CreatePortal
-                        onCancel={this.navigateMap.bind(this, 0)} />
-                </PersonaBarPage>
-                }
-                {props.selectedPage === 2 && <PersonaBarPage isOpen={props.selectedPage === 2}>
-                    <ExportPortal
-                        onCancel={this.cancelExport.bind(this)} />
-                </PersonaBarPage>}
-            </div>
-        );
-    }
+  render() {
+    const { props } = this;
+    return (
+      <div className="sites-Root">
+        <PersonaBarPage
+          isOpen={props.selectedPage === 0 || props.selectedPage === 2}
+        >
+          <PortalList
+            onAddNewSite={this.onAddNewSite.bind(this)}
+            onExportPortal={this.onExportPortal.bind(this)}
+          />
+        </PersonaBarPage>
+        {props.selectedPage === 1 && (
+          <PersonaBarPage isOpen={props.selectedPage === 1}>
+            <CreatePortal onCancel={this.navigateMap.bind(this, 0)} />
+          </PersonaBarPage>
+        )}
+        {props.selectedPage === 2 && (
+          <PersonaBarPage isOpen={props.selectedPage === 2}>
+            <ExportPortal onCancel={this.cancelExport.bind(this)} />
+          </PersonaBarPage>
+        )}
+      </div>
+    );
+  }
 }
 
 App.PropTypes = {
-    dispatch: PropTypes.func.isRequired,
-    selectedPage: PropTypes.number,
-    selectedPageVisibleIndex: PropTypes.number
+  dispatch: PropTypes.func.isRequired,
+  selectedPage: PropTypes.number,
+  selectedPageVisibleIndex: PropTypes.number
 };
 
-
 function mapStateToProps(state) {
-    return {
-        selectedPage: state.visiblePanel.selectedPage,
-        selectedPageVisibleIndex: state.visiblePanel.selectedPageVisibleIndex,
-        portalBeingExported: state.exportPortal.portalBeingExported
-    };
+  return {
+    selectedPage: state.visiblePanel.selectedPage,
+    selectedPageVisibleIndex: state.visiblePanel.selectedPageVisibleIndex,
+    portalBeingExported: state.exportPortal.portalBeingExported
+  };
 }
-
 
 export default connect(mapStateToProps)(App);

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/components/PortalList/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/components/PortalList/index.jsx
@@ -1,76 +1,102 @@
-import PropTypes from 'prop-types';
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { PersonaBarPageHeader, PersonaBarPageBody, GridCell, Button } from "@dnnsoftware/dnn-react-common";
+import {
+  PersonaBarPageHeader,
+  PersonaBarPageBody,
+  GridCell,
+  Button
+} from "@dnnsoftware/dnn-react-common";
 import { ListView } from "dnn-sites-common-components";
 import Localization from "localization";
 import utilities from "utils/applicationSettings";
-import { CommonPaginationActions, CommonPortalListActions } from "dnn-sites-common-actions";
+import {
+  CommonPaginationActions,
+  CommonPortalListActions
+} from "dnn-sites-common-actions";
 import styles from "./style.less";
 
 class PortalList extends Component {
-    componentWillMount() {
-        const {props} = this;
-        // props.dispatch(CommonPortalListActions.deletePortal(16));
-        props.dispatch(CommonPortalListActions.loadPortals({
-            portalGroupId: props.pagination.portalGroupId,
-            filter: props.pagination.filter,
-            pageIndex: props.pagination.pageIndex,
-            pageSize: props.pagination.pageSize
-        }));
-    }
+  componentWillMount() {
+    const { props } = this;
+    props.dispatch(
+      CommonPortalListActions.loadPortals({
+        portalGroupId: props.pagination.portalGroupId,
+        filter: props.pagination.filter,
+        pageIndex: props.pagination.pageIndex,
+        pageSize: props.pagination.pageSize
+      })
+    );
+  }
 
-    loadMore(event) {
-        if (event) {
-            event.preventDefault();
-        }
-        const { props } = this;
-        props.dispatch(CommonPaginationActions.loadMore(() => {
-            props.dispatch(CommonPortalListActions.loadPortals({
-                portalGroupId: props.pagination.portalGroupId,
-                filter: props.pagination.filter,
-                pageIndex: props.pagination.pageIndex + 1,
-                pageSize: props.pagination.pageSize
-            }, true));
-        }));
+  loadMore(event) {
+    if (event) {
+      event.preventDefault();
     }
-    render() {
-        const {props} = this;
-        return (
-            <GridCell className={styles.sitesPortalList}>
-                <PersonaBarPageHeader title={Localization.get("Sites")}>
-                    <Button type="primary" onClick={props.onAddNewSite.bind(this)} size="large">{Localization.get("AddNewSite")}</Button>
-                </PersonaBarPageHeader>
-                <PersonaBarPageBody>
-                    <ListView
-                        onAddNewSite={props.onAddNewSite.bind(this)}
-                        culture={utilities.applicationSettings.cultureCode}
-                        />
-
-                    {props.portals.length < props.totalCount &&
-                        <GridCell className="load-more-button">
-                            <Button type="primary" onClick={this.loadMore.bind(this)}>{Localization.get("LoadMore.Button")}</Button>
-                        </GridCell>
-                    }
-                </PersonaBarPageBody>
-            </GridCell>
+    const { props } = this;
+    props.dispatch(
+      CommonPaginationActions.loadMore(() => {
+        props.dispatch(
+          CommonPortalListActions.loadPortals(
+            {
+              portalGroupId: props.pagination.portalGroupId,
+              filter: props.pagination.filter,
+              pageIndex: props.pagination.pageIndex + 1,
+              pageSize: props.pagination.pageSize
+            },
+            true
+          )
         );
-    }
+      })
+    );
+  }
+  render() {
+    const { props } = this;
+    return (
+      <GridCell className={styles.sitesPortalList}>
+        <PersonaBarPageHeader title={Localization.get("Sites")}>
+          <Button
+            type="primary"
+            onClick={props.onAddNewSite.bind(this)}
+            size="large"
+          >
+            {Localization.get("AddNewSite")}
+          </Button>
+        </PersonaBarPageHeader>
+        <PersonaBarPageBody>
+          <ListView
+            onAddNewSite={props.onAddNewSite.bind(this)}
+            onExportPortal={props.onExportPortal.bind(this)}
+            culture={utilities.applicationSettings.cultureCode}
+          />
+
+          {props.portals.length < props.totalCount && (
+            <GridCell className="load-more-button">
+              <Button type="primary" onClick={this.loadMore.bind(this)}>
+                {Localization.get("LoadMore.Button")}
+              </Button>
+            </GridCell>
+          )}
+        </PersonaBarPageBody>
+      </GridCell>
+    );
+  }
 }
 
 PortalList.propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    onAddNewSite: PropTypes.func,
-    onEditSite: PropTypes.func,
-    portals: PropTypes.array
+  dispatch: PropTypes.func.isRequired,
+  onAddNewSite: PropTypes.func,
+  onEditSite: PropTypes.func,
+  onExportPortal: PropTypes.func,
+  portals: PropTypes.array
 };
 function mapStateToProps(state) {
-    return {
-        portals: state.portal.portals,
-        totalCount: state.portal.totalCount,
-        viewMode: state.viewMode,
-        pagination: state.pagination
-    };
+  return {
+    portals: state.portal.portals,
+    totalCount: state.portal.totalCount,
+    viewMode: state.viewMode,
+    pagination: state.pagination
+  };
 }
 
 export default connect(mapStateToProps)(PortalList);


### PR DESCRIPTION
Since the introduction of the PersonaBar we have lost the ability to export a portal template. This PR brings back a button on the site list that will take the user to a page from where the portal template can be created.