### PR TITLE
Fixed NullReferenceException when StandardFolderProvider is used in a Search provider task

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
@@ -199,7 +199,9 @@ namespace DotNetNuke.Services.FileSystem
             // Does site management want the cachebuster parameter?
             if (portalSettings.AddCachebusterToResourceUris)
             {
-                var cachebusterToken = UrlUtils.EncryptParameter(file.LastModificationTime.GetHashCode().ToString());
+                var cachebusterToken = UrlUtils.EncryptParameter(
+                    file.LastModificationTime.GetHashCode().ToString(),
+                    portalSettings.GUID.ToString());
 
                 return TestableGlobals.Instance.ResolveUrl(fullPath + "?ver=" + cachebusterToken);
             }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
@@ -604,6 +604,36 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         #region GetFilesUrl
 
         [Test]
+        public void GetFileUrl_WhenCurrentPortalSettingsReturnsNull_DontThrow()
+        {
+            // arrange
+            var sfp = new Mock<StandardFolderProvider>
+            {
+                CallBase = true
+            };
+
+            sfp.Setup(x => x.GetPortalSettings(Constants.CONTENT_ValidPortalId))
+                .Returns(GetPortalSettingsMock());
+
+            _fileInfo.Setup(x => x.FileName)
+                .Returns(Constants.FOLDER_ValidFileName);
+
+            _fileInfo.Setup(x => x.PortalId)
+                .Returns(Constants.CONTENT_ValidPortalId);
+
+            _portalControllerMock.Setup(x => x.GetCurrentPortalSettings())
+                .Returns<PortalSettings>(null);
+
+            // act
+            string fileUrl = null;
+            TestDelegate action = () => fileUrl = sfp.Object.GetFileUrl(_fileInfo.Object);
+
+            // assert
+            Assert.DoesNotThrow(action);
+            Assert.IsNotNull(fileUrl);
+        }
+
+        [Test]
         [TestCase("(")]
         [TestCase(")")]
         [TestCase("")]        


### PR DESCRIPTION
Fixes #3838

## Summary
Calling the `EncryptParameter(string, string)` overload instead of the `EncryptParameter(string)` overload because the latter invokes `PortalController.Instance.GetCurrentPortalSettings()` which is known to produce a `NullReferenceException` in the context of a Scheduler task.