### PR TITLE
Prevent Role Groups dropdown expand on delete

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/FiltersBar/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/FiltersBar/index.jsx
@@ -26,7 +26,9 @@ class FiltersBar extends Component {
         };
         canEdit = util.settings.isHost || util.settings.isAdmin || util.settings.permissions.EDIT;
     }
-    onDeleteGroup() {
+    onDeleteGroup(e) {
+        e.stopPropagation();
+
         const {props} = this;
         this.closeDropDown();
         util.utilities.confirm(resx.get("DeleteRoleGroup.Confirm"), resx.get("Delete"), resx.get("Cancel"), () => {

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleEditor/RoleGroupEditor/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleEditor/RoleGroupEditor/index.jsx
@@ -58,7 +58,9 @@ class RoleGroupEditor extends Component {
         });
     }
 
-    onCancel() {
+    onCancel(e) {
+        e.stopPropagation();
+
         this.setState({
             group: {}
         }, () => {
@@ -68,7 +70,9 @@ class RoleGroupEditor extends Component {
         });
     }
 
-    onSave() {
+    onSave(e) {
+        e.stopPropagation();
+
         const {props, state} = this;
         this.submitted = true;
         if (this.validateForm()) {


### PR DESCRIPTION
Fixes #3949

## Summary
The Edit and Delete icons next to the selected role group are components that are rendered within the dropdown, so the dropdown was intercepting all the bubbling clicks, and thus expanding.
This change adds the necessary `stopPropagation()` calls on the bubbling events so that the dropdown doesn't expand at the wrong times.