### PR TITLE
Fix resource manager to use the revised upload file handler in the core

### DIFF
--- a/DNN Platform/Library/Common/Utilities/ValidationUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/ValidationUtils.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Common.Utilities
             return FIPSCompliant.EncryptAES(key, key, Host.GUID);
         }
 
-        internal static string ComputeValidationCode(IList<object> parameters)
+        public static string ComputeValidationCode(IList<object> parameters)
         {
             if (parameters != null && parameters.Any())
             {

--- a/DNN Platform/Library/Services/FileSystem/FileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileManager.cs
@@ -248,7 +248,7 @@ namespace DotNetNuke.Services.FileSystem
             }
         }
 
-        private FileExtensionWhitelist WhiteList
+        public FileExtensionWhitelist WhiteList
         {
             get
             {

--- a/DNN Platform/Library/Services/FileSystem/IFileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/IFileManager.cs
@@ -2,6 +2,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // 
+using DotNetNuke.Common.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -277,5 +278,10 @@ namespace DotNetNuke.Services.FileSystem
         /// <param name="file">The file to download.</param>
         /// <param name="contentDisposition">Indicates how to display the document once downloaded.</param>
         void WriteFileToResponse(IFileInfo file, ContentDisposition contentDisposition);
+
+        /// <summary>
+        /// Current user's file upload extension whitelist
+        /// </summary>
+        FileExtensionWhitelist WhiteList { get; }
     }
 }

--- a/DNN Platform/Modules/ResourceManager/App_LocalResources/ResourceManager.resx
+++ b/DNN Platform/Modules/ResourceManager/App_LocalResources/ResourceManager.resx
@@ -276,4 +276,7 @@
   <data name="GroupIconCantBeDeleted.Error" xml:space="preserve">
     <value>The Group Icon file can't be deleted.</value>
   </data>
