### PR TITLE
Optimize WildcardToRegex for file search

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -1843,15 +1843,7 @@ namespace DotNetNuke.Services.FileSystem
 
         private static Regex WildcardToRegex(string pattern)
         {
-            if (!pattern.Contains("*") && !pattern.Contains("?"))
-            {
-                pattern = ".*" + Regex.Escape(pattern) + ".*";
-            }
-            else
-            {
-                pattern = Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".");
-            }
-
+            pattern = Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".");
             return RegexUtils.GetCachedRegex(pattern, RegexOptions.IgnoreCase);
         }
 


### PR DESCRIPTION
## Summary
This PR optimizes `WildcardToRegex()` to remove unnecessary start/end wildcard characters per comments on #3962.  Thanks to @bdukes for the RegEx tip!

Also, since `Replace(oldValue, newValue)` just returns the current instance unchanged if the `oldValue` is not found, I thought we could further optimize by removing the check for `*` or `?` in the search term.