### PR TITLE
Migrate Static APIs to from PortalController to IPortalController

### DIFF
--- a/DNN Platform/Library/Entities/Portals/IPortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/IPortalController.cs
@@ -20,13 +20,11 @@ namespace DotNetNuke.Entities.Portals
     /// </remarks>
     public interface IPortalController
     {
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Creates a new portal alias.
         /// </summary>
         /// <param name="portalId">Id of the portal.</param>
         /// <param name="portalAlias">Portal Alias to be created.</param>
-        /// -----------------------------------------------------------------------------
         void AddPortalAlias(int portalId, string portalAlias);
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Portals/IPortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/IPortalController.cs
@@ -7,7 +7,7 @@ namespace DotNetNuke.Entities.Portals
     using System;
     using System.Collections;
     using System.Collections.Generic;
-
+    using System.Xml.XPath;
     using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Entities.Users;
 
@@ -220,5 +220,264 @@ namespace DotNetNuke.Entities.Portals
         /// Adds or Updates or Deletes a portal setting value.
         /// </summary>
         void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode, bool isSecure);
+
+        /// <summary>
+        /// Adds the portal dictionary.
+        /// </summary>
+        /// <param name="portalId">The portal id.</param>
+        /// <param name="tabId">The tab id.</param>
+        void AddPortalDictionary(int portalId, int tabId);
+
+        /// <summary>
+        /// Creates the root folder for a child portal.
+        /// </summary>
+        /// <remarks>
+        /// If call this method, it will create the specific folder if the folder doesn't exist;
+        /// and will copy subhost.aspx to the folder if there is no 'Default.aspx'.
+        /// </remarks>
+        /// <param name="ChildPath">The child path.</param>
+        /// <returns>
+        /// If the method executed successful, it will return NullString, otherwise return error message.
+        /// </returns>
+        /// <example>
+        /// <code lang="C#">
+        /// string childPhysicalPath = Server.MapPath(childPath);
+        /// message = PortalController.CreateChildPortalFolder(childPhysicalPath);
+        /// </code>
+        /// </example>
+        string CreateChildPortalFolder(string childPath);
+
+        /// <summary>
+        /// Deletes all expired portals.
+        /// </summary>
+        /// <param name="serverPath">The server path.</param>
+        void DeleteExpiredPortals(string serverPath);
+
+        /// <summary>
+        /// Deletes the portal.
+        /// </summary>
+        /// <param name="portal">The portal.</param>
+        /// <param name="serverPath">The server path.</param>
+        /// <returns>If the method executed successful, it will return NullString, otherwise return error message.</returns>
+        string DeletePortal(PortalInfo portal, string serverPath);
+
+        /// <summary>
+        /// Get the portal folder froma child portal alias.
+        /// </summary>
+        /// <param name="alias">portal alias.</param>
+        /// <returns>folder path of the child portal.</returns>
+        string GetPortalFolder(string alias);
+
+        /// <summary>Delete the child portal folder and try to remove its parent when parent folder is empty.</summary>
+        /// <param name="serverPath">the server path.</param>
+        /// <param name="portalFolder">the child folder path.</param>
+        void DeletePortalFolder(string serverPath, string portalFolder);
+
+        /// <summary>
+        /// Gets the portal dictionary.
+        /// </summary>
+        /// <returns>portal dictionary. the dictionary's Key -> Value is: TabId -> PortalId.</returns>
+        Dictionary<int, int> GetPortalDictionary();
+
+        /// <summary>
+        /// GetPortalsByName gets all the portals whose name matches a provided filter expression.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <param name="nameToMatch">The email address to use to find a match.</param>
+        /// <param name="pageIndex">The page of records to return.</param>
+        /// <param name="pageSize">The size of the page.</param>
+        /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
+        /// <returns>An ArrayList of PortalInfo objects.</returns>
+        ArrayList GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords);
+
+        ArrayList GetPortalsByUser(int userId);
+
+        int GetEffectivePortalId(int portalId);
+
+        /// <summary>
+        /// Gets all expired portals.
+        /// </summary>
+        /// <returns>all expired portals as array list.</returns>
+        ArrayList GetExpiredPortals();
+
+        /// <summary>
+        /// Determines whether the portal is child portal.
+        /// </summary>
+        /// <param name="portal">The portal.</param>
+        /// <param name="serverPath">The server path.</param>
+        /// <returns>
+        ///   <c>true</c> if the portal is child portal; otherwise, <c>false</c>.
+        /// </returns>
+        bool IsChildPortal(PortalInfo portal, string serverPath);
+
+        bool IsMemberOfPortalGroup(int portalId);
+
+        /// <summary>
+        /// Deletes the portal setting (neutral and for all languages).
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        void DeletePortalSetting(int portalID, string settingName);
+
+        /// <summary>
+        /// Deletes the portal setting in this language.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        void DeletePortalSetting(int portalID, string settingName, string cultureCode);
+
+        /// <summary>
+        /// Deletes all portal settings by portal id.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        void DeletePortalSettings(int portalID);
+
+        /// <summary>
+        /// Deletes all portal settings by portal id and for a given language (Null: all languages and neutral settings).
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        void DeletePortalSettings(int portalID, string cultureCode);
+
+        /// <summary>
+        /// takes in a text value, decrypts it with a FIPS compliant algorithm and returns the value.
+        /// </summary>
+        /// <param name="settingName">the setting to read.</param>
+        /// <param name="passPhrase">the pass phrase used for encryption/decryption.</param>
+        /// <returns></returns>
+        string GetEncryptedString(string settingName, int portalID, string passPhrase);
+
+        /// <summary>
+        /// Gets the portal setting.
+        /// </summary>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        string GetPortalSetting(string settingName, int portalID, string defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting for a specific language (or neutral).
+        /// </summary>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
+        /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
+        string GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode);
+
+        /// <summary>
+        /// Gets the portal setting as boolean.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting as boolean for a specific language (or neutral).
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">default value.</param>
+        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
+        /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
+        bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode);
+
+        /// <summary>
+        /// Gets the portal setting as integer.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        int GetPortalSettingAsInteger(string key, int portalID, int defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting as double.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalId">The portal Id.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        double GetPortalSettingAsDouble(string key, int portalId, double defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting as integer for a specific language (or neutral).
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
+        /// <returns>Returns setting's value if portal contains the specific setting (for specified lang, otherwise return defaultValue.</returns>
+        int GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode);
+
+        /// <summary>
+        /// takes in a text value, encrypts it with a FIPS compliant algorithm and stores.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">host settings key.</param>
+        /// <param name="settingValue">host settings value.</param>
+        /// <param name="passPhrase">pass phrase to allow encryption/decryption.</param>
+        void UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase);
+
+        /// <summary>
+        /// Updates a single neutral (not language specific) portal setting and clears it from the cache.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="settingValue">The setting value.</param>
+        void UpdatePortalSetting(int portalID, string settingName, string settingValue);
+
+        /// <summary>
+        /// Updates a single neutral (not language specific) portal setting, optionally without clearing the cache.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="settingValue">The setting value.</param>
+        /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
+        void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache);
+
+        /// <summary>
+        /// Checks the desktop modules whether is installed.
+        /// </summary>
+        /// <param name="nav">The nav.</param>
+        /// <returns>Empty string if the module hasn't been installed, otherwise return the friendly name.</returns>
+        string CheckDesktopModulesInstalled(XPathNavigator nav);
+
+        /// <summary>
+        ///   function provides the language for portalinfo requests
+        ///   in case where language has not been installed yet, will return the core install default of en-us.
+        /// </summary>
+        /// <param name="portalID"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// </remarks>
+        string GetActivePortalLanguage(int portalID);
+
+        /// <summary>
+        ///   return the current DefaultLanguage value from the Portals table for the requested Portalid.
+        /// </summary>
+        /// <param name = "portalID"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// </remarks>
+        string GetPortalDefaultLanguage(int portalID);
+
+        /// <summary>
+        ///   set the required DefaultLanguage in the Portals table for a particular portal
+        ///   saves having to update an entire PortalInfo object.
+        /// </summary>
+        /// <param name="portalID"></param>
+        /// <param name="CultureCode"></param>
+        /// <remarks>
+        /// </remarks>
+        void UpdatePortalDefaultLanguage(int portalID, string cultureCode);
+
+        void IncrementCrmVersion(int portalID);
+
+        void IncrementOverridingPortalsCrmVersion();
     }
 }

--- a/DNN Platform/Library/Entities/Portals/IPortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/IPortalController.cs
@@ -12,9 +12,12 @@ namespace DotNetNuke.Entities.Portals
     using DotNetNuke.Entities.Users;
 
     /// <summary>
-    /// Do not implement.  This interface is meant for reference and unit test purposes only.
-    /// There is no guarantee that this interface will not change.
+    /// IPortalController provides business layer APIs for the portal.
     /// </summary>
