### PR TITLE
Restores icons in language editor

### DIFF
--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/editLanguagePanel/resourceEditor/fullEditor.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/editLanguagePanel/resourceEditor/fullEditor.jsx
@@ -59,7 +59,7 @@ class FullEditor extends Component {
                                             data-role={button} 
                                             href='#'
                                             onClick={this.execCommand.bind(this, button)}
-                                            dangerouslySetInnerHTML={{ __html: require("./icons/" + button + ".svg") }}
+                                            dangerouslySetInnerHTML={{ __html: require("./icons/" + button + ".svg").default }}
                                             key={i}>
                                         </a>
                                     );


### PR DESCRIPTION
Closes #3754

There was a breaking change with I believe raw-loader or file-loader
or svg-loader or some such, we already had 2 other similar PRs for
this same issue in other areas.

After that dependency update, I think in 9.5.0,
we now need to add `.default` at the end of svg imports.

This fixes the same issue in the language resources editor.

I did a search to find if we missed this in other spots and did not find
any other instance.

![image](https://user-images.githubusercontent.com/6371568/81523095-cadaef80-931a-11ea-8b1b-39aaa120e5bc.png)

Also, as discussed in Slack, we would like to get this in 9.6.1-rc2 since we have so many contributors right now working on localization and this is a very small front-end only change.