### PR TITLE
Fixes an issue that prevented creating new pages

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
@@ -494,7 +494,7 @@ namespace Dnn.PersonaBar.Pages.Services
         public HttpResponseMessage GetDefaultSettings(int pageId = 0)
         {
             var settings = this.pagesController.GetDefaultSettings(pageId);
-            return this.Request.CreateResponse(HttpStatusCode.OK, settings);
+            return this.Request.CreateResponse(HttpStatusCode.OK, new { page= settings, new DnnFileUploadOptions().ValidationCode });
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #3866 in the same way as in #3865 and #3769
The validation code is also needed when creating a new page, not only when editing an existing page.