### PR TITLE
Issue-3953 - Default site alias comes as pre-selected on SEO URL edit page

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/EditUrl.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/EditUrl.jsx
@@ -75,7 +75,10 @@ class EditUrl extends Component {
         const {url, saving, pageHasParent, siteAliases, primaryAliasId, isOpened, onSave, onCancel} = this.props;
         const aliases = this.getOptions(siteAliases);
         const siteAliasUsageOptions = this.getSiteAliasUsageOptions(pageHasParent);
-        if (!this.state.hasChanges && url.siteAlias.Key !== primaryAliasId) 
+        if (
+            !this.state.hasChanges &&
+            url.siteAlias.Key !== primaryAliasId &&
+            url.id == null) 
         {
             this.props.onChange("siteAlias", primaryAliasId); 
         }


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3953 

## Summary
Site alias is set to default only on create pages and not on edit pages.

Demo: https://drive.google.com/file/d/1q6RzNpwihqZ3QqIrbFx5adTAszMkPrg9/view?usp=sharing