+    /// <remarks>
+    /// DotNetNuke supports the concept of virtualised sites in a single install. This means that multiple sites,
+    /// each potentially with multiple unique URL's, can exist in one instance of DotNetNuke i.e. one set of files and one database.
+    /// </remarks>
     public interface IPortalController
     {
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -30,7 +30,6 @@ namespace DotNetNuke.Entities.Portals
     using DotNetNuke.Entities.Urls;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Entities.Users.Social;
-    using DotNetNuke.Framework;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Security.Membership;
     using DotNetNuke.Security.Permissions;
@@ -45,7 +44,7 @@ namespace DotNetNuke.Entities.Portals
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Web.Client;
     using ICSharpCode.SharpZipLib.Zip;
-
+    using Microsoft.Extensions.DependencyInjection;
     using FileInfo = DotNetNuke.Services.FileSystem.FileInfo;
     using IAbPortalSettings = DotNetNuke.Abstractions.Portals.IPortalSettings;
 
@@ -56,7 +55,7 @@ namespace DotNetNuke.Entities.Portals
     /// DotNetNuke supports the concept of virtualised sites in a single install. This means that multiple sites,
     /// each potentially with multiple unique URL's, can exist in one instance of DotNetNuke i.e. one set of files and one database.
     /// </remarks>
-    public partial class PortalController : ServiceLocator<IPortalController, PortalController>, IPortalController
+    public partial class PortalController : IPortalController
     {
         public const string HtmlText_TimeToAutoSave = "HtmlText_TimeToAutoSave";
         public const string HtmlText_AutoSaveEnabled = "HtmlText_AutoSaveEnabled";
@@ -64,6 +63,24 @@ namespace DotNetNuke.Entities.Portals
         protected const string HttpContextKeyPortalSettingsDictionary = "PortalSettingsDictionary{0}{1}";
 
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(PortalController));
+
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController' with Dependency Injection. Scheduled removal in v11.0.0.")]
+        protected static Func<IPortalController> Factory => () => Instance;
+
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController' with Dependency Injection. Scheduled removal in v11.0.0.")]
+        protected static Func<IPortalController> GetFactory() => Factory;
+
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController' with Dependency Injection. Scheduled removal in v11.0.0.")]
+        public static void SetTestableInstance(IPortalController instance) =>
+            throw new NotSupportedException("'PortalController.SetTestableInstance' is no longer supported, use Dependency Injection to resolve 'IPortalController'");
+
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController' with Dependency Injection. Scheduled removal in v11.0.0.")]
+        public static void ClearInstance() =>
+            throw new NotSupportedException("'PortalController.SetTestableInstance' is no longer supported, use Dependency Injection to resolve 'IPortalController'");
+
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController' with Dependency Injection. Scheduled removal in v11.0.0.")]
+        public static IPortalController Instance => Globals.DependencyProvider.GetService<IPortalController>();
+
 
         /// <summary>
         /// Adds the portal dictionary.
@@ -166,7 +183,7 @@ namespace DotNetNuke.Entities.Portals
             string message = string.Empty;
 
             // check if this is the last portal
-            var portals = Instance.GetPortals();
+            var portals = GetPortals();
             if (portals.Count > 1)
             {
                 if (portal != null)
@@ -319,7 +336,8 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByUser' instance method. Scheduled removal in v11.0.0.")]
-        public static ArrayList GetPortalsByUser(int userId) => Instance.GetPortalsByUser(userId);
+        public static ArrayList GetPortalsByUser(int userId) =>
+            Instance.GetPortalsByUser(userId);
 
         /// <inheritdoc />
         ArrayList IPortalController.GetPortalsByUser(int userId)
@@ -329,14 +347,15 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEffectivePortalId' instance method. Scheduled removal in v11.0.0.")]
-        public static int GetEffectivePortalId(int portalId) => Instance.GetEffectivePortalId(portalId);
+        public static int GetEffectivePortalId(int portalId) =>
+            Instance.GetEffectivePortalId(portalId);
 
         /// <inheritdoc />
         int IPortalController.GetEffectivePortalId(int portalId)
         {
             if (portalId > Null.NullInteger && Globals.Status != Globals.UpgradeStatus.Upgrade)
             {
-                var portal = Instance.GetPortal(portalId);
+                var portal = GetPortal(portalId);
                 var portalGroup = (from p in PortalGroupController.Instance.GetPortalGroups()
                                    where p.PortalGroupId == portal.PortalGroupID
                                    select p)
@@ -356,7 +375,8 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <returns>all expired portals as array list.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetExpiredPortals' instance method. Scheduled removal in v11.0.0.")]
-        public static ArrayList GetExpiredPortals() => Instance.GetExpiredPortals();
+        public static ArrayList GetExpiredPortals() =>
+            Instance.GetExpiredPortals();
 
         /// <inheritdoc />
         ArrayList IPortalController.GetExpiredPortals()
@@ -400,12 +420,13 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsMemberOfPortalGroup' instance method. Scheduled removal in v11.0.0.")]
-        public static bool IsMemberOfPortalGroup(int portalId) => Instance.IsMemberOfPortalGroup(portalId);
+        public static bool IsMemberOfPortalGroup(int portalId) =>
+            Instance.IsMemberOfPortalGroup(portalId);
 
         /// <inheritdoc />
         bool IPortalController.IsMemberOfPortalGroup(int portalId)
         {
-            var portal = Instance.GetPortal(portalId);
+            var portal = GetPortal(portalId);
 
             return portal != null && portal.PortalGroupID > Null.NullInteger;
         }
@@ -448,7 +469,8 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instance method. Scheduled removal in v11.0.0.")]
-        public static void DeletePortalSettings(int portalID) => Instance.DeletePortalSettings(portalID);
+        public static void DeletePortalSettings(int portalID) =>
+            Instance.DeletePortalSettings(portalID);
 
         /// <inheritdoc />
         void IPortalController.DeletePortalSettings(int portalID)
@@ -511,7 +533,7 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 string setting;
-                Instance.GetPortalSettings(portalID).TryGetValue(settingName, out setting);
+                GetPortalSettings(portalID).TryGetValue(settingName, out setting);
                 retValue = string.IsNullOrEmpty(setting) ? defaultValue : setting;
             }
             catch (Exception exc)
@@ -541,7 +563,7 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 string setting;
-                Instance.GetPortalSettings(portalID, cultureCode).TryGetValue(settingName, out setting);
+                GetPortalSettings(portalID, cultureCode).TryGetValue(settingName, out setting);
                 retValue = string.IsNullOrEmpty(setting) ? defaultValue : setting;
             }
             catch (Exception exc)
@@ -570,7 +592,7 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 string setting;
-                Instance.GetPortalSettings(portalID).TryGetValue(key, out setting);
+                GetPortalSettings(portalID).TryGetValue(key, out setting);
                 if (string.IsNullOrEmpty(setting))
                 {
                     retValue = defaultValue;
@@ -643,7 +665,7 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 string setting;
-                Instance.GetPortalSettings(portalID).TryGetValue(key, out setting);
+                GetPortalSettings(portalID).TryGetValue(key, out setting);
                 if (string.IsNullOrEmpty(setting))
                 {
                     retValue = defaultValue;
@@ -679,7 +701,7 @@ namespace DotNetNuke.Entities.Portals
             try
             {
                 string setting;
-                Instance.GetPortalSettings(portalId).TryGetValue(key, out setting);
+                GetPortalSettings(portalId).TryGetValue(key, out setting);
                 if (string.IsNullOrEmpty(setting))
                 {
                     retValue = defaultValue;
@@ -824,10 +846,9 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
         /// <param name="cultureCode">culture code for language specific settings, null string ontherwise.</param>
         /// <param name="isSecure">When true it encrypt the value before storing it in the database.</param>
-        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode, bool isSecure)
-        {
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
+        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode, bool isSecure) =>
             Instance.UpdatePortalSetting(portalID, settingName, settingValue, clearCache, cultureCode, isSecure);
-        }
 
         /// <summary>
         /// Checks the desktop modules whether is installed.
@@ -886,7 +907,8 @@ namespace DotNetNuke.Entities.Portals
         /// <remarks>
         /// </remarks>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetActivePortalLanguage' instance method. Scheduled removal in v11.0.0.")]
-        public static string GetActivePortalLanguage(int portalID) => Instance.GetActivePortalLanguage(portalID);
+        public static string GetActivePortalLanguage(int portalID) =>
+            Instance.GetActivePortalLanguage(portalID);
 
         /// <inheritdoc />
         string IPortalController.GetActivePortalLanguage(int portalID)
@@ -985,7 +1007,8 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementCrmVersion' instance method. Scheduled removal in v11.0.0.")]
-        public static void IncrementCrmVersion(int portalID) => Instance.IncrementCrmVersion(portalID);
+        public static void IncrementCrmVersion(int portalID) =>
+            Instance.IncrementCrmVersion(portalID);
 
         /// <inheritdoc />
         void IPortalController.IncrementCrmVersion(int portalID)
@@ -1000,12 +1023,13 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementOverridingPortalsCrmVersion' instance method. Scheduled removal in v11.0.0.")]
-        public static void IncrementOverridingPortalsCrmVersion() => Instance.IncrementOverridingPortalsCrmVersion();
+        public static void IncrementOverridingPortalsCrmVersion() =>
+            Instance.IncrementOverridingPortalsCrmVersion();
 
         /// <inheritdoc />
         void IPortalController.IncrementOverridingPortalsCrmVersion()
         {
-            foreach (PortalInfo portal in Instance.GetPortals())
+            foreach (PortalInfo portal in GetPortals())
             {
                 string setting = GetPortalSetting(ClientResourceSettings.OverrideDefaultSettingsKey, portal.PortalID, "False");
                 bool overriden;
@@ -1672,12 +1696,9 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        protected override Func<IPortalController> GetFactory()
-        {
-            return () => new PortalController();
-        }
+        
 
-        private static void CreateDefaultPortalRoles(int portalId, int administratorId, ref int administratorRoleId, ref int registeredRoleId, ref int subscriberRoleId, int unverifiedRoleId)
+        private void CreateDefaultPortalRoles(int portalId, int administratorId, ref int administratorRoleId, ref int registeredRoleId, ref int subscriberRoleId, int unverifiedRoleId)
         {
             // create required roles if not already created
             if (administratorRoleId == -1)
@@ -1705,7 +1726,7 @@ namespace DotNetNuke.Entities.Portals
             RoleController.Instance.AddUserRole(portalId, administratorId, subscriberRoleId, RoleStatus.Approved, false, Null.NullDate, Null.NullDate);
         }
 
-        private static string CreateProfileDefinitions(int portalId, string templateFilePath)
+        private string CreateProfileDefinitions(int portalId, string templateFilePath)
         {
             string strMessage = Null.NullString;
             try
@@ -1743,7 +1764,7 @@ namespace DotNetNuke.Entities.Portals
             return strMessage;
         }
 
-        private static int CreatePortal(string portalName, string homeDirectory, string cultureCode)
+        private int CreatePortal(string portalName, string homeDirectory, string cultureCode)
         {
             // add portal
             int PortalId = -1;
@@ -1788,7 +1809,7 @@ namespace DotNetNuke.Entities.Portals
             return PortalId;
         }
 
-        private static int CreateRole(RoleInfo role)
+        private int CreateRole(RoleInfo role)
         {
             int roleId;
 
@@ -1806,7 +1827,7 @@ namespace DotNetNuke.Entities.Portals
             return roleId;
         }
 
-        private static int CreateRole(int portalId, string roleName, string description, float serviceFee, int billingPeriod, string billingFrequency, float trialFee, int trialPeriod, string trialFrequency,
+        private int CreateRole(int portalId, string roleName, string description, float serviceFee, int billingPeriod, string billingFrequency, float trialFee, int trialPeriod, string trialFrequency,
                                bool isPublic, bool isAuto)
         {
             RoleInfo objRoleInfo = new RoleInfo();
@@ -1825,7 +1846,7 @@ namespace DotNetNuke.Entities.Portals
             return CreateRole(objRoleInfo);
         }
 
-        private static void CreateRoleGroup(RoleGroupInfo roleGroup)
+        private void CreateRoleGroup(RoleGroupInfo roleGroup)
         {
             // First check if the role exists
             var objRoleGroupInfo = RoleController.GetRoleGroupByName(roleGroup.PortalID, roleGroup.RoleGroupName);
@@ -1840,11 +1861,11 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        private static void DeletePortalInternal(int portalId)
+        private void DeletePortalInternal(int portalId)
         {
             UserController.DeleteUsers(portalId, false, true);
 
-            var portal = Instance.GetPortal(portalId);
+            var portal =  GetPortal(portalId);
 
             DataProvider.Instance().DeletePortalInfo(portalId);
 
@@ -1888,7 +1909,7 @@ namespace DotNetNuke.Entities.Portals
             return true;
         }
 
-        private static PortalSettings GetCurrentPortalSettingsInternal()
+        private PortalSettings GetCurrentPortalSettingsInternal()
         {
             PortalSettings objPortalSettings = null;
             if (HttpContext.Current != null)
@@ -1899,18 +1920,16 @@ namespace DotNetNuke.Entities.Portals
             return objPortalSettings;
         }
 
-        private static PortalInfo GetPortalInternal(int portalId, string cultureCode)
-        {
-            return Instance.GetPortalList(cultureCode).SingleOrDefault(p => p.PortalID == portalId);
-        }
+        private PortalInfo GetPortalInternal(int portalId, string cultureCode) =>
+            GetPortalList(cultureCode).SingleOrDefault(p => p.PortalID == portalId);
 
-        private static object GetPortalDefaultLanguageCallBack(CacheItemArgs cacheItemArgs)
+        private object GetPortalDefaultLanguageCallBack(CacheItemArgs cacheItemArgs)
         {
             int portalID = (int)cacheItemArgs.ParamList[0];
             return DataProvider.Instance().GetPortalDefaultLanguage(portalID);
         }
 
-        private static object GetPortalDictionaryCallback(CacheItemArgs cacheItemArgs)
+        private object GetPortalDictionaryCallback(CacheItemArgs cacheItemArgs)
         {
             var portalDic = new Dictionary<int, int>();
             if (Host.Host.PerformanceSetting != Globals.PerformanceSettings.NoCaching)
@@ -1940,7 +1959,7 @@ namespace DotNetNuke.Entities.Portals
             return portalDic;
         }
 
-        private static object GetPortalSettingsDictionaryCallback(CacheItemArgs cacheItemArgs)
+        private object GetPortalSettingsDictionaryCallback(CacheItemArgs cacheItemArgs)
         {
             var portalId = (int)cacheItemArgs.ParamList[0];
             var dicSettings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
@@ -1995,7 +2014,7 @@ namespace DotNetNuke.Entities.Portals
             return dicSettings;
         }
 
-        private static void ParseFiles(XmlNodeList nodeFiles, int portalId, FolderInfo folder)
+        private void ParseFiles(XmlNodeList nodeFiles, int portalId, FolderInfo folder)
         {
             var fileManager = FileManager.Instance;
 
@@ -2050,7 +2069,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        private static void ParseFolderPermissions(XmlNodeList nodeFolderPermissions, int portalId, FolderInfo folder)
+        private void ParseFolderPermissions(XmlNodeList nodeFolderPermissions, int portalId, FolderInfo folder)
         {
             PermissionController permissionController = new PermissionController();
             int permissionId = 0;
@@ -2114,7 +2133,7 @@ namespace DotNetNuke.Entities.Portals
             FolderPermissionController.SaveFolderPermissions(folder);
         }
 
-        private static void EnsureRequiredProvidersForFolderTypes()
+        private void EnsureRequiredProvidersForFolderTypes()
         {
             if (ComponentFactory.GetComponent<CryptographyProvider>() == null)
             {
@@ -2123,7 +2142,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        private static void EnsureFolderProviderRegistration<TAbstract>(FolderTypeConfig folderTypeConfig, XmlDocument webConfig)
+        private void EnsureFolderProviderRegistration<TAbstract>(FolderTypeConfig folderTypeConfig, XmlDocument webConfig)
             where TAbstract : class
         {
             var providerBusinessClassNode = webConfig.SelectSingleNode("configuration/dotnetnuke/folder/providers/add[@name='" + folderTypeConfig.Provider + "']");
@@ -2135,7 +2154,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        private static bool EnableBrowserLanguageInDefault(int portalId)
+        private bool EnableBrowserLanguageInDefault(int portalId)
         {
             bool retValue = Null.NullBoolean;
             try
@@ -2159,7 +2178,7 @@ namespace DotNetNuke.Entities.Portals
             return retValue;
         }
 
-        private static Dictionary<string, string> GetPortalSettingsDictionary(int portalId, string cultureCode)
+        private Dictionary<string, string> GetPortalSettingsDictionary(int portalId, string cultureCode)
         {
             var httpContext = HttpContext.Current;
 
@@ -2195,7 +2214,7 @@ namespace DotNetNuke.Entities.Portals
             return dictionary;
         }
 
-        private static string GetActivePortalLanguageFromHttpContext(HttpContext httpContext, int portalId)
+        private string GetActivePortalLanguageFromHttpContext(HttpContext httpContext, int portalId)
         {
             var cultureCode = string.Empty;
 
@@ -2218,7 +2237,7 @@ namespace DotNetNuke.Entities.Portals
             return cultureCode;
         }
 
-        private static LocaleCollection ParseEnabledLocales(XmlNode nodeEnabledLocales, int portalId)
+        private LocaleCollection ParseEnabledLocales(XmlNode nodeEnabledLocales, int portalId)
         {
             var defaultLocale = LocaleController.Instance.GetDefaultLocale(portalId);
             var returnCollection = new LocaleCollection { { defaultLocale.Code, defaultLocale } };
@@ -2249,7 +2268,7 @@ namespace DotNetNuke.Entities.Portals
             return returnCollection;
         }
 
-        private static void ParseProfileDefinitions(XmlNode nodeProfileDefinitions, int portalId)
+        private void ParseProfileDefinitions(XmlNode nodeProfileDefinitions, int portalId)
         {
             var listController = new ListController();
             Dictionary<string, ListEntryInfo> colDataTypes = listController.GetListEntryInfoDictionary("DataType");
@@ -2332,7 +2351,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        private static void ParsePortalDesktopModules(XPathNavigator nav, int portalID)
+        private void ParsePortalDesktopModules(XPathNavigator nav, int portalID)
         {
             foreach (XPathNavigator desktopModuleNav in nav.Select("portalDesktopModule"))
             {
@@ -2381,7 +2400,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        private static void UpdatePortalSettingInternal(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode, bool isSecure)
+        private void UpdatePortalSettingInternal(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode, bool isSecure)
         {
             string currentSetting = GetPortalSetting(settingName, portalID, string.Empty, cultureCode);
 
@@ -3441,7 +3460,7 @@ namespace DotNetNuke.Entities.Portals
             }
             else
             {
-                var portalInfo = Instance.GetPortal(portalId);
+                var portalInfo = GetPortal(portalId);
                 var defaultLocale = LocaleController.Instance.GetLocale(portalInfo.DefaultLanguage);
                 if (defaultLocale == null)
                 {

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -70,7 +70,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="portalId">The portal id.</param>
         /// <param name="tabId">The tab id.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.AddPortalDictionary' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.AddPortalDictionary' instance method. Scheduled removal in v11.0.0.")]
         public static void AddPortalDictionary(int portalId, int tabId) =>
             AddPortalDictionary(portalId, tabId);
 
@@ -104,7 +104,7 @@ namespace DotNetNuke.Entities.Portals
         /// message = PortalController.CreateChildPortalFolder(childPhysicalPath);
         /// </code>
         /// </example>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CreateChildPortalFolder' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CreateChildPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static string CreateChildPortalFolder(string ChildPath) =>
             CreateChildPortalFolder(ChildPath);
 
@@ -157,7 +157,7 @@ namespace DotNetNuke.Entities.Portals
         /// Deletes all expired portals.
         /// </summary>
         /// <param name="serverPath">The server path.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeleteExpiredPortals' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeleteExpiredPortals' instance method. Scheduled removal in v11.0.0.")]
         public static void DeleteExpiredPortals(string serverPath) =>
             DeleteExpiredPortals(serverPath);
 
@@ -179,7 +179,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portal">The portal.</param>
         /// <param name="serverPath">The server path.</param>
         /// <returns>If the method executed successful, it will return NullString, otherwise return error message.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortal' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortal' instance method. Scheduled removal in v11.0.0.")]
         public static string DeletePortal(PortalInfo portal, string serverPath) =>
             DeletePortal(portal, serverPath);
 
@@ -256,7 +256,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="alias">portal alias.</param>
         /// <returns>folder path of the child portal.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalFolder(string alias) =>
             GetPortalFolder(alias);
 
@@ -280,7 +280,7 @@ namespace DotNetNuke.Entities.Portals
         /// <summary>Delete the child portal folder and try to remove its parent when parent folder is empty.</summary>
         /// <param name="serverPath">the server path.</param>
         /// <param name="portalFolder">the child folder path.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalFolder(string serverPath, string portalFolder) =>
             DeletePortalFolder(serverPath, portalFolder);
 
@@ -312,7 +312,7 @@ namespace DotNetNuke.Entities.Portals
         /// Gets the portal dictionary.
         /// </summary>
         /// <returns>portal dictionary. the dictionary's Key -> Value is: TabId -> PortalId.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDictionary' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDictionary' instance method. Scheduled removal in v11.0.0.")]
         public static Dictionary<int, int> GetPortalDictionary() =>
             GetPortalDictionary();
 
@@ -338,7 +338,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
         /// <returns>An ArrayList of PortalInfo objects.</returns>
         /// -----------------------------------------------------------------------------
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByName' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByName' instance method. Scheduled removal in v11.0.0.")]
         public static ArrayList GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords) =>
             GetPortalsByName(nameToMatch, pageIndex, pageSize, ref totalRecords);
 
@@ -364,7 +364,7 @@ namespace DotNetNuke.Entities.Portals
             return CBO.FillCollection(DataProvider.Instance().GetPortalsByName(nameToMatch, pageIndex, pageSize), ref type, ref totalRecords);
         }
 
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByUser' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByUser' instance method. Scheduled removal in v11.0.0.")]
         public static ArrayList GetPortalsByUser(int userId) => GetPortalsByUser(userId);
 
         ArrayList IPortalController.GetPortalsByUser(int userId)
@@ -373,7 +373,7 @@ namespace DotNetNuke.Entities.Portals
             return CBO.FillCollection(DataProvider.Instance().GetPortalsByUser(userId), type);
         }
 
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEffectivePortalId' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEffectivePortalId' instance method. Scheduled removal in v11.0.0.")]
         public static int GetEffectivePortalId(int portalId) => GetEffectivePortalId(portalId);
 
         int IPortalController.GetEffectivePortalId(int portalId)
@@ -399,7 +399,7 @@ namespace DotNetNuke.Entities.Portals
         /// Gets all expired portals.
         /// </summary>
         /// <returns>all expired portals as array list.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetExpiredPortals' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetExpiredPortals' instance method. Scheduled removal in v11.0.0.")]
         public static ArrayList GetExpiredPortals() => GetExpiredPortals();
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>
         ///   <c>true</c> if the portal is child portal; otherwise, <c>false</c>.
         /// </returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsChildPortal' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsChildPortal' instance method. Scheduled removal in v11.0.0.")]
         public static bool IsChildPortal(PortalInfo portal, string serverPath) =>
             IsChildPortal(portal, serverPath);
 
@@ -453,7 +453,7 @@ namespace DotNetNuke.Entities.Portals
             return isChild;
         }
 
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsMemberOfPortalGroup' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsMemberOfPortalGroup' instance method. Scheduled removal in v11.0.0.")]
         public static bool IsMemberOfPortalGroup(int portalId) => IsMemberOfPortalGroup(portalId);
 
         bool IPortalController.IsMemberOfPortalGroup(int portalId)
@@ -468,7 +468,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
         /// <param name="settingName">Name of the setting.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSetting(int portalID, string settingName) =>
             DeletePortalSetting(portalID, settingName);
 
@@ -488,7 +488,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="settingName">Name of the setting.</param>
         /// <param name="cultureCode">The culture code.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSetting(int portalID, string settingName, string cultureCode) =>
             DeletePortalSetting(portalID, settingName, cultureCode);
 
@@ -509,7 +509,7 @@ namespace DotNetNuke.Entities.Portals
         /// Deletes all portal settings by portal id.
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSettings(int portalID) => DeletePortalSettings(portalID);
 
         /// <summary>
@@ -525,7 +525,7 @@ namespace DotNetNuke.Entities.Portals
         /// Deletes all portal settings by portal id and for a given language (Null: all languages and neutral settings).
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSettings(int portalID, string cultureCode) =>
             DeletePortalSettings(portalID, cultureCode);
 
@@ -546,7 +546,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">the setting to read.</param>
         /// <param name="passPhrase">the pass phrase used for encryption/decryption.</param>
         /// <returns></returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEncryptedString' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEncryptedString' instance method. Scheduled removal in v11.0.0.")]
         public static string GetEncryptedString(string settingName, int portalID, string passPhrase) =>
             GetEncryptedString(settingName, portalID, passPhrase);
 
@@ -573,7 +573,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalSetting(string settingName, int portalID, string defaultValue) =>
             GetPortalSetting(settingName, portalID, defaultValue);
 
@@ -609,7 +609,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="defaultValue">The default value.</param>
         /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
         /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode) =>
             GetPortalSetting(settingName, portalID, defaultValue, cultureCode);
 
@@ -645,7 +645,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="defaultValue">default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instance method. Scheduled removal in v11.0.0.")]
         public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue) =>
             GetPortalSettingAsBoolean(key, portalID, defaultValue);
 
@@ -688,7 +688,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="defaultValue">default value.</param>
         /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
         /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instance method. Scheduled removal in v11.0.0.")]
         public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode) =>
             GetPortalSettingAsBoolean(key, portalID, defaultValue, cultureCode);
 
@@ -731,7 +731,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instance method. Scheduled removal in v11.0.0.")]
         public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue) =>
             GetPortalSettingAsInteger(key, portalID, defaultValue);
 
@@ -773,7 +773,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalId">The portal Id.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsDouble' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsDouble' instance method. Scheduled removal in v11.0.0.")]
         public static double GetPortalSettingAsDouble(string key, int portalId, double defaultValue) =>
             GetPortalSettingAsDouble(key, portalId, defaultValue);
 
@@ -816,7 +816,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="defaultValue">The default value.</param>
         /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
         /// <returns>Returns setting's value if portal contains the specific setting (for specified lang, otherwise return defaultValue.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instance method. Scheduled removal in v11.0.0.")]
         public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode) =>
             GetPortalSettingAsInteger(key, portalID, defaultValue, cultureCode);
 
@@ -859,7 +859,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">host settings key.</param>
         /// <param name="settingValue">host settings value.</param>
         /// <param name="passPhrase">pass phrase to allow encryption/decryption.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdateEncryptedString' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdateEncryptedString' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase) =>
             UpdateEncryptedString(portalID, settingName, settingValue, passPhrase);
 
@@ -887,7 +887,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="settingName">Name of the setting.</param>
         /// <param name="settingValue">The setting value.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue) =>
             UpdatePortalSetting(portalID, settingName, settingValue);
 
@@ -909,7 +909,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">Name of the setting.</param>
         /// <param name="settingValue">The setting value.</param>
         /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache) =>
             UpdatePortalSetting(portalID, settingName, settingValue, clearCache);
 
@@ -946,7 +946,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingValue">The setting value.</param>
         /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
         /// <param name="cultureCode">culture code for language specific settings, null string ontherwise.</param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode) =>
             UpdatePortalSetting(portalID, settingName, settingValue, clearCache, cultureCode);
 
@@ -971,7 +971,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="nav">The nav.</param>
         /// <returns>Empty string if the module hasn't been installed, otherwise return the friendly name.</returns>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CheckDesktopModulesInstalled' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CheckDesktopModulesInstalled' instance method. Scheduled removal in v11.0.0.")]
         public static string CheckDesktopModulesInstalled(XPathNavigator nav) =>
             CheckDesktopModulesInstalled(nav);
 
@@ -1026,7 +1026,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns></returns>
         /// <remarks>
         /// </remarks>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetActivePortalLanguage' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetActivePortalLanguage' instance method. Scheduled removal in v11.0.0.")]
         public static string GetActivePortalLanguage(int portalID) => GetActivePortalLanguage(portalID);
 
         /// <summary>
@@ -1099,7 +1099,7 @@ namespace DotNetNuke.Entities.Portals
         ///   return the current DefaultLanguage value from the Portals table for the requested Portalid.
         /// </summary>
         /// <param name="portalID"></param>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDefaultLanguage' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDefaultLanguage' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalDefaultLanguage(int portalID) =>
             GetPortalDefaultLanguage(portalID);
 
@@ -1121,7 +1121,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name = "CultureCode"></param>
         /// <remarks>
         /// </remarks>
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalDefaultLanguage' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalDefaultLanguage' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalDefaultLanguage(int portalID, string CultureCode) =>
             UpdatePortalDefaultLanguage(portalID, CultureCode);
 

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1143,7 +1143,7 @@ namespace DotNetNuke.Entities.Portals
             DataProvider.Instance().EnsureLocalizationExists(portalID, CultureCode);
         }
 
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementCrmVersion' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementCrmVersion' instance method. Scheduled removal in v11.0.0.")]
         public static void IncrementCrmVersion(int portalID) => IncrementCrmVersion(portalID);
 
         void IPortalController.IncrementCrmVersion(int portalID)

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -74,11 +74,7 @@ namespace DotNetNuke.Entities.Portals
         public static void AddPortalDictionary(int portalId, int tabId) =>
             Instance.AddPortalDictionary(portalId, tabId);
 
-        /// <summary>
-        /// Adds the portal dictionary.
-        /// </summary>
-        /// <param name="portalId">The portal id.</param>
-        /// <param name="tabId">The tab id.</param>
+        /// <inheritdoc />
         void IPortalController.AddPortalDictionary(int portalId, int tabId)
         {
             
@@ -108,23 +104,7 @@ namespace DotNetNuke.Entities.Portals
         public static string CreateChildPortalFolder(string ChildPath) =>
             Instance.CreateChildPortalFolder(ChildPath);
 
-        /// <summary>
-        /// Creates the root folder for a child portal.
-        /// </summary>
-        /// <remarks>
-        /// If call this method, it will create the specific folder if the folder doesn't exist;
-        /// and will copy subhost.aspx to the folder if there is no 'Default.aspx'.
-        /// </remarks>
-        /// <param name="ChildPath">The child path.</param>
-        /// <returns>
-        /// If the method executed successful, it will return NullString, otherwise return error message.
-        /// </returns>
-        /// <example>
-        /// <code lang="C#">
-        /// string childPhysicalPath = Server.MapPath(childPath);
-        /// message = PortalController.CreateChildPortalFolder(childPhysicalPath);
-        /// </code>
-        /// </example>
+        /// <inheritdoc />
         string IPortalController.CreateChildPortalFolder(string ChildPath)
         {
             string message = Null.NullString;
@@ -161,10 +141,7 @@ namespace DotNetNuke.Entities.Portals
         public static void DeleteExpiredPortals(string serverPath) =>
             Instance.DeleteExpiredPortals(serverPath);
 
-        /// <summary>
-        /// Deletes all expired portals.
-        /// </summary>
-        /// <param name="serverPath">The server path.</param>
+        /// <inheritdoc />
         void IPortalController.DeleteExpiredPortals(string serverPath)
         {
             foreach (PortalInfo portal in GetExpiredPortals())
@@ -183,12 +160,7 @@ namespace DotNetNuke.Entities.Portals
         public static string DeletePortal(PortalInfo portal, string serverPath) =>
             Instance.DeletePortal(portal, serverPath);
 
-        /// <summary>
-        /// Deletes the portal.
-        /// </summary>
-        /// <param name="portal">The portal.</param>
-        /// <param name="serverPath">The server path.</param>
-        /// <returns>If the method executed successful, it will return NullString, otherwise return error message.</returns>
+        /// <inheritdoc />
         string IPortalController.DeletePortal(PortalInfo portal, string serverPath)
         {
             string message = string.Empty;
@@ -259,12 +231,8 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalFolder(string alias) =>
             Instance.GetPortalFolder(alias);
-
-        /// <summary>
-        /// Get the portal folder froma child portal alias.
-        /// </summary>
-        /// <param name="alias">portal alias.</param>
-        /// <returns>folder path of the child portal.</returns>
+        
+        /// <inheritdoc />
         string IPortalController.GetPortalFolder(string alias)
         {
             alias = alias.ToLowerInvariant().Replace("http://", string.Empty).Replace("https://", string.Empty);
@@ -284,9 +252,7 @@ namespace DotNetNuke.Entities.Portals
         public static void DeletePortalFolder(string serverPath, string portalFolder) =>
             Instance.DeletePortalFolder(serverPath, portalFolder);
 
-        /// <summary>Delete the child portal folder and try to remove its parent when parent folder is empty.</summary>
-        /// <param name="serverPath">the server path.</param>
-        /// <param name="portalFolder">the child folder path.</param>
+        /// <inheritdoc />
         void IPortalController.DeletePortalFolder(string serverPath, string portalFolder)
         {
             var physicalPath = serverPath + portalFolder;
@@ -316,10 +282,7 @@ namespace DotNetNuke.Entities.Portals
         public static Dictionary<int, int> GetPortalDictionary() =>
             Instance.GetPortalDictionary();
 
-        /// <summary>
-        /// Gets the portal dictionary.
-        /// </summary>
-        /// <returns>portal dictionary. the dictionary's Key -> Value is: TabId -> PortalId.</returns>
+        /// <inheritdoc />
         Dictionary<int, int> IPortalController.GetPortalDictionary()
         {
             string cacheKey = string.Format(DataCache.PortalDictionaryCacheKey);
@@ -342,16 +305,7 @@ namespace DotNetNuke.Entities.Portals
         public static ArrayList GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords) =>
             Instance.GetPortalsByName(nameToMatch, pageIndex, pageSize, ref totalRecords);
 
-        /// <summary>
-        /// GetPortalsByName gets all the portals whose name matches a provided filter expression.
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
-        /// <param name="nameToMatch">The email address to use to find a match.</param>
-        /// <param name="pageIndex">The page of records to return.</param>
-        /// <param name="pageSize">The size of the page.</param>
-        /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
-        /// <returns>An ArrayList of PortalInfo objects.</returns>
+        /// <inheritdoc />
         ArrayList IPortalController.GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords)
         {
             if (pageIndex == -1)
@@ -367,6 +321,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByUser' instance method. Scheduled removal in v11.0.0.")]
         public static ArrayList GetPortalsByUser(int userId) => Instance.GetPortalsByUser(userId);
 
+        /// <inheritdoc />
         ArrayList IPortalController.GetPortalsByUser(int userId)
         {
             Type type = typeof(PortalInfo);
@@ -376,6 +331,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEffectivePortalId' instance method. Scheduled removal in v11.0.0.")]
         public static int GetEffectivePortalId(int portalId) => Instance.GetEffectivePortalId(portalId);
 
+        /// <inheritdoc />
         int IPortalController.GetEffectivePortalId(int portalId)
         {
             if (portalId > Null.NullInteger && Globals.Status != Globals.UpgradeStatus.Upgrade)
@@ -402,10 +358,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetExpiredPortals' instance method. Scheduled removal in v11.0.0.")]
         public static ArrayList GetExpiredPortals() => Instance.GetExpiredPortals();
 
-        /// <summary>
-        /// Gets all expired portals.
-        /// </summary>
-        /// <returns>all expired portals as array list.</returns>
+        /// <inheritdoc />
         ArrayList IPortalController.GetExpiredPortals()
         {
             return CBO.FillCollection(DataProvider.Instance().GetExpiredPortals(), typeof(PortalInfo));
@@ -423,14 +376,7 @@ namespace DotNetNuke.Entities.Portals
         public static bool IsChildPortal(PortalInfo portal, string serverPath) =>
             Instance.IsChildPortal(portal, serverPath);
 
-        /// <summary>
-        /// Determines whether the portal is child portal.
-        /// </summary>
-        /// <param name="portal">The portal.</param>
-        /// <param name="serverPath">The server path.</param>
-        /// <returns>
-        ///   <c>true</c> if the portal is child portal; otherwise, <c>false</c>.
-        /// </returns>
+        /// <inheritdoc />
         bool IPortalController.IsChildPortal(PortalInfo portal, string serverPath)
         {
             bool isChild = Null.NullBoolean;
@@ -456,6 +402,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsMemberOfPortalGroup' instance method. Scheduled removal in v11.0.0.")]
         public static bool IsMemberOfPortalGroup(int portalId) => Instance.IsMemberOfPortalGroup(portalId);
 
+        /// <inheritdoc />
         bool IPortalController.IsMemberOfPortalGroup(int portalId)
         {
             var portal = Instance.GetPortal(portalId);
@@ -472,11 +419,7 @@ namespace DotNetNuke.Entities.Portals
         public static void DeletePortalSetting(int portalID, string settingName) =>
             Instance.DeletePortalSetting(portalID, settingName);
 
-        /// <summary>
-        /// Deletes the portal setting (neutral and for all languages).
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="settingName">Name of the setting.</param>
+        /// <inheritdoc />
         void IPortalController.DeletePortalSetting(int portalID, string settingName)
         {
             DeletePortalSetting(portalID, settingName, Null.NullString);
@@ -492,12 +435,7 @@ namespace DotNetNuke.Entities.Portals
         public static void DeletePortalSetting(int portalID, string settingName, string cultureCode) =>
             Instance.DeletePortalSetting(portalID, settingName, cultureCode);
 
-        /// <summary>
-        /// Deletes the portal setting in this language.
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="settingName">Name of the setting.</param>
-        /// <param name="cultureCode">The culture code.</param>
+        /// <inheritdoc />
         void IPortalController.DeletePortalSetting(int portalID, string settingName, string cultureCode)
         {
             DataProvider.Instance().DeletePortalSetting(portalID, settingName, cultureCode.ToLowerInvariant());
@@ -512,10 +450,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSettings(int portalID) => Instance.DeletePortalSettings(portalID);
 
-        /// <summary>
-        /// Deletes all portal settings by portal id.
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
+        /// <inheritdoc />
         void IPortalController.DeletePortalSettings(int portalID)
         {
             DeletePortalSettings(portalID, Null.NullString);
@@ -529,10 +464,7 @@ namespace DotNetNuke.Entities.Portals
         public static void DeletePortalSettings(int portalID, string cultureCode) =>
             Instance.DeletePortalSettings(portalID, cultureCode);
 
-        /// <summary>
-        /// Deletes all portal settings by portal id and for a given language (Null: all languages and neutral settings).
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
+        /// <inheritdoc />
         void IPortalController.DeletePortalSettings(int portalID, string cultureCode)
         {
             DataProvider.Instance().DeletePortalSettings(portalID, cultureCode);
@@ -550,12 +482,7 @@ namespace DotNetNuke.Entities.Portals
         public static string GetEncryptedString(string settingName, int portalID, string passPhrase) =>
             Instance.GetEncryptedString(settingName, portalID, passPhrase);
 
-        /// <summary>
-        /// takes in a text value, decrypts it with a FIPS compliant algorithm and returns the value.
-        /// </summary>
-        /// <param name="settingName">the setting to read.</param>
-        /// <param name="passPhrase">the pass phrase used for encryption/decryption.</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         string IPortalController.GetEncryptedString(string settingName, int portalID, string passPhrase)
         {
             Requires.NotNullOrEmpty("key", settingName);
@@ -577,13 +504,7 @@ namespace DotNetNuke.Entities.Portals
         public static string GetPortalSetting(string settingName, int portalID, string defaultValue) =>
             Instance.GetPortalSetting(settingName, portalID, defaultValue);
 
-        /// <summary>
-        /// Gets the portal setting.
-        /// </summary>
-        /// <param name="settingName">Name of the setting.</param>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         string IPortalController.GetPortalSetting(string settingName, int portalID, string defaultValue)
         {
             var retValue = Null.NullString;
@@ -613,14 +534,7 @@ namespace DotNetNuke.Entities.Portals
         public static string GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode) =>
             Instance.GetPortalSetting(settingName, portalID, defaultValue, cultureCode);
 
-        /// <summary>
-        /// Gets the portal setting for a specific language (or neutral).
-        /// </summary>
-        /// <param name="settingName">Name of the setting.</param>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
-        /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         string IPortalController.GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode)
         {
             var retValue = Null.NullString;
@@ -649,13 +563,7 @@ namespace DotNetNuke.Entities.Portals
         public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue) =>
             Instance.GetPortalSettingAsBoolean(key, portalID, defaultValue);
 
-        /// <summary>
-        /// Gets the portal setting as boolean.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="defaultValue">default value.</param>
-        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         bool IPortalController.GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue)
         {
             bool retValue = Null.NullBoolean;
@@ -692,14 +600,7 @@ namespace DotNetNuke.Entities.Portals
         public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode) =>
             Instance.GetPortalSettingAsBoolean(key, portalID, defaultValue, cultureCode);
 
-        /// <summary>
-        /// Gets the portal setting as boolean for a specific language (or neutral).
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="defaultValue">default value.</param>
-        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
-        /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         bool IPortalController.GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode)
         {
             bool retValue = Null.NullBoolean;
@@ -735,13 +636,7 @@ namespace DotNetNuke.Entities.Portals
         public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue) =>
             Instance.GetPortalSettingAsInteger(key, portalID, defaultValue);
 
-        /// <summary>
-        /// Gets the portal setting as integer.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         int IPortalController.GetPortalSettingAsInteger(string key, int portalID, int defaultValue)
         {
             int retValue = Null.NullInteger;
@@ -777,13 +672,7 @@ namespace DotNetNuke.Entities.Portals
         public static double GetPortalSettingAsDouble(string key, int portalId, double defaultValue) =>
             Instance.GetPortalSettingAsDouble(key, portalId, defaultValue);
 
-        /// <summary>
-        /// Gets the portal setting as double.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="portalId">The portal Id.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         double IPortalController.GetPortalSettingAsDouble(string key, int portalId, double defaultValue)
         {
             double retValue = Null.NullDouble;
@@ -820,14 +709,7 @@ namespace DotNetNuke.Entities.Portals
         public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode) =>
             Instance.GetPortalSettingAsInteger(key, portalID, defaultValue, cultureCode);
 
-        /// <summary>
-        /// Gets the portal setting as integer for a specific language (or neutral).
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="defaultValue">The default value.</param>
-        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
-        /// <returns>Returns setting's value if portal contains the specific setting (for specified lang, otherwise return defaultValue.</returns>
+        /// <inheritdoc />
         int IPortalController.GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode)
         {
             int retValue = Null.NullInteger;
@@ -863,13 +745,7 @@ namespace DotNetNuke.Entities.Portals
         public static void UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase) =>
             Instance.UpdateEncryptedString(portalID, settingName, settingValue, passPhrase);
 
-        /// <summary>
-        /// takes in a text value, encrypts it with a FIPS compliant algorithm and stores.
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="settingName">host settings key.</param>
-        /// <param name="settingValue">host settings value.</param>
-        /// <param name="passPhrase">pass phrase to allow encryption/decryption.</param>
+        /// <inheritdoc />
         void IPortalController.UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase)
         {
             Requires.NotNullOrEmpty("key", settingName);
@@ -891,12 +767,7 @@ namespace DotNetNuke.Entities.Portals
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue) =>
             Instance.UpdatePortalSetting(portalID, settingName, settingValue);
 
-        /// <summary>
-        /// Updates a single neutral (not language specific) portal setting and clears it from the cache.
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="settingName">Name of the setting.</param>
-        /// <param name="settingValue">The setting value.</param>
+        /// <inheritdoc />
         void IPortalController.UpdatePortalSetting(int portalID, string settingName, string settingValue)
         {
             UpdatePortalSetting(portalID, settingName, settingValue, true);
@@ -913,13 +784,7 @@ namespace DotNetNuke.Entities.Portals
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache) =>
             Instance.UpdatePortalSetting(portalID, settingName, settingValue, clearCache);
 
-        /// <summary>
-        /// Updates a single neutral (not language specific) portal setting, optionally without clearing the cache.
-        /// </summary>
-        /// <param name="portalID">The portal ID.</param>
-        /// <param name="settingName">Name of the setting.</param>
-        /// <param name="settingValue">The setting value.</param>
-        /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
+        /// <inheritdoc />
         void IPortalController.UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache)
         {
             UpdatePortalSetting(portalID, settingName, settingValue, clearCache, Null.NullString, false);
@@ -973,11 +838,7 @@ namespace DotNetNuke.Entities.Portals
         public static string CheckDesktopModulesInstalled(XPathNavigator nav) =>
             Instance.CheckDesktopModulesInstalled(nav);
 
-        /// <summary>
-        /// Checks the desktop modules whether is installed.
-        /// </summary>
-        /// <param name="nav">The nav.</param>
-        /// <returns>Empty string if the module hasn't been installed, otherwise return the friendly name.</returns>
+        /// <inheritdoc />
         string IPortalController.CheckDesktopModulesInstalled(XPathNavigator nav)
         {
             string friendlyName;
@@ -1027,14 +888,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetActivePortalLanguage' instance method. Scheduled removal in v11.0.0.")]
         public static string GetActivePortalLanguage(int portalID) => Instance.GetActivePortalLanguage(portalID);
 
-        /// <summary>
-        ///   function provides the language for portalinfo requests
-        ///   in case where language has not been installed yet, will return the core install default of en-us.
-        /// </summary>
-        /// <param name = "portalID"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// </remarks>
+        /// <inheritdoc />
         string IPortalController.GetActivePortalLanguage(int portalID)
         {
             // get Language
@@ -1101,10 +955,7 @@ namespace DotNetNuke.Entities.Portals
         public static string GetPortalDefaultLanguage(int portalID) =>
             Instance.GetPortalDefaultLanguage(portalID);
 
-        /// <summary>
-        ///   return the current DefaultLanguage value from the Portals table for the requested Portalid.
-        /// </summary>
-        /// <param name="portalID"></param>
+        /// <inheritdoc />
         string IPortalController.GetPortalDefaultLanguage(int portalID)
         {
             string cacheKey = string.Format("PortalDefaultLanguage_{0}", portalID);
@@ -1123,15 +974,7 @@ namespace DotNetNuke.Entities.Portals
         public static void UpdatePortalDefaultLanguage(int portalID, string CultureCode) =>
             Instance.UpdatePortalDefaultLanguage(portalID, CultureCode);
 
-
-        /// <summary>
-        ///   set the required DefaultLanguage in the Portals table for a particular portal
-        ///   saves having to update an entire PortalInfo object.
-        /// </summary>
-        /// <param name = "portalID"></param>
-        /// <param name = "CultureCode"></param>
-        /// <remarks>
-        /// </remarks>
+        /// <inheritdoc />
         void IPortalController.UpdatePortalDefaultLanguage(int portalID, string CultureCode)
         {
             DataProvider.Instance().UpdatePortalDefaultLanguage(portalID, CultureCode);
@@ -1144,6 +987,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementCrmVersion' instance method. Scheduled removal in v11.0.0.")]
         public static void IncrementCrmVersion(int portalID) => Instance.IncrementCrmVersion(portalID);
 
+        /// <inheritdoc />
         void IPortalController.IncrementCrmVersion(int portalID)
         {
             int currentVersion;
@@ -1158,6 +1002,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementOverridingPortalsCrmVersion' instance method. Scheduled removal in v11.0.0.")]
         public static void IncrementOverridingPortalsCrmVersion() => Instance.IncrementOverridingPortalsCrmVersion();
 
+        /// <inheritdoc />
         void IPortalController.IncrementOverridingPortalsCrmVersion()
         {
             foreach (PortalInfo portal in Instance.GetPortals())
@@ -1174,11 +1019,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /// <summary>
-        /// Creates a new portal alias.
-        /// </summary>
-        /// <param name="portalId">Id of the portal.</param>
-        /// <param name="portalAlias">Portal Alias to be created.</param>
+        /// <inheritdoc />
         public void AddPortalAlias(int portalId, string portalAlias)
         {
             // Check if the Alias exists
@@ -1192,11 +1033,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /// <summary>
-        /// Copies the page template.
-        /// </summary>
-        /// <param name="templateFile">The template file.</param>
-        /// <param name="mappedHomeDirectory">The mapped home directory.</param>
+        /// <inheritdoc />
         public void CopyPageTemplate(string templateFile, string mappedHomeDirectory)
         {
             string hostTemplateFile = string.Format("{0}Templates\\{1}", Globals.HostMapPath, templateFile);
@@ -1217,20 +1054,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /// <summary>
-        /// Creates the portal.
-        /// </summary>
-        /// <param name="portalName">Name of the portal.</param>
-        /// <param name="adminUserId">The obj admin user.</param>
-        /// <param name="description">The description.</param>
-        /// <param name="keyWords">The key words.</param>
-        /// <param name="template"> </param>
-        /// <param name="homeDirectory">The home directory.</param>
-        /// <param name="portalAlias">The portal alias.</param>
-        /// <param name="serverPath">The server path.</param>
-        /// <param name="childPath">The child path.</param>
-        /// <param name="isChildPortal">if set to <c>true</c> means the portal is child portal.</param>
-        /// <returns>Portal id.</returns>
+        /// <inheritdoc />
         public int CreatePortal(string portalName, int adminUserId, string description, string keyWords, PortalTemplateInfo template,
                                 string homeDirectory, string portalAlias, string serverPath, string childPath, bool isChildPortal)
         {
@@ -1293,20 +1117,7 @@ namespace DotNetNuke.Entities.Portals
             return portalId;
         }
 
-        /// <summary>
-        /// Creates the portal.
-        /// </summary>
-        /// <param name="portalName">Name of the portal.</param>
-        /// <param name="adminUser">The obj admin user.</param>
-        /// <param name="description">The description.</param>
-        /// <param name="keyWords">The key words.</param>
-        /// <param name="template"> </param>
-        /// <param name="homeDirectory">The home directory.</param>
-        /// <param name="portalAlias">The portal alias.</param>
-        /// <param name="serverPath">The server path.</param>
-        /// <param name="childPath">The child path.</param>
-        /// <param name="isChildPortal">if set to <c>true</c> means the portal is child portal.</param>
-        /// <returns>Portal id.</returns>
+        /// <inheritdoc />
         public int CreatePortal(string portalName, UserInfo adminUser, string description, string keyWords, PortalTemplateInfo template,
                                 string homeDirectory, string portalAlias, string serverPath, string childPath, bool isChildPortal)
         {
@@ -1377,10 +1188,7 @@ namespace DotNetNuke.Entities.Portals
             return portalId;
         }
 
-        /// <summary>
-        /// Get all the available portal templates grouped by culture.
-        /// </summary>
-        /// <returns>List of PortalTemplateInfo objects.</returns>
+        /// <inheritdoc />
         public IList<PortalTemplateInfo> GetAvailablePortalTemplates()
         {
             var list = new List<PortalTemplateInfo>();
@@ -1409,11 +1217,7 @@ namespace DotNetNuke.Entities.Portals
             return list;
         }
 
-        /// <summary>
-        ///   Gets information of a portal.
-        /// </summary>
-        /// <param name = "portalId">Id of the portal.</param>
-        /// <returns>PortalInfo object with portal definition.</returns>
+        /// <inheritdoc />
         public PortalInfo GetPortal(int portalId)
         {
             if (portalId == -1)
@@ -1433,12 +1237,7 @@ namespace DotNetNuke.Entities.Portals
             return portal;
         }
 
-        /// <summary>
-        ///   Gets information of a portal.
-        /// </summary>
-        /// <param name = "portalId">Id of the portal.</param>
-        /// <param name="cultureCode">The culture code.</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public PortalInfo GetPortal(int portalId, string cultureCode)
         {
             if (portalId == -1)
@@ -1486,30 +1285,19 @@ namespace DotNetNuke.Entities.Portals
             return portal;
         }
 
-        /// <summary>
-        /// Gets the portal.
-        /// </summary>
-        /// <param name="uniqueId">The unique id.</param>
-        /// <returns>Portal info.</returns>
+        /// <inheritdoc />
         public PortalInfo GetPortal(Guid uniqueId)
         {
             return this.GetPortalList(Null.NullString).SingleOrDefault(p => p.GUID == uniqueId);
         }
 
-        /// <summary>
-        /// Gets information from all portals.
-        /// </summary>
-        /// <returns>ArrayList of PortalInfo objects.</returns>
+        /// <inheritdoc />
         public ArrayList GetPortals()
         {
             return new ArrayList(this.GetPortalList(Null.NullString));
         }
 
-        /// <summary>
-        /// Get portals in specific culture.
-        /// </summary>
-        /// <param name="cultureCode">The culture code.</param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public List<PortalInfo> GetPortalList(string cultureCode)
         {
             string cacheKey = string.Format(DataCache.PortalCacheKey, Null.NullInteger, cultureCode);
@@ -1518,33 +1306,19 @@ namespace DotNetNuke.Entities.Portals
                 c => CBO.FillCollection<PortalInfo>(DataProvider.Instance().GetPortals(cultureCode)));
         }
 
-        /// <summary>
-        /// Gets the portal settings dictionary.
-        /// </summary>
-        /// <param name="portalId">The portal ID.</param>
-        /// <returns>portal settings.</returns>
+        /// <inheritdoc />
         public Dictionary<string, string> GetPortalSettings(int portalId)
         {
             return GetPortalSettingsDictionary(portalId, string.Empty);
         }
 
-        /// <summary>
-        /// Gets the portal settings dictionary.
-        /// </summary>
-        /// <param name="portalId">The portal ID.</param>
-        /// <param name="cultureCode">The culture code.</param>
-        /// <returns>portal settings.</returns>
+        /// <inheritdoc />
         public Dictionary<string, string> GetPortalSettings(int portalId, string cultureCode)
         {
             return GetPortalSettingsDictionary(portalId, cultureCode);
         }
 
-        /// <summary>
-        /// Load info for a portal template.
-        /// </summary>
-        /// <param name="templatePath">Full path to the portal template.</param>
-        /// <param name="cultureCode">the culture code if any for the localization of the portal template.</param>
-        /// <returns>A portal template.</returns>
+        /// <inheritdoc />
         public PortalTemplateInfo GetPortalTemplate(string templatePath, string cultureCode)
         {
             var template = new PortalTemplateInfo(templatePath, cultureCode);
@@ -1557,11 +1331,7 @@ namespace DotNetNuke.Entities.Portals
             return template;
         }
 
-        /// <summary>
-        /// Gets the portal space used bytes.
-        /// </summary>
-        /// <param name="portalId">The portal id.</param>
-        /// <returns>Space used in bytes.</returns>
+        /// <inheritdoc />
         public long GetPortalSpaceUsedBytes(int portalId)
         {
             long size = 0;
@@ -1588,12 +1358,7 @@ namespace DotNetNuke.Entities.Portals
             return size;
         }
 
-        /// <summary>
-        /// Verifies if there's enough space to upload a new file on the given portal.
-        /// </summary>
-        /// <param name="portalId">Id of the portal.</param>
-        /// <param name="fileSizeBytes">Size of the file being uploaded.</param>
-        /// <returns>True if there's enough space available to upload the file.</returns>
+        /// <inheritdoc />
         public bool HasSpaceAvailable(int portalId, long fileSizeBytes)
         {
             int hostSpace;
@@ -1618,12 +1383,7 @@ namespace DotNetNuke.Entities.Portals
             return (((this.GetPortalSpaceUsedBytes(portalId) + fileSizeBytes) / Math.Pow(1024, 2)) <= hostSpace) || hostSpace == 0;
         }
 
-        /// <summary>
-        ///   Remaps the Special Pages such as Home, Profile, Search
-        ///   to their localized versions.
-        /// </summary>
-        /// <remarks>
-        /// </remarks>
+        /// <inheritdoc />
         public void MapLocalizedSpecialPages(int portalId, string cultureCode)
         {
             DataCache.ClearHostCache(true);
@@ -1727,12 +1487,7 @@ namespace DotNetNuke.Entities.Portals
             this.UpdatePortalInternal(targetPortal, false);
         }
 
-        /// <summary>
-        /// Removes the related PortalLocalization record from the database, adds optional clear cache.
-        /// </summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <inheritdoc />
         public void RemovePortalLocalization(int portalId, string cultureCode, bool clearCache = true)
         {
             DataProvider.Instance().RemovePortalLocalization(portalId, cultureCode);
@@ -1742,17 +1497,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /// <summary>
-        /// Processess a template file for the new portal.
-        /// </summary>
-        /// <param name="portalId">PortalId of the new portal.</param>
-        /// <param name="template">The template.</param>
-        /// <param name="administratorId">UserId for the portal administrator. This is used to assign roles to this user.</param>
-        /// <param name="mergeTabs">Flag to determine whether Module content is merged.</param>
-        /// <param name="isNewPortal">Flag to determine is the template is applied to an existing portal or a new one.</param>
-        /// <remarks>
-        /// The roles and settings nodes will only be processed on the portal template file.
-        /// </remarks>
+        /// <inheritdoc />
         public void ParseTemplate(int portalId, PortalTemplateInfo template, int administratorId, PortalTemplateModuleAction mergeTabs, bool isNewPortal)
         {
             string templatePath, templateFile;
@@ -1761,16 +1506,7 @@ namespace DotNetNuke.Entities.Portals
             this.ParseTemplateInternal(portalId, templatePath, templateFile, administratorId, mergeTabs, isNewPortal);
         }
 
-        /// <summary>
-        /// Processes the resource file for the template file selected.
-        /// </summary>
-        /// <param name="portalPath">New portal's folder.</param>
-        /// <param name="resoureceFile">full path to the resource file.</param>
-        /// <remarks>
-        /// The resource file is a zip file with the same name as the selected template file and with
-        /// an extension of .resources (to disable this file being downloaded).
-        /// For example: for template file "portal.template" a resource file "portal.template.resources" can be defined.
-        /// </remarks>
+        /// <inheritdoc />
         public void ProcessResourceFileExplicit(string portalPath, string resoureceFile)
         {
             try
@@ -1783,11 +1519,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /// <summary>
-        /// Updates the portal expiry.
-        /// </summary>
-        /// <param name="portalId">The portal id.</param>
-        /// <param name="cultureCode">The culture code.</param>
+        /// <inheritdoc />
         public void UpdatePortalExpiry(int portalId, string cultureCode)
         {
             var portal = this.GetPortal(portalId, cultureCode);
@@ -1802,10 +1534,7 @@ namespace DotNetNuke.Entities.Portals
             this.UpdatePortalInfo(portal);
         }
 
-        /// <summary>
-        /// Updates basic portal information.
-        /// </summary>
-        /// <param name="portal"></param>
+        /// <inheritdoc />
         public void UpdatePortalInfo(PortalInfo portal)
         {
             this.UpdatePortalInternal(portal, true);
@@ -3964,29 +3693,26 @@ namespace DotNetNuke.Entities.Portals
             DataCache.ClearHostCache(true);
         }
 
-        /// <summary>
-        /// Gets the current portal settings.
-        /// </summary>
-        /// <returns>portal settings.</returns>
+        /// <inheritdoc />
         PortalSettings IPortalController.GetCurrentPortalSettings()
         {
             return GetCurrentPortalSettingsInternal();
         }
 
+        /// <inheritdoc />
         IAbPortalSettings IPortalController.GetCurrentSettings()
         {
             return GetCurrentPortalSettingsInternal();
         }
 
+        /// <inheritdoc />
         [Obsolete("Deprecated in DNN 9.2.0. Use the overloaded one with the 'isSecure' parameter instead. Scheduled removal in v11.0.0.")]
         void IPortalController.UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode)
         {
             UpdatePortalSettingInternal(portalID, settingName, settingValue, clearCache, cultureCode, false);
         }
 
-        /// <summary>
-        /// Adds or Updates or Deletes a portal setting value.
-        /// </summary>
+        /// <inheritdoc />
         void IPortalController.UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode, bool isSecure)
         {
             UpdatePortalSettingInternal(portalID, settingName, settingValue, clearCache, cultureCode, isSecure);

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -70,8 +70,18 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="portalId">The portal id.</param>
         /// <param name="tabId">The tab id.</param>
-        public static void AddPortalDictionary(int portalId, int tabId)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.AddPortalDictionary' instnace method. Scheduled removal in v11.0.0.")]
+        public static void AddPortalDictionary(int portalId, int tabId) =>
+            AddPortalDictionary(portalId, tabId);
+
+        /// <summary>
+        /// Adds the portal dictionary.
+        /// </summary>
+        /// <param name="portalId">The portal id.</param>
+        /// <param name="tabId">The tab id.</param>
+        void IPortalController.AddPortalDictionary(int portalId, int tabId)
         {
+            
             var portalDic = GetPortalDictionary();
             portalDic[tabId] = portalId;
             DataCache.SetCache(DataCache.PortalDictionaryCacheKey, portalDic);
@@ -94,7 +104,28 @@ namespace DotNetNuke.Entities.Portals
         /// message = PortalController.CreateChildPortalFolder(childPhysicalPath);
         /// </code>
         /// </example>
-        public static string CreateChildPortalFolder(string ChildPath)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CreateChildPortalFolder' instnace method. Scheduled removal in v11.0.0.")]
+        public static string CreateChildPortalFolder(string ChildPath) =>
+            CreateChildPortalFolder(ChildPath);
+
+        /// <summary>
+        /// Creates the root folder for a child portal.
+        /// </summary>
+        /// <remarks>
+        /// If call this method, it will create the specific folder if the folder doesn't exist;
+        /// and will copy subhost.aspx to the folder if there is no 'Default.aspx'.
+        /// </remarks>
+        /// <param name="ChildPath">The child path.</param>
+        /// <returns>
+        /// If the method executed successful, it will return NullString, otherwise return error message.
+        /// </returns>
+        /// <example>
+        /// <code lang="C#">
+        /// string childPhysicalPath = Server.MapPath(childPath);
+        /// message = PortalController.CreateChildPortalFolder(childPhysicalPath);
+        /// </code>
+        /// </example>
+        string IPortalController.CreateChildPortalFolder(string ChildPath)
         {
             string message = Null.NullString;
 
@@ -126,7 +157,15 @@ namespace DotNetNuke.Entities.Portals
         /// Deletes all expired portals.
         /// </summary>
         /// <param name="serverPath">The server path.</param>
-        public static void DeleteExpiredPortals(string serverPath)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeleteExpiredPortals' instnace method. Scheduled removal in v11.0.0.")]
+        public static void DeleteExpiredPortals(string serverPath) =>
+            DeleteExpiredPortals(serverPath);
+
+        /// <summary>
+        /// Deletes all expired portals.
+        /// </summary>
+        /// <param name="serverPath">The server path.</param>
+        void IPortalController.DeleteExpiredPortals(string serverPath)
         {
             foreach (PortalInfo portal in GetExpiredPortals())
             {
@@ -140,7 +179,17 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portal">The portal.</param>
         /// <param name="serverPath">The server path.</param>
         /// <returns>If the method executed successful, it will return NullString, otherwise return error message.</returns>
-        public static string DeletePortal(PortalInfo portal, string serverPath)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortal' instnace method. Scheduled removal in v11.0.0.")]
+        public static string DeletePortal(PortalInfo portal, string serverPath) =>
+            DeletePortal(portal, serverPath);
+
+        /// <summary>
+        /// Deletes the portal.
+        /// </summary>
+        /// <param name="portal">The portal.</param>
+        /// <param name="serverPath">The server path.</param>
+        /// <returns>If the method executed successful, it will return NullString, otherwise return error message.</returns>
+        string IPortalController.DeletePortal(PortalInfo portal, string serverPath)
         {
             string message = string.Empty;
 
@@ -207,7 +256,16 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="alias">portal alias.</param>
         /// <returns>folder path of the child portal.</returns>
-        public static string GetPortalFolder(string alias)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instnace method. Scheduled removal in v11.0.0.")]
+        public static string GetPortalFolder(string alias) =>
+            GetPortalFolder(alias);
+
+        /// <summary>
+        /// Get the portal folder froma child portal alias.
+        /// </summary>
+        /// <param name="alias">portal alias.</param>
+        /// <returns>folder path of the child portal.</returns>
+        string IPortalController.GetPortalFolder(string alias)
         {
             alias = alias.ToLowerInvariant().Replace("http://", string.Empty).Replace("https://", string.Empty);
             var appPath = Globals.ApplicationPath + "/";
@@ -222,7 +280,14 @@ namespace DotNetNuke.Entities.Portals
         /// <summary>Delete the child portal folder and try to remove its parent when parent folder is empty.</summary>
         /// <param name="serverPath">the server path.</param>
         /// <param name="portalFolder">the child folder path.</param>
-        public static void DeletePortalFolder(string serverPath, string portalFolder)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instnace method. Scheduled removal in v11.0.0.")]
+        public static void DeletePortalFolder(string serverPath, string portalFolder) =>
+            DeletePortalFolder(serverPath, portalFolder);
+
+        /// <summary>Delete the child portal folder and try to remove its parent when parent folder is empty.</summary>
+        /// <param name="serverPath">the server path.</param>
+        /// <param name="portalFolder">the child folder path.</param>
+        void IPortalController.DeletePortalFolder(string serverPath, string portalFolder)
         {
             var physicalPath = serverPath + portalFolder;
             Globals.DeleteFolderRecursive(physicalPath);
@@ -247,7 +312,15 @@ namespace DotNetNuke.Entities.Portals
         /// Gets the portal dictionary.
         /// </summary>
         /// <returns>portal dictionary. the dictionary's Key -> Value is: TabId -> PortalId.</returns>
-        public static Dictionary<int, int> GetPortalDictionary()
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDictionary' instnace method. Scheduled removal in v11.0.0.")]
+        public static Dictionary<int, int> GetPortalDictionary() =>
+            GetPortalDictionary();
+
+        /// <summary>
+        /// Gets the portal dictionary.
+        /// </summary>
+        /// <returns>portal dictionary. the dictionary's Key -> Value is: TabId -> PortalId.</returns>
+        Dictionary<int, int> IPortalController.GetPortalDictionary()
         {
             string cacheKey = string.Format(DataCache.PortalDictionaryCacheKey);
             return CBO.GetCachedObject<Dictionary<int, int>>(new CacheItemArgs(cacheKey, DataCache.PortalDictionaryTimeOut, DataCache.PortalDictionaryCachePriority), GetPortalDictionaryCallback);
@@ -265,7 +338,21 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
         /// <returns>An ArrayList of PortalInfo objects.</returns>
         /// -----------------------------------------------------------------------------
-        public static ArrayList GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByName' instnace method. Scheduled removal in v11.0.0.")]
+        public static ArrayList GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords) =>
+            GetPortalsByName(nameToMatch, pageIndex, pageSize, ref totalRecords);
+
+        /// <summary>
+        /// GetPortalsByName gets all the portals whose name matches a provided filter expression.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <param name="nameToMatch">The email address to use to find a match.</param>
+        /// <param name="pageIndex">The page of records to return.</param>
+        /// <param name="pageSize">The size of the page.</param>
+        /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
+        /// <returns>An ArrayList of PortalInfo objects.</returns>
+        ArrayList IPortalController.GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords)
         {
             if (pageIndex == -1)
             {
@@ -277,13 +364,19 @@ namespace DotNetNuke.Entities.Portals
             return CBO.FillCollection(DataProvider.Instance().GetPortalsByName(nameToMatch, pageIndex, pageSize), ref type, ref totalRecords);
         }
 
-        public static ArrayList GetPortalsByUser(int userId)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByUser' instnace method. Scheduled removal in v11.0.0.")]
+        public static ArrayList GetPortalsByUser(int userId) => GetPortalsByUser(userId);
+
+        ArrayList IPortalController.GetPortalsByUser(int userId)
         {
             Type type = typeof(PortalInfo);
             return CBO.FillCollection(DataProvider.Instance().GetPortalsByUser(userId), type);
         }
 
-        public static int GetEffectivePortalId(int portalId)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEffectivePortalId' instnace method. Scheduled removal in v11.0.0.")]
+        public static int GetEffectivePortalId(int portalId) => GetEffectivePortalId(portalId);
+
+        int IPortalController.GetEffectivePortalId(int portalId)
         {
             if (portalId > Null.NullInteger && Globals.Status != Globals.UpgradeStatus.Upgrade)
             {
@@ -306,7 +399,14 @@ namespace DotNetNuke.Entities.Portals
         /// Gets all expired portals.
         /// </summary>
         /// <returns>all expired portals as array list.</returns>
-        public static ArrayList GetExpiredPortals()
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetExpiredPortals' instnace method. Scheduled removal in v11.0.0.")]
+        public static ArrayList GetExpiredPortals() => GetExpiredPortals();
+
+        /// <summary>
+        /// Gets all expired portals.
+        /// </summary>
+        /// <returns>all expired portals as array list.</returns>
+        ArrayList IPortalController.GetExpiredPortals()
         {
             return CBO.FillCollection(DataProvider.Instance().GetExpiredPortals(), typeof(PortalInfo));
         }
@@ -319,7 +419,19 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>
         ///   <c>true</c> if the portal is child portal; otherwise, <c>false</c>.
         /// </returns>
-        public static bool IsChildPortal(PortalInfo portal, string serverPath)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsChildPortal' instnace method. Scheduled removal in v11.0.0.")]
+        public static bool IsChildPortal(PortalInfo portal, string serverPath) =>
+            IsChildPortal(portal, serverPath);
+
+        /// <summary>
+        /// Determines whether the portal is child portal.
+        /// </summary>
+        /// <param name="portal">The portal.</param>
+        /// <param name="serverPath">The server path.</param>
+        /// <returns>
+        ///   <c>true</c> if the portal is child portal; otherwise, <c>false</c>.
+        /// </returns>
+        bool IPortalController.IsChildPortal(PortalInfo portal, string serverPath)
         {
             bool isChild = Null.NullBoolean;
             var arr = PortalAliasController.Instance.GetPortalAliasesByPortalId(portal.PortalID).ToList();
@@ -341,7 +453,10 @@ namespace DotNetNuke.Entities.Portals
             return isChild;
         }
 
-        public static bool IsMemberOfPortalGroup(int portalId)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsMemberOfPortalGroup' instnace method. Scheduled removal in v11.0.0.")]
+        public static bool IsMemberOfPortalGroup(int portalId) => IsMemberOfPortalGroup(portalId);
+
+        bool IPortalController.IsMemberOfPortalGroup(int portalId)
         {
             var portal = Instance.GetPortal(portalId);
 
@@ -353,7 +468,16 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
         /// <param name="settingName">Name of the setting.</param>
-        public static void DeletePortalSetting(int portalID, string settingName)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static void DeletePortalSetting(int portalID, string settingName) =>
+            DeletePortalSetting(portalID, settingName);
+
+        /// <summary>
+        /// Deletes the portal setting (neutral and for all languages).
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        void IPortalController.DeletePortalSetting(int portalID, string settingName)
         {
             DeletePortalSetting(portalID, settingName, Null.NullString);
         }
@@ -364,7 +488,17 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="settingName">Name of the setting.</param>
         /// <param name="cultureCode">The culture code.</param>
-        public static void DeletePortalSetting(int portalID, string settingName, string cultureCode)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static void DeletePortalSetting(int portalID, string settingName, string cultureCode) =>
+            DeletePortalSetting(portalID, settingName, cultureCode);
+
+        /// <summary>
+        /// Deletes the portal setting in this language.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        void IPortalController.DeletePortalSetting(int portalID, string settingName, string cultureCode)
         {
             DataProvider.Instance().DeletePortalSetting(portalID, settingName, cultureCode.ToLowerInvariant());
             EventLogController.Instance.AddLog("SettingName", settingName + ((cultureCode == Null.NullString) ? string.Empty : " (" + cultureCode + ")"), GetCurrentPortalSettingsInternal(), UserController.Instance.GetCurrentUserInfo().UserID, EventLogController.EventLogType.PORTAL_SETTING_DELETED);
@@ -375,7 +509,14 @@ namespace DotNetNuke.Entities.Portals
         /// Deletes all portal settings by portal id.
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
-        public static void DeletePortalSettings(int portalID)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instnace method. Scheduled removal in v11.0.0.")]
+        public static void DeletePortalSettings(int portalID) => DeletePortalSettings(portalID);
+
+        /// <summary>
+        /// Deletes all portal settings by portal id.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        void IPortalController.DeletePortalSettings(int portalID)
         {
             DeletePortalSettings(portalID, Null.NullString);
         }
@@ -384,7 +525,15 @@ namespace DotNetNuke.Entities.Portals
         /// Deletes all portal settings by portal id and for a given language (Null: all languages and neutral settings).
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
-        public static void DeletePortalSettings(int portalID, string cultureCode)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instnace method. Scheduled removal in v11.0.0.")]
+        public static void DeletePortalSettings(int portalID, string cultureCode) =>
+            DeletePortalSettings(portalID, cultureCode);
+
+        /// <summary>
+        /// Deletes all portal settings by portal id and for a given language (Null: all languages and neutral settings).
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        void IPortalController.DeletePortalSettings(int portalID, string cultureCode)
         {
             DataProvider.Instance().DeletePortalSettings(portalID, cultureCode);
             EventLogController.Instance.AddLog("PortalID", portalID.ToString() + ((cultureCode == Null.NullString) ? string.Empty : " (" + cultureCode + ")"), GetCurrentPortalSettingsInternal(), UserController.Instance.GetCurrentUserInfo().UserID, EventLogController.EventLogType.PORTAL_SETTING_DELETED);
@@ -397,7 +546,17 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">the setting to read.</param>
         /// <param name="passPhrase">the pass phrase used for encryption/decryption.</param>
         /// <returns></returns>
-        public static string GetEncryptedString(string settingName, int portalID, string passPhrase)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEncryptedString' instnace method. Scheduled removal in v11.0.0.")]
+        public static string GetEncryptedString(string settingName, int portalID, string passPhrase) =>
+            GetEncryptedString(settingName, portalID, passPhrase);
+
+        /// <summary>
+        /// takes in a text value, decrypts it with a FIPS compliant algorithm and returns the value.
+        /// </summary>
+        /// <param name="settingName">the setting to read.</param>
+        /// <param name="passPhrase">the pass phrase used for encryption/decryption.</param>
+        /// <returns></returns>
+        string IPortalController.GetEncryptedString(string settingName, int portalID, string passPhrase)
         {
             Requires.NotNullOrEmpty("key", settingName);
             Requires.NotNullOrEmpty("passPhrase", passPhrase);
@@ -414,7 +573,18 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        public static string GetPortalSetting(string settingName, int portalID, string defaultValue)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static string GetPortalSetting(string settingName, int portalID, string defaultValue) =>
+            GetPortalSetting(settingName, portalID, defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting.
+        /// </summary>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        string IPortalController.GetPortalSetting(string settingName, int portalID, string defaultValue)
         {
             var retValue = Null.NullString;
             try
@@ -439,7 +609,19 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="defaultValue">The default value.</param>
         /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
         /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
-        public static string GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static string GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode) =>
+            GetPortalSetting(settingName, portalID, defaultValue, cultureCode);
+
+        /// <summary>
+        /// Gets the portal setting for a specific language (or neutral).
+        /// </summary>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
+        /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
+        string IPortalController.GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode)
         {
             var retValue = Null.NullString;
             try
@@ -463,7 +645,18 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="defaultValue">default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instnace method. Scheduled removal in v11.0.0.")]
+        public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue) =>
+            GetPortalSettingAsBoolean(key, portalID, defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting as boolean.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        bool IPortalController.GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue)
         {
             bool retValue = Null.NullBoolean;
             try
@@ -495,7 +688,19 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="defaultValue">default value.</param>
         /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
         /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
-        public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instnace method. Scheduled removal in v11.0.0.")]
+        public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode) =>
+            GetPortalSettingAsBoolean(key, portalID, defaultValue, cultureCode);
+
+        /// <summary>
+        /// Gets the portal setting as boolean for a specific language (or neutral).
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">default value.</param>
+        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
+        /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
+        bool IPortalController.GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode)
         {
             bool retValue = Null.NullBoolean;
             try
@@ -526,7 +731,18 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instnace method. Scheduled removal in v11.0.0.")]
+        public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue) =>
+            GetPortalSettingAsInteger(key, portalID, defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting as integer.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        int IPortalController.GetPortalSettingAsInteger(string key, int portalID, int defaultValue)
         {
             int retValue = Null.NullInteger;
             try
@@ -557,7 +773,18 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalId">The portal Id.</param>
         /// <param name="defaultValue">The default value.</param>
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
-        public static double GetPortalSettingAsDouble(string key, int portalId, double defaultValue)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsDouble' instnace method. Scheduled removal in v11.0.0.")]
+        public static double GetPortalSettingAsDouble(string key, int portalId, double defaultValue) =>
+            GetPortalSettingAsDouble(key, portalId, defaultValue);
+
+        /// <summary>
+        /// Gets the portal setting as double.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalId">The portal Id.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
+        double IPortalController.GetPortalSettingAsDouble(string key, int portalId, double defaultValue)
         {
             double retValue = Null.NullDouble;
             try
@@ -589,7 +816,19 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="defaultValue">The default value.</param>
         /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
         /// <returns>Returns setting's value if portal contains the specific setting (for specified lang, otherwise return defaultValue.</returns>
-        public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instnace method. Scheduled removal in v11.0.0.")]
+        public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode) =>
+            GetPortalSettingAsInteger(key, portalID, defaultValue, cultureCode);
+
+        /// <summary>
+        /// Gets the portal setting as integer for a specific language (or neutral).
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <param name="cultureCode">culture code of the language to retrieve (not empty).</param>
+        /// <returns>Returns setting's value if portal contains the specific setting (for specified lang, otherwise return defaultValue.</returns>
+        int IPortalController.GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode)
         {
             int retValue = Null.NullInteger;
             try
@@ -620,7 +859,18 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">host settings key.</param>
         /// <param name="settingValue">host settings value.</param>
         /// <param name="passPhrase">pass phrase to allow encryption/decryption.</param>
-        public static void UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdateEncryptedString' instnace method. Scheduled removal in v11.0.0.")]
+        public static void UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase) =>
+            UpdateEncryptedString(portalID, settingName, settingValue, passPhrase);
+
+        /// <summary>
+        /// takes in a text value, encrypts it with a FIPS compliant algorithm and stores.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">host settings key.</param>
+        /// <param name="settingValue">host settings value.</param>
+        /// <param name="passPhrase">pass phrase to allow encryption/decryption.</param>
+        void IPortalController.UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase)
         {
             Requires.NotNullOrEmpty("key", settingName);
             Requires.PropertyNotNull("value", settingValue);
@@ -637,7 +887,17 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         /// <param name="settingName">Name of the setting.</param>
         /// <param name="settingValue">The setting value.</param>
-        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue) =>
+            UpdatePortalSetting(portalID, settingName, settingValue);
+
+        /// <summary>
+        /// Updates a single neutral (not language specific) portal setting and clears it from the cache.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="settingValue">The setting value.</param>
+        void IPortalController.UpdatePortalSetting(int portalID, string settingName, string settingValue)
         {
             UpdatePortalSetting(portalID, settingName, settingValue, true);
         }
@@ -649,7 +909,18 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">Name of the setting.</param>
         /// <param name="settingValue">The setting value.</param>
         /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
-        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache) =>
+            UpdatePortalSetting(portalID, settingName, settingValue, clearCache);
+
+        /// <summary>
+        /// Updates a single neutral (not language specific) portal setting, optionally without clearing the cache.
+        /// </summary>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="settingName">Name of the setting.</param>
+        /// <param name="settingValue">The setting value.</param>
+        /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
+        void IPortalController.UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache)
         {
             UpdatePortalSetting(portalID, settingName, settingValue, clearCache, Null.NullString, false);
         }
@@ -675,10 +946,9 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingValue">The setting value.</param>
         /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
         /// <param name="cultureCode">culture code for language specific settings, null string ontherwise.</param>
-        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode)
-        {
-            UpdatePortalSetting(portalID, settingName, settingValue, clearCache, cultureCode, false);
-        }
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instnace method. Scheduled removal in v11.0.0.")]
+        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode) =>
+            UpdatePortalSetting(portalID, settingName, settingValue, clearCache, cultureCode);
 
         /// <summary>
         /// Updates a language specific or neutral portal setting and optionally clears it from the cache.
@@ -701,7 +971,16 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="nav">The nav.</param>
         /// <returns>Empty string if the module hasn't been installed, otherwise return the friendly name.</returns>
-        public static string CheckDesktopModulesInstalled(XPathNavigator nav)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CheckDesktopModulesInstalled' instnace method. Scheduled removal in v11.0.0.")]
+        public static string CheckDesktopModulesInstalled(XPathNavigator nav) =>
+            CheckDesktopModulesInstalled(nav);
+
+        /// <summary>
+        /// Checks the desktop modules whether is installed.
+        /// </summary>
+        /// <param name="nav">The nav.</param>
+        /// <returns>Empty string if the module hasn't been installed, otherwise return the friendly name.</returns>
+        string IPortalController.CheckDesktopModulesInstalled(XPathNavigator nav)
         {
             string friendlyName;
             DesktopModuleInfo desktopModule;
@@ -747,7 +1026,18 @@ namespace DotNetNuke.Entities.Portals
         /// <returns></returns>
         /// <remarks>
         /// </remarks>
-        public static string GetActivePortalLanguage(int portalID)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetActivePortalLanguage' instnace method. Scheduled removal in v11.0.0.")]
+        public static string GetActivePortalLanguage(int portalID) => GetActivePortalLanguage(portalID);
+
+        /// <summary>
+        ///   function provides the language for portalinfo requests
+        ///   in case where language has not been installed yet, will return the core install default of en-us.
+        /// </summary>
+        /// <param name = "portalID"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// </remarks>
+        string IPortalController.GetActivePortalLanguage(int portalID)
         {
             // get Language
             string Language = Localization.SystemLocale;
@@ -808,11 +1098,16 @@ namespace DotNetNuke.Entities.Portals
         /// <summary>
         ///   return the current DefaultLanguage value from the Portals table for the requested Portalid.
         /// </summary>
-        /// <param name = "portalID"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// </remarks>
-        public static string GetPortalDefaultLanguage(int portalID)
+        /// <param name="portalID"></param>
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDefaultLanguage' instnace method. Scheduled removal in v11.0.0.")]
+        public static string GetPortalDefaultLanguage(int portalID) =>
+            GetPortalDefaultLanguage(portalID);
+
+        /// <summary>
+        ///   return the current DefaultLanguage value from the Portals table for the requested Portalid.
+        /// </summary>
+        /// <param name="portalID"></param>
+        string IPortalController.GetPortalDefaultLanguage(int portalID)
         {
             string cacheKey = string.Format("PortalDefaultLanguage_{0}", portalID);
             return CBO.GetCachedObject<string>(new CacheItemArgs(cacheKey, DataCache.PortalCacheTimeOut, DataCache.PortalCachePriority, portalID), GetPortalDefaultLanguageCallBack);
@@ -826,7 +1121,20 @@ namespace DotNetNuke.Entities.Portals
         /// <param name = "CultureCode"></param>
         /// <remarks>
         /// </remarks>
-        public static void UpdatePortalDefaultLanguage(int portalID, string CultureCode)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalDefaultLanguage' instnace method. Scheduled removal in v11.0.0.")]
+        public static void UpdatePortalDefaultLanguage(int portalID, string CultureCode) =>
+            UpdatePortalDefaultLanguage(portalID, CultureCode);
+
+
+        /// <summary>
+        ///   set the required DefaultLanguage in the Portals table for a particular portal
+        ///   saves having to update an entire PortalInfo object.
+        /// </summary>
+        /// <param name = "portalID"></param>
+        /// <param name = "CultureCode"></param>
+        /// <remarks>
+        /// </remarks>
+        void IPortalController.UpdatePortalDefaultLanguage(int portalID, string CultureCode)
         {
             DataProvider.Instance().UpdatePortalDefaultLanguage(portalID, CultureCode);
 
@@ -835,7 +1143,10 @@ namespace DotNetNuke.Entities.Portals
             DataProvider.Instance().EnsureLocalizationExists(portalID, CultureCode);
         }
 
-        public static void IncrementCrmVersion(int portalID)
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementCrmVersion' instnace method. Scheduled removal in v11.0.0.")]
+        public static void IncrementCrmVersion(int portalID) => IncrementCrmVersion(portalID);
+
+        void IPortalController.IncrementCrmVersion(int portalID)
         {
             int currentVersion;
             var versionSetting = GetPortalSetting(ClientResourceSettings.VersionKey, portalID, "1");
@@ -846,7 +1157,10 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        public static void IncrementOverridingPortalsCrmVersion()
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementOverridingPortalsCrmVersion' instnace method. Scheduled removal in v11.0.0.")]
+        public static void IncrementOverridingPortalsCrmVersion() => IncrementOverridingPortalsCrmVersion();
+
+        void IPortalController.IncrementOverridingPortalsCrmVersion()
         {
             foreach (PortalInfo portal in Instance.GetPortals())
             {

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -72,7 +72,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="tabId">The tab id.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.AddPortalDictionary' instance method. Scheduled removal in v11.0.0.")]
         public static void AddPortalDictionary(int portalId, int tabId) =>
-            AddPortalDictionary(portalId, tabId);
+            Instance.AddPortalDictionary(portalId, tabId);
 
         /// <summary>
         /// Adds the portal dictionary.
@@ -106,7 +106,7 @@ namespace DotNetNuke.Entities.Portals
         /// </example>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CreateChildPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static string CreateChildPortalFolder(string ChildPath) =>
-            CreateChildPortalFolder(ChildPath);
+            Instance.CreateChildPortalFolder(ChildPath);
 
         /// <summary>
         /// Creates the root folder for a child portal.
@@ -159,7 +159,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="serverPath">The server path.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeleteExpiredPortals' instance method. Scheduled removal in v11.0.0.")]
         public static void DeleteExpiredPortals(string serverPath) =>
-            DeleteExpiredPortals(serverPath);
+            Instance.DeleteExpiredPortals(serverPath);
 
         /// <summary>
         /// Deletes all expired portals.
@@ -181,7 +181,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>If the method executed successful, it will return NullString, otherwise return error message.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortal' instance method. Scheduled removal in v11.0.0.")]
         public static string DeletePortal(PortalInfo portal, string serverPath) =>
-            DeletePortal(portal, serverPath);
+            Instance.DeletePortal(portal, serverPath);
 
         /// <summary>
         /// Deletes the portal.
@@ -258,7 +258,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>folder path of the child portal.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalFolder(string alias) =>
-            GetPortalFolder(alias);
+            Instance.GetPortalFolder(alias);
 
         /// <summary>
         /// Get the portal folder froma child portal alias.
@@ -282,7 +282,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalFolder">the child folder path.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalFolder' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalFolder(string serverPath, string portalFolder) =>
-            DeletePortalFolder(serverPath, portalFolder);
+            Instance.DeletePortalFolder(serverPath, portalFolder);
 
         /// <summary>Delete the child portal folder and try to remove its parent when parent folder is empty.</summary>
         /// <param name="serverPath">the server path.</param>
@@ -314,7 +314,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>portal dictionary. the dictionary's Key -> Value is: TabId -> PortalId.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDictionary' instance method. Scheduled removal in v11.0.0.")]
         public static Dictionary<int, int> GetPortalDictionary() =>
-            GetPortalDictionary();
+            Instance.GetPortalDictionary();
 
         /// <summary>
         /// Gets the portal dictionary.
@@ -340,7 +340,7 @@ namespace DotNetNuke.Entities.Portals
         /// -----------------------------------------------------------------------------
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByName' instance method. Scheduled removal in v11.0.0.")]
         public static ArrayList GetPortalsByName(string nameToMatch, int pageIndex, int pageSize, ref int totalRecords) =>
-            GetPortalsByName(nameToMatch, pageIndex, pageSize, ref totalRecords);
+            Instance.GetPortalsByName(nameToMatch, pageIndex, pageSize, ref totalRecords);
 
         /// <summary>
         /// GetPortalsByName gets all the portals whose name matches a provided filter expression.
@@ -365,7 +365,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalsByUser' instance method. Scheduled removal in v11.0.0.")]
-        public static ArrayList GetPortalsByUser(int userId) => GetPortalsByUser(userId);
+        public static ArrayList GetPortalsByUser(int userId) => Instance.GetPortalsByUser(userId);
 
         ArrayList IPortalController.GetPortalsByUser(int userId)
         {
@@ -374,7 +374,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEffectivePortalId' instance method. Scheduled removal in v11.0.0.")]
-        public static int GetEffectivePortalId(int portalId) => GetEffectivePortalId(portalId);
+        public static int GetEffectivePortalId(int portalId) => Instance.GetEffectivePortalId(portalId);
 
         int IPortalController.GetEffectivePortalId(int portalId)
         {
@@ -400,7 +400,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <returns>all expired portals as array list.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetExpiredPortals' instance method. Scheduled removal in v11.0.0.")]
-        public static ArrayList GetExpiredPortals() => GetExpiredPortals();
+        public static ArrayList GetExpiredPortals() => Instance.GetExpiredPortals();
 
         /// <summary>
         /// Gets all expired portals.
@@ -421,7 +421,7 @@ namespace DotNetNuke.Entities.Portals
         /// </returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsChildPortal' instance method. Scheduled removal in v11.0.0.")]
         public static bool IsChildPortal(PortalInfo portal, string serverPath) =>
-            IsChildPortal(portal, serverPath);
+            Instance.IsChildPortal(portal, serverPath);
 
         /// <summary>
         /// Determines whether the portal is child portal.
@@ -454,7 +454,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IsMemberOfPortalGroup' instance method. Scheduled removal in v11.0.0.")]
-        public static bool IsMemberOfPortalGroup(int portalId) => IsMemberOfPortalGroup(portalId);
+        public static bool IsMemberOfPortalGroup(int portalId) => Instance.IsMemberOfPortalGroup(portalId);
 
         bool IPortalController.IsMemberOfPortalGroup(int portalId)
         {
@@ -470,7 +470,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingName">Name of the setting.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSetting(int portalID, string settingName) =>
-            DeletePortalSetting(portalID, settingName);
+            Instance.DeletePortalSetting(portalID, settingName);
 
         /// <summary>
         /// Deletes the portal setting (neutral and for all languages).
@@ -490,7 +490,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="cultureCode">The culture code.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSetting(int portalID, string settingName, string cultureCode) =>
-            DeletePortalSetting(portalID, settingName, cultureCode);
+            Instance.DeletePortalSetting(portalID, settingName, cultureCode);
 
         /// <summary>
         /// Deletes the portal setting in this language.
@@ -510,7 +510,7 @@ namespace DotNetNuke.Entities.Portals
         /// </summary>
         /// <param name="portalID">The portal ID.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instance method. Scheduled removal in v11.0.0.")]
-        public static void DeletePortalSettings(int portalID) => DeletePortalSettings(portalID);
+        public static void DeletePortalSettings(int portalID) => Instance.DeletePortalSettings(portalID);
 
         /// <summary>
         /// Deletes all portal settings by portal id.
@@ -527,7 +527,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID">The portal ID.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.DeletePortalSettings' instance method. Scheduled removal in v11.0.0.")]
         public static void DeletePortalSettings(int portalID, string cultureCode) =>
-            DeletePortalSettings(portalID, cultureCode);
+            Instance.DeletePortalSettings(portalID, cultureCode);
 
         /// <summary>
         /// Deletes all portal settings by portal id and for a given language (Null: all languages and neutral settings).
@@ -548,7 +548,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns></returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetEncryptedString' instance method. Scheduled removal in v11.0.0.")]
         public static string GetEncryptedString(string settingName, int portalID, string passPhrase) =>
-            GetEncryptedString(settingName, portalID, passPhrase);
+            Instance.GetEncryptedString(settingName, portalID, passPhrase);
 
         /// <summary>
         /// takes in a text value, decrypts it with a FIPS compliant algorithm and returns the value.
@@ -575,7 +575,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalSetting(string settingName, int portalID, string defaultValue) =>
-            GetPortalSetting(settingName, portalID, defaultValue);
+            Instance.GetPortalSetting(settingName, portalID, defaultValue);
 
         /// <summary>
         /// Gets the portal setting.
@@ -611,7 +611,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalSetting(string settingName, int portalID, string defaultValue, string cultureCode) =>
-            GetPortalSetting(settingName, portalID, defaultValue, cultureCode);
+            Instance.GetPortalSetting(settingName, portalID, defaultValue, cultureCode);
 
         /// <summary>
         /// Gets the portal setting for a specific language (or neutral).
@@ -647,7 +647,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instance method. Scheduled removal in v11.0.0.")]
         public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue) =>
-            GetPortalSettingAsBoolean(key, portalID, defaultValue);
+            Instance.GetPortalSettingAsBoolean(key, portalID, defaultValue);
 
         /// <summary>
         /// Gets the portal setting as boolean.
@@ -690,7 +690,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting in specified language or neutral, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsBoolean' instance method. Scheduled removal in v11.0.0.")]
         public static bool GetPortalSettingAsBoolean(string key, int portalID, bool defaultValue, string cultureCode) =>
-            GetPortalSettingAsBoolean(key, portalID, defaultValue, cultureCode);
+            Instance.GetPortalSettingAsBoolean(key, portalID, defaultValue, cultureCode);
 
         /// <summary>
         /// Gets the portal setting as boolean for a specific language (or neutral).
@@ -733,7 +733,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instance method. Scheduled removal in v11.0.0.")]
         public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue) =>
-            GetPortalSettingAsInteger(key, portalID, defaultValue);
+            Instance.GetPortalSettingAsInteger(key, portalID, defaultValue);
 
         /// <summary>
         /// Gets the portal setting as integer.
@@ -775,7 +775,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsDouble' instance method. Scheduled removal in v11.0.0.")]
         public static double GetPortalSettingAsDouble(string key, int portalId, double defaultValue) =>
-            GetPortalSettingAsDouble(key, portalId, defaultValue);
+            Instance.GetPortalSettingAsDouble(key, portalId, defaultValue);
 
         /// <summary>
         /// Gets the portal setting as double.
@@ -818,7 +818,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Returns setting's value if portal contains the specific setting (for specified lang, otherwise return defaultValue.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalSettingAsInteger' instance method. Scheduled removal in v11.0.0.")]
         public static int GetPortalSettingAsInteger(string key, int portalID, int defaultValue, string cultureCode) =>
-            GetPortalSettingAsInteger(key, portalID, defaultValue, cultureCode);
+            Instance.GetPortalSettingAsInteger(key, portalID, defaultValue, cultureCode);
 
         /// <summary>
         /// Gets the portal setting as integer for a specific language (or neutral).
@@ -861,7 +861,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="passPhrase">pass phrase to allow encryption/decryption.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdateEncryptedString' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdateEncryptedString(int portalID, string settingName, string settingValue, string passPhrase) =>
-            UpdateEncryptedString(portalID, settingName, settingValue, passPhrase);
+            Instance.UpdateEncryptedString(portalID, settingName, settingValue, passPhrase);
 
         /// <summary>
         /// takes in a text value, encrypts it with a FIPS compliant algorithm and stores.
@@ -889,7 +889,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingValue">The setting value.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue) =>
-            UpdatePortalSetting(portalID, settingName, settingValue);
+            Instance.UpdatePortalSetting(portalID, settingName, settingValue);
 
         /// <summary>
         /// Updates a single neutral (not language specific) portal setting and clears it from the cache.
@@ -911,7 +911,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="clearCache">if set to <c>true</c> [clear cache].</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache) =>
-            UpdatePortalSetting(portalID, settingName, settingValue, clearCache);
+            Instance.UpdatePortalSetting(portalID, settingName, settingValue, clearCache);
 
         /// <summary>
         /// Updates a single neutral (not language specific) portal setting, optionally without clearing the cache.
@@ -933,10 +933,8 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="settingValue">The setting value.</param>
         /// <param name="cultureCode">culture code for language specific settings, null string ontherwise.</param>
         [Obsolete("Deprecated in DNN 9.2.0. Use the overloaded one with the 'isSecure' parameter instead. Scheduled removal in v11.0.0.")]
-        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, string cultureCode)
-        {
-            UpdatePortalSetting(portalID, settingName, settingValue, true, cultureCode, false);
-        }
+        public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, string cultureCode) =>
+            Instance.UpdatePortalSetting(portalID, settingName, settingValue, true, cultureCode, false);
 
         /// <summary>
         /// Updates a language specific or neutral portal setting and optionally clears it from the cache.
@@ -948,7 +946,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="cultureCode">culture code for language specific settings, null string ontherwise.</param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalSetting' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalSetting(int portalID, string settingName, string settingValue, bool clearCache, string cultureCode) =>
-            UpdatePortalSetting(portalID, settingName, settingValue, clearCache, cultureCode);
+            Instance.UpdatePortalSetting(portalID, settingName, settingValue, clearCache, cultureCode);
 
         /// <summary>
         /// Updates a language specific or neutral portal setting and optionally clears it from the cache.
@@ -973,7 +971,7 @@ namespace DotNetNuke.Entities.Portals
         /// <returns>Empty string if the module hasn't been installed, otherwise return the friendly name.</returns>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.CheckDesktopModulesInstalled' instance method. Scheduled removal in v11.0.0.")]
         public static string CheckDesktopModulesInstalled(XPathNavigator nav) =>
-            CheckDesktopModulesInstalled(nav);
+            Instance.CheckDesktopModulesInstalled(nav);
 
         /// <summary>
         /// Checks the desktop modules whether is installed.
@@ -1027,7 +1025,7 @@ namespace DotNetNuke.Entities.Portals
         /// <remarks>
         /// </remarks>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetActivePortalLanguage' instance method. Scheduled removal in v11.0.0.")]
-        public static string GetActivePortalLanguage(int portalID) => GetActivePortalLanguage(portalID);
+        public static string GetActivePortalLanguage(int portalID) => Instance.GetActivePortalLanguage(portalID);
 
         /// <summary>
         ///   function provides the language for portalinfo requests
@@ -1101,7 +1099,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="portalID"></param>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.GetPortalDefaultLanguage' instance method. Scheduled removal in v11.0.0.")]
         public static string GetPortalDefaultLanguage(int portalID) =>
-            GetPortalDefaultLanguage(portalID);
+            Instance.GetPortalDefaultLanguage(portalID);
 
         /// <summary>
         ///   return the current DefaultLanguage value from the Portals table for the requested Portalid.
@@ -1123,7 +1121,7 @@ namespace DotNetNuke.Entities.Portals
         /// </remarks>
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.UpdatePortalDefaultLanguage' instance method. Scheduled removal in v11.0.0.")]
         public static void UpdatePortalDefaultLanguage(int portalID, string CultureCode) =>
-            UpdatePortalDefaultLanguage(portalID, CultureCode);
+            Instance.UpdatePortalDefaultLanguage(portalID, CultureCode);
 
 
         /// <summary>
@@ -1144,7 +1142,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementCrmVersion' instance method. Scheduled removal in v11.0.0.")]
-        public static void IncrementCrmVersion(int portalID) => IncrementCrmVersion(portalID);
+        public static void IncrementCrmVersion(int portalID) => Instance.IncrementCrmVersion(portalID);
 
         void IPortalController.IncrementCrmVersion(int portalID)
         {
@@ -1158,7 +1156,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementOverridingPortalsCrmVersion' instance method. Scheduled removal in v11.0.0.")]
-        public static void IncrementOverridingPortalsCrmVersion() => IncrementOverridingPortalsCrmVersion();
+        public static void IncrementOverridingPortalsCrmVersion() => Instance.IncrementOverridingPortalsCrmVersion();
 
         void IPortalController.IncrementOverridingPortalsCrmVersion()
         {

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1157,7 +1157,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementOverridingPortalsCrmVersion' instnace method. Scheduled removal in v11.0.0.")]
+        [Obsolete("Deprecated in DNN 9.7.0. Use the 'IPortalController.IncrementOverridingPortalsCrmVersion' instance method. Scheduled removal in v11.0.0.")]
         public static void IncrementOverridingPortalsCrmVersion() => IncrementOverridingPortalsCrmVersion();
 
         void IPortalController.IncrementOverridingPortalsCrmVersion()

--- a/DNN Platform/Library/Obsolete/PortalController.cs
+++ b/DNN Platform/Library/Obsolete/PortalController.cs
@@ -34,7 +34,7 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in DotNetNuke 7.3. Replaced by PortalController.Instance.GetCurrentPortalSettings. Scheduled removal in v10.0.0.")]
         public static PortalSettings GetCurrentPortalSettings()
         {
-            return GetCurrentPortalSettingsInternal();
+            return (Instance as PortalController)?.GetCurrentPortalSettingsInternal();
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke
             services.AddSingleton<Html5ModuleControlFactory>();
             services.AddSingleton<ReflectedModuleControlFactory>();
 
-            services.AddTransient(x => PortalController.Instance);
+            services.AddTransient(x => ActivatorUtilities.GetServiceOrCreateInstance<PortalController>(Globals.DependencyProvider));
             services.AddTransient<INavigationManager, NavigationManager>();
         }
     }


### PR DESCRIPTION
Closes: #3934

## Summary
Completes Dependency Injection support for the `IPortalController` by making the remaining static APIs available on the interface
