### PR TITLE
Adding a page URL of type Active (200) without specifying a site adds uneditable 301 URLs

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/EditUrl.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/EditUrl.jsx
@@ -140,7 +140,10 @@ class EditUrl extends Component {
                         <Button type="secondary" onClick={onCancel} disabled={saving}>
                             {Localization.get("Cancel")}
                         </Button>
-                        <Button type="primary" onClick={onSave} disabled={!this.state.hasChanges || saving}>
+                        <Button
+                            type="primary"
+                            onClick={onSave}
+                            disabled={!this.state.hasChanges || url == null || url.siteAlias == null || url.siteAlias.Key == null || saving}>
                             {Localization.get("Save")}
                         </Button>
                     </div>


### PR DESCRIPTION
Fixes #3924

## Summary
Null check is added into the Save button to disable it when Site Alias field is empty.

Demo: https://drive.google.com/file/d/12DpeK8Yf9AZJWjlKupUUC0T8KvyhtugY/view?usp=sharing