### PR TITLE
SiteMapProvider - Fix to exclude non-indexed sites to avoid SEO ranking penalty

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -65,7 +65,7 @@ namespace DotNetNuke.Services.Sitemap
                         (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
                         (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && this.IsTabPublic(tab.TabPermissions))
                     {
-                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished)
+                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && tab.Indexed)
                         {
                             try
                             {

--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -65,7 +65,7 @@ namespace DotNetNuke.Services.Sitemap
                         (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
                         (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && this.IsTabPublic(tab.TabPermissions))
                     {
-                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && tab.Indexed)
+                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && Convert.ToBoolean(tab.TabSettings["AllowIndex"]))
                         {
                             try
                             {


### PR DESCRIPTION
fixes #3901

## Summary
Previous submission wasn't correct.  It seems the tab's "Indexed" property is referring to a ContentItem and not the tab's setting.  This submission is referencing the proper TabSetting "AllowIndex"