### PR TITLE
Fix to membership module due to cast error when using JWT auth

### DIFF
--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -254,7 +254,12 @@ namespace DotNetNuke.HttpModules.Membership
                 }
 
                 // if user's password changed after the user cookie created, then force user to login again.
-                var issueDate = ((FormsIdentity)context.User.Identity)?.Ticket.IssueDate;
+                DateTime? issueDate = null;
+                if (context.User.Identity.GetType() == typeof(FormsIdentity))
+                {
+                    issueDate = ((FormsIdentity)context.User.Identity)?.Ticket.IssueDate;
+                }
+
                 return !Null.IsNull(issueDate) && issueDate < user.Membership.LastPasswordChangeDate;
             }
             catch (Exception ex)

--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -255,9 +255,9 @@ namespace DotNetNuke.HttpModules.Membership
 
                 // if user's password changed after the user cookie created, then force user to login again.
                 DateTime? issueDate = null;
-                if (context.User.Identity is FormsIdentity)
+                if (context.User.Identity is FormsIdentity formsIdentity)
                 {
-                    issueDate = ((FormsIdentity)context.User.Identity)?.Ticket.IssueDate;
+                    issueDate = formsIdentity.Ticket.IssueDate;
                 }
 
                 return !Null.IsNull(issueDate) && issueDate < user.Membership.LastPasswordChangeDate;

--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -255,7 +255,7 @@ namespace DotNetNuke.HttpModules.Membership
 
                 // if user's password changed after the user cookie created, then force user to login again.
                 DateTime? issueDate = null;
-                if (context.User.Identity.GetType() == typeof(FormsIdentity))
+                if (context.User.Identity is FormsIdentity)
                 {
                     issueDate = ((FormsIdentity)context.User.Identity)?.Ticket.IssueDate;
                 }


### PR DESCRIPTION
JWT auth sets the thread identity to a "GenericIdentity". The membership module, when checking for having to log off a user, assumes the thread identity is a FormsIdentity. When the exception gets thrown the user is logged out. Hence all JWT traffic is broken. This checks for the type before casting it.