### PR TITLE
Fix portal template import

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1458,16 +1458,6 @@ namespace DotNetNuke.Entities.Portals
                 UpdatePortalSetting(portalId, "EnableSkinWidgets", XmlUtils.GetNodeValue(nodeSettings, "enableskinwidgets", string.Empty));
             }
 
-            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "showcookieconsent", string.Empty)))
-            {
-                UpdatePortalSetting(portalId, "ShowCookieConsent", XmlUtils.GetNodeValue(nodeSettings, "showcookieconsent", "False"));
-            }
-
-            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "cookiemorelink", string.Empty)))
-            {
-                UpdatePortalSetting(portalId, "CookieMoreLink", XmlUtils.GetNodeValue(nodeSettings, "cookiemorelink", string.Empty), true, currentCulture);
-            }
-
             // Enable AutoSAve feature
             if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "enableautosave", string.Empty)))
             {
@@ -1551,6 +1541,47 @@ namespace DotNetNuke.Entities.Portals
             {
                 UpdatePortalSetting(portalId, "EnableBrowserLanguage", XmlUtils.GetNodeValue(nodeSettings, "enablebrowserlanguage", string.Empty));
             }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "showcookieconsent", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "ShowCookieConsent", XmlUtils.GetNodeValue(nodeSettings, "showcookieconsent", "False"));
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "cookiemorelink", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "CookieMoreLink", XmlUtils.GetNodeValue(nodeSettings, "cookiemorelink", string.Empty), true, currentCulture);
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "dataconsentactive", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "DataConsentActive", XmlUtils.GetNodeValue(nodeSettings, "dataconsentactive", "False"));
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "dataconsenttermslastchange", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "DataConsentTermsLastChange", XmlUtils.GetNodeValue(nodeSettings, "dataconsenttermslastchange", string.Empty), true, currentCulture);
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "dataconsentconsentredirect", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "DataConsentConsentRedirect", XmlUtils.GetNodeValue(nodeSettings, "dataconsentconsentredirect", string.Empty), true, currentCulture);
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "dataconsentuserdeleteaction", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "DataConsentUserDeleteAction", XmlUtils.GetNodeValue(nodeSettings, "dataconsentuserdeleteaction", string.Empty), true, currentCulture);
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "dataconsentdelay", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "DataConsentDelay", XmlUtils.GetNodeValue(nodeSettings, "dataconsentdelay", string.Empty), true, currentCulture);
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "dataconsentdelaymeasurement", string.Empty)))
+            {
+                UpdatePortalSetting(portalId, "DataConsentDelayMeasurement", XmlUtils.GetNodeValue(nodeSettings, "dataconsentdelaymeasurement", string.Empty), true, currentCulture);
+            }
+
         }
 
         private void ParseRoleGroups(XPathNavigator nav, int portalID, int administratorId)
@@ -1739,6 +1770,14 @@ namespace DotNetNuke.Entities.Portals
                     case "500tab":
                         portal.Custom500TabId = tab.TabID;
                         logType = "Custom500Tab";
+                        break;
+                    case "termstab":
+                        portal.TermsTabId = tab.TabID;
+                        logType = "TermsTabId";
+                        break;
+                    case "privacytab":
+                        portal.PrivacyTabId = tab.TabID;
+                        logType = "PrivacyTabId";
                         break;
                 }
 

--- a/DNN Platform/Website/DesktopModules/Admin/Portals/portal.template.xsd
+++ b/DNN Platform/Website/DesktopModules/Admin/Portals/portal.template.xsd
@@ -7,7 +7,6 @@
         <xs:element name="settings" maxOccurs="1" minOccurs="0">
           <xs:complexType>
             <xs:all>
-              <xs:element name="showcookieconsent" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="enableskinwidgets" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="enableautosave" type="xs:string" minOccurs="0" maxOccurs="1"/>
               <xs:element name="timetoautosave" type="xs:integer" minOccurs="0" maxOccurs="1" />
@@ -42,8 +41,16 @@
               <xs:element name="pageheadtext" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="injectmodulehyperlink" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="addcompatiblehttpheader" type="xs:string" minOccurs="0" maxOccurs="1" />
-			  <xs:element name="allowuseruiculture" type="xs:string" minOccurs="0" maxOccurs="1" />
-			  <xs:element name="enablebrowserlanguage" type="xs:string" minOccurs="0" maxOccurs="1" />			  
+              <xs:element name="allowuseruiculture" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="enablebrowserlanguage" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="showcookieconsent" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="cookiemorelink" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="dataconsentactive" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="dataconsenttermslastchange" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="dataconsentconsentredirect" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="dataconsentuserdeleteaction" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="dataconsentdelay" type="xs:integer" minOccurs="0" maxOccurs="1" />
+              <xs:element name="dataconsentdelaymeasurement" type="xs:string" minOccurs="0" maxOccurs="1" />
             </xs:all>
             <xs:attribute name="sku" type="xs:string"/>
           </xs:complexType>
@@ -64,18 +71,18 @@
                   <xs:all>
                     <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1" />
                     <xs:element name="active" type="xs:string" minOccurs="1" maxOccurs="1" />
-                      <xs:element name="settings" minOccurs="0" maxOccurs="1">
-                          <xs:complexType>
-                              <xs:sequence>
-                                  <xs:element name="setting" minOccurs="0" maxOccurs="unbounded">
-                                      <xs:complexType>
-                                          <xs:attribute name="name" type="xs:string"/>
-                                          <xs:attribute name="value" type="xs:string"/>
-                                      </xs:complexType>
-                                  </xs:element>
-                              </xs:sequence>
-                          </xs:complexType>
-                      </xs:element>
+                    <xs:element name="settings" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="setting" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string"/>
+                              <xs:attribute name="value" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
                   </xs:all>
                 </xs:complexType>
               </xs:element>
@@ -438,7 +445,7 @@
                       <xs:complexType>
                         <xs:sequence>
                           <xs:element name="layout" minOccurs="0" maxOccurs="unbounded">
-                            <xs:complexType> 
+                            <xs:complexType>
                               <xs:all>
                                 <xs:element name="control" type="xs:string" minOccurs="1" maxOccurs="1" />
                               </xs:all>
@@ -576,8 +583,10 @@
       <xs:enumeration value="logintab"/>
       <xs:enumeration value="splashtab"/>
       <xs:enumeration value="404tab"/>
-	  <xs:enumeration value="500tab"/>
-	  <xs:enumeration value="searchtab"/>
+      <xs:enumeration value="500tab"/>
+      <xs:enumeration value="searchtab"/>
+      <xs:enumeration value="termstab"/>
+      <xs:enumeration value="privacytab"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="alignmentEnum">

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -2768,6 +2768,12 @@
     <Content Include="images\xml.gif" />
     <Content Include="images\yellow-warning.gif" />
     <Content Include="images\yellow-warning_16px.gif" />
+    <None Include="DesktopModules\Admin\Portals\portal.template.xsd">
+      <SubType>Designer</SubType>
+    </None>
+    <Content Include="DesktopModules\Admin\Portals\portal.template.xsx">
+      <DependentUpon>portal.template.xsd</DependentUpon>
+    </Content>
     <None Include="Install\App_LocalResources\Locales.xml" />
     <Content Include="Install\AuthSystem\PlaceHolder.txt" />
     <Content Include="Install\Cleanup\PlaceHolder.txt" />


### PR DESCRIPTION
The new portal templates include items in portal settings that were not yet included in the import. Items to do with Cookie Consent and Data Consent. This PR adds them to the schema that is used to verify a template and the code that imports the template.