### PR TITLE
Improves deprecation of search indexes

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -815,6 +815,7 @@
     <Compile Include="Services\Search\Entities\SortFields.cs" />
     <Compile Include="Services\Search\Entities\SearchStopWords.cs" />
     <Compile Include="Services\Search\Entities\SynonymsGroup.cs" />
+    <Compile Include="Services\Search\IndexingProviderBase.cs" />
     <Compile Include="Services\Search\Internals\Constants.cs" />
     <Compile Include="Services\Search\Internals\ISearchQueryStringParser.cs" />
     <Compile Include="Services\Search\Internals\LuceneResults.cs" />

--- a/DNN Platform/Library/Services/Search/IndexingProviderBase.cs
+++ b/DNN Platform/Library/Services/Search/IndexingProviderBase.cs
@@ -16,29 +16,16 @@ using DotNetNuke.Services.Search.Internals;
 
 namespace DotNetNuke.Services.Search
 {
-    /// <summary>A base class for search indexers</summary>
-    [Obsolete("Legacy Indexing base class -- Deprecated in DNN 7.1. Use 'IndexingProviderBase' instead.. Scheduled removal in v10.0.0.")]
-    public abstract class IndexingProvider
+    /// <summary>A base class for search indexers.</summary>
+    public abstract class IndexingProviderBase
     {
         /// <summary>This method must save search documents in batches to minimize memory usage instead of returning all documents at once.</summary>
-        /// <param name="portalId">ID of the portal for which to index items</param>
-        /// <param name="startDateLocal">Minimum modification date of items that need to be indexed</param>
-        /// <param name="indexer">A delegate function to send the collection of documents to for saving/indexing</param>
+        /// <param name="portalId">ID of the portal for which to index items.</param>
+        /// <param name="startDateLocal">Minimum modification date of items that need to be indexed.</param>
+        /// <param name="indexer">A delegate function to send the collection of documents to for saving/indexing.</param>
         /// <returns>The number of documents indexed</returns>
-        public virtual int IndexSearchDocuments(int portalId,
-            ScheduleHistoryItem schedule, DateTime startDateLocal, Action<IEnumerable<SearchDocument>> indexer)
-        {
-            throw new NotImplementedException();
-        }
-
-        [Obsolete("Deprecated in DNN 7.4.2 Use 'IndexSearchDocuments' instead for lower memory footprint during search.. Scheduled removal in v10.0.0.")]
-        public virtual IEnumerable<SearchDocument> GetSearchDocuments(int portalId, DateTime startDateLocal)
-        {
-            return Enumerable.Empty<SearchDocument>();
-        }
-
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
-        public abstract SearchItemInfoCollection GetSearchIndexItems(int portalId);
+        public abstract int IndexSearchDocuments(int portalId,
+            ScheduleHistoryItem schedule, DateTime startDateLocal, Action<IEnumerable<SearchDocument>> indexer);
 
         private const string TimePostfix = "UtcTime";
         private const string DataPostfix = "Data";
@@ -81,6 +68,18 @@ namespace DotNetNuke.Services.Search
         protected void SetLastCheckpointData(int portalId, int scheduleId, string data)
         {
             SearchHelper.Instance.SetIndexerCheckpointData(scheduleId, ScheduleItemSettingKey(portalId, DataPostfix), data);
+        }
+
+        [Obsolete("Deprecated in DNN 7.4.2 Use 'IndexSearchDocuments' instead for lower memory footprint during search.. Scheduled removal in v10.0.0.")]
+        public virtual IEnumerable<SearchDocument> GetSearchDocuments(int portalId, DateTime startDateLocal)
+        {
+            return Enumerable.Empty<SearchDocument>();
+        }
+
+        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
+        public virtual SearchItemInfoCollection GetSearchIndexItems(int portalId)
+        {
+            return null;
         }
 
         /// <summary>

--- a/DNN Platform/Library/Services/Search/ModuleIndexer.cs
+++ b/DNN Platform/Library/Services/Search/ModuleIndexer.cs
@@ -36,7 +36,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    public class ModuleIndexer : IndexingProvider
+    public class ModuleIndexer : IndexingProviderBase
     {
         #region Private Fields
 
@@ -281,109 +281,6 @@ namespace DotNetNuke.Services.Search
 				select mii.ModuleInfo;
 		}
 
-
-        #endregion
-
-        #region Obsolete Methods
-
-        /// -----------------------------------------------------------------------------
-        /// <summary>
-        /// LEGACY: Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.
-        /// Used for Legacy Search (ISearchable) 
-        /// 
-        /// GetSearchIndexItems gets the SearchInfo Items for the Portal
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        /// <param name="portalId">The Id of the Portal</param>
-        /// -----------------------------------------------------------------------------
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
-        public override SearchItemInfoCollection GetSearchIndexItems(int portalId)
-        {
-            var searchItems = new SearchItemInfoCollection();
-            var searchCollection = GetModuleList(portalId);
-            foreach (SearchContentModuleInfo scModInfo in searchCollection)
-            {
-                try
-                {
-                    var myCollection = scModInfo.ModControllerType.GetSearchItems(scModInfo.ModInfo);
-                    if (myCollection != null)
-                    {
-                        foreach (SearchItemInfo searchItem in myCollection)
-                        {
-                            searchItem.TabId = scModInfo.ModInfo.TabID;
-                        }
-
-                        Logger.Trace("ModuleIndexer: " + myCollection.Count + " search documents found for module [" + scModInfo.ModInfo.DesktopModule.ModuleName + " mid:" + scModInfo.ModInfo.ModuleID + "]");
-
-                        searchItems.AddRange(myCollection);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Exceptions.Exceptions.LogException(ex);
-                }
-            }
-            return searchItems;
-        }
-
-        /// -----------------------------------------------------------------------------
-        /// <summary>
-        /// LEGACY: Deprecated in DNN 7.1. Use 'GetSearchModules' instead.
-        /// Used for Legacy Search (ISearchable) 
-        /// 
-        /// GetModuleList gets a collection of SearchContentModuleInfo Items for the Portal
-        /// </summary>
-        /// <remarks>
-        /// Parses the Modules of the Portal, determining whetehr they are searchable.
-        /// </remarks>
-        /// <param name="portalId">The Id of the Portal</param>
-        /// -----------------------------------------------------------------------------
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'GetSearchModules' instead.. Scheduled removal in v10.0.0.")]
-        protected SearchContentModuleInfoCollection GetModuleList(int portalId)
-        {
-            var results = new SearchContentModuleInfoCollection();
-            var arrModules = ModuleController.Instance.GetSearchModules(portalId);
-            var businessControllers = new Hashtable();
-            var htModules = new Hashtable();
-            
-            foreach (var module in arrModules.Cast<ModuleInfo>().Where(module => !htModules.ContainsKey(module.ModuleID)))
-            {
-                try
-                {
-                    //Check if the business controller is in the Hashtable
-                    var controller = businessControllers[module.DesktopModule.BusinessControllerClass];
-                    if (!String.IsNullOrEmpty(module.DesktopModule.BusinessControllerClass))
-                    {
-                        //If nothing create a new instance
-                        if (controller == null)
-                        {
-                            //Add to hashtable
-                            controller = Reflection.CreateObject(module.DesktopModule.BusinessControllerClass, module.DesktopModule.BusinessControllerClass);                              
-                            businessControllers.Add(module.DesktopModule.BusinessControllerClass, controller);
-                        }                            
-                        //Double-Check that module supports ISearchable
-
-                        //Check if module inherits from ModuleSearchBase                        
-                        if (controller is ISearchable && !(controller is ModuleSearchBase))
-                        {
-                            var contentInfo = new SearchContentModuleInfo {ModControllerType = (ISearchable) controller, ModInfo = module};
-                            results.Add(contentInfo);
-                        }                           
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex);
-                    ThrowLogError(module, ex);
-                }
-                finally
-                {
-                    htModules.Add(module.ModuleID, module.ModuleID);
-                }
-            }
-            return results;
-        }
 
         #endregion
 

--- a/DNN Platform/Library/Services/Search/SearchEngine.cs
+++ b/DNN Platform/Library/Services/Search/SearchEngine.cs
@@ -172,7 +172,7 @@ namespace DotNetNuke.Services.Search
         /// </summary>
         /// <param name="indexer"></param>
         /// -----------------------------------------------------------------------------
-        private int GetAndStoreSearchDocuments(IndexingProvider indexer)
+        private int GetAndStoreSearchDocuments(IndexingProviderBase indexer)
         {
             IList<SearchDocument> searchDocs;
             var portals = PortalController.Instance.GetPortals();
@@ -296,7 +296,7 @@ namespace DotNetNuke.Services.Search
         /// <param name="indexer">The Index Provider that will index the content of the portal</param>
         /// -----------------------------------------------------------------------------
         [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
-        protected SearchItemInfoCollection GetContent(IndexingProvider indexer)
+        protected SearchItemInfoCollection GetContent(IndexingProviderBase indexer)
         {
             var searchItems = new SearchItemInfoCollection();
             var portals = PortalController.Instance.GetPortals();

--- a/DNN Platform/Library/Services/Search/TabIndexer.cs
+++ b/DNN Platform/Library/Services/Search/TabIndexer.cs
@@ -30,7 +30,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    public class TabIndexer : IndexingProvider
+    public class TabIndexer : IndexingProviderBase
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(TabIndexer));
         private static readonly int TabSearchTypeId = SearchHelper.Instance.GetSearchTypeByName("tab").SearchTypeId;
@@ -126,12 +126,6 @@ namespace DotNetNuke.Services.Search
             SetLocalTimeOfLastIndexedItem(portalId, scheduleId, searchDocuments.Last().ModifiedTimeUtc);
             searchDocuments.Clear();
             return total;
-        }
-
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
-        public override SearchItemInfoCollection GetSearchIndexItems(int portalId)
-        {
-            return null;
         }
     }
 }

--- a/DNN Platform/Library/Services/Search/UserIndexer.cs
+++ b/DNN Platform/Library/Services/Search/UserIndexer.cs
@@ -40,7 +40,7 @@ namespace DotNetNuke.Services.Search
     /// <remarks>
     /// </remarks>
     /// -----------------------------------------------------------------------------
-    public class UserIndexer : IndexingProvider
+    public class UserIndexer : IndexingProviderBase
     {
         internal const string UserIndexResetFlag = "UserIndexer_ReIndex";
         internal const string ValueSplitFlag = "$$$";
@@ -408,16 +408,6 @@ namespace DotNetNuke.Services.Search
         {
             var schema = reader.GetSchemaTable();
             return schema != null && schema.Select("ColumnName = '" + col + "'").Length > 0;
-        }
-
-        #endregion
-
-        #region Obsoleted Methods
-
-        [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
-        public override SearchItemInfoCollection GetSearchIndexItems(int portalId)
-        {
-            return null;
         }
 
         #endregion


### PR DESCRIPTION
Closes #3776

Please read the issue during review. This is what comes to mind, but if there are better ideas, I am open to them :)

Basically my idea is to deprecate the whole base class, created a new copy of it which has the recommended method enforced and the deprecated method optional. That way 3rd parties will be able to change class now and be ready BEFORE the required method is removed.