### PR TITLE
Fix random replacement of http with https in resources (issue #3599)

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -699,15 +699,19 @@ namespace DotNetNuke.Entities.Portals
             var isPublic = true;
             switch (lowerPropertyName)
             {
+                case "scheme":
+                    propertyNotFound = false;
+                    result = SSLEnabled ? "https" : "http";
+                    break;
                 case "url":
                     propertyNotFound = false;
                     result = PropertyAccess.FormatString(PortalAlias.HTTPAlias, format);
                     break;
-                case "fullurl": //return portal alias with protocol
+                case "fullurl": //return portal alias with protocol - note this depends on HttpContext
                     propertyNotFound = false;
                     result = PropertyAccess.FormatString(Globals.AddHTTP(PortalAlias.HTTPAlias), format);
                     break;
-                case "passwordreminderurl": //if regsiter page defined in portal settings, then get that page url, otherwise return home page.
+                case "passwordreminderurl": //if regsiter page defined in portal settings, then get that page url, otherwise return home page. - note this depends on HttpContext
                     propertyNotFound = false;
                     var reminderUrl = Globals.AddHTTP(PortalAlias.HTTPAlias);
                     if (RegisterTabId > Null.NullInteger)

--- a/DNN Platform/Library/Services/Localization/LocalizationProvider.cs
+++ b/DNN Platform/Library/Services/Localization/LocalizationProvider.cs
@@ -80,18 +80,7 @@ namespace DotNetNuke.Services.Localization
                 Logger.WarnFormat("Missing localization key. key:{0} resFileRoot:{1} threadCulture:{2} userlan:{3}", key, resourceFileRoot, Thread.CurrentThread.CurrentUICulture, language);
             }
 
-            return string.IsNullOrEmpty(resourceValue) ? string.Empty : RemoveHttpUrlsIfSiteisSSLEnabled(portalSettings, resourceValue);
-        }
-
-        private string RemoveHttpUrlsIfSiteisSSLEnabled(PortalSettings portalSettings, string resourceValue)
-        {
-
-            if (portalSettings != null && (portalSettings.SSLEnabled || portalSettings.SSLEnforced))
-            {
-                resourceValue = resourceValue.Replace(@"http:", @"https:");
-            }
-
-            return resourceValue;
+            return string.IsNullOrEmpty(resourceValue) ? string.Empty : resourceValue;
         }
 
         /// <summary>


### PR DESCRIPTION
An earlier "fix" for urls in emails added a blanket replace on each and every resource being retrieved. This is not just incorrect (as it also affects resources that should not be touched), it is also a performance hit.

This PR rolls back the fix and adds a "scheme" token to the portal settings. The [portal:scheme] token will resolve to either "https" or "http" depending on SSLEnabled for the portal. It is not used in any email in the framework currently, but if someone needs this in a template, it can be used.

Note that using the scheme token looks at the entire portal, so won't be a solution for those with mixed http/https situations. The [portal:fullurl] uses the current page's SSL setting, but obviously depends on context and so was never meant for emails.