### PR TITLE
Allow superusers login using email

### DIFF
--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -5,6 +5,7 @@
 #region Usings
 
 using System;
+using System.Linq;
 using System.Web;
 using Microsoft.Extensions.DependencyInjection;
 using DotNetNuke.Abstractions;
@@ -259,7 +260,12 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
                 if (emailUsedAsUsername)
                 {
                     // one additonal call to db to see if an account with that email actually exists
-                    userByEmail = UserController.GetUserByEmail(PortalController.GetEffectivePortalId(PortalId), userName);                     
+                    int totalRecords = 0;
+                    var effectivePortalId = PortalController.GetEffectivePortalId(PortalId);
+                    userByEmail = UserController
+                        .GetUsersByEmail(Null.NullInteger, userName, Null.NullInteger, Null.NullInteger, ref totalRecords)
+                        .Cast<UserInfo>()
+                        .FirstOrDefault(user => user.IsSuperUser || user.PortalID == effectivePortalId);
 
                     if (userByEmail != null)
                     {


### PR DESCRIPTION
Fixes #3676

## Summary
The logic in Login.ascx.cs was only authenticating users by email when the users existed in current portal, which is not the case when super users attempt to log in.
I changed this logic to search not only for portal users but also for super users as well. This is accomplished by calling `GetUsersByEmail` instead of `GetUserByEmail`.