### PR TITLE
Enable Scheduling - Add TZ to page StartDate and EndDate

### DIFF
--- a/DNN Platform/Library/Common/Utilities/Null.cs
+++ b/DNN Platform/Library/Common/Utilities/Null.cs
@@ -215,6 +215,13 @@ namespace DotNetNuke.Common.Utilities
             return objValue != DBNull.Value ? Convert.ToDateTime(objValue) : NullDate;
         }
 
+        public static DateTime SetNullDateTime(object objValue, DateTimeKind dateTimeKind)
+        {
+            return objValue != DBNull.Value
+                ? DateTime.SpecifyKind(Convert.ToDateTime(objValue), dateTimeKind)
+                : NullDate;
+        }
+
         public static int SetNullInteger(object objValue)
         {
             return objValue != DBNull.Value ? Convert.ToInt32(objValue) : NullInteger;

--- a/DNN Platform/Library/Entities/Tabs/TabInfo.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabInfo.cs
@@ -856,8 +856,8 @@ namespace DotNetNuke.Entities.Tabs
             this.SkinSrc = Null.SetNullString(dr["SkinSrc"]);
             this.ContainerSrc = Null.SetNullString(dr["ContainerSrc"]);
             this.TabPath = Null.SetNullString(dr["TabPath"]);
-            this.StartDate = Null.SetNullDateTime(dr["StartDate"]);
-            this.EndDate = Null.SetNullDateTime(dr["EndDate"]);
+            this.StartDate = Null.SetNullDateTime(dr["StartDate"], DateTimeKind.Utc);
+            this.EndDate = Null.SetNullDateTime(dr["EndDate"], DateTimeKind.Utc);
             this.HasChildren = Null.SetNullBoolean(dr["HasChildren"]);
             this.RefreshInterval = Null.SetNullInteger(dr["RefreshInterval"]);
             this.PageHeadText = Null.SetNullString(dr["PageHeadText"]);

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageDetails/PageDetailsFooter/PageDetailsFooter.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageDetails/PageDetailsFooter/PageDetailsFooter.jsx
@@ -21,6 +21,15 @@ class PageDetailsFooter extends Component {
 
     onChangeValue(key, value) {
         const {onChangeField} = this.props;
+
+        switch (key) {
+            case "startDate":
+            case "endDate":
+                // the DatePicker returns strings, but we need dates
+                value = new Date(value);
+                break;
+        }
+
         onChangeField(key, value);
     }
 

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/services/pageService.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/services/pageService.js
@@ -118,7 +118,10 @@ const PageService = function () {
     const toFrontEndPage = function (pageResult) {
         return {
             ...pageResult.page,
-            schedulingEnabled: pageResult.page.startDate || pageResult.page.endDate,
+            schedulingEnabled: pageResult.page.startDate !== null || pageResult.page.endDate !== null,
+            // the API returns strings, but we need dates
+            startDate: pageResult.page.startDate === null ? null : new Date(pageResult.page.startDate),
+            endDate: pageResult.page.endDate === null ? null : new Date(pageResult.page.endDate),
             validationCode: pageResult.ValidationCode,
         };
     };


### PR DESCRIPTION
Fixes #3918

## Summary
This is both a back-end issue and a front-end issue.

Initially, when start/end datetime is null, and the user picks a datetime in the date picker, the front-end sends the datetimes correctly as UTC, and the back-end API saves the datetimes correctly in the database as UTC.

Later, during browser refresh, the `GetPageDetails` API is called, which fails to specify the `DateTimeKind` as UTC when filling the DTO from the database, and therefore the datetimes are serialized back as local datetimes, which produces the offset in the front-end.

At this point, if the user changes the datetime back to the original value, this time the date picker returns a `String` instead of a javascript `Date` object, and the TZ info is lost there, and the API then receives a local datetime. This sort of fixes the problem thereafter, but out of pure luck I would say.

This pull request basically adds the lost TZ both in the back-end (by specifying the `DateTimeKind`) and the front-end (using Date objects with the view model instead of strings).