### PR TITLE
Unify CLS Compliance and Com Visibility

### DIFF
--- a/DNN Platform/Admin Modules/Dnn.Modules.Console/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Console/Properties/AssemblyInfo.cs
@@ -12,10 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Dnn.Modules.Console")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("A7C9F51B-63D8-4D81-B59D-A5B78B7E9A7C")]

--- a/DNN Platform/Admin Modules/Dnn.Modules.ModuleCreator/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Admin Modules/Dnn.Modules.ModuleCreator/Properties/AssemblyInfo.cs
@@ -12,10 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Dnn.Modules.ModuleCreator")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("151DE947-22E1-449E-8BAA-050AFE397E7C")]

--- a/DNN Platform/Connectors/Azure/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Connectors/Azure/Properties/AssemblyInfo.cs
@@ -2,11 +2,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // 
-﻿#region Usings
+#region Usings
 using System;
 using System.Reflection;
 #endregion
 
 [assembly: AssemblyTitle("DotNetNuke")]
 
-[assembly: CLSCompliant(true)]

--- a/DNN Platform/Controls/CountryListBox/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Controls/CountryListBox/Properties/AssemblyInfo.cs
@@ -14,7 +14,6 @@ using System.Web.UI;
 [assembly: AssemblyTitle("DotNetNuke")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
 
-[assembly: CLSCompliant(true)]
 [assembly: Guid("3D57E77F-F723-48BB-A58C-3FAB63C562D4")]
 
 [assembly: TagPrefix("DotNetNuke.UI.WebControls.CountryListBox", "DotNetNuke")]

--- a/DNN Platform/Dnn.AuthServices.Jwt/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Properties/AssemblyInfo.cs
@@ -18,11 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3b2fa1d9-ec7d-4cec-8ff5-a7700cf5cb40")]
 

--- a/DNN Platform/DotNetNuke.Instrumentation/Properties/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/Properties/AssemblyInfo.cs
@@ -11,12 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Instrumentation")]
 [assembly: AssemblyDescription("DotNetNuke's Instrumentation Framework")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]     
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("cb8f5692-4ea1-4397-85ec-094334605289")]

--- a/DNN Platform/DotNetNuke.Web.Client/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/AssemblyInfo.cs
@@ -13,9 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Web.Client")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
 
-[assembly: CLSCompliant(false)]
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("cc3cf175-3d9b-4176-9808-6185851a13f5")]
 

--- a/DNN Platform/DotNetNuke.Web.Deprecated/Properties/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/Properties/AssemblyInfo.cs
@@ -20,8 +20,6 @@ using System.Web.UI;
 
 [assembly: AssemblyTitle("DotNetNuke.Web.Deprecated")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
-[assembly: CLSCompliant(true)]
-[assembly: ComVisible(false)]
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("a5e0864a-df43-4b6a-8e5f-3ba6b368d876")]

--- a/DNN Platform/DotNetNuke.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Properties/AssemblyInfo.cs
@@ -14,11 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b1e2ff0c-06b0-4e4d-a828-a7cab3817220")]
 

--- a/DNN Platform/DotNetNuke.Web.Razor/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/AssemblyInfo.cs
@@ -17,7 +17,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("DotNetNuke.Web.Razor")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
-[assembly: ComVisible(false)]
 
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/DNN Platform/DotNetNuke.Web/Properties/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Web/Properties/AssemblyInfo.cs
@@ -19,8 +19,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("DotNetNuke.Web")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
-[assembly: CLSCompliant(true)]
-[assembly: ComVisible(false)]
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("99d0e26d-a924-41d2-a195-33496a3f48ad")]

--- a/DNN Platform/DotNetNuke.Website.Deprecated/Properties/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Website.Deprecated/Properties/AssemblyInfo.cs
@@ -20,8 +20,6 @@ using System.Web.UI;
 
 [assembly: AssemblyTitle("DotNetNuke.Website.Deprecated")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
-[assembly: CLSCompliant(false)]
-[assembly: ComVisible(false)]
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("4B693EF0-E5D9-4647-B9F1-CD057D8DC011")]

--- a/DNN Platform/HttpModules/Properties/AssemblyInfo.cs
+++ b/DNN Platform/HttpModules/Properties/AssemblyInfo.cs
@@ -14,7 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.HttpModules")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
 
-[assembly: CLSCompliant(true)]
 [assembly: Guid("7FF35751-D6A3-4DA0-A5E7-2F1AB026832B")]
 
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Core")]

