### PR TITLE
Support C# Async Constructs During Page Rendering

### DIFF
--- a/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
+++ b/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
@@ -72,6 +72,7 @@
       <Link>SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="DependencyInjection\ServiceRequestScopeModule.cs" />
+    <Compile Include="Localization\LocalizationModule.cs" />
     <Compile Include="MobileRedirect\MobileRedirectModule.cs" />
     <Compile Include="OutputCaching\OutputCacheModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/DNN Platform/HttpModules/Localization/LocalizationModule.cs
+++ b/DNN Platform/HttpModules/Localization/LocalizationModule.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.HttpModules.Localization
+{
+    using System;
+    using System.Web;
+
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Services.Localization;
+
+    /// <summary>Sets up localization for all requests.</summary>
+    public class LocalizationModule : IHttpModule
+    {
+        /// <inheritdoc />
+        public void Init(HttpApplication context)
+        {
+            context.BeginRequest += Context_BeginRequest;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // intentionally left empty
+        }
+
+        private static void Context_BeginRequest(object sender, EventArgs e)
+        {
+            var isInstallPage = HttpContext.Current.Request.Url.LocalPath.ToLowerInvariant().Contains("installwizard.aspx");
+            if (isInstallPage)
+            {
+                return;
+            }
+
+            var portalSettings = PortalController.Instance.GetCurrentSettings();
+            Localization.SetThreadCultures(Localization.GetPageLocale(portalSettings), portalSettings);
+        }
+    }
+}

--- a/DNN Platform/Library/Framework/PageBase.cs
+++ b/DNN Platform/Library/Framework/PageBase.cs
@@ -426,12 +426,6 @@ namespace DotNetNuke.Framework
         protected override void OnInit(EventArgs e)
         {
             var isInstallPage = HttpContext.Current.Request.Url.LocalPath.ToLowerInvariant().Contains("installwizard.aspx");
-            if (!isInstallPage)
-            {
-                var portalSettings = PortalController.Instance.GetCurrentSettings();
-                Localization.SetThreadCultures(Localization.GetPageLocale(portalSettings), portalSettings);
-            }
-
             if (ScriptManager.GetCurrent(this) == null)
             {
                 AJAX.AddScriptManager(this, !isInstallPage);

--- a/DNN Platform/Library/Framework/PageBase.cs
+++ b/DNN Platform/Library/Framework/PageBase.cs
@@ -428,7 +428,8 @@ namespace DotNetNuke.Framework
             var isInstallPage = HttpContext.Current.Request.Url.LocalPath.ToLowerInvariant().Contains("installwizard.aspx");
             if (!isInstallPage)
             {
-                Localization.SetThreadCultures(this.PageCulture, this.PortalSettings);
+                var portalSettings = PortalController.Instance.GetCurrentSettings();
+                Localization.SetThreadCultures(Localization.GetPageLocale(portalSettings), portalSettings);
             }
 
             if (ScriptManager.GetCurrent(this) == null)

--- a/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
+++ b/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
@@ -167,6 +167,10 @@
     <Content Include="App_LocalResources\SharedResources.resx" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\DotNetNuke.Web\DotNetNuke.Web.csproj">
       <Project>{ee1329fe-fd88-4e1a-968c-345e394ef080}</Project>
       <Name>DotNetNuke.Web</Name>

--- a/DNN Platform/Modules/CoreMessaging/Services/SubscriptionsController.cs
+++ b/DNN Platform/Modules/CoreMessaging/Services/SubscriptionsController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Modules.CoreMessaging.Services
 {
     using System;
@@ -14,6 +13,7 @@ namespace DotNetNuke.Modules.CoreMessaging.Services
     using System.Web.Http;
     using System.Xml;
 
+    using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Modules.CoreMessaging.ViewModels;
     using DotNetNuke.Services.Exceptions;
@@ -154,7 +154,7 @@ namespace DotNetNuke.Modules.CoreMessaging.Services
             {
                 if (!string.IsNullOrEmpty(culture))
                 {
-                    Localization.SetThreadCultures(new CultureInfo(culture), this.PortalSettings);
+                    Localization.SetThreadCultures(new CultureInfo(culture), (IPortalSettings)this.PortalSettings);
                 }
 
                 var dictionary = new Dictionary<string, string>();

--- a/DNN Platform/Website/Default.aspx
+++ b/DNN Platform/Website/Default.aspx
@@ -1,4 +1,4 @@
-<%@ Page Language="C#" AutoEventWireup="True" Inherits="DotNetNuke.Framework.DefaultPage" CodeBehind="Default.aspx.cs" %>
+<%@ Page Language="C#" AutoEventWireup="True" Inherits="DotNetNuke.Framework.DefaultPage" CodeBehind="Default.aspx.cs" Async="true" %>
 <%@ Register TagPrefix="dnncrm" Namespace="DotNetNuke.Web.Client.ClientResourceManagement" Assembly="DotNetNuke.Web.Client" %>
 <%@ Register TagPrefix="dnn" Namespace="DotNetNuke.Common.Controls" Assembly="DotNetNuke" %>
 <asp:literal id="skinDocType" runat="server" ViewStateMode="Disabled"/>
@@ -12,14 +12,14 @@
     <meta id="MetaCopyright" runat="Server" name="COPYRIGHT" Visible="False"/>
     <meta id="MetaGenerator" runat="Server" name="GENERATOR" Visible="False"/>
     <meta id="MetaAuthor" runat="Server" name="AUTHOR" Visible="False"/>
-    <meta id="MetaRobots" runat="server" name="ROBOTS" Visible="False" />    
+    <meta id="MetaRobots" runat="server" name="ROBOTS" Visible="False" />
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadCss"></asp:PlaceHolder>
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadJs"></asp:PlaceHolder>
     <asp:placeholder id="CSS" runat="server" />
     <asp:placeholder id="SCRIPTS" runat="server" />
 </head>
 <body id="Body" runat="server">
-    
+
     <dnn:Form ID="Form" runat="server" ENCTYPE="multipart/form-data">
         <asp:PlaceHolder ID="BodySCRIPTS" runat="server" />
         <asp:Label ID="SkinError" runat="server" CssClass="NormalRed" Visible="False"></asp:Label>

--- a/DNN Platform/Website/Install/Config/09.08.00.config
+++ b/DNN Platform/Website/Install/Config/09.08.00.config
@@ -1,0 +1,7 @@
+<configuration>
+  <nodes configfile="web.config">
+    <node path="/configuration/system.webServer/modules" action="update" key="name" collision="overwrite">
+      <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
+    </node>
+  </nodes>
+</configuration>

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -82,6 +82,7 @@
     <modules>
       <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
+      <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -82,6 +82,7 @@
     <modules>
       <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
+      <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>


### PR DESCRIPTION
## Summary
Thanks @mitchelsellers for tracking down the answer to our `async` issues.

This turns on [`Async`](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ydy4x04a(v=vs.100)?redirectedfrom=MSDN#attributes) for `Default.aspx`.

Previously, when we attempted this in #2089, we ran into an issue with the culture not being preserved throughout the entire page lifecycle.  So, for example, the page may have been loaded in a non-English context, but the URLs were generated for en-US anyway.

The solution is to set the thread culture via an `IHttpModule` implementation, rather than via the page's `OnInit` method.  This allows the culture to persist throughout the page request.