### PR TITLE
Implement a Token Provider interface

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
@@ -1,10 +1,42 @@
-﻿using DotNetNuke.Services.Tokens;
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Web.Common.Internal
 {
-using System;
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Web;
+    using System.Web.Security;
+    using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.ComponentModel;
+    using DotNetNuke.Data;
+    using DotNetNuke.Framework;
+    using DotNetNuke.HttpModules.DependencyInjection;
+    using DotNetNuke.Instrumentation;
+    using DotNetNuke.Modules.HTMLEditorProvider;
+    using DotNetNuke.Modules.NavigationProvider;
+    using DotNetNuke.Security.Cookies;
+    using DotNetNuke.Security.Membership;
+    using DotNetNuke.Security.Permissions;
+    using DotNetNuke.Security.Profile;
+    using DotNetNuke.Security.Roles;
+    using DotNetNuke.Services.Cache;
+    using DotNetNuke.Services.ClientCapability;
+    using DotNetNuke.Services.Cryptography;
+    using DotNetNuke.Services.FileSystem;
+    using DotNetNuke.Services.Installer.Blocker;
+    using DotNetNuke.Services.Log.EventLog;
+    using DotNetNuke.Services.ModuleCache;
+    using DotNetNuke.Services.OutputCache;
+    using DotNetNuke.Services.Scheduling;
+    using DotNetNuke.Services.Search;
+    using DotNetNuke.Services.Search.Internals;
+    using DotNetNuke.Services.Sitemap;
+    using DotNetNuke.Services.Tokens;
+    using DotNetNuke.Services.Url.FriendlyUrl;
+
     /// <summary>
     /// DotNetNuke Http Application. It will handle Start, End, BeginRequest, Error event for whole application.
     /// </summary>
@@ -213,35 +245,4 @@ using System;
             return InstallBlocker.Instance.IsInstallInProgress();
         }
     }
-using System.Linq;
-using System.Net;
-using System.Web;
-using System.Web.Security;
-using DotNetNuke.Common;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.ComponentModel;
-using DotNetNuke.Data;
-using DotNetNuke.Framework;
-using DotNetNuke.HttpModules.DependencyInjection;
-using DotNetNuke.Instrumentation;
-using DotNetNuke.Modules.HTMLEditorProvider;
-using DotNetNuke.Modules.NavigationProvider;
-using DotNetNuke.Security.Cookies;
-using DotNetNuke.Security.Membership;
-using DotNetNuke.Security.Permissions;
-using DotNetNuke.Security.Profile;
-using DotNetNuke.Security.Roles;
-using DotNetNuke.Services.Cache;
-using DotNetNuke.Services.ClientCapability;
-using DotNetNuke.Services.Cryptography;
-using DotNetNuke.Services.FileSystem;
-using DotNetNuke.Services.Installer.Blocker;
-using DotNetNuke.Services.Log.EventLog;
-using DotNetNuke.Services.ModuleCache;
-using DotNetNuke.Services.OutputCache;
-using DotNetNuke.Services.Scheduling;
-using DotNetNuke.Services.Search;
-using DotNetNuke.Services.Search.Internals;
-using DotNetNuke.Services.Sitemap;
-using DotNetNuke.Services.Url.FriendlyUrl;
 }

--- a/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
@@ -1,48 +1,16 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿using DotNetNuke.Services.Tokens;
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Web.Common.Internal
 {
-    using System;
-    using System.Linq;
-    using System.Net;
-    using System.Web;
-    using System.Web.Security;
-
-    using DotNetNuke.Common;
-    using DotNetNuke.Common.Utilities;
-    using DotNetNuke.ComponentModel;
-    using DotNetNuke.Data;
-    using DotNetNuke.Framework;
-    using DotNetNuke.HttpModules.DependencyInjection;
-    using DotNetNuke.Instrumentation;
-    using DotNetNuke.Modules.HTMLEditorProvider;
-    using DotNetNuke.Modules.NavigationProvider;
-    using DotNetNuke.Security.Cookies;
-    using DotNetNuke.Security.Membership;
-    using DotNetNuke.Security.Permissions;
-    using DotNetNuke.Security.Profile;
-    using DotNetNuke.Security.Roles;
-    using DotNetNuke.Services.Cache;
-    using DotNetNuke.Services.ClientCapability;
-    using DotNetNuke.Services.Cryptography;
-    using DotNetNuke.Services.FileSystem;
-    using DotNetNuke.Services.Installer.Blocker;
-    using DotNetNuke.Services.Log.EventLog;
-    using DotNetNuke.Services.ModuleCache;
-    using DotNetNuke.Services.OutputCache;
-    using DotNetNuke.Services.Scheduling;
-    using DotNetNuke.Services.Search;
-    using DotNetNuke.Services.Search.Internals;
-    using DotNetNuke.Services.Sitemap;
-    using DotNetNuke.Services.Url.FriendlyUrl;
-
+using System;
     /// <summary>
     /// DotNetNuke Http Application. It will handle Start, End, BeginRequest, Error event for whole application.
     /// </summary>
     public class DotNetNukeHttpApplication : HttpApplication
     {
-        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(DotNetNukeHttpApplication));
+    	private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof (DotNetNukeHttpApplication));
 
         private static readonly string[] Endings =
             {
@@ -71,85 +39,6 @@ namespace DotNetNuke.Web.Common.Internal
                     ComponentFactory.RegisterComponentInstance<TAbstract>(name, new TConcrete());
                 }
             }