--- a/DNN Platform/Library/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Library/Properties/AssemblyInfo.cs
@@ -19,8 +19,6 @@ using DotNetNuke.Application;
 
 [assembly: AssemblyTitle("DotNetNuke")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
-[assembly: CLSCompliant(true)]
-
 [assembly: AssemblyStatus(ReleaseMode.Alpha)]
 
 // Allow internal variables to be visible to testing projects

--- a/DNN Platform/Modules/CoreMessaging/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Modules/CoreMessaging/Properties/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Modules.CoreMessaging")]
 [assembly: AssemblyDescription("Core Messaging Module")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("202668dd-13b4-4cdf-969b-a63dd9bc92cb")]

--- a/DNN Platform/Modules/DDRMenu/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Modules/DDRMenu/Properties/AssemblyInfo.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("DotNetNuke.Modules.DDRMenu")]
 [assembly: AssemblyDescription("DDR Menu for Open Source Web Application Framework")]
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3b7331d9-4c26-4936-8198-be5410591f8c")]

--- a/DNN Platform/Modules/DigitalAssets/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Modules/DigitalAssets/Properties/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Modules.DigitalAssets")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5ef01dd5-84a1-49f3-9232-067440288455")]

--- a/DNN Platform/Modules/Groups/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Modules/Groups/Properties/AssemblyInfo.cs
@@ -13,5 +13,3 @@ using System.Runtime.InteropServices;
 //
 [assembly: AssemblyTitle("DotNetNuke Corporation Social Groups")]
 [assembly: AssemblyDescription("A DotNetNuke Module from DotNetNuke Corporation Software")]
-[assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]

--- a/DNN Platform/Modules/HTML/AssemblyInfo.cs
+++ b/DNN Platform/Modules/HTML/AssemblyInfo.cs
@@ -19,7 +19,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("DotNetNuke.Modules.Html")]
 [assembly: AssemblyDescription("HTML Module for Open Source Web Application Framework")]
-[assembly: ComVisible(false)]
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("334e9cee-0d47-4d70-924b-b5098a3432cb")]

--- a/DNN Platform/Modules/HtmlEditorManager/AssemblyInfo.cs
+++ b/DNN Platform/Modules/HtmlEditorManager/AssemblyInfo.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("DotNetNuke Html Editor Management")]
 [assembly: AssemblyDescription("DotNetNuke Html Editor Management")]
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c0277e5b-480d-45bf-80ab-6b9f85dad7e1")]

--- a/DNN Platform/Modules/Journal/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Modules/Journal/Properties/AssemblyInfo.cs
@@ -13,5 +13,3 @@ using System.Runtime.InteropServices;
 //
 [assembly: AssemblyTitle("DotNetNuke CorporationJournal")]
 [assembly: AssemblyDescription("A DotNetNuke Module from DotNetNuke Corporation Software")]
-[assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]

--- a/DNN Platform/Modules/MemberDirectory/AssemblyInfo.cs
+++ b/DNN Platform/Modules/MemberDirectory/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("MemberDirectory")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("60bd6828-ffd8-4bcd-bdc8-63de729d1613")]

--- a/DNN Platform/Modules/RazorHost/AssemblyInfo.cs
+++ b/DNN Platform/Modules/RazorHost/AssemblyInfo.cs
@@ -17,7 +17,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("DotNetNuke.Modules.RazorHostView")]
 [assembly: AssemblyDescription("Razor Host Module")]
