### PR TITLE
Abstracted AllowIndex logic into TabInfo property

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabInfo.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabInfo.cs
@@ -116,6 +116,16 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         [XmlIgnore]
+        public bool AllowIndex
+        {
+            get
+            {
+                return this.TabSettings["AllowIndex"] == null 
+                       || "true".Equals(this.TabSettings["AllowIndex"].ToString(), StringComparison.CurrentCultureIgnoreCase);
+            }
+        }
+
+        [XmlIgnore]
         public Dictionary<int, ModuleInfo> ChildModules
         {
             get

--- a/DNN Platform/Library/Services/Search/TabIndexer.cs
+++ b/DNN Platform/Library/Services/Search/TabIndexer.cs
@@ -49,10 +49,7 @@ namespace DotNetNuke.Services.Search
             var searchDocuments = new List<SearchDocument>();
             var tabs = (
                 from t in TabController.Instance.GetTabsByPortal(portalId).AsList()
-                where t.LastModifiedOnDate > startDateLocal && (t.TabSettings["AllowIndex"] == null ||
-                                                                "true".Equals(
-                                                                    t.TabSettings["AllowIndex"].ToString(),
-                                                                    StringComparison.CurrentCultureIgnoreCase))
+                where t.LastModifiedOnDate > startDateLocal && (t.AllowIndex)
                 select t).OrderBy(t => t.LastModifiedOnDate).ThenBy(t => t.TabID).ToArray();
 
             if (tabs.Any())

--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -65,7 +65,7 @@ namespace DotNetNuke.Services.Sitemap
                         (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
                         (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && this.IsTabPublic(tab.TabPermissions))
                     {
-                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && tab.Indexed)
+                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && tab.AllowIndex)
                         {
                             try
                             {


### PR DESCRIPTION
Updated usage in TabIndexer.cs
Used same logic for check in CoreSitemapProvider.cs

Fixes #3901
Closes #3902 

## Summary
Used same logic from TabIndexer by abstracting to a property on TabInfo and used in both TabIndexer.cs and CoreSitemapProvider.cs
