### PR TITLE
Visualizer not able to change settings in shared pages

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabChangeTracker.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabChangeTracker.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Entities.Tabs
 {
     using System;
@@ -14,6 +13,8 @@ namespace DotNetNuke.Entities.Tabs
 
     public class TabChangeTracker : ServiceLocator<ITabChangeTracker, TabChangeTracker>, ITabChangeTracker
     {
+        public const string IsModuleDoesNotBelongToPage = nameof(IsModuleDoesNotBelongToPage);
+
         public void TrackModuleAddition(ModuleInfo module, int moduleVersion, int userId)
         {
             var unPublishedVersion = TabVersionBuilder.Instance.GetUnPublishedVersion(module.TabID);
@@ -32,9 +33,12 @@ namespace DotNetNuke.Entities.Tabs
         {
             if (ModuleController.Instance.IsSharedModule(module) && moduleVersion != Null.NullInteger)
             {
-                throw new InvalidOperationException(Localization.GetExceptionMessage(
+                var exceptionToThrow = new InvalidOperationException(
+                    Localization.GetExceptionMessage(
                     "ModuleDoesNotBelongToPage",
                     "This module does not belong to the page. Please, move to its master page to change the module"));
+                exceptionToThrow.Data.Add(IsModuleDoesNotBelongToPage, true);
+                throw exceptionToThrow;
             }
 
             var unPublishedVersion = TabVersionBuilder.Instance.GetUnPublishedVersion(module.TabID);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Entities\Portals\PortalSettingsControllerTests.cs" />
     <Compile Include="Entities\Portals\PortalSettingsTests.cs" />
     <Compile Include="Entities\Tabs\TabControllerTests.cs" />
+    <Compile Include="Entities\Tabs\TabChangeTrackerTests.cs" />
     <Compile Include="Entities\Urls\FriendlyUrlControllerTests.cs" />
     <Compile Include="Framework\ServicesFrameworkTests.cs" />
     <Compile Include="Framework\JavaScriptLibraries\JavaScriptTests.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Tabs/TabChangeTrackerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Tabs/TabChangeTrackerTests.cs
@@ -1,15 +1,22 @@
-﻿using System;
-using DotNetNuke.Entities.Modules;
-using DotNetNuke.Entities.Tabs;
-using DotNetNuke.Framework;
-using Moq;
-using NUnit.Framework;
-
-namespace DotNetNuke.Tests.Core.Entities.Tabs
+﻿namespace DotNetNuke.Tests.Core.Entities.Tabs
 {
+    using System;
+
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Framework;
+    using Moq;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Contains UTs for <see cref="TabChangeTracker"/>.
+    /// </summary>
     [TestFixture]
     public class TabChangeTrackerTests
     {
+        /// <summary>
+        /// UT for <see cref="TabChangeTracker.TrackModuleModification(ModuleInfo, int, int)" />.
+        /// </summary>
         [Test]
         public void TrackModuleModification_WithSharedModule_ThrowsException()
         {

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Tabs/TabChangeTrackerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Tabs/TabChangeTrackerTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using DotNetNuke.Entities.Modules;
+using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Framework;
+using Moq;
+using NUnit.Framework;
+
+namespace DotNetNuke.Tests.Core.Entities.Tabs
+{
+    [TestFixture]
+    public class TabChangeTrackerTests
+    {
+        [Test]
+        public void TrackModuleModification_WithSharedModule_ThrowsException()
+        {
+            // Arrange
+            var tabChangeTracker = new TabChangeTracker();
+            var mockedModuleController = new Mock<IModuleController>();
+            mockedModuleController
+                .Setup(s => s.IsSharedModule(It.IsAny<ModuleInfo>()))
+                .Returns(true);
+            ServiceLocator<IModuleController, ModuleController>.SetTestableInstance(mockedModuleController.Object);
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => tabChangeTracker.TrackModuleModification(null, 1, 0));
+            Assert.AreEqual(true, exception.Data?[TabChangeTracker.IsModuleDoesNotBelongToPage]);
+        }
+    }
+}

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ModuleService.js
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ModuleService.js
@@ -54,6 +54,17 @@ if (typeof dnn.ContentEditorManager === "undefined" || dnn.ContentEditorManager 
                         return;
                     }
 
+                    if (xhr != null &&
+                        xhr.responseJSON != null &&
+                        xhr.responseJSON.message != null) {
+                        $.dnnAlert({
+                            title: 'Error',
+                            text: xhr.responseJSON.message
+                        });
+
+                        return;
+                    }
+
                     $.dnnAlert({
                         title: 'Error',
                         text: 'Error occurred when request service \'' + method + '\'.'


### PR DESCRIPTION
Fixes #3911
Fix summary: A differentiable exception is thrown now so that the message of the exception can be shown if the exception data includes "IsModuleDoesNotBelongToPage" bool; the exception type is not changed to not cause any regressions (some places might depend on that specific exception type). There is also another PR made (on an Engage repo) which checks the thrown exception in [SettingsController.cs](https://github.com/trilogy-group/Dnn.Evoq.Module.StructuredContent/blob/1bf07ddd58829befd455ae2d81806181e086bfd3/src/StructuredContent.Visualizer/Services/SettingsController.cs)

Demo: https://drive.google.com/file/d/10QAWw7IES9l3lY_nc-88r0LVsOGWx-ut/view?usp=sharing
