### PR TITLE
Fixed an issue where it was impossible to select a page for non default sites in SEO

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PagePicker/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PagePicker/index.jsx
@@ -278,7 +278,7 @@ class PagePicker extends Component {
 
     getSelected(page, isCurrentOrDescendant) {
         let className = "page-value";
-        if ((page.Selectable || this.props.isSeoPage) && !isCurrentOrDescendant)      
+        if ((page.Selectable || this.props.AllowSelectUnselectablePages) && !isCurrentOrDescendant)      
             className += (page.CheckedState !== 1 ? " selected" : "");
         else
             className += " non-selectable";
@@ -302,7 +302,7 @@ class PagePicker extends Component {
             return <li key={page.TabId} className={"page-item page-" + page.TabId + (page.HasChildren ? " has-children" : "") + (page.IsOpen ? " opened" : " closed") }>
                 {(!page.IsOpen && page.HasChildren) && <div className="arrow-icon" dangerouslySetInnerHTML={{ __html: ArrowRightIcon }} onClick={this.getDescendants.bind(this, page, null) }></div>}
                 {(page.IsOpen && page.HasChildren) && <div className="arrow-icon" dangerouslySetInnerHTML={{ __html: ArrowDownIcon }} onClick={this.getDescendants.bind(this, page, null) }></div>}
-                <div className={this.getSelected(page, parentNotSelectable) } onClick={(page.Selectable || this.props.isSeoPage) && !parentNotSelectable ? this.onPageSelect.bind(this, page) : void (0) }>
+                <div className={this.getSelected(page, parentNotSelectable) } onClick={(page.Selectable || this.props.AllowSelectUnselectablePages) && !parentNotSelectable ? this.onPageSelect.bind(this, page) : void (0) }>
                     { props.ShowIcon &&
                         <div className={pageClass } dangerouslySetInnerHTML={{ __html: pageIcon }}></div>
                     }
@@ -736,7 +736,7 @@ PagePicker.defaultProps = {
         includeDeletedChildren: true
     },
     selectedTabId: -1,
-    isSeoPage: false
+    AllowSelectUnselectablePages: false
 };
 
 export default PagePicker;

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PagePicker/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PagePicker/index.jsx
@@ -7,7 +7,6 @@ import "./style.less";
 import Service from "./Service";
 import PagePickerScrollbar from "./PagePickerScrollbar";
 
-
 function format() {
     let format = arguments[0];
     let methodsArguments = arguments;
@@ -279,10 +278,11 @@ class PagePicker extends Component {
 
     getSelected(page, isCurrentOrDescendant) {
         let className = "page-value";
-        if (page.Selectable && !isCurrentOrDescendant)      
+        if ((page.Selectable || this.props.isSeoPage) && !isCurrentOrDescendant)      
             className += (page.CheckedState !== 1 ? " selected" : "");
         else
             className += " non-selectable";
+
         return className;
     }
 
@@ -302,7 +302,7 @@ class PagePicker extends Component {
             return <li key={page.TabId} className={"page-item page-" + page.TabId + (page.HasChildren ? " has-children" : "") + (page.IsOpen ? " opened" : " closed") }>
                 {(!page.IsOpen && page.HasChildren) && <div className="arrow-icon" dangerouslySetInnerHTML={{ __html: ArrowRightIcon }} onClick={this.getDescendants.bind(this, page, null) }></div>}
                 {(page.IsOpen && page.HasChildren) && <div className="arrow-icon" dangerouslySetInnerHTML={{ __html: ArrowDownIcon }} onClick={this.getDescendants.bind(this, page, null) }></div>}
-                <div className={this.getSelected(page, parentNotSelectable) } onClick={page.Selectable && !parentNotSelectable ? this.onPageSelect.bind(this, page) : void (0) }>
+                <div className={this.getSelected(page, parentNotSelectable) } onClick={(page.Selectable || this.props.isSeoPage) && !parentNotSelectable ? this.onPageSelect.bind(this, page) : void (0) }>
                     { props.ShowIcon &&
                         <div className={pageClass } dangerouslySetInnerHTML={{ __html: pageIcon }}></div>
                     }
@@ -735,8 +735,8 @@ PagePicker.defaultProps = {
         sortOrder: 0,
         includeDeletedChildren: true
     },
-    selectedTabId: -1
+    selectedTabId: -1,
+    isSeoPage: false
 };
-
 
 export default PagePicker;

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/testUrl/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/testUrl/index.jsx
@@ -103,7 +103,7 @@ class TestUrlPanelBody extends Component {
                     noneSpecifiedText={noneSpecifiedText}
                     CountText={"{0} Results"}
                     PortalTabsParameters={PageToTestParameters} 
-                    isSeoPage={true} />
+                    AllowSelectUnselectablePages={true} />
             </InputGroup>
             <InputGroup>
                 <Label

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/testUrl/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/src/components/testUrl/index.jsx
@@ -102,7 +102,8 @@ class TestUrlPanelBody extends Component {
                     defaultLabel={noneSpecifiedText}
                     noneSpecifiedText={noneSpecifiedText}
                     CountText={"{0} Results"}
-                    PortalTabsParameters={PageToTestParameters} />
+                    PortalTabsParameters={PageToTestParameters} 
+                    isSeoPage={true} />
             </InputGroup>
             <InputGroup>
                 <Label


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3947

## Summary
Fixed PagePicker for non default sites to not deny selection in case of call from Seo.Web
