### PR TITLE
Fix for issue Newly created sub-folder not shown if the parent folder…

### DIFF
--- a/DNN Platform/Library/Common/Utilities/PathUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/PathUtils.cs
@@ -222,7 +222,7 @@ namespace DotNetNuke.Common.Utilities
         }
 
         /// <summary>
-        /// Strips the original path by removing starting 0 or 0\\.
+        /// Strips the original path by removing starting 0\\.
         /// </summary>
         /// <param name="originalPath">The original path.</param>
         /// <returns>The stripped path.</returns>
@@ -235,7 +235,7 @@ namespace DotNetNuke.Common.Utilities
                 return FolderPathRx.Replace(originalPath, string.Empty);
             }
 
-            return originalPath.StartsWith("0") ? originalPath.Substring(1) : originalPath;
+            return originalPath;
         }
 
         internal string GetUserFolderPathElementInternal(int userId, UserFolderElement mode)


### PR DESCRIPTION
… name starts with "0"

Fixes #3975 

## Summary
Trimming the prefix "0" from folder name creates a folder with different name compared to the user provided name and the subfolder is also not created in the user provided folder name. 

Removing the code which trims the prefix "0" from folder name addresses this issue