### PR TITLE
Fixed an issue with search results page rendering

### DIFF
--- a/DNN Platform/Website/Resources/Shared/scripts/dnn.searchBox.js
+++ b/DNN Platform/Website/Resources/Shared/scripts/dnn.searchBox.js
@@ -38,9 +38,9 @@
             var markup = '<div class="dnnSearchBox">';
             var advancedEnabled = this.options.showAdvanced && this.options.advancedId && $('#' + this.options.advancedId).length;
             if (advancedEnabled) {
-                markup += '<span class="dnnSearchBox_advanced_query" /><a class="dnnSearchBoxClearAdvanced"></a>';
+                markup += '<span class="dnnSearchBox_advanced_query"></span><a class="dnnSearchBoxClearAdvanced"></a>';
             }
-            markup += '<input id="' + this.options.id + '_input" type="text" autocomplete="off" aria-label="Search" />' +
+            markup += '<input id="' + this.options.id + '_input" type="text" autocomplete="off" aria-label="Search"></input>' +
                             '<a class="dnnSearchBoxClearText"></a>';
 
             markup += '<a class="dnnSearchButton"></a>';

--- a/DNN Platform/Website/Resources/Shared/scripts/dnn.searchBox.js
+++ b/DNN Platform/Website/Resources/Shared/scripts/dnn.searchBox.js
@@ -40,7 +40,7 @@
             if (advancedEnabled) {
                 markup += '<span class="dnnSearchBox_advanced_query"></span><a class="dnnSearchBoxClearAdvanced"></a>';
             }
-            markup += '<input id="' + this.options.id + '_input" type="text" autocomplete="off" aria-label="Search"></input>' +
+            markup += '<input id="' + this.options.id + '_input" type="text" autocomplete="off" aria-label="Search" />' +
                             '<a class="dnnSearchBoxClearText"></a>';
 
             markup += '<a class="dnnSearchButton"></a>';


### PR DESCRIPTION
Closes #3712

Due to jQuery 3.5.0 not supporting shortcuts to closing html tags in templates:
ie: `<div class="something" />` is no longer supported and needs to be rewritten as `<div class="something></div>`

This PR fixes those instances used in the jQuery code for the search results.