### PR TITLE
Allow Dependency Injection in more places

### DIFF
--- a/DNN Platform/Library/Entities/Modules/DesktopModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleController.cs
@@ -659,14 +659,11 @@ namespace DotNetNuke.Entities.Modules
 
         private void CheckInterfacesImplementation(ref DesktopModuleInfo desktopModuleInfo)
         {
-            var businessController = Reflection.CreateType(desktopModuleInfo.BusinessControllerClass);
-            var controller = Reflection.CreateObject(desktopModuleInfo.BusinessControllerClass, desktopModuleInfo.BusinessControllerClass);
+            var businessControllerType = Reflection.CreateType(desktopModuleInfo.BusinessControllerClass);
 
-            desktopModuleInfo.IsPortable = businessController.GetInterfaces().Contains(typeof(IPortable));
-#pragma warning disable 0618
-            desktopModuleInfo.IsSearchable = (controller is ModuleSearchBase) || businessController.GetInterfaces().Contains(typeof(ISearchable));
-#pragma warning restore 0618
-            desktopModuleInfo.IsUpgradeable = businessController.GetInterfaces().Contains(typeof(IUpgradeable));
+            desktopModuleInfo.IsPortable = typeof(IPortable).IsAssignableFrom(businessControllerType);
+            desktopModuleInfo.IsSearchable = typeof(ModuleSearchBase).IsAssignableFrom(businessControllerType) || typeof(ISearchable).IsAssignableFrom(businessControllerType);
+            desktopModuleInfo.IsUpgradeable = typeof(IUpgradeable).IsAssignableFrom(businessControllerType);
         }
     }
 }

--- a/DNN Platform/Library/Entities/Modules/IPortable.cs
+++ b/DNN Platform/Library/Entities/Modules/IPortable.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Entities.Modules
 {
     /// <summary>A contract specifying the ability to import and export the content of a module.</summary>

--- a/DNN Platform/Library/Entities/Modules/IUpgradeable.cs
+++ b/DNN Platform/Library/Entities/Modules/IUpgradeable.cs
@@ -1,11 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Entities.Modules
 {
+    /// <summary>
+    /// A contract specifying the ability for a module's business controller
+    /// class to run custom upgrade logic after the module has been installed.
+    /// </summary>
     public interface IUpgradeable
     {
+        /// <summary>Runs custom upgrade logic for a module.</summary>
+        /// <param name="Version">The version the module is being upgraded to.</param>
+        /// <returns>A status message.</returns>
         string UpgradeModule(string Version);
     }
 }

--- a/DNN Platform/Library/Entities/Modules/IVersionable.cs
+++ b/DNN Platform/Library/Entities/Modules/IVersionable.cs
@@ -5,8 +5,8 @@
 namespace DotNetNuke.Entities.Modules
 {
     /// <summary>
-    /// This interface allow the page to interact with his modules to delete/rollback or publish a specific version.
-    /// The module that wants support page versioning need to implement it in the Bussiness controller.
+    /// This interface allow the page to interact with the module to delete/rollback or publish a specific version.
+    /// The module that wants to support page versioning needs to implement it in the Business controller.
     /// </summary>
     public interface IVersionable
     {

--- a/DNN Platform/Library/Entities/Modules/ModuleSearchBase.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleSearchBase.cs
@@ -24,11 +24,11 @@ namespace DotNetNuke.Entities.Modules
         /// It is important to include all the relevant Properties for Updated content (sames as supplied for New document), as partial SearchDocument cannot be Updated in Search Index.
         /// This is different from standard SQL Update where selective columns can updated. In this case, entire Document must be supplied during Update or else information will be lost.
         /// For Deleted content, set IsActive = false property.
-        /// When IsActive = true, an attempt is made to delete any existing document with same UniqueKey, PortalId, SearchTypeId=Module, ModuleDefitionId and ModuleId(if specified).
+        /// When IsActive = true, an attempt is made to delete any existing document with same UniqueKey, PortalId, SearchTypeId=Module, ModuleDefinitionId and ModuleId(if specified).
         /// System calls the module based on Scheduler Frequency. This call is performed for modules that have indicated supportedFeature type="Searchable" in manifest.
-        /// Call is performed for every Module Definition defined by the Module. If a module has more than one Module Defition, module must return data for the main Module Defition,
+        /// Call is performed for every Module Definition defined by the Module. If a module has more than one Module Definition, module must return data for the main Module Definition,
         /// or else duplicate content may get stored.
-        /// Module must include ModuleDefition Id in the SearchDocument. In addition ModuleId and / or TabId can also be specified if module has TabId / ModuleId specific content.</remarks>
+        /// Module must include ModuleDefinition Id in the SearchDocument. In addition ModuleId and / or TabId can also be specified if module has TabId / ModuleId specific content.</remarks>
         public abstract IList<SearchDocument> GetModifiedSearchDocuments(ModuleInfo moduleInfo, DateTime beginDateUtc);
     }
 }

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -44,7 +44,10 @@ namespace DotNetNuke.Entities.Portals
     // using DotNetNuke.Services.Upgrade.Internals.InstallConfiguration;
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Web.Client;
+
     using ICSharpCode.SharpZipLib.Zip;
+    
+    using Microsoft.Extensions.DependencyInjection;
 
     using FileInfo = DotNetNuke.Services.FileSystem.FileInfo;
     using IAbPortalSettings = DotNetNuke.Abstractions.Portals.IPortalSettings;
@@ -2090,7 +2093,7 @@ namespace DotNetNuke.Entities.Portals
             var typeClass = Type.GetType(providerBusinessClassNode.Attributes["type"].Value);
             if (typeClass != null)
             {
-                ComponentFactory.RegisterComponentInstance<TAbstract>(folderTypeConfig.Provider, Activator.CreateInstance(typeClass));
+                ComponentFactory.RegisterComponentInstance<TAbstract>(folderTypeConfig.Provider, ActivatorUtilities.CreateInstance(Globals.DependencyProvider, typeClass));
             }
         }
 