-        }
-
-        private static bool IsInstallOrUpgradeRequest(HttpRequest request)
-        {
-            var url = request.Url.LocalPath.ToLowerInvariant();
-
-            return url.EndsWith("webresource.axd")
-                   || url.EndsWith("scriptresource.axd")
-                   || url.EndsWith("captcha.aspx")
-                   || url.Contains("upgradewizard.aspx")
-                   || url.Contains("installwizard.aspx")
-                   || url.EndsWith("install.aspx");
-        }
-
-        private void Application_Error(object sender, EventArgs eventArgs)
-        {
-            // Code that runs when an unhandled error occurs
-            if (HttpContext.Current != null)
-            {
-                // Get the exception object.
-                Logger.Trace("Dumping all Application Errors");
-                foreach (Exception exc in HttpContext.Current.AllErrors)
-                {
-                    Logger.Fatal(exc);
-                }
-
-                Logger.Trace("End Dumping all Application Errors");
-            }
-        }
-
-        private void Application_Start(object sender, EventArgs eventArgs)
-        {
-            Logger.InfoFormat("Application Starting ({0})", Globals.ElapsedSinceAppStart); // just to start the timer
-
-            var name = Config.GetSetting("ServerName");
-            Globals.ServerName = string.IsNullOrEmpty(name) ? Dns.GetHostName() : name;
-
-            Globals.DependencyProvider = new LazyServiceProvider();
-            var startup = new Startup();
-            (Globals.DependencyProvider as LazyServiceProvider).SetProvider(startup.DependencyProvider);
-            ServiceRequestScopeModule.SetServiceProvider(Globals.DependencyProvider);
-
-            ComponentFactory.Container = new SimpleContainer();
-
-            ComponentFactory.InstallComponents(new ProviderInstaller("databaseConnection", typeof(DatabaseConnectionProvider), typeof(SqlDatabaseConnectionProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("data", typeof(DataProvider), typeof(SqlDataProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("caching", typeof(CachingProvider), typeof(FBCachingProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("logging", typeof(LoggingProvider), typeof(DBLoggingProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("scheduling", typeof(SchedulingProvider), typeof(DNNScheduler)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("searchIndex", typeof(IndexingProvider), typeof(ModuleIndexer)));
-#pragma warning disable 0618
-            ComponentFactory.InstallComponents(new ProviderInstaller("searchDataStore", typeof(SearchDataStoreProvider), typeof(SearchDataStore)));
-#pragma warning restore 0618
-            ComponentFactory.InstallComponents(new ProviderInstaller("members", typeof(MembershipProvider), typeof(AspNetMembershipProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("roles", typeof(RoleProvider), typeof(DNNRoleProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("profiles", typeof(ProfileProvider), typeof(DNNProfileProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("permissions", typeof(PermissionProvider), typeof(CorePermissionProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("outputCaching", typeof(OutputCachingProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("moduleCaching", typeof(ModuleCachingProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("sitemap", typeof(SitemapProvider), typeof(CoreSitemapProvider)));
-
-            ComponentFactory.InstallComponents(new ProviderInstaller("friendlyUrl", typeof(FriendlyUrlProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("folder", typeof(FolderProvider)));
-            RegisterIfNotAlreadyRegistered<FolderProvider, StandardFolderProvider>("StandardFolderProvider");
-            RegisterIfNotAlreadyRegistered<FolderProvider, SecureFolderProvider>("SecureFolderProvider");
-            RegisterIfNotAlreadyRegistered<FolderProvider, DatabaseFolderProvider>("DatabaseFolderProvider");
-            RegisterIfNotAlreadyRegistered<PermissionProvider>();
-            ComponentFactory.InstallComponents(new ProviderInstaller("htmlEditor", typeof(HtmlEditorProvider), ComponentLifeStyleType.Transient));
-            ComponentFactory.InstallComponents(new ProviderInstaller("navigationControl", typeof(NavigationProvider), ComponentLifeStyleType.Transient));
-            ComponentFactory.InstallComponents(new ProviderInstaller("clientcapability", typeof(ClientCapabilityProvider)));
-            ComponentFactory.InstallComponents(new ProviderInstaller("cryptography", typeof(CryptographyProvider), typeof(FipsCompilanceCryptographyProvider)));
-
-            Logger.InfoFormat("Application Started ({0})", Globals.ElapsedSinceAppStart); // just to start the timer
-            DotNetNukeShutdownOverload.InitializeFcnSettings();
-
-            // register the assembly-lookup to correct the breaking rename in DNN 9.2
-            DotNetNuke.Services.Zip.SharpZipLibRedirect.RegisterSharpZipLibRedirect();
-
-            // DotNetNukeSecurity.Initialize();
         }
 
         private void Application_End(object sender, EventArgs eventArgs)
@@ -201,6 +90,86 @@ namespace DotNetNuke.Web.Common.Internal
             Logger.Info("Application Ended");
         }
 
+        private void Application_Start(object sender, EventArgs eventArgs)
+        {
+            Logger.InfoFormat("Application Starting ({0})", Globals.ElapsedSinceAppStart); // just to start the timer
+
+            var name = Config.GetSetting("ServerName");
+            Globals.ServerName = string.IsNullOrEmpty(name) ? Dns.GetHostName() : name;
+
+            Globals.DependencyProvider = new LazyServiceProvider();
+            var startup = new Startup();
+            (Globals.DependencyProvider as LazyServiceProvider).SetProvider(startup.DependencyProvider);
+            ServiceRequestScopeModule.SetServiceProvider(Globals.DependencyProvider);
+
+            ComponentFactory.Container = new SimpleContainer();
+
+            ComponentFactory.InstallComponents(new ProviderInstaller("databaseConnection", typeof(DatabaseConnectionProvider), typeof(SqlDatabaseConnectionProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("data", typeof(DataProvider), typeof(SqlDataProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("caching", typeof(CachingProvider), typeof(FBCachingProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("logging", typeof(LoggingProvider), typeof(DBLoggingProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("scheduling", typeof(SchedulingProvider), typeof(DNNScheduler)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("searchIndex", typeof(IndexingProvider), typeof(ModuleIndexer)));
+#pragma warning disable 0618
+            ComponentFactory.InstallComponents(new ProviderInstaller("searchDataStore", typeof(SearchDataStoreProvider), typeof(SearchDataStore)));
+#pragma warning restore 0618
+            ComponentFactory.InstallComponents(new ProviderInstaller("members", typeof(MembershipProvider), typeof(AspNetMembershipProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("roles", typeof(RoleProvider), typeof(DNNRoleProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("profiles", typeof(ProfileProvider), typeof(DNNProfileProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("permissions", typeof(PermissionProvider), typeof(CorePermissionProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("outputCaching", typeof(OutputCachingProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("moduleCaching", typeof(ModuleCachingProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("sitemap", typeof(SitemapProvider), typeof(CoreSitemapProvider)));
+
+            ComponentFactory.InstallComponents(new ProviderInstaller("friendlyUrl", typeof(FriendlyUrlProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("folder", typeof(FolderProvider)));
+            RegisterIfNotAlreadyRegistered<FolderProvider, StandardFolderProvider>("StandardFolderProvider");
+            RegisterIfNotAlreadyRegistered<FolderProvider, SecureFolderProvider>("SecureFolderProvider");
+            RegisterIfNotAlreadyRegistered<FolderProvider, DatabaseFolderProvider>("DatabaseFolderProvider");
+            RegisterIfNotAlreadyRegistered<PermissionProvider>();
+            ComponentFactory.InstallComponents(new ProviderInstaller("htmlEditor", typeof(HtmlEditorProvider), ComponentLifeStyleType.Transient));
+            ComponentFactory.InstallComponents(new ProviderInstaller("navigationControl", typeof(NavigationProvider), ComponentLifeStyleType.Transient));
+            ComponentFactory.InstallComponents(new ProviderInstaller("clientcapability", typeof(ClientCapabilityProvider)));
+            ComponentFactory.InstallComponents(new ProviderInstaller("cryptography", typeof(CryptographyProvider), typeof(FipsCompilanceCryptographyProvider)));
+			ComponentFactory.InstallComponents(new ProviderInstaller("tokens", typeof(TokenProvider)));
+
+            Logger.InfoFormat("Application Started ({0})", Globals.ElapsedSinceAppStart); // just to start the timer
+            DotNetNukeShutdownOverload.InitializeFcnSettings();
+
+            // register the assembly-lookup to correct the breaking rename in DNN 9.2
+            DotNetNuke.Services.Zip.SharpZipLibRedirect.RegisterSharpZipLibRedirect();
+
+            // DotNetNukeSecurity.Initialize();
+        }
+
+        private static bool IsInstallOrUpgradeRequest(HttpRequest request)
+        {
+            var url = request.Url.LocalPath.ToLowerInvariant();
+
+            return url.EndsWith("webresource.axd")
+                   || url.EndsWith("scriptresource.axd")
+                   || url.EndsWith("captcha.aspx")
+                   || url.Contains("upgradewizard.aspx")
+                   || url.Contains("installwizard.aspx")
+                   || url.EndsWith("install.aspx");
+        }
+
+        private void Application_Error(object sender, EventArgs eventArgs)
+        {
+            // Code that runs when an unhandled error occurs
+            if (HttpContext.Current != null)
+            {
+                // Get the exception object.
+                Logger.Trace("Dumping all Application Errors");
+                foreach (Exception exc in HttpContext.Current.AllErrors)
+                {
+                    Logger.Fatal(exc);
+                }
+
+                Logger.Trace("End Dumping all Application Errors");
+            }
+        }
+
         private void Application_BeginRequest(object sender, EventArgs e)
         {
             var app = (HttpApplication)sender;
@@ -230,18 +199,49 @@ namespace DotNetNuke.Web.Common.Internal
             Initialize.RunSchedule(app.Request);
         }
 
-        private void Application_PreSendRequestHeaders(object sender, EventArgs e)
-        {
-            if (HttpContext.Current != null && HttpContext.Current.Handler is PageBase)
-            {
-                var page = HttpContext.Current.Handler as PageBase;
-                page.HeaderIsWritten = true;
-            }
-        }
+		private void Application_PreSendRequestHeaders(object sender, EventArgs e)
+		{
+			if (HttpContext.Current != null && HttpContext.Current.Handler is PageBase)
+			{
+				var page = HttpContext.Current.Handler as PageBase;
+				page.HeaderIsWritten = true;
+			}
+		}
 
         private bool IsInstallInProgress(HttpApplication app)
         {
             return InstallBlocker.Instance.IsInstallInProgress();
         }
     }
+using System.Linq;
+using System.Net;
+using System.Web;
+using System.Web.Security;
+using DotNetNuke.Common;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.ComponentModel;
+using DotNetNuke.Data;
+using DotNetNuke.Framework;
+using DotNetNuke.HttpModules.DependencyInjection;
+using DotNetNuke.Instrumentation;
+using DotNetNuke.Modules.HTMLEditorProvider;
+using DotNetNuke.Modules.NavigationProvider;
+using DotNetNuke.Security.Cookies;
+using DotNetNuke.Security.Membership;
+using DotNetNuke.Security.Permissions;
+using DotNetNuke.Security.Profile;
+using DotNetNuke.Security.Roles;
+using DotNetNuke.Services.Cache;
+using DotNetNuke.Services.ClientCapability;
+using DotNetNuke.Services.Cryptography;
+using DotNetNuke.Services.FileSystem;
+using DotNetNuke.Services.Installer.Blocker;
+using DotNetNuke.Services.Log.EventLog;
+using DotNetNuke.Services.ModuleCache;
+using DotNetNuke.Services.OutputCache;
+using DotNetNuke.Services.Scheduling;
+using DotNetNuke.Services.Search;
+using DotNetNuke.Services.Search.Internals;
+using DotNetNuke.Services.Sitemap;
+using DotNetNuke.Services.Url.FriendlyUrl;
 }

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -872,6 +872,9 @@
     <Compile Include="Services\Tokens\PropertyAccess\JavaScriptPropertyAccess.cs" />
     <Compile Include="Services\Tokens\PropertyAccess\JsonPropertyAccess.cs" />
     <Compile Include="Services\Tokens\Scope.cs" />
+    <Compile Include="Services\Tokens\CoreTokenProvider.cs" />
+    <Compile Include="Services\Tokens\TokenContext.cs" />
+    <Compile Include="Services\Tokens\TokenProvider.cs" />
     <Compile Include="Services\Upgrade\DnnInstallLogger.cs" />
     <Compile Include="Services\Upgrade\Internals\IInstallController.cs" />
     <Compile Include="Services\Upgrade\Internals\InstallConfiguration\ConnectionConfig.cs" />

--- a/DNN Platform/Library/Services/Tokens/BaseCustomTokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/BaseCustomTokenReplace.cs
@@ -18,11 +18,16 @@ using System;
             get => ComponentFactory.GetComponent<TokenProvider>();
         }
 
-        public TokenContext TokenContext { get; set; } = new TokenContext();
-
-        protected Dictionary<string, IPropertyAccess> PropertySource {
-            get => TokenContext.PropertySource;
+        TokenContext _tokenContext = new TokenContext();
+        public TokenContext TokenContext {
+            get => _tokenContext;
+            set {
+                _tokenContext = value;
+                PropertySource = _tokenContext.PropertySource;
+            }
         }
+
+        protected Dictionary<string, IPropertyAccess> PropertySource;
 
         /// <summary>
         /// Gets or sets /sets the user object representing the currently accessing user (permission).
@@ -75,6 +80,10 @@ using System;
         {
             get => TokenContext.CurrentAccessLevel;
             set => TokenContext.CurrentAccessLevel = value;
+        }
+
+        public BaseCustomTokenReplace() {
+            PropertySource = TokenContext.PropertySource;
         }
 
         /// <summary>

--- a/DNN Platform/Library/Services/Tokens/BaseCustomTokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/BaseCustomTokenReplace.cs
@@ -1,12 +1,17 @@
-﻿using System.Globalization;
-using DotNetNuke.ComponentModel;
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Services.Tokens
 {
-using System;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using DotNetNuke.ComponentModel;
+    using DotNetNuke.Entities.Users;
+
+    using Localization = DotNetNuke.Services.Localization.Localization;
 
     /// <summary>
     /// BaseCustomTokenReplace  allows to add multiple sources implementing <see cref="IPropertyAccess">IPropertyAccess</see>.
@@ -194,10 +199,4 @@ using System;
             return Provider is CoreTokenProvider ? base.ReplaceTokens(sourceText) : Provider.Tokenize(sourceText, TokenContext);
         }
     }
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
-using DotNetNuke.Entities.Users;
-
-    using Localization = DotNetNuke.Services.Localization.Localization;
 }

--- a/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
@@ -26,17 +26,35 @@ using System;
         private const string TokenReplaceCacheKeyDefault = "TokenReplaceRegEx_Default";
         private const string TokenReplaceCacheKeyObjectless = "TokenReplaceRegEx_Objectless";
 
+
+        private CultureInfo _formatProvider;
+        private string _language;
+
         /// <summary>
         /// Gets the Format provider as Culture info from stored language or current culture.
         /// </summary>
         /// <value>An CultureInfo.</value>
-        protected abstract CultureInfo FormatProvider { get; }
+        protected virtual CultureInfo FormatProvider
+        {
+            get { return _formatProvider ?? (_formatProvider = Thread.CurrentThread.CurrentUICulture); }
+        }
 
         /// <summary>
         /// Gets or sets /sets the language to be used, e.g. for date format.
         /// </summary>
         /// <value>A string, representing the locale.</value>
-        public abstract string Language { get; set; }
+        public virtual string Language
+        {
+            get
+            {
+                return _language;
+            }
+            set
+            {
+                _language = value;
+                _formatProvider = new CultureInfo(_language);
+            }
+        }
 
         /// <summary>
         /// Gets the Regular expression for the token to be replaced.

--- a/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
@@ -4,24 +4,17 @@
 
 namespace DotNetNuke.Services.Tokens
 {
-    using System;
-    using System.Globalization;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Threading;
-
-    using DotNetNuke.Common.Utilities;
-
+using System;
     /// <summary>
-    /// The BaseTokenReplace class provides the tokenization of tokens formatted
+    /// The BaseTokenReplace class provides the tokenization of tokens formatted  
     /// [object:property] or [object:property|format|ifEmpty] or [custom:no] within a string
     /// with the appropriate current property/custom values.
     /// </summary>
     /// <remarks></remarks>
     public abstract class BaseTokenReplace
     {
-        protected const string ObjectLessToken = "no_object";
 
+        protected const string ObjectLessToken = "no_object";
         private const string ExpressionDefault =
             "(?:(?<text>\\[\\])|\\[(?:(?<object>[^{}\\]\\[:]+):(?<property>[^\\]\\[\\|]+))(?:\\|(?:(?<format>[^\\]\\[]+)\\|(?<ifEmpty>[^\\]\\[]+))|\\|(?:(?<format>[^\\|\\]\\[]+)))?\\])|(?<text>\\[[^\\]\\[]+\\])|(?<text>[^\\]\\[]+)";
 
@@ -33,35 +26,17 @@ namespace DotNetNuke.Services.Tokens
         private const string TokenReplaceCacheKeyDefault = "TokenReplaceRegEx_Default";
         private const string TokenReplaceCacheKeyObjectless = "TokenReplaceRegEx_Objectless";
 
-        private CultureInfo _formatProvider;
-        private string _language;
+        /// <summary>
+        /// Gets the Format provider as Culture info from stored language or current culture.
+        /// </summary>
+        /// <value>An CultureInfo.</value>
+        protected abstract CultureInfo FormatProvider { get; }
 
         /// <summary>
         /// Gets or sets /sets the language to be used, e.g. for date format.
         /// </summary>
         /// <value>A string, representing the locale.</value>
-        public string Language
-        {
-            get
-            {
-                return this._language;
-            }
-
-            set
-            {
-                this._language = value;
-                this._formatProvider = new CultureInfo(this._language);
-            }
-        }
-
-        /// <summary>
-        /// Gets the Format provider as Culture info from stored language or current culture.
-        /// </summary>
-        /// <value>An CultureInfo.</value>
-        protected CultureInfo FormatProvider
-        {
-            get { return this._formatProvider ?? (this._formatProvider = Thread.CurrentThread.CurrentUICulture); }
-        }
+        public abstract string Language { get; set; }
 
         /// <summary>
         /// Gets the Regular expression for the token to be replaced.
@@ -126,4 +101,10 @@ namespace DotNetNuke.Services.Tokens
             return result.ToString();
         }
     }
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+using DotNetNuke.Common.Utilities;
 }

--- a/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/BaseTokenReplace.cs
@@ -1,10 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Services.Tokens
 {
-using System;
+    using System;
+    using System.Globalization;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+
+    using DotNetNuke.Common.Utilities;
+
     /// <summary>
     /// The BaseTokenReplace class provides the tokenization of tokens formatted  
     /// [object:property] or [object:property|format|ifEmpty] or [custom:no] within a string
@@ -119,10 +125,4 @@ using System;
             return result.ToString();
         }
     }
-using System.Globalization;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-
-using DotNetNuke.Common.Utilities;
 }

--- a/DNN Platform/Library/Services/Tokens/CoreTokenProvider.cs
+++ b/DNN Platform/Library/Services/Tokens/CoreTokenProvider.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Services.Tokens {
+    public class CoreTokenProvider : TokenProvider {
+
+        public override bool ContainsTokens(string content, TokenContext context) {
+            return false; // already determined by BaseCustomTokenReplace
+        }
+
+        public override string Tokenize(string content, TokenContext context) {
+            return content; // conttent already tokenized by BaseCustomTokenReplace
+        }
+    }
+}

--- a/DNN Platform/Library/Services/Tokens/CoreTokenProvider.cs
+++ b/DNN Platform/Library/Services/Tokens/CoreTokenProvider.cs
@@ -10,7 +10,10 @@ namespace DotNetNuke.Services.Tokens {
         }
 
         public override string Tokenize(string content, TokenContext context) {
-            return content; // conttent already tokenized by BaseCustomTokenReplace
+            var tokenizer = new TokenReplace() {
+                TokenContext = context
+            };
+            return tokenizer.ReplaceEnvironmentTokens(content);
         }
     }
 }

--- a/DNN Platform/Library/Services/Tokens/CoreTokenProvider.cs
+++ b/DNN Platform/Library/Services/Tokens/CoreTokenProvider.cs
@@ -1,18 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
-namespace DotNetNuke.Services.Tokens {
-    public class CoreTokenProvider : TokenProvider {
-
-        public override bool ContainsTokens(string content, TokenContext context) {
+namespace DotNetNuke.Services.Tokens 
+{
+    public class CoreTokenProvider : TokenProvider 
+    {
+        public override bool ContainsTokens(string content, TokenContext context) 
+        {
             return false; // already determined by BaseCustomTokenReplace
         }
 
-        public override string Tokenize(string content, TokenContext context) {
-            var tokenizer = new TokenReplace() {
-                TokenContext = context
-            };
+        public override string Tokenize(string content, TokenContext context) 
+        {
+            var tokenizer = new TokenReplace { TokenContext = context };
             return tokenizer.ReplaceEnvironmentTokens(content);
         }
     }

--- a/DNN Platform/Library/Services/Tokens/TokenContext.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenContext.cs
@@ -1,21 +1,22 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+namespace DotNetNuke.Services.Tokens
+{
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Threading;
 
-using DotNetNuke.Entities.Modules;
-using DotNetNuke.Entities.Portals;
-using DotNetNuke.Entities.Tabs;
-using DotNetNuke.Entities.Users;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Threading;
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Entities.Users;
 
-namespace DotNetNuke.Services.Tokens {
     /// <summary>
     /// The context in which tokenization should happen. 
     /// </summary>
-    public class TokenContext {
-
+    public class TokenContext 
+    {
         /// <summary>
         /// Gets/sets the user object representing the currently accessing user (permission)
         /// </summary>

--- a/DNN Platform/Library/Services/Tokens/TokenContext.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenContext.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using DotNetNuke.Entities.Modules;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Entities.Users;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+
+namespace DotNetNuke.Services.Tokens {
+    /// <summary>
+    /// The context in which tokenization should happen. 
+    /// </summary>
+    public class TokenContext {
+
+        /// <summary>
+        /// Gets/sets the user object representing the currently accessing user (permission)
+        /// </summary>
+        /// <value>UserInfo oject</value>
+        public UserInfo AccessingUser { get; set; }
+
+        /// <summary>
+        /// Gets/sets the user object to use for 'User:' token replacement
+        /// </summary>
+        /// <value>UserInfo oject</value>
+        public UserInfo User { get; set; }
+
+        /// <summary>
+        /// Gets/sets the portal settings object to use for 'Portal:' token replacement
+        /// </summary>
+        /// <value>PortalSettings oject</value>
+        public PortalSettings Portal { get; set; }
+
+        /// <summary>
+        /// Gets/sets the tab settings object to use for 'Tab:' token replacement
+        /// </summary>
+        public TabInfo Tab { get; set; }
+
+        /// <summary>
+        /// Gets/sets the module settings object to use for 'Module:' token replacement
+        /// </summary>
+        public ModuleInfo Module { get; set; }
+
+        /// <summary>
+        /// Gets the Format provider as Culture info from stored language or current culture
+        /// </summary>
+        /// <value>An CultureInfo</value>
+        public CultureInfo Language { get; set; } = Thread.CurrentThread.CurrentUICulture;
+
+        /// <summary>
+        /// Gets/sets the current Access Level controlling access to critical user settings
+        /// </summary>
+        /// <value>A TokenAccessLevel as defined above</value>
+        public Scope CurrentAccessLevel { get; set; }
+
+        /// <summary>
+        /// If DebugMessages are enabled, unknown Tokens are replaced with Error Messages 
+        /// </summary>
+        public bool DebugMessages { get; set; }
+
+        public Dictionary<string, IPropertyAccess> PropertySource { get; private set; } = new Dictionary<string, IPropertyAccess>();
+
+
+        /// <summary>
+        /// Custom data that the caller can share with the Token Provider
+        /// </summary>
+        public object Data { get; set; }
+
+    }
+}

--- a/DNN Platform/Library/Services/Tokens/TokenContext.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenContext.cs
@@ -62,12 +62,5 @@ namespace DotNetNuke.Services.Tokens {
         public bool DebugMessages { get; set; }
 
         public Dictionary<string, IPropertyAccess> PropertySource { get; private set; } = new Dictionary<string, IPropertyAccess>();
-
-
-        /// <summary>
-        /// Custom data that the caller can share with the Token Provider
-        /// </summary>
-        public object Data { get; set; }
-
     }
 }

--- a/DNN Platform/Library/Services/Tokens/TokenProvider.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenProvider.cs
@@ -1,9 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
-namespace DotNetNuke.Services.Tokens {
-    public abstract class TokenProvider {
+namespace DotNetNuke.Services.Tokens
+{
+    public abstract class TokenProvider
+    {
         public abstract bool ContainsTokens(string content, TokenContext context);
         public abstract string Tokenize(string content, TokenContext context);
     }

--- a/DNN Platform/Library/Services/Tokens/TokenProvider.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenProvider.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Services.Tokens {
+    public abstract class TokenProvider {
+        public abstract bool ContainsTokens(string content, TokenContext context);
+        public abstract string Tokenize(string content, TokenContext context);
+    }
+}

--- a/DNN Platform/Library/Services/Tokens/TokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenReplace.cs
@@ -111,7 +111,6 @@ using System.Collections;
         private void DetermineLanguage(string language)
         {
             Language = string.IsNullOrEmpty(language) ? new Localization.Localization().CurrentUICulture : language;
-            TokenContext.Language = new System.Globalization.CultureInfo(Language);
         }
 
         private void DetermineModule(int moduleID)

--- a/DNN Platform/Library/Services/Tokens/TokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenReplace.cs
@@ -4,15 +4,7 @@
 
 namespace DotNetNuke.Services.Tokens
 {
-    using System.Collections;
-    using System.Data;
-    using System.Web;
-
-    using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Host;
-    using DotNetNuke.Entities.Modules;
-    using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Entities.Users;
+using System.Collections;
 
     /// <summary>
     /// The TokenReplace class provides the option to replace tokens formatted
@@ -25,7 +17,6 @@ namespace DotNetNuke.Services.Tokens
     /// <remarks></remarks>
     public class TokenReplace : BaseCustomTokenReplace
     {
-        private ModuleInfo _moduleInfo;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenReplace"/> class.
@@ -91,53 +82,13 @@ namespace DotNetNuke.Services.Tokens
         /// <param name="moduleID">ID of the current module.</param>
         public TokenReplace(Scope accessLevel, string language, PortalSettings portalSettings, UserInfo user, int moduleID)
         {
-            this.ModuleId = int.MinValue;
             this.CurrentAccessLevel = accessLevel;
-            if (accessLevel != Scope.NoSettings)
-            {
-                if (portalSettings == null)
-                {
-                    if (HttpContext.Current != null)
-                    {
-                        this.PortalSettings = PortalController.Instance.GetCurrentPortalSettings();
-                    }
-                }
-                else
-                {
-                    this.PortalSettings = portalSettings;
-                }
 
-                if (user == null)
-                {
-                    if (HttpContext.Current != null)
-                    {
-                        this.User = (UserInfo)HttpContext.Current.Items["UserInfo"];
-                    }
-                    else
-                    {
-                        this.User = new UserInfo();
-                    }
-
-                    this.AccessingUser = this.User;
-                }
-                else
-                {
-                    this.User = user;
-                    if (HttpContext.Current != null)
-                    {
-                        this.AccessingUser = (UserInfo)HttpContext.Current.Items["UserInfo"];
-                    }
-                    else
-                    {
-                        this.AccessingUser = new UserInfo();
-                    }
-                }
-
-                this.Language = string.IsNullOrEmpty(language) ? new Localization.Localization().CurrentUICulture : language;
-                if (moduleID != Null.NullInteger)
-                {
-                    this.ModuleId = moduleID;
-                }
+            if (accessLevel != Scope.NoSettings) {
+                DeterminePortal(portalSettings);
+                DetermineUser(user);
+                DetermineLanguage(language);
+                DetermineModule(moduleID);
             }
 
             this.PropertySource["date"] = new DateTimePropertyAccess();
@@ -146,51 +97,79 @@ namespace DotNetNuke.Services.Tokens
             this.PropertySource["culture"] = new CulturePropertyAccess();
         }
 
+        private void DeterminePortal(PortalSettings portalSettings)
+        {
+            PortalSettings = portalSettings ?? PortalController.Instance.GetCurrentPortalSettings();
+        }
+
+        private void DetermineUser(UserInfo user)
+        {
+            AccessingUser = HttpContext.Current != null ? (UserInfo)HttpContext.Current.Items["UserInfo"] : new UserInfo();
+            User = user ?? AccessingUser;
+        }
+
+        private void DetermineLanguage(string language)
+        {
+            Language = string.IsNullOrEmpty(language) ? new Localization.Localization().CurrentUICulture : language;
+            TokenContext.Language = new System.Globalization.CultureInfo(Language);
+        }
+
+        private void DetermineModule(int moduleID)
+        {
+            if (moduleID != Null.NullInteger)
+                ModuleId = moduleID;
+        }
+
         /// <summary>
         /// Gets or sets /sets the current ModuleID to be used for 'User:' token replacement.
         /// </summary>
         /// <value>ModuleID (Integer).</value>
-        public int ModuleId { get; set; }
+        public int ModuleId {
+            get => TokenContext.Module?.ModuleID ?? Null.NullInteger;
+            set => TokenContext.Module = GetModule(value);
+        }
+
+        private ModuleInfo GetModule(int moduleId)
+        {
+            if (moduleId == TokenContext.Module?.ModuleID)
+                return TokenContext.Module;
+
+            if (moduleId <= 0)
+                return null;
+
+            var tab = TokenContext.Tab ?? PortalSettings?.ActiveTab;
+            if (tab != null && tab.TabID > 0)
+                return ModuleController.Instance.GetModule(ModuleId, tab.TabID, false);
+
+            return ModuleController.Instance.GetModule(ModuleId, Null.NullInteger, true);
+        }
 
         /// <summary>
-        /// Gets or sets /sets the module settings object to use for 'Module:' token replacement.
+        /// Gets or sets the module settings object to use for 'Module:' token replacement.
         /// </summary>
         public ModuleInfo ModuleInfo
         {
-            get
-            {
-                if (this.ModuleId > int.MinValue && (this._moduleInfo == null || this._moduleInfo.ModuleID != this.ModuleId))
-                {
-                    if (this.PortalSettings != null && this.PortalSettings.ActiveTab != null)
-                    {
-                        this._moduleInfo = ModuleController.Instance.GetModule(this.ModuleId, this.PortalSettings.ActiveTab.TabID, false);
-                    }
-                    else
-                    {
-                        this._moduleInfo = ModuleController.Instance.GetModule(this.ModuleId, Null.NullInteger, true);
-                    }
-                }
-
-                return this._moduleInfo;
-            }
-
-            set
-            {
-                this._moduleInfo = value;
-            }
+            get => TokenContext.Module;
+            set => TokenContext.Module = value;
         }
 
         /// <summary>
         /// Gets or sets /sets the portal settings object to use for 'Portal:' token replacement.
         /// </summary>
         /// <value>PortalSettings oject.</value>
-        public PortalSettings PortalSettings { get; set; }
+        public PortalSettings PortalSettings {
+            get => TokenContext.Portal;
+            set => TokenContext.Portal = value;
+        }
 
         /// <summary>
         /// Gets or sets /sets the user object to use for 'User:' token replacement.
         /// </summary>
         /// <value>UserInfo oject.</value>
-        public UserInfo User { get; set; }
+        public UserInfo User {
+            get => TokenContext.User;
+            set => TokenContext.User = value;
+        }
 
         /// <summary>
         /// Replaces tokens in sourceText parameter with the property values.
@@ -329,4 +308,11 @@ namespace DotNetNuke.Services.Tokens
             }
         }
     }
+using System.Data;
+using System.Web;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Host;
+using DotNetNuke.Entities.Modules;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Users;
 }

--- a/DNN Platform/Library/Services/Tokens/TokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenReplace.cs
@@ -1,10 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Services.Tokens
 {
-using System.Collections;
+    using System.Collections;
+    using System.Data;
+    using System.Web;
+
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Entities.Host;
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Users;
 
     /// <summary>
     /// The TokenReplace class provides the option to replace tokens formatted
@@ -17,7 +24,6 @@ using System.Collections;
     /// <remarks></remarks>
     public class TokenReplace : BaseCustomTokenReplace
     {
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenReplace"/> class.
         /// creates a new TokenReplace object for default context.
@@ -307,11 +313,4 @@ using System.Collections;
             }
         }
     }
-using System.Data;
-using System.Web;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.Entities.Host;
-using DotNetNuke.Entities.Modules;
-using DotNetNuke.Entities.Portals;
-using DotNetNuke.Entities.Users;
 }

--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -390,6 +390,12 @@
         <add name="JWTAuth" type="Dnn.AuthServices.Jwt.Auth.JwtAuthMessageHandler, Dnn.AuthServices.Jwt" enabled="true" defaultInclude="true" forceSSL="false" />
       </messageHandlers>
     </authServices>
+    <tokens defaultProvider="CoreTokenProvider">
+      <providers>
+        <clear />
+        <add name="CoreTokenProvider" type="DotNetNuke.Services.Tokens.CoreTokenProvider, DotNetNuke" />
+      </providers>
+    </tokens>
   </dotnetnuke>
   <NUnit>
     <TestRunner>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Tokens/TokenReplaceTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Tokens/TokenReplaceTests.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.Tokens
 {
+    using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Modules.Actions;
@@ -28,6 +28,7 @@ namespace DotNetNuke.Tests.Core.Services.Tokens
         [SetUp]
         public void SetUp()
         {
+            ComponentFactory.RegisterComponentInstance<TokenProvider>(new CoreTokenProvider());
             this._mockCache = MockComponentProvider.CreateDataCacheProvider();
             this._mockHostController = new Mock<IHostController>();
             this._portalController = new Mock<IPortalController>();

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -25,6 +25,7 @@
       <section name="authServices" requirePermission="false" type="DotNetNuke.Web.ConfigSection.AuthServicesConfiguration, DotNetNuke.Web" />
       <section name="cryptography" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
       <section name="databaseConnection" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
+      <section name="tokens" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
     </sectionGroup>
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor">
       <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor" requirePermission="false" />
@@ -409,6 +410,12 @@
         <add name="FipsCompilanceCryptographyProvider" type="DotNetNuke.Services.Cryptography.FipsCompilanceCryptographyProvider, DotNetNuke" providerPath="~\Providers\CryptographyProviders\FipsCompilanceCryptographyProvider\" />
       </providers>
     </cryptography>
+    <tokens defaultProvider="CoreTokenProvider">
+      <providers>
+        <clear />
+        <add name="CoreTokenProvider" type="DotNetNuke.Services.Tokens.CoreTokenProvider, DotNetNuke" />
+      </providers>
+    </tokens>
   </dotnetnuke>
   <clientDependency version="0" fileDependencyExtensions=".js,.css">
     <fileRegistration defaultProvider="DnnPageHeaderProvider">

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -25,6 +25,7 @@
       <section name="authServices" requirePermission="false" type="DotNetNuke.Web.ConfigSection.AuthServicesConfiguration, DotNetNuke.Web" />
       <section name="cryptography" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
       <section name="databaseConnection" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
+      <section name="tokens" requirePermission="false" type="DotNetNuke.Framework.Providers.ProviderConfigurationHandler, DotNetNuke" />
     </sectionGroup>
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor">
       <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor" requirePermission="false" />
@@ -410,6 +411,12 @@
         <add name="FipsCompilanceCryptographyProvider" type="DotNetNuke.Services.Cryptography.FipsCompilanceCryptographyProvider, DotNetNuke" providerPath="~\Providers\CryptographyProviders\FipsCompilanceCryptographyProvider\" />
       </providers>
     </cryptography>
+    <tokens defaultProvider="CoreTokenProvider">
+      <providers>
+        <clear />
+        <add name="CoreTokenProvider" type="DotNetNuke.Services.Tokens.CoreTokenProvider, DotNetNuke" />
+      </providers>
+    </tokens>
   </dotnetnuke>
   <clientDependency version="0" fileDependencyExtensions=".js,.css">
     <fileRegistration defaultProvider="DnnPageHeaderProvider">


### PR DESCRIPTION
#3819. 

The token replacement code is very exposed through public and protected members. My implementation leaves all of those in place to avoid breaking existing functionality. Therefore, all the core tokenization code still lives in the BaseCustomTokenReplace, BaseTokenReplace and TokenReplace classes. 

If the provider is different than the CoreTokenProvider, it calls that provider instead. The CoreTokenProvider also has a simple implementation that calls the TokenReplace class. This is in case someone decides to use the provider instead of calling TokenReplace directly.

The changes I did also consolidate all parameters related to tokenization into a single TokenContext class that can be easily passed around.

Tested on DNN 9.6.1 with some simple scenarios and everything seems to work as before.
