### PR TITLE
Fixed content export validation

### DIFF
--- a/DNN Platform/Website/admin/Modules/Export.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Export.ascx.cs
@@ -219,23 +219,24 @@ namespace DotNetNuke.Modules.Admin.Modules
         {
             try
             {
+                IFolderInfo folder = null;
                 if (cboFolders.SelectedItem != null && !String.IsNullOrEmpty(txtFile.Text))
                 {
-                    var folder = FolderManager.Instance.GetFolder(cboFolders.SelectedItemValueAsInt);
-                    if (folder != null)
-                    {
-                        var strFile = "content." + CleanName(Module.DesktopModule.ModuleName) + "." + CleanName(txtFile.Text) + ".export";
-                        var strMessage = ExportModule(ModuleId, strFile, folder);
-                        if (String.IsNullOrEmpty(strMessage))
-                        {
-                            Response.Redirect(ReturnURL, true);
-                        }
-                        else
-                        {
-                            UI.Skins.Skin.AddModuleMessage(this, strMessage, ModuleMessage.ModuleMessageType.RedError);
-                        }
-                    }
+                    folder = FolderManager.Instance.GetFolder(cboFolders.SelectedItemValueAsInt);
+                }
 
+                if (folder != null)
+                {
+                    var strFile = "content." + CleanName(Module.DesktopModule.ModuleName) + "." + CleanName(txtFile.Text) + ".export";
+                    var strMessage = ExportModule(ModuleId, strFile, folder);
+                    if (String.IsNullOrEmpty(strMessage))
+                    {
+                        Response.Redirect(ReturnURL, true);
+                    }
+                    else
+                    {
+                        UI.Skins.Skin.AddModuleMessage(this, strMessage, ModuleMessage.ModuleMessageType.RedError);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #3720

## Summary
The validation message appears only if the folder dropdown's selected item is null, but this never happens because the "< None Specified >" item is selected by default, which has a value of `-1`. So I changed this to check whether the actual folder returned by the folder provider is null. This works for the "None Specified" item too.