### PR TITLE
Locks versions of image-actions

### DIFF
--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Compress Images
-        uses: calibreapp/image-actions@master
+        uses: calibreapp/image-actions@v1.1.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -9,6 +9,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Compress Images
-        uses: calibreapp/image-actions@v1.1.0
+        uses: calibreapp/image-actions@1.1.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Our images-action workflow was referencing the master branch of the actions repositories.

The recommendation for github actions is to reference tags and not branches because branches can change at any time and be unstable. This might be the reason why we got many PRs that included a ton of images minification in different PRs.

This PR locks us on the latest version without subjecting us to "nightly builds"