### PR TITLE
Popup message content changed to avoid plural confusion

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -667,7 +667,7 @@
     <value>Allowable File Extensions:</value>
   </data>
   <data name="OtherSettingsUpdateSuccess.Text" xml:space="preserve">
-    <value>Settings has been updated.</value>
+    <value>Configuration has been updated.</value>
   </data>
   <data name="OtherSettingsError.Text" xml:space="preserve">
     <value>Could not update settings. Please try later.</value>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -667,7 +667,7 @@
     <value>Allowable File Extensions:</value>
   </data>
   <data name="OtherSettingsUpdateSuccess.Text" xml:space="preserve">
-    <value>Configuration has been updated.</value>
+    <value>Settings have been updated.</value>
   </data>
   <data name="OtherSettingsError.Text" xml:space="preserve">
     <value>Could not update settings. Please try later.</value>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3979 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
The popup message is changed from "Settings has been updated." to "Configuration has been updated." to avoid plural confusion with Settings vs Setting