### PR TITLE
Fix weird shorting in site settings PB heading

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PersonaBarPageHeader/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PersonaBarPageHeader/index.jsx
@@ -19,7 +19,7 @@ const hotspotStyles = {
 
 const PersonaBarPageHeader = ({ title, children, tooltip, titleMaxWidth, titleCharLimit }) => {
 
-    titleCharLimit = titleCharLimit ? titleCharLimit : 20;
+    titleCharLimit = titleCharLimit ? titleCharLimit : 50;
 
     const renderTitle = () => {
         switch (true) {

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/App.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/App.jsx
@@ -141,6 +141,7 @@ class App extends Component {
 
     render() {
         const {props, state} = this;
+        const localeTitleCharLimit = 50;
         return (
             <div className="siteSettings-app">
                 <SiteLanguageSelector
@@ -151,7 +152,7 @@ class App extends Component {
                     backToReferrerFunc={state.backToReferrerFunc}
                 />
                 <PersonaBarPage isOpen={props.selectedPage === 0}>
-                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")}>
+                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")} titleCharLimit={localeTitleCharLimit}>
                     </PersonaBarPageHeader>
                     <Body
                         portalId={state.portalId}
@@ -168,7 +169,7 @@ class App extends Component {
                 </PersonaBarPage>
 
                 <PersonaBarPage isOpen={props.selectedPage === Pages.HtmlEditorManager}>
-                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")}>
+                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")} titleCharLimit={localeTitleCharLimit}>
                     </PersonaBarPageHeader>
                     {props.selectedPage === Pages.HtmlEditorManager &&
                         <HtmlEditorManager portalId={state.portalId} closeHtmlEditorManager={this.closePersonaBarPage.bind(this)} />

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/App.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/App.jsx
@@ -141,7 +141,6 @@ class App extends Component {
 
     render() {
         const {props, state} = this;
-        const localeTitleCharLimit = 50;
         return (
             <div className="siteSettings-app">
                 <SiteLanguageSelector
@@ -152,7 +151,7 @@ class App extends Component {
                     backToReferrerFunc={state.backToReferrerFunc}
                 />
                 <PersonaBarPage isOpen={props.selectedPage === 0}>
-                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")} titleCharLimit={localeTitleCharLimit}>
+                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")}>
                     </PersonaBarPageHeader>
                     <Body
                         portalId={state.portalId}
@@ -169,7 +168,7 @@ class App extends Component {
                 </PersonaBarPage>
 
                 <PersonaBarPage isOpen={props.selectedPage === Pages.HtmlEditorManager}>
-                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")} titleCharLimit={localeTitleCharLimit}>
+                    <PersonaBarPageHeader title={resx.get("nav_SiteSettings")}>
                     </PersonaBarPageHeader>
                     {props.selectedPage === Pages.HtmlEditorManager &&
                         <HtmlEditorManager portalId={state.portalId} closeHtmlEditorManager={this.closePersonaBarPage.bind(this)} />


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

Fixes #3690


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Extend PersonaBarPageHeader component titleCharLimit yo better suit localized versions, 50 seems to be better here than component default 20.

![3690--fix-pb-heading-locale-shorting](https://user-images.githubusercontent.com/2019600/82793087-05936a80-9e79-11ea-87b2-4b9cd21aee9b.PNG)