+  <data name="InvalidExtensionMessage.Text" xml:space="preserve">
+    <value> is not of a type that is allowed to be uploaded</value>
+  </data>
 </root>

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/.eslintskipwords.js
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/.eslintskipwords.js
@@ -156,5 +156,7 @@ module.exports = [
     "vnd",
     "noellipsis",
     "hostname",
-    "popstate"
+    "popstate",
+    "whitelist",
+    "substr"
 ];

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/actions/addAssetPanelActions.js
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/actions/addAssetPanelActions.js
@@ -114,6 +114,11 @@ const addAssetPanelActions = {
         const fileTooBigMessage = LocalizeService.getString("FileSizeErrorMessage");
         return dispatch =>
             dispatch(fileUploadError(fileName, fileName + fileTooBigMessage + maxSize));
+    },
+    invalidExtensionError(fileName) {
+        const invalidExtensionMessage = LocalizeService.getString("InvalidExtensionMessage");
+        return dispatch =>
+            dispatch(fileUploadError(fileName, fileName + invalidExtensionMessage));
     }
 /*,
     startUpload() {

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FileDetails.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FileDetails.jsx
@@ -1,7 +1,6 @@
 import React, {PropTypes} from "react";
 import itemService from "../services/itemsService";
 import localizeService from "../services/localizeService";
-import Switch from "dnn-switch";
 
 const FileDetails = ({file, handlers, validationErrors}) => (
     <div className="item-details" >

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderDetails.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderDetails.jsx
@@ -1,8 +1,6 @@
 import React, {PropTypes} from "react";
-import Switch from "dnn-switch";
 import localizeService from "../services/localizeService";
 import itemsService from "../services/itemsService";
-import DropDown from "dnn-dropdown";
 
 const FolderDetails = ({folder, handlers, validationErrors}) => (
     <div className="item-details">

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderPicker.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderPicker.jsx
@@ -35,7 +35,7 @@ export default class FolderPicker extends React.Component {
         this.getFolders();
     }
 
-    componentWillUnmount(){   
+    componentWillUnmount() {   
         this.unmounted = true;
     }
 
@@ -54,7 +54,7 @@ export default class FolderPicker extends React.Component {
     }
 
     setFolders(result) {
-        if(this.unmounted){
+        if (this.unmounted) {
             return;
         }
         
@@ -68,14 +68,14 @@ export default class FolderPicker extends React.Component {
         this.setState({ folders: result.Tree });
     }
 
-    findNode(node, condition){
-        if(condition(node)){
+    findNode(node, condition) {
+        if (condition(node)) {
             return node;
         }
 
-        for(let i = 0; i < node.children.length; i++) {
+        for (let i = 0; i < node.children.length; i++) {
             let found = this.findNode(node.children[i], condition);
-            if(found !== null){
+            if (found !== null) {
                 return found;
             }
         }

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/Item.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/Item.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 
-function truncateString(content, length){
-    if(typeof length === "undefined"){
+function truncateString(content, length) {
+    if (typeof length === "undefined") {
         length = 13;
     }
 

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/containers/DropZoneContainer.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/containers/DropZoneContainer.jsx
@@ -3,13 +3,29 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import DropZone from "react-dropzone";
 import addAssetPanelActions from "../actions/addAssetPanelActions";
+import api from "../globals/api";
 
 class DropZoneContainer extends React.Component {
     validateFile(file) {
-        const { maxUploadSize, maxFileUploadSizeHumanReadable, fileSizeError } = this.props;
+        const { maxUploadSize, maxFileUploadSizeHumanReadable, fileSizeError, invalidExtensionError } = this.props;
 
         if (file.size > maxUploadSize) {
             fileSizeError(file.name, maxFileUploadSizeHumanReadable);
+            return false;
+        }
+
+        const validExtensions = api.getWhitelistObject().extensionWhitelist.split(",");
+        const ext = file.name.substr(file.name.lastIndexOf(".") + 1);
+        let valid = false;
+        for (let i = 0; i < validExtensions.length; i++) {
+            const extension = validExtensions[i];
+            if (extension !== ext) continue;
+            valid = true;
+            break;
+        }
+
+        if (!valid) {
+            invalidExtensionError(file.name);
             return false;
         }
 
@@ -55,7 +71,8 @@ DropZoneContainer.propTypes = {
     trackProgress: PropTypes.func,
     maxUploadSize: PropTypes.number,
     maxFileUploadSizeHumanReadable: PropTypes.string,
-    fileSizeError: PropTypes.func
+    fileSizeError: PropTypes.func,
+    invalidExtensionError: PropTypes.func
 };
 
 function mapStateToProps(state) {
@@ -76,7 +93,8 @@ function mapDispatchToProps(dispatch) {
             showPanel: addAssetPanelActions.showPanel,
             uploadFiles: addAssetPanelActions.uploadFiles,
             trackProgress: addAssetPanelActions.trackProgress,
-            fileSizeError: addAssetPanelActions.fileSizeError
+            fileSizeError: addAssetPanelActions.fileSizeError,
+            invalidExtensionError: addAssetPanelActions.invalidExtensionError
         }, dispatch)
     };
 }

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/globals/api.js
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/globals/api.js
@@ -2,6 +2,8 @@ let tabId = -1;
 let moduleId = -1;
 let groupId = -1;
 let moduleName = "";
+let extensionWhitelist = "";
+let validationCode = "";
 
 const ANTIFORGERY_TOKEN_KEY = "__RequestVerificationToken";
 
@@ -135,6 +137,8 @@ const api = {
         moduleName = options.moduleName;
         tabId = options.tabId;
         groupId = options.groupId;
+        extensionWhitelist = options.extensionWhitelist;
+        validationCode = options.validationCode;
     },
 
     getAntiForgeryToken() {
@@ -234,8 +238,14 @@ const api = {
             tabId,
             groupId
         };
-
         return headersObject;
+    },
+    getWhitelistObject() {
+        const whitelistObject = {
+            extensionWhitelist,
+            validationCode
+        };
+        return whitelistObject;
     }
 };
 export default api;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/services/itemsService.js
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/services/itemsService.js
@@ -73,6 +73,9 @@ function uploadFile(file, folderPath, overwrite, trackProgress) {
     if (overwrite && typeof overwrite === "boolean") {
         formData.append("overwrite", overwrite);
     }
+    let {extensionWhitelist, validationCode} = api.getWhitelistObject();
+    formData.append("filter", extensionWhitelist);
+    formData.append("validationCode", validationCode);
     const url = getUrl(FILE_UPLOAD, true);
     
     return api.postFile(url, formData, trackProgress);

--- a/DNN Platform/Modules/ResourceManager/View.ascx
+++ b/DNN Platform/Modules/ResourceManager/View.ascx
@@ -1,57 +1,59 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeBehind="View.ascx.cs" Inherits="Dnn.Modules.ResourceManager.View" %>
 
-<asp:Panel runat="server" id="ResourceManagerContainer" CssClass="rm-container" data-init-callback="initResourceLibrary">
+<asp:Panel runat="server" ID="ResourceManagerContainer" CssClass="rm-container" data-init-callback="initResourceLibrary">
 </asp:Panel>
 
 <script>
-    $(function () {
-        function resxCallback200(data) {
-            var resx = data.localization;
-            var options = {
-                containerId: '<%=ResourceManagerContainer.ClientID%>',
-                moduleId: <%=ModuleId%>,
-                portalId: <%=PortalId%>,
-                groupId: <%=GroupId%>,
-                moduleName: 'ResourceManager',
-                tabId: <%=TabId%>,
-                resx: resx,
-                homeFolderId: <%=HomeFolderId%>,
-                numItems: <%=FolderPanelNumItems%>,
-                itemWidth: <%=ItemWidth%>,
-                maxUploadSize: <%=MaxUploadSize%>,
-                maxFileUploadSizeHumanReadable: '<%=MaxUploadSizeHumanReadable%>',
-                sortingOptions: JSON.parse('<%=SortingFields%>'),
-                sorting: '<%=DefaultSortingField%>',
-                userLogged: '<%=UserLogged%>' === 'True'
-            }
+  $(function () {
+    function resxCallback200(data) {
+      var resx = data.localization;
+      var options = {
+        containerId: '<%=ResourceManagerContainer.ClientID%>',
+        moduleId: <%=ModuleId%>,
+        portalId: <%=PortalId%>,
+        groupId: <%=GroupId%>,
+        moduleName: 'ResourceManager',
+        tabId: <%=TabId%>,
+        resx: resx,
+        homeFolderId: <%=HomeFolderId%>,
+        numItems: <%=FolderPanelNumItems%>,
+        itemWidth: <%=ItemWidth%>,
+        maxUploadSize: <%=MaxUploadSize%>,
+        maxFileUploadSizeHumanReadable: '<%=MaxUploadSizeHumanReadable%>',
+        sortingOptions: JSON.parse('<%=SortingFields%>'),
+        sorting: '<%=DefaultSortingField%>',
+        userLogged: '<%=UserLogged%>' === 'True',
+        extensionWhitelist: '<%= ExtensionWhitelist %>',
+        validationCode: '<%= ValidationCode %>'
+      }
 
-            var openFolderId = <%=OpenFolderId%>;
-            if (openFolderId) {
-                options.openFolderId = openFolderId;
-                options.openFolderPath = JSON.parse('<%=OpenFolderPath%>');
-            }
+      var openFolderId = <%=OpenFolderId%>;
+      if (openFolderId) {
+        options.openFolderId = openFolderId;
+        options.openFolderPath = JSON.parse('<%=OpenFolderPath%>');
+      }
 
-            window.dnn.ResourceManager.instance.init(options);
-        };
+      window.dnn.ResourceManager.instance.init(options);
+    };
 
-        var localizationOptions = {
-            service: 'ResourceManager',
-            controller: 'Localization',
-            resxName: 'ResourceManagerResourcesResx',
-            resourceSettings: {
-                local: {
-                    culture: '<%=ResxCulture%>',
-                    resxTimeStamp: '<%=ResxTimeStamp%>'
-                }
-            },
-            resources: {
-                method: 'GetResources',
-                paramName: null,
-                callback200: resxCallback200,
-                callbackError: null
-            }
-        };
+    var localizationOptions = {
+      service: 'ResourceManager',
+      controller: 'Localization',
+      resxName: 'ResourceManagerResourcesResx',
+      resourceSettings: {
+        local: {
+          culture: '<%=ResxCulture%>',
+            resxTimeStamp: '<%=ResxTimeStamp%>'
+        }
+      },
+      resources: {
+        method: 'GetResources',
+        paramName: null,
+        callback200: resxCallback200,
+        callbackError: null
+      }
+    };
 
-        dnn.utils.Localization(localizationOptions);
-    });
+    dnn.utils.Localization(localizationOptions);
+  });
 </script>

--- a/DNN Platform/Modules/ResourceManager/View.ascx.cs
+++ b/DNN Platform/Modules/ResourceManager/View.ascx.cs
@@ -19,6 +19,8 @@ using Dnn.Modules.ResourceManager.Components;
 using DnnExceptions = DotNetNuke.Services.Exceptions.Exceptions;
 using DotNetNuke.Common.Utilities;
 using Dnn.Modules.ResourceManager.Exceptions;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Dnn.Modules.ResourceManager
 {
@@ -66,6 +68,33 @@ namespace Dnn.Modules.ResourceManager
                     id = Null.NullInteger;
                 _gid = id;
                 return _gid.Value;
+            }
+        }
+        private string _extensionWhitelist;
+        public string ExtensionWhitelist
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_extensionWhitelist))
+                {
+                    _extensionWhitelist = FileManager.Instance.WhiteList.ToStorageString();
+                }
+                return _extensionWhitelist;
+            }
+        }
+        private string _validationCode;
+        public string ValidationCode
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_validationCode))
+                {
+                    var parameters = new List<object>() { ExtensionWhitelist.Split(',').Select(i => i.Trim()).ToList() };
+                    parameters.Add(PortalSettings.PortalId);
+                    parameters.Add(PortalSettings.UserInfo.UserID);
+                    _validationCode = ValidationUtils.ComputeValidationCode(parameters);
+                }
+                return _validationCode;
             }
         }
 


### PR DESCRIPTION
This fixes this module which wouldn't work on a recent DNN version due to changes we made to the API. It also adds a client-side check to prevent non-suspecting users from uploading a file they're not allowed to.