### PR TITLE
Fixes exception when DnnImageHandler returns a cached response

### DIFF
--- a/DNN Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs
@@ -254,7 +254,7 @@ namespace DotNetNuke.Services.GeneratedImage
             {
                 if (this.ImageStore.TryTransmitIfContains(cacheId, context.Response))
                 {
-                    context.Response.End();
+                    context.Response.Flush();
                     return;
                 }
             }


### PR DESCRIPTION
Fixes #3872

# Summary
This error occurs when the image was already generated by `DnnImageHandler` in a previous request and now it's cached in the `~\App_Data\_imagecache` folder.

A quick workaround is to  switch server cache off, in the web config:
```xml
<configuration>
  ...
  <appSettings>
    <add key="DnnImageHandler" value="enableclientcache=False;enableservercache=False" />
    ...
```
but then of course all images are re-generated everytime.

As explained [here](https://stackoverflow.com/a/20080696) and [here](https://forums.asp.net/post/3970586.aspx), the problem is that the `System.Web.HttpResponseWrapper.TransmitFile(string)` method, followed by `Response.End()` produces the exception mentioned in #3872.

This sequence can be seen in code, in following lines:

https://github.com/dnnsoftware/Dnn.Platform/blob/1bb11bf84317381917b7b9aa15ddf8b9a34bd3ba/DNN%20Platform/Library/Services/GeneratedImage/DiskImageStore.cs#L291
https://github.com/dnnsoftware/Dnn.Platform/blob/1bb11bf84317381917b7b9aa15ddf8b9a34bd3ba/DNN%20Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs#L257

Replacing `Response.End()` with `Response.Flush()` fixed the issue.