### PR TITLE
handled empty string comparison to null case for non-existent display…

### DIFF
--- a/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx.cs
@@ -587,7 +587,9 @@ namespace DotNetNuke.Modules.Admin.Users
                 if (string.IsNullOrEmpty(this.PortalSettings.Registration.DisplayNameFormat))
                 {
                     var cleanDisplayName = PortalSecurity.Instance.InputFilter(this.User.DisplayName, filterFlags);
-                    if (!cleanDisplayName.Equals(this.User.DisplayName))
+                    var participantsAreEmptyOrNull = string.IsNullOrWhiteSpace(cleanDisplayName)
+                        && string.IsNullOrWhiteSpace(this.User.DisplayName);
+                    if (!participantsAreEmptyOrNull && !cleanDisplayName.Equals(this.User.DisplayName))
                     {
                         this.CreateStatus = UserCreateStatus.InvalidDisplayName;
                     }


### PR DESCRIPTION
… name field in register form

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3971 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Custom register form configured without Display Name field on it. Non-existent display name field has null value and after cleaning the input of display name, the cleaned value became empty string. A subsequent comparison between null and empty string marks this Display Name as invalid input.