-[assembly: ComVisible(false)]
 
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Properties/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Authentication.Facebook")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5daaeabb-45e5-4a06-8514-fe652db2b8e2")]

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Properties/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Authentication.Google")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d026234c-38c4-486a-bfe0-12fd42a1af28")]

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Properties/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Authentication.LiveConnect")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("292b57dc-1fed-4876-b695-f649e95380e4")]

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Properties/AssemblyInfo.cs
@@ -11,10 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("DotNetNuke.Authentication.Twitter")]
 [assembly: AssemblyDescription("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("649b8c27-7dce-4578-b133-ac4b04752fdc")]

--- a/DNN Platform/Providers/FolderProviders/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Providers/FolderProviders/Properties/AssemblyInfo.cs
@@ -8,5 +8,3 @@ using System.Reflection;
 #endregion
 
 [assembly: AssemblyTitle("DotNetNuke")]
-
-[assembly: CLSCompliant(false)]

--- a/DNN Platform/Syndication/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Syndication/Properties/AssemblyInfo.cs
@@ -13,4 +13,3 @@ using System.Reflection;
 [assembly: AssemblyDescription("")]
 
 [assembly: AssemblyDelaySign(false)]
-[assembly: CLSCompliant(true)]

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/Properties/AssemblyInfo.cs
@@ -18,11 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b5980c04-f368-4b30-8ec9-5c2b17a581f2")]
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Authentication/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Authentication/AssemblyInfo.cs
@@ -18,12 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("DotNetNuke")]
 
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("d75fde76-1008-42ce-82ab-1f00c1dab8ef")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/AssemblyInfo.cs
@@ -18,12 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("DotNetNuke")]
 
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("72dae17b-530c-4613-b492-1e9c977d97ee")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/AssemblyInfo.cs
@@ -18,12 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("DotNetNuke")]
 
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("87fa9a95-fc7c-43d9-b548-a43988fcd5c1")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/AssemblyInfo.cs
@@ -18,12 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("DotNetNuke")]
 
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("64515746-cc3b-4467-b393-55410c33b5a3")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/Properties/AssemblyInfo.cs
@@ -17,13 +17,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("DotNetNuke is copyright 2002-2018 by Dnn Corporation. All Rights Reserved.")]
 [assembly: AssemblyTrademark("DotNetNuke")]
 
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("87fa9a95-fc7c-43d9-b548-a43988fcd5c1")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.UI/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.UI/AssemblyInfo.cs
@@ -18,12 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("DotNetNuke")]
 
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("f6b15e10-1d6a-4626-b355-fd0227da78ff")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/Properties/AssemblyInfo.cs
@@ -18,11 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3c8cc79d-e28d-47c5-8292-484249cea625")]
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/AssemblyInfo.cs
@@ -17,13 +17,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("DotNetNuke is copyright 2002-2018 by DotNetNuke Corporation. All Rights Reserved.")]
 [assembly: AssemblyTrademark("DotNetNuke")]
 
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("f9904f9b-176f-469d-a5fd-f3011b2cc52e")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Properties/AssemblyInfo.cs
@@ -18,11 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e67e51dd-f18e-4213-8a80-6f63e9b7df32")]
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Properties/AssemblyInfo.cs
@@ -18,11 +18,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ed0826aa-771d-489a-a4eb-d06a6abb58d0")]
 

--- a/DNN Platform/Website/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Website/Properties/AssemblyInfo.cs
@@ -17,7 +17,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("DotNetNuke.Website")]
 [assembly: AssemblyDescription("Open Source Web Application Framework")]
-[assembly: ComVisible(false)]
 
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Properties/AssemblyInfo.cs
@@ -13,11 +13,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("859C93DE-7107-4F63-9631-B8499A2263BB")]
 

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.Library/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.Library/Properties/AssemblyInfo.cs
@@ -15,11 +15,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8FF8E77F-CAF7-461A-8BC1-CB11E5C425E7")]

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // 
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -14,9 +14,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Dnn.EditBar.UI")]
 [assembly: AssemblyDescription("Dnn.EditBar.UI")]
-[assembly: CLSCompliant(true)]
-
-[assembly: ComVisible(false)]
 
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Properties/AssemblyInfo.cs
@@ -15,11 +15,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("8FF8E77F-CAF7-461A-8BC1-CB11E5C425E7")]

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Properties/AssemblyInfo.cs
@@ -14,9 +14,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Dnn.PersonaBar.UI")]
 [assembly: AssemblyDescription("Dnn.PersonaBar.UI")]
-[assembly: CLSCompliant(true)]
-
-[assembly: ComVisible(false)]
 
 //The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/Properties/AssemblyInfo.cs
@@ -12,10 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("05515510-9979-4424-8d0a-647f32a25fe7")]

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Properties/AssemblyInfo.cs
@@ -12,10 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a64708ef-4972-48a3-b7b9-6b65e47efe27")]

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Users.Tests/Properties/AssemblyInfo.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Users.Tests/Properties/AssemblyInfo.cs
@@ -6,5 +6,4 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Dnn.PersonaBar.Users.Tests")]
-[assembly: ComVisible(false)]
 [assembly: Guid("15506c01-a730-46b9-8571-99c20226aae6")]

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -4,7 +4,9 @@
 // 
 #region Usings
 
+using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 #endregion
 
@@ -14,6 +16,8 @@ using System.Reflection;
 
 // Review the values of the assembly attributes
 
+[assembly: CLSCompliant(false)]
+[assembly: ComVisible(false)]
 [assembly: AssemblyCompany(".NET Foundation")]
 [assembly: AssemblyProduct("https://dnncommunity.org")]
 [assembly: AssemblyCopyright("DNN Platform is copyright 2002-2020 by .NET Foundation. All Rights Reserved.")]


### PR DESCRIPTION
The CLSCompliance and ComVisible attributes are all over the place in the project. Because I was experiencing build issues locally, I decided to clean this up. Removing it from the individual AssemblyInfo files and putting it in the global SolutionInfo.cs.