### PR TITLE
Fixes a null reference exception with ISearchable

### DIFF
--- a/DNN Platform/Library/Services/Search/IndexingProviderBase.cs
+++ b/DNN Platform/Library/Services/Search/IndexingProviderBase.cs
@@ -79,7 +79,7 @@ namespace DotNetNuke.Services.Search
         [Obsolete("Legacy Search (ISearchable) -- Deprecated in DNN 7.1. Use 'IndexSearchDocuments' instead.. Scheduled removal in v10.0.0.")]
         public virtual SearchItemInfoCollection GetSearchIndexItems(int portalId)
         {
-            return null;
+            return new SearchItemInfoCollection();
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #3805

This is a followup on PR #3777

For context the deprecated class had the deprecated method required and the recommended one not required. PR #3777 deprecated the whole class for easier migration and reversed the required vs the non-required methods so developers can implement the new way without hacks or build warnings.

In that PR, a mistake was made on the deprecated method where we default to return null, but that caused a null reference exception on old modules. This PR replaces that return for an empty collection, which solves the same goal without an exception.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
