### PR TITLE
Tabs that are not Indexed shouldn't be in the SiteMap

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -65,7 +65,7 @@ namespace DotNetNuke.Services.Sitemap
                         (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
                         (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && this.IsTabPublic(tab.TabPermissions))
                     {
-                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished)
+                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && tab.Indexed)
                         {
                             try
                             {


### PR DESCRIPTION
Fixes #3896 

## Summary
Non-indexed tabs should not be included in the sitemap. This effectively tells the crawler two different statements.  

The only change needed is to validate that the tab is supposed to be index prior to exporting it to the sitemap.