--- a/DNN Platform/Library/Entities/Tabs/TabVersions/TabVersionBuilder.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabVersions/TabVersionBuilder.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
     using System.Data.SqlClient;
     using System.Linq;
 
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Modules;
@@ -16,6 +17,8 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
     using DotNetNuke.Framework;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Localization;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     public class TabVersionBuilder : ServiceLocator<ITabVersionBuilder, TabVersionBuilder>, ITabVersionBuilder
     {
@@ -240,8 +243,11 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
 
         public int GetModuleContentLatestVersion(ModuleInfo module)
         {
-            var versionableController = this.GetVersionableController(module);
-            return versionableController != null ? versionableController.GetLatestVersion(module.ModuleID) : DefaultVersionNumber;
+            var (scope, versionableController) = this.GetVersionableController(module);
+            using (scope)
+            {
+                return versionableController?.GetLatestVersion(module.ModuleID) ?? DefaultVersionNumber;
+            }
         }
 
         protected override Func<ITabVersionBuilder> GetFactory()
@@ -756,18 +762,23 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
                 return Null.NullInteger;
             }
 
-            var versionableController = this.GetVersionableController(moduleInfo);
-            if (versionableController == null)
+            var (scope, versionableController) = this.GetVersionableController(moduleInfo);
+            using (scope)
             {
-                return Null.NullInteger;
-            }
+                if (versionableController == null)
+                {
+                    return Null.NullInteger;
+                }
 
-            if (this._moduleController.IsSharedModule(moduleInfo))
-            {
-                return versionableController.GetPublishedVersion(moduleInfo.ModuleID);
-            }
+                if (this._moduleController.IsSharedModule(moduleInfo))
+                {
+                    return versionableController.GetPublishedVersion(moduleInfo.ModuleID);
+                }
 
-            return versionableController.RollBackVersion(unPublishedDetail.ModuleId, unPublishedDetail.ModuleVersion);
+                return versionableController.RollBackVersion(
+                    unPublishedDetail.ModuleId,
+                    unPublishedDetail.ModuleVersion);
+            }
         }
 
         private void PublishDetail(int tabId, TabVersionDetail unPublishedDetail)
@@ -779,10 +790,10 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
                 return;
             }
 
-            var versionableController = this.GetVersionableController(moduleInfo);
-            if (versionableController != null)
+            var (scope, versionableController) = this.GetVersionableController(moduleInfo);
+            using (scope)
             {
-                versionableController.PublishVersion(unPublishedDetail.ModuleId, unPublishedDetail.ModuleVersion);
+                versionableController?.PublishVersion(unPublishedDetail.ModuleId, unPublishedDetail.ModuleVersion);
             }
         }
 
@@ -795,27 +806,37 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
                 return;
             }
 
-            var versionableController = this.GetVersionableController(moduleInfo);
-            if (versionableController != null)
+            var (scope, versionableController) = this.GetVersionableController(moduleInfo);
+            using (scope)
             {
-                versionableController.DeleteVersion(unPublishedDetail.ModuleId, unPublishedDetail.ModuleVersion);
+                versionableController?.DeleteVersion(unPublishedDetail.ModuleId, unPublishedDetail.ModuleVersion);
             }
         }
 
