### PR TITLE
Fix MVC NuGet package and improve devsite build script

### DIFF
--- a/Build/Cake/devsite.cake
+++ b/Build/Cake/devsite.cake
@@ -1,13 +1,19 @@
 // Tasks to help you create and maintain a local DNN development site.
 // Note these tasks depend on the correct settings in your settings file.
 
-Task("ResetDevSite")
+Task("BuildToTempFolder")
     .IsDependentOn("SetVersion")
     .IsDependentOn("UpdateDnnManifests")
     .IsDependentOn("ResetDatabase")
     .IsDependentOn("PreparePackaging")
 	.IsDependentOn("OtherPackages")
 	.IsDependentOn("ExternalExtensions")
+    .Does(() => 
+    {
+    });
+
+Task("ResetDevSite")
+	.IsDependentOn("BuildToTempFolder")
 	.IsDependentOn("CopyToDevSite")
 	.IsDependentOn("CopyWebConfigToDevSite")
     .Does(() => 

--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -19,8 +19,8 @@
       <dependency id="DotNetNuke.Web.Client" version="$version$" />
       <dependency id="DotNetNuke.WebApi" version="$version$" />
       <dependency id="Microsoft.AspNet.Mvc" version="5.1.3" />
-      <dependency id="Microsoft.AspNet.Razor" version="3.1.1" />
-      <dependency id="Microsoft.AspNet.WebPages" version="3.1.1" />
+      <dependency id="Microsoft.AspNet.Razor" version="3.1.2" />
+      <dependency id="Microsoft.AspNet.WebPages" version="3.1.2" />
       <dependency id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
     </dependencies>
   </metadata>

--- a/DNN Platform/Connectors/Azure/packages.config
+++ b/DNN Platform/Connectors/Azure/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="RestSharp" version="104.1" targetFramework="net45" allowedVersions="[104.1.0.0]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="RestSharp" version="104.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Dnn.AuthServices.Jwt/packages.config
+++ b/DNN Platform/Dnn.AuthServices.Jwt/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net45" allowedVersions="[4.0.2.206221351]" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net45" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Deprecated/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/packages.config
@@ -1,7 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Deprecated/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60" />
     <Reference Include="Microsoft.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebHelpers.3.1.1\lib\net45\Microsoft.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebHelpers.3.1.2\lib\net45\Microsoft.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -54,7 +54,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -71,22 +71,22 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Routing">
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -95,11 +95,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WebMatrix.Data, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.Data.3.1.1\lib\net45\WebMatrix.Data.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.Data.3.1.2\lib\net45\WebMatrix.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebMatrix.WebData, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.WebData.3.1.1\lib\net45\WebMatrix.WebData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.WebData.3.1.2\lib\net45\WebMatrix.WebData.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/DNN Platform/DotNetNuke.Web.Mvc/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Mvc/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" allowedVersions="[5.1.3]" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebHelpers" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
+  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebHelpers" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Mvc/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Mvc/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebHelpers" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebHelpers" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNuke.Web.Razor.csproj
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNuke.Web.Razor.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebHelpers.3.1.1\lib\net45\Microsoft.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebHelpers.3.1.2\lib\net45\Microsoft.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -63,33 +63,33 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="WebMatrix.Data, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.Data.3.1.1\lib\net45\WebMatrix.Data.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.Data.3.1.2\lib\net45\WebMatrix.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebMatrix.WebData, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.WebData.3.1.1\lib\net45\WebMatrix.WebData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.WebData.3.1.2\lib\net45\WebMatrix.WebData.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/DNN Platform/DotNetNuke.Web.Razor/Library.build
+++ b/DNN Platform/DotNetNuke.Web.Razor/Library.build
@@ -9,12 +9,12 @@
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\DotNetNuke.Web.Razor.dll" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\DotNetNuke.Web.Razor.pdb" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\DotNetNuke.Web.Razor.xml" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.WebPages.Data.3.1.1\lib\net45\WebMatrix.Data.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.WebPages.WebData.3.1.1\lib\net45\WebMatrix.WebData.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\Packages\Microsoft.AspNet.WebHelpers.3.1.1\lib\net45\Microsoft.Web.Helpers.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\System.Web.Helpers.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\System.Web.Razor.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\System.Web.WebPages.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\System.Web.WebPages.Razor.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\WebMatrix.Data.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\WebMatrix.WebData.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Microsoft.Web.Helpers.dll" DestinationFolder="$(WebsitePath)/bin" />
   </Target>
 </Project>

--- a/DNN Platform/DotNetNuke.Web.Razor/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Razor/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebHelpers" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebHelpers" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Razor/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Razor/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebHelpers" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebHelpers" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages.Data" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages.WebData" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -125,7 +125,7 @@
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -137,21 +137,21 @@
       <HintPath>..\..\Packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/DNN Platform/DotNetNuke.Web/Library.build
+++ b/DNN Platform/DotNetNuke.Web/Library.build
@@ -20,6 +20,6 @@
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\DotNetNuke.Web.xml" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\DotNetNuke.DependencyInjection.pdb" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\DotNetNuke.DependencyInjection.dll" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="..\..\packages\WebFormsMvp.1.4.1.0\lib\WebFormsMvp.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\WebFormsMvp.dll" DestinationFolder="$(WebsitePath)/bin" />
   </Target>
 </Project>

--- a/DNN Platform/DotNetNuke.Web/packages.config
+++ b/DNN Platform/DotNetNuke.Web/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dnn.ClientDependency" version="1.9.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45"/>
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" allowedVersions="[1.4.1.0]" />
+  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web/packages.config
+++ b/DNN Platform/DotNetNuke.Web/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dnn.ClientDependency" version="1.9.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45"/>
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -161,25 +161,25 @@
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/DNN Platform/Library/packages.config
+++ b/DNN Platform/Library/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dnn.ClientDependency" version="1.9.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="3.1.1" targetFramework="net472" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="PetaPoco.Compiled" version="6.0.415" targetFramework="net472" />
-  <package id="QuickIO.NET" version="2.6.2.0" targetFramework="net45" allowedVersions="[2.6.2.0]" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" allowedVersions="[0.86.0]" />
+  <package id="QuickIO.NET" version="2.6.2.0" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Library/packages.config
+++ b/DNN Platform/Library/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dnn.ClientDependency" version="1.9.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="3.1.1" targetFramework="net472" />

--- a/DNN Platform/Modules/CoreMessaging/packages.config
+++ b/DNN Platform/Modules/CoreMessaging/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
+++ b/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
@@ -89,14 +89,29 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.WebPages">
-      <HintPath>..\..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/DNN Platform/Modules/DDRMenu/packages.config
+++ b/DNN Platform/Modules/DDRMenu/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/DigitalAssets/packages.config
+++ b/DNN Platform/Modules/DigitalAssets/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/DnnExportImport/packages.config
+++ b/DNN Platform/Modules/DnnExportImport/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.1.0" targetFramework="net45" allowedVersions="[3.1.0]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="LiteDB" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/DnnExportImportLibrary/packages.config
+++ b/DNN Platform/Modules/DnnExportImportLibrary/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LiteDB" version="3.1.0" targetFramework="net45" allowedVersions="[3.1.0]" />
+  <package id="LiteDB" version="3.1.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/Groups/packages.config
+++ b/DNN Platform/Modules/Groups/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/HtmlEditorManager/packages.config
+++ b/DNN Platform/Modules/HtmlEditorManager/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" allowedVersions="[1.4.1.0]" />
+  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Modules/Journal/packages.config
+++ b/DNN Platform/Modules/Journal/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/MemberDirectory/packages.config
+++ b/DNN Platform/Modules/MemberDirectory/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" allowedVersions="[1.4.1.0]" />
+  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Tests/DNN.Integration.Test.Framework/packages.config
+++ b/DNN Platform/Tests/DNN.Integration.Test.Framework/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" allowedVersions="[0.86.0]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Authentication/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Authentication/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" allowedVersions="[4.0.8876.1]" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" allowedVersions="[0.86.0]" />
+  <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.2.1" targetFramework="net45" allowedVersions="[4.2.1]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NBuilder" version="5.0.0" targetFramework="net45" allowedVersions="[5.0.0]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net45" allowedVersions="[3.1.0]" />
-  <package id="NTestDataBuilder" version="1.0.2" targetFramework="net45" allowedVersions="[1.0.2]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Castle.Core" version="4.2.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NBuilder" version="5.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net45" />
+  <package id="NTestDataBuilder" version="1.0.2" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net45" allowedVersions="[4.4.0]" />
+  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.UI/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.UI/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" allowedVersions="[6.1.7601.17515]" />
+  <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/DotNetNuke.Tests.Web.Mvc.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/DotNetNuke.Tests.Web.Mvc.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -64,19 +64,19 @@
       <HintPath>..\..\..\Packages\Microsoft.AspNet.Mvc.5.1.3\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/packages.config
@@ -2,13 +2,13 @@
 <packages>
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" allowedVersions="[5.1.3]" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" allowedVersions="[4.2.1502.0911]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" allowedVersions="[2.6.4]" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" allowedVersions="[1.4.1.0]" />
+  <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -138,9 +138,9 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.Helpers.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
@@ -150,22 +150,22 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Packages\Microsoft.AspNet.Mvc.5.1.3\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.1.2\lib\net45\System.Web.Razor.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Microsoft.AspNet.Razor.3.1.1\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Services" />
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.1.2\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Microsoft.AspNet.WebPages.3.1.1\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/DNN Platform/Website/packages.config
+++ b/DNN Platform/Website/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />

--- a/DNN Platform/Website/packages.config
+++ b/DNN Platform/Website/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" allowedVersions="[5.1.3]" />
-  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
-  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" allowedVersions="[3.1.1]" />
+  <package id="Microsoft.AspNet.Mvc" version="5.1.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" allowedVersions="[1.0.0.0]" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" allowedVersions="[0.86.0]" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This PR fixes the MVC Nuget package definition as Microsoft.AspNet.Mvc v 5.1.3 depends on Microsoft.AspNet.WebPages and Microsoft.AspNet.Razor 3.1.2 or higher.

It also makes a small improvement to the devsite build scripts so we can test build without refreshing the dev site in case we want to test that locally.