### PR TITLE
Prevented unnecessary call to getCultureList method on website change

### DIFF
--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/siteLanguageSelector/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/siteLanguageSelector/index.jsx
@@ -65,35 +65,37 @@ class SiteLanguageSelector extends Component {
 
     onSiteChange(event) {
         let {state, props} = this;
-        props.dispatch(SearchActions.getCultureList(event.value, () => {
-            let culture = this.validateCultureCode();
-            if (state.cultureCode !== culture) {
-                this.setState({
-                    portalId: event.value,
-                    cultureCode: culture
-                });
-                this.triggerEvent("portalIdCultureCodeChanged",
-                    {
+        if(event.value !== state.portalId){
+            props.dispatch(SearchActions.getCultureList(event.value, () => {
+                let culture = this.validateCultureCode();
+                if (state.cultureCode !== culture) {
+                    this.setState({
                         portalId: event.value,
-                        cultureCode: culture,
-                        referrer: props.referrer,
-                        referrerText: props.referrerText,
-                        backToReferrerFunc: props.backToReferrerFunc
+                        cultureCode: culture
                     });
-            }
-            else {
-                this.setState({
-                    portalId: event.value
-                });
-                this.triggerEvent("portalIdChanged",
-                    {
-                        portalId: event.value,
-                        referrer: props.referrer,
-                        referrerText: props.referrerText,
-                        backToReferrerFunc: props.backToReferrerFunc
+                    this.triggerEvent("portalIdCultureCodeChanged",
+                        {
+                            portalId: event.value,
+                            cultureCode: culture,
+                            referrer: props.referrer,
+                            referrerText: props.referrerText,
+                            backToReferrerFunc: props.backToReferrerFunc
+                        });
+                }
+                else {
+                    this.setState({
+                        portalId: event.value
                     });
-            }
-        }));
+                    this.triggerEvent("portalIdChanged",
+                        {
+                            portalId: event.value,
+                            referrer: props.referrer,
+                            referrerText: props.referrerText,
+                            backToReferrerFunc: props.backToReferrerFunc
+                        });
+                }
+            }));
+        }
     }
 
     onLanguageChange(event) {

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/siteLanguageSelector/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/siteLanguageSelector/index.jsx
@@ -65,37 +65,40 @@ class SiteLanguageSelector extends Component {
 
     onSiteChange(event) {
         let {state, props} = this;
-        if(event.value !== state.portalId){
-            props.dispatch(SearchActions.getCultureList(event.value, () => {
-                let culture = this.validateCultureCode();
-                if (state.cultureCode !== culture) {
-                    this.setState({
-                        portalId: event.value,
-                        cultureCode: culture
-                    });
-                    this.triggerEvent("portalIdCultureCodeChanged",
-                        {
-                            portalId: event.value,
-                            cultureCode: culture,
-                            referrer: props.referrer,
-                            referrerText: props.referrerText,
-                            backToReferrerFunc: props.backToReferrerFunc
-                        });
-                }
-                else {
-                    this.setState({
-                        portalId: event.value
-                    });
-                    this.triggerEvent("portalIdChanged",
-                        {
-                            portalId: event.value,
-                            referrer: props.referrer,
-                            referrerText: props.referrerText,
-                            backToReferrerFunc: props.backToReferrerFunc
-                        });
-                }
-            }));
+
+        if(event.value === state.portalId){
+            return;
         }
+
+        props.dispatch(SearchActions.getCultureList(event.value, () => {
+            let culture = this.validateCultureCode();
+            if (state.cultureCode !== culture) {
+                this.setState({
+                    portalId: event.value,
+                    cultureCode: culture
+                });
+                this.triggerEvent("portalIdCultureCodeChanged",
+                    {
+                        portalId: event.value,
+                        cultureCode: culture,
+                        referrer: props.referrer,
+                        referrerText: props.referrerText,
+                        backToReferrerFunc: props.backToReferrerFunc
+                    });
+            }
+            else {
+                this.setState({
+                    portalId: event.value
+                });
+                this.triggerEvent("portalIdChanged",
+                    {
+                        portalId: event.value,
+                        referrer: props.referrer,
+                        referrerText: props.referrerText,
+                        backToReferrerFunc: props.backToReferrerFunc
+                    });
+            }
+        }));
     }
 
     onLanguageChange(event) {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3922 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
onSitechange(event) will invoke getCultureList method only if portalId is changed and prevent otherwise.