-        private IVersionable GetVersionableController(ModuleInfo moduleInfo)
+        private (IDisposable, IVersionable) GetVersionableController(ModuleInfo moduleInfo)
         {
             if (string.IsNullOrEmpty(moduleInfo.DesktopModule.BusinessControllerClass))
             {
-                return null;
+                return (null, null);
             }
 
-            object controller = Reflection.CreateObject(moduleInfo.DesktopModule.BusinessControllerClass, string.Empty);
-            if (controller is IVersionable)
+            IServiceScope serviceScope = null;
+            var controllerType = Reflection.CreateType(moduleInfo.DesktopModule.BusinessControllerClass);
+            try
             {
-                return controller as IVersionable;
+                serviceScope = Globals.DependencyProvider.CreateScope();
+                if (ActivatorUtilities.CreateInstance(serviceScope.ServiceProvider, controllerType) is IVersionable controller)
+                {
+                    return (serviceScope, controller);
+                }
+            }
+            catch
+            {
+                serviceScope?.Dispose();
+                throw;
             }
 
-            return null;
+            return (null, null);
         }
 
         private void CreateFirstTabVersion(int tabId, TabInfo tab, IEnumerable<ModuleInfo> modules)
@@ -839,8 +860,11 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
 
         private int GetModuleContentPublishedVersion(ModuleInfo module)
         {
-            var versionableController = this.GetVersionableController(module);
-            return versionableController != null ? versionableController.GetPublishedVersion(module.ModuleID) : Null.NullInteger;
+            var (scope, versionableController) = this.GetVersionableController(module);
+            using (scope)
+            {
+                return versionableController?.GetPublishedVersion(module.ModuleID) ?? Null.NullInteger;
+            }
         }
     }
 }

--- a/DNN Platform/Library/Prompt/CommandRepository.cs
+++ b/DNN Platform/Library/Prompt/CommandRepository.cs
@@ -1,20 +1,24 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-using DotNetNuke.Abstractions.Prompt;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.Framework;
-using DotNetNuke.Framework.Reflections;
-using DotNetNuke.Services.Localization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
-using System.Web.Caching;
-
 namespace DotNetNuke.Prompt
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text.RegularExpressions;
+    using System.Web.Caching;
+
+    using DotNetNuke.Abstractions.Prompt;
+    using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Framework;
+    using DotNetNuke.Framework.Reflections;
+    using DotNetNuke.Services.Localization;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     public class CommandRepository : ServiceLocator<ICommandRepository, CommandRepository>, ICommandRepository
     {
         protected override Func<ICommandRepository> GetFactory()
@@ -33,7 +37,7 @@ namespace DotNetNuke.Prompt
             var allCommands = CommandList();
             if (allCommands.ContainsKey(commandName))
             {
-                return (IConsoleCommand)Activator.CreateInstance(Type.GetType(allCommands[commandName].TypeFullName));
+                return (IConsoleCommand)ActivatorUtilities.CreateInstance(Globals.DependencyProvider, Type.GetType(allCommands[commandName].TypeFullName));
             }
             return null;
         }
@@ -63,16 +67,22 @@ namespace DotNetNuke.Prompt
                 var version = assemblyName.Version.ToString();
                 var commandAttribute = (ConsoleCommandAttribute)attr;
                 var key = commandAttribute.Name.ToUpper();
-                var localResourceFile = ((IConsoleCommand)Activator.CreateInstance(cmd))?.LocalResourceFile;
-                commands.Add(key, new Command
+                
+                string localResourceFile;
+                using (var serviceScope = Globals.DependencyProvider.CreateScope())
                 {
-                    Category = LocalizeString(commandAttribute.CategoryKey, localResourceFile),
-                    Description = LocalizeString(commandAttribute.DescriptionKey, localResourceFile),
-                    Key = key,
-                    Name = commandAttribute.Name,
-                    Version = version,
-                    TypeFullName = cmd.AssemblyQualifiedName
-                });
+                    localResourceFile = ((IConsoleCommand)ActivatorUtilities.CreateInstance(serviceScope.ServiceProvider, cmd))?.LocalResourceFile;
+                }
+
+                commands.Add(key, new Command
+                                  {
+                                      Category = LocalizeString(commandAttribute.CategoryKey, localResourceFile),
+                                      Description = LocalizeString(commandAttribute.DescriptionKey, localResourceFile),
+                                      Key = key,
+                                      Name = commandAttribute.Name,
+                                      Version = version,
+                                      TypeFullName = cmd.AssemblyQualifiedName
+                                  });
             }
             return commands;
         }

