### PR TITLE
Use newer logic to send Host SMTP test emails

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -126,8 +126,9 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                var mailFrom = Host.HostEmail;
-                var mailTo = request.SmtpServerMode == "h" ? Host.HostEmail : PortalSettings.UserInfo.Email;
+                var smtpHostMode = request.SmtpServerMode == "h";
+                var mailFrom = smtpHostMode ? Host.HostEmail : PortalSettings.Email;
+                var mailTo = UserInfo.Email;
 
                 var errMessage = Mail.SendMail(mailFrom,
                     mailTo,


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3813 
For Reference: logic was added here but only administrators got the fix... so this would be in addition to the following PR https://github.com/dnnsoftware/Dnn.Platform/pull/3237
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

In the above referenced PR the logic was created to send emails to the user using host or portal while logged in as administrator.

A second controller is used for host accounts which also needed the same logic to allow testing different portals SMTP settings while logged in as a host similar to how you can while logged in as an administrator currently.  

The same logic needs added to the host users SMTP test method that is being used for administrator SMTP tests as it is still utilizing the previous logic for the Send From and To variables that get set.

This PR puts the same administrator SMTP test logic in the host method.

Additional Context:
I will work on making sure documentation supports this over the next week if this is accepted.

I thought this worked before but again maybe it was me testing logged in as an administrator, logged in as host currently only tests Host SMTP Settings even when Site SMTP Server Settings  is set to Portal.

One issue that still remains is error handling a blank Host Email in Host SMTP Settings...

Thanks for the support hope this helps!