### PR TITLE
Host users should bypass the whitelist

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileManager.cs
@@ -1809,7 +1809,7 @@ namespace DotNetNuke.Services.FileSystem
             //regex is meant to block files like "foo.asp;.png" which can take advantage
             //of a vulnerability in IIS6 which treasts such files as .asp, not .png
             return !string.IsNullOrEmpty(extension)
-                   && WhiteList.IsAllowedExtension(extension)
+                   && (WhiteList.IsAllowedExtension(extension) || UserController.Instance.GetCurrentUserInfo().IsSuperUser)
                    && !Globals.FileExtensionRegex.IsMatch(fileName);
         }
 


### PR DESCRIPTION
This came out of testing. Our recent work on Whitelists contained a flaw where hosts were still subject to their own whitelist which runs counter to the philosophy of the framework.