### PR TITLE
Change "Dotnetnuke Professional" to "DNN Platform" in 2 releasenotes.txt files

### DIFF
--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/releaseNotes.txt
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/releaseNotes.txt
@@ -1,1 +1,1 @@
-There are no release notes for this version of DotNetNuke Professional Edition
+There are no release notes for this version of DNN Platform.

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/releaseNotes.txt
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/releaseNotes.txt
@@ -1,1 +1,1 @@
-There are no release notes for this version of DotNetNuke Professional Edition
+There are no release notes for this version of DNN Platform.


### PR DESCRIPTION
Fixes #3739


## Summary
I changed the text "DotNetNuke Professional Edition" to "DNN Platform"