### PR TITLE
pencil icon aligned for unpublished pages

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
@@ -70,7 +70,7 @@
         margin-left: 5px;
         
         display: inline-block;
-        width: 150px;
+        width: 130px;
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -170,6 +170,7 @@
         width: 20px;
         height: 20px;
         display: inline-block;
+        position: absolute;
         svg:hover {
             fill: @alto;
         }


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3960 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
The pencil icon was misaligned due to a recent change that had introduced ellipsis for longer page names. The pencil icon will now show after a fixed text length which is required for ellipsis to work.
![image](https://user-images.githubusercontent.com/22594255/89455899-924c8580-d752-11ea-8857-ecba5db0fcd4.png)