--- a/DNN Platform/Library/Services/Connections/ConnectionsManager.cs
+++ b/DNN Platform/Library/Services/Connections/ConnectionsManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Services.Connections
 {
     using System;
@@ -9,10 +8,13 @@ namespace DotNetNuke.Services.Connections
     using System.Linq;
     using System.Reflection;
 
+    using DotNetNuke.Common;
     using DotNetNuke.Framework;
     using DotNetNuke.Framework.Reflections;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Installer.Packages;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     public sealed class ConnectionsManager : ServiceLocator<IConnectionsManager, ConnectionsManager>, IConnectionsManager
     {
@@ -55,7 +57,7 @@ namespace DotNetNuke.Services.Connections
             {
                 try
                 {
-                    var processor = Activator.CreateInstance(type) as IConnector;
+                    var processor = ActivatorUtilities.CreateInstance(Globals.DependencyProvider, type) as IConnector;
                     if (processor != null
                             && !string.IsNullOrEmpty(processor.Name)
                             && !_processors.ContainsKey(processor.Name))

--- a/DNN Platform/Library/Services/Search/Controllers/ModuleResultController.cs
+++ b/DNN Platform/Library/Services/Search/Controllers/ModuleResultController.cs
@@ -178,6 +178,7 @@ namespace DotNetNuke.Services.Search.Controllers
                 {
                     if (!_moduleSearchControllers.ContainsKey(module.DesktopModule.BusinessControllerClass))
                     {
+                        // TODO: enable dependency injection
                         var controller = Reflection.CreateObject(module.DesktopModule.BusinessControllerClass, module.DesktopModule.BusinessControllerClass) as IModuleSearchResultController;
                         _moduleSearchControllers.Add(module.DesktopModule.BusinessControllerClass, controller);
                     }

--- a/DNN Platform/Library/UI/Modules/Html5/Html5ModuleTokenReplace.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/Html5ModuleTokenReplace.cs
@@ -61,6 +61,7 @@ namespace DotNetNuke.UI.Modules.Html5
 
             try
             {
+                // TODO: enable dependency injection
                 var controller = Reflection.CreateObject(bizClass, bizClass) as ICustomTokenProvider;
                 _businessControllers.Add(bizClass, controller);
 

--- a/DNN Platform/Library/UI/Modules/ModuleControlBase.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleControlBase.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.UI.Modules
     /// -----------------------------------------------------------------------------
     /// <summary>
     /// ModuleControlBase is a base class for Module Controls that inherits from the
-    /// Control base class.  As with all MontrolControl base classes it implements
+    /// Control base class.  As with all ModuleControl base classes it implements
     /// IModuleControl.
     /// </summary>
     /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/UI/Modules/ModuleInjectionManager.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInjectionManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.UI.Modules
 {
     using System;
@@ -9,10 +8,13 @@ namespace DotNetNuke.UI.Modules
     using System.Linq;
 
     using DotNetNuke.Collections.Internal;
+    using DotNetNuke.Common;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework.Reflections;
     using DotNetNuke.Instrumentation;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     internal class ModuleInjectionManager
     {
@@ -49,7 +51,7 @@ namespace DotNetNuke.UI.Modules
                 IModuleInjectionFilter filter;
                 try
                 {
-                    filter = Activator.CreateInstance(filterType) as IModuleInjectionFilter;
+                    filter = ActivatorUtilities.CreateInstance(Globals.DependencyProvider, filterType) as IModuleInjectionFilter;
                 }
                 catch (Exception e)
                 {

--- a/DNN Platform/Library/UI/Skins/Pane.cs
+++ b/DNN Platform/Library/UI/Skins/Pane.cs
@@ -132,7 +132,7 @@ namespace DotNetNuke.UI.Skins
                 sanitizedModuleName = Globals.CreateValidClass(module.DesktopModule.ModuleName, false);
             }
 
-            if (this.IsVesionableModule(module))
+            if (this.IsVersionableModule(module))
             {
                 classFormatString += " DnnVersionableControl";
             }
@@ -581,7 +581,7 @@ namespace DotNetNuke.UI.Skins
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// ModuleMoveToPanePostBack excutes when a module is moved by Drag-and-Drop.
+        /// ModuleMoveToPanePostBack executes when a module is moved by Drag-and-Drop.
         /// </summary>
         /// <param name="args">A ClientAPIPostBackEventArgs object.</param>
         /// -----------------------------------------------------------------------------
@@ -602,15 +602,15 @@ namespace DotNetNuke.UI.Skins
             }
         }
 
-        private bool IsVesionableModule(ModuleInfo moduleInfo)
+        private bool IsVersionableModule(ModuleInfo moduleInfo)
         {
             if (string.IsNullOrEmpty(moduleInfo.DesktopModule.BusinessControllerClass))
             {
                 return false;
             }
 
-            object controller = Framework.Reflection.CreateObject(moduleInfo.DesktopModule.BusinessControllerClass, string.Empty);
-            return controller is IVersionable;
+            var controllerType = Framework.Reflection.CreateType(moduleInfo.DesktopModule.BusinessControllerClass);
+            return typeof(IVersionable).IsAssignableFrom(controllerType);
         }
     }
 }

--- a/DNN Platform/Modules/DnnExportImport/Components/Controllers/BaseController.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Controllers/BaseController.cs
@@ -71,7 +71,7 @@ namespace Dnn.ExportImport.Components.Controllers
         }
 
         /// <summary>
-        /// Retrieves one page of paginated proceessed jobs.
+        /// Retrieves one page of paginated processed jobs.
         /// </summary>
         /// <returns></returns>
         public AllJobsResult GetAllJobs(int portalId, int currentPortalId, int? pageSize, int? pageIndex, int? jobType, string keywords)

--- a/DNN Platform/Website/admin/Modules/Export.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Export.ascx.cs
@@ -165,10 +165,10 @@ namespace DotNetNuke.Modules.Admin.Modules
                 {
                     try
                     {
-                        var objObject = Reflection.CreateObject(this.Module.DesktopModule.BusinessControllerClass, this.Module.DesktopModule.BusinessControllerClass);
-
+                        var businessControllerType = Reflection.CreateType(this.Module.DesktopModule.BusinessControllerClass, this.Module.DesktopModule.BusinessControllerClass, UseCache: true);
+                        
                         // Double-check
-                        if (objObject is IPortable)
+                        if (typeof(IPortable).IsAssignableFrom(businessControllerType))
                         {
                             XmlDocument moduleXml = new XmlDocument { XmlResolver = null };
                             XmlNode moduleNode = ModuleController.SerializeModule(moduleXml, this.Module, true);

--- a/DNN Platform/Website/admin/Modules/Import.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Import.ascx.cs
@@ -22,6 +22,7 @@ namespace DotNetNuke.Modules.Admin.Modules
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Skins.Controls;
+
     using Microsoft.Extensions.DependencyInjection;
 
     public partial class Import : PortalModuleBase
@@ -199,8 +200,8 @@ namespace DotNetNuke.Modules.Admin.Modules
                 {
                     try
                     {
-                        var objObject = Reflection.CreateObject(this.Module.DesktopModule.BusinessControllerClass, this.Module.DesktopModule.BusinessControllerClass);
-                        if (objObject is IPortable)
+                        var businessControllerType = Reflection.CreateType(this.Module.DesktopModule.BusinessControllerClass, this.Module.DesktopModule.BusinessControllerClass, UseCache: true);
+                        if (ActivatorUtilities.CreateInstance(this.DependencyProvider, businessControllerType) is IPortable controller)
                         {
                             var xmlDoc = new XmlDocument { XmlResolver = null };
                             try
@@ -223,7 +224,7 @@ namespace DotNetNuke.Modules.Admin.Modules
                                     // DNN26810 if rootnode = "content", import only content(the old way)
                                     if (xmlDoc.DocumentElement.Name.ToLowerInvariant() == "content")
                                     {
-                                        ((IPortable)objObject).ImportModule(this.ModuleId, xmlDoc.DocumentElement.InnerXml, strVersion, this.UserInfo.UserID);
+                                        controller.ImportModule(this.ModuleId, xmlDoc.DocumentElement.InnerXml, strVersion, this.UserInfo.UserID);
                                     }
 
                                     // otherwise (="module") import the new way

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1432,6 +1432,7 @@ namespace Dnn.PersonaBar.Pages.Components
                     {
                         if (!string.IsNullOrEmpty(newModule.DesktopModule.BusinessControllerClass))
                         {
+                            // TODO: enable dependency injection
                             var objObject = Reflection.CreateObject(newModule.DesktopModule.BusinessControllerClass, newModule.DesktopModule.BusinessControllerClass);
                             var o = objObject as IPortable;
                             if (o != null)


### PR DESCRIPTION
## Summary
We can enable dependency injection in more places.  This is a work-in-progress PR which replaces `Activator.CreateInstance(type)` with `ActivatorUtilities.CreateInstance(serviceProvider, type)`.

The main complication with this is that we need to be able to dispose of services when the instance we've created is out of scope.  In some places there's a straightforward way to do this, and in some places there is not.