### PR TITLE
Limit rc action to run only on release branches

### DIFF
--- a/.github/workflows/updateVersions.yml
+++ b/.github/workflows/updateVersions.yml
@@ -5,11 +5,11 @@ on: create
 jobs:
   updateVersions:
     runs-on: ubuntu-latest
+    if: ${{ github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/') }}
     steps:
     - uses: actions/checkout@v2
 
     - name: Get the release branch version
-      if: ${{ github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/') }}
       uses: valadas/get-release-branch-version@v1
       id: branchVersion
       


### PR DESCRIPTION
An issue was found where the action would run on any branch.
By mistake the filter was on just one of the steps
instead of the whole action.

This PR fixes that and applies the filter to the whole action.

This is a release management task and we are self-approving it for that reason