### PR TITLE
Replace DNN Corp copyright in Blank Website and Default Website templates with generic copyright

### DIFF
--- a/DNN Platform/Website/Portals/_default/Blank Website.template.en-US.resx
+++ b/DNN Platform/Website/Portals/_default/Blank Website.template.en-US.resx
@@ -124,7 +124,7 @@
     <value>en-US</value>
   </data>
   <data name="Setting.FooterText.Text" xml:space="preserve">
-    <value>Copyright [year] by DNN Corp</value>
+    <value>Copyright [year] by My Website</value>
   </data>
   <data name="PortalDescription.Text" xml:space="preserve">
     <value>Blank Template</value>

--- a/DNN Platform/Website/Portals/_default/Default Website.template.en-US.resx
+++ b/DNN Platform/Website/Portals/_default/Default Website.template.en-US.resx
@@ -130,7 +130,7 @@
     <value>en-US</value>
   </data>
   <data name="Setting.FooterText.Text" xml:space="preserve">
-    <value>Copyright [year] by DNN Corp</value>
+    <value>Copyright [year] by My Website</value>
   </data>
   <data name="Tab.404ErrorPage..Module.Content.Text" xml:space="preserve">
     <value>Sorry, the page you are looking for cannot be found and might have been removed, had its name changed, or is temporarily unavailable. It is recommended that you start again from the homepage. Feel free to contact us if the problem persists or if you definitely cannot find what you’re looking for.</value>


### PR DESCRIPTION
## Summary
Replaces `DNN Corp` in copyright for **Blank Website** and **Default Website** templates with `My Website` to make this more generic and user friendly.

Resolves #3715 