### PR TITLE
Added retry to CompressionUtil.OpenCreate to prevent failures during site export

### DIFF
--- a/DNN Platform/Modules/DnnExportImport/Components/Common/CompressionUtil.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Common/CompressionUtil.cs
@@ -12,6 +12,7 @@ namespace Dnn.ExportImport.Components.Common
     using System.IO.MemoryMappedFiles;
     using System.Linq;
     using System.Text;
+    using DotNetNuke.Common.Utilities.Internal;
 
     public static class CompressionUtil
     {
@@ -199,6 +200,27 @@ namespace Dnn.ExportImport.Components.Common
         /// <param name="archiveFileName"></param>
         /// <returns></returns>
         public static ZipArchive OpenCreate(string archiveFileName)
+        {
+            if (string.IsNullOrWhiteSpace(archiveFileName))
+            {
+                throw new ArgumentNullException(nameof(archiveFileName));
+            }
+
+            ZipArchive zip = null;
+
+            RetryableAction.RetryEverySecondFor30Seconds(
+                () => zip = OpenCreateUnsafe(archiveFileName),
+                $"{nameof(OpenCreateUnsafe)}(\"{archiveFileName}\")");
+
+            return zip;
+        }
+
+        /// <summary>
+        /// Open the archive file for read and write (no retry).
+        /// </summary>
+        /// <param name="archiveFileName">The full zip file path.</param>
+        /// <returns>A <see cref="ZipArchive"/> instance.</returns>
+        internal static ZipArchive OpenCreateUnsafe(string archiveFileName)
         {
             return File.Exists(archiveFileName)
                 ? ZipFile.Open(archiveFileName, ZipArchiveMode.Update, Encoding.UTF8)


### PR DESCRIPTION
Fixes #3964

## Summary
DNN creates the export zip files in App_Data\ExportImport folder, but it does not add all necessary files at once. It closes and re-opens the zip file many times to add additional files. So DFS detects that the zip file is no longer locked and it starts replication. But then DNN attempts to open it again to add more files, and fails. All of this is noticeable only on large sites.
Typically, replication takes just a few seconds, so I used the `RetryableAction` to add a simple retrial mechanism to `CompressionUtil.OpenCreate(string)` to prevent such files from being skipped during export.

## Note
I'm targetting the `release/9.7.0` branch because `develop` is currently missing some important commits.
1) if decision is to approve and include this fix in 9.7.0, then this PR can be merged as-is
2) if decision is to defer to next version, then:
a) DO NOT MERGE right now
b) wait until release/9.7.0 is merged into develop
c) change this PR to target develop (it should not give any conflicts)
d) merge