### PR TITLE
Fixed user role icons not showing

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/DatePicker/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/DatePicker/index.jsx
@@ -353,7 +353,7 @@ class DatePicker extends Component {
         const showInput = this.props.showInput !== false;
 
         const mode = this.props.mode ? "_" + this.props.mode : "";
-        let icon = require(`./img/calendar${mode}.svg`);
+        let icon = require(`./img/calendar${mode}.svg`).default;
         if (this.props.icon) {
             icon = this.props.icon;
         }


### PR DESCRIPTION
Fixes #3619

## Summary
To be honest, I can't really explain the internals of why this code change fixes this issue. What I know is that the way modules are exported/imported evolved and now it's mandatory to specify the default object for modules like this one, which is essentially a directory on disk.

This fixes both the Users panel and the Roles panel.