### PR TITLE
Adds action to automated versioning on RC

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -40,10 +40,8 @@ Provide any additional context that may be helpful in understanding and/or resol
 <!-- 
 Please add X in at least one of the boxes as appropriate. In order for an issue to be accepted, a developer needs to be able to reproduce the issue on a currently supported version. If you are looking for a workaround for an issue with an older version, please visit the forums at https://dnncommunity.org/forums
 -->
-* [ ] 10.0.0 alpha build
-* [ ]  9.6.1 alpha build
-* [ ]  9.6.0 latest supported release
-* [ ]  9.5.0 
+* [ ] 10.00.00 alpha build
+* [ ] 09.06.00 latest supported release
 
 ## Affected browser
 <!-- 

--- a/.github/workflows/updateVersions.yml
+++ b/.github/workflows/updateVersions.yml
@@ -1,0 +1,36 @@
+name: Update Versions
+on: create
+
+# Sets the manifest and other files version upon creation of a release branch
+jobs:
+  updateVersions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get the release branch version
+      if: ${{ github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/') }}
+      uses: valadas/get-release-branch-version@v1
+      id: branchVersion
+      
+    - name: Set versions
+      uses: valadas/set-dnn-manifest-versions@v1
+      with:
+        version: ${{ steps.branchVersion.outputs.manifestSafeVersionString }}
+        skipFile: './Build/Cake/unversionedManifests.txt'
+        includeSolutionInfo: true
+        includeIssueTemplates: true
+        includePackageJson: true
+        includeDnnReactCommon: true
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v2.7.1
+      with:
+        commit-message: Updates versions as per release candidate creation
+        title: Updates versions as per release candidate creation
+        body: This is a release managemnt task and we are self-approving it for that reason.
+        # A comma separated list of labels.
+        labels: 'Type: Build/Release'
+        # The pull request branch name.
+        branch: update-versions/patch
+        # The branch suffix type.
+        branch-suffix: short-commit-hash

--- a/Build/Cake/unversionedManifests.txt
+++ b/Build/Cake/unversionedManifests.txt
@@ -1,0 +1,4 @@
+DNN Platform/Components/Microsoft.*/**/*.dnn
+DNN Platform/Components/Newtonsoft/*.dnn
+DNN Platform/JavaScript Libraries/**/*.dnn
+Temp/**/*.dnn

--- a/Build/Cake/version.cake
+++ b/Build/Cake/version.cake
@@ -6,12 +6,7 @@ var buildId = EnvironmentVariable("BUILD_BUILDID") ?? "0";
 var buildNumber = "";
 var productVersion = "";
 
-var unversionedManifests = new string[] {
-  "DNN Platform/Components/Microsoft.*/**/*.dnn",
-  "DNN Platform/Components/Newtonsoft/*.dnn",
-  "DNN Platform/JavaScript Libraries/**/*.dnn",
-  "Temp/**/*.dnn"
-};
+var unversionedManifests = FileReadLines("./Build/Cake/unversionedManifests.txt");
 
 Task("BuildServerSetVersion")
   .IsDependentOn("SetVersion")


### PR DESCRIPTION
Upon creation of a release/x.x.x branch, updates the following:

- Updates all versions in Dnn manifests
- Updates AssemblyInfo
- Adds RC to issue template
- Updates versions in package.json files

This can only be tested upon creation of a release
branch so we need to merge this before release/9.6.1 in order to test it.

Example usage in a copy of this repository:
Action: https://github.com/valadas/Dnn.Platform.Copy/runs/654270580?check_suite_focus=true

PR generated: https://github.com/valadas/Dnn.Platform.Copy/pull/20
