### PR TITLE
Created IApplicationInfo and IApplicationStatusInfo for Dependency Injection

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
@@ -1,0 +1,113 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Application
+{
+    using System;
+
+    /// <summary>
+    /// The Application class contains properties that describe the DotNetNuke Application.
+    /// </summary>
+    public interface IApplicationInfo
+    {
+        /// <summary>
+        /// Gets the company to which the DotNetNuke application is related.
+        /// </summary>
+        /// <value>Fixed result: DotNetNuke Corporation.</value>
+        string Company { get; }
+
+        /// <summary>
+        /// Gets the version of the currently installed DotNetNuke framework/application
+        /// Can be prior to Version, if the application is pending to be upgraded.
+        /// </summary>
+        /// <value>The version as retreieved from the database version table.</value>
+        Version CurrentVersion { get; }
+
+        /// <summary>
+        /// Gets the description of the application.
+        /// </summary>
+        /// <value>Fixed result: DNN Platform.</value>
+        string Description { get; }
+
+        /// <summary>
+        /// Gets the help URL related to the DotNetNuke application.
+        /// </summary>
+        /// <value>Fixed result: https://dnndocs.com/. </value>
+        string HelpUrl { get; }
+
+        /// <summary>
+        /// Gets the legal copyright.
+        /// </summary>
+        /// <value>Dynamic: DNN Platform is copyright 2002-todays year by .NET Foundation".</value>
+        string LegalCopyright { get; }
+
+        /// <summary>
+        /// Gets the name of the application.
+        /// </summary>
+        /// <value>Fixed result: DNNCORP.CE.</value>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the SKU (Stock Keeping Unit).
+        /// </summary>
+        /// <value>Fixed result: DNN.</value>
+        string SKU { get; }
+
+        /// <summary>
+        /// Gets the status of the DotnetNuke application.
+        /// </summary>
+        /// <remarks>
+        /// If the value is not be Stable, you will see the exactly status and version in page's title if allow display beta message in host setting.
+        /// </remarks>
+        /// <value>
+        /// The value can be: None, Alpha, Beta, RC, Stable.
+        /// </value>
+        ReleaseMode Status { get; }
+
+        /// <summary>
+        /// Gets the title of the application.
+        /// </summary>
+        /// <value>Fixed value: DotNetNuke.</value>
+        string Title { get; }
+
+        /// <summary>
+        /// Gets the trademark.
+        /// </summary>
+        /// <value>Fixed value: DotNetNuke,DNN.</value>
+        string Trademark { get; }
+
+        /// <summary>
+        /// Gets the type of the application.
+        /// </summary>
+        /// <value>Fixed value: Framework.</value>
+        string Type { get; }
+
+        /// <summary>
+        /// Gets the upgrade URL.
+        /// </summary>
+        /// <value>Fixed value: https://dnnplatform.io. </value>
+        string UpgradeUrl { get; }
+
+        /// <summary>
+        /// Gets the URL of the application.
+        /// </summary>
+        /// <value>Fixed value: https://dnncommunity.org.</value>
+        string Url { get; }
+
+        /// <summary>
+        /// Gets the version of the DotNetNuke framework/application.
+        /// </summary>
+        /// <value>The version as retreieved from the Executing assembly.</value>
+        Version Version { get; }
+
+        /// <summary>
+        ///   Determine whether a product specific change is to be applied.
+        /// </summary>
+        /// <param name = "productNames">list of product names.</param>
+        /// <returns>true if product is within list of names.</returns>
+        /// <remarks>
+        /// </remarks>
+        bool ApplyToProduct(string productNames);
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationStatusInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationStatusInfo.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Application
+{
+    using System;
+
+    /// <summary>
+    /// The Application Status Info, includes information about installation
+    /// and database version.
+    /// </summary>
+    public interface IApplicationStatusInfo
+    {
+        /// <summary>
+        /// Gets the status of application.
+        /// </summary>
+        UpgradeStatus Status { get; }
+
+        /// <summary>
+        /// Gets the application map path.
+        /// </summary>
+        /// <value>
+        /// The application map path.
+        /// </value>
+        string ApplicationMapPath { get; }
+
+        /// <summary>
+        /// Gets the database version.
+        /// </summary>
+        Version DatabaseVersion { get; }
+
+        /// <summary>
+        /// IsInstalled looks at various file artifacts to determine if DotNetNuke has already been installed.
+        /// </summary>
+        /// <returns>true if installed else false.</returns>
+        /// <remarks>
+        /// If DotNetNuke has been installed, then we should treat database connection errors as real errors.
+        /// If DotNetNuke has not been installed, then we should expect to have database connection problems
+        /// since the connection string may not have been configured yet, which can occur during the installation
+        /// wizard.
+        /// </remarks>
+        bool IsInstalled();
+
+        /// <summary>
+        /// Updates the database version.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        void UpdateDatabaseVersion(Version version);
+
+        /// <summary>
+        /// Needs documentation.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        /// <returns>true is success else false.</returns>
+        bool IncrementalVersionExists(Version version);
+
+        /// <summary>
+        /// Get the last application iteration.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        /// <returns>The result.</returns>
+        int GetLastAppliedIteration(Version version);
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationStatusInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationStatusInfo.cs
@@ -43,10 +43,23 @@ namespace DotNetNuke.Abstractions.Application
         bool IsInstalled();
 
         /// <summary>
+        /// Sets the status.
+        /// </summary>
+        /// <param name="status">The status.</param>
+        void SetStatus(UpgradeStatus status);
+
+        /// <summary>
         /// Updates the database version.
         /// </summary>
         /// <param name="version">The version.</param>
         void UpdateDatabaseVersion(Version version);
+
+        /// <summary>
+        /// Updates the database version.
+        /// </summary>
+        /// <param name="version">The version.</param>
+        /// <param name="increment">The increment.</param>
+        void UpdateDatabaseVersionIncrement(Version version, int increment);
 
         /// <summary>
         /// Needs documentation.

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IDnnContext.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IDnnContext.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Application
+{
+    /// <summary>
+    /// Defines the context for the environment of the DotNetNuke application.
+    /// </summary>
+    public interface IDnnContext
+    {
+        /// <summary>
+        /// Gets get the application.
+        /// </summary>
+        IApplicationInfo Application { get; }
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Application/ReleaseMode.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/ReleaseMode.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-namespace DotNetNuke.Application
-{
-    using System;
 
+namespace DotNetNuke.Abstractions.Application
+{
     /// <summary>
     /// The enumeration of release mode.
     /// </summary>
@@ -47,37 +46,5 @@ namespace DotNetNuke.Application
         /// Stable release version
         /// </summary>
         Stable = 4,
-    }
-
-    /// <summary>
-    /// The status of current assembly.
-    /// </summary>
-    /// <example>
-    /// [assembly: AssemblyStatus(ReleaseMode.Stable)].
-    /// </example>
-    [AttributeUsage(AttributeTargets.Assembly)]
-    public class AssemblyStatusAttribute : Attribute
-    {
-        private readonly ReleaseMode _releaseMode;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AssemblyStatusAttribute" /> class.
-        /// </summary>
-        /// <param name="releaseMode">The release mode.</param>
-        public AssemblyStatusAttribute(ReleaseMode releaseMode)
-        {
-            this._releaseMode = releaseMode;
-        }
-
-        /// <summary>
-        /// Gets status of current assembly.
-        /// </summary>
-        public ReleaseMode Status
-        {
-            get
-            {
-                return this._releaseMode;
-            }
-        }
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Application/UpgradeStatus.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/UpgradeStatus.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Application
+{
+    /// <summary>
+    /// Enumeration Of Application upgrade status.
+    /// </summary>
+    public enum UpgradeStatus
+    {
+        /// <summary>
+        /// The application need update to a higher version.
+        /// </summary>
+        Upgrade = 0,
+
+        /// <summary>
+        /// The application need to install itself.
+        /// </summary>
+        Install = 1,
+
+        /// <summary>
+        /// The application is normal running.
+        /// </summary>
+        None = 2,
+
+        /// <summary>
+        /// The application occur error when running.
+        /// </summary>
+        Error = 3,
+
+        /// <summary>
+        /// The application status is unknown,
+        /// </summary>
+        /// <remarks>This status should never be returned. its is only used as a flag that Status hasn't been determined.</remarks>
+        Unknown = 4,
+    }
+}

--- a/DNN Platform/DotNetNuke.Web/Common/LazyServiceProvider.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/LazyServiceProvider.cs
@@ -5,28 +5,30 @@
 namespace DotNetNuke.Web.Common
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
+    using System.ComponentModel;
 
-    public class LazyServiceProvider : IServiceProvider
+    public class LazyServiceProvider : IServiceProvider, INotifyPropertyChanged
     {
-        private IServiceProvider _serviceProvider;
+        private IServiceProvider serviceProvider;
 
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc/>
         public object GetService(Type serviceType)
         {
-            if (this._serviceProvider is null)
+            if (this.serviceProvider is null)
             {
                 throw new Exception("Cannot resolve services until the service provider is built.");
             }
 
-            return this._serviceProvider.GetService(serviceType);
+            return this.serviceProvider.GetService(serviceType);
         }
 
         internal void SetProvider(IServiceProvider serviceProvider)
         {
-            this._serviceProvider = serviceProvider;
+            this.serviceProvider = serviceProvider;
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(serviceProvider)));
         }
     }
 }

--- a/DNN Platform/Library/Application/Application.cs
+++ b/DNN Platform/Library/Application/Application.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.Application
         /// <summary>
         /// Initializes a new instance of the <see cref="Application"/> class.
         /// </summary>
-        protected internal Application()
+        public Application()
         {
         }
 

--- a/DNN Platform/Library/Application/Application.cs
+++ b/DNN Platform/Library/Application/Application.cs
@@ -7,26 +7,25 @@ namespace DotNetNuke.Application
     using System.Diagnostics;
     using System.Reflection;
 
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
 
-    /// <summary>
-    /// The Application class contains properties that describe the DotNetNuke Application.
-    /// </summary>
-    /// <remarks>
-    /// </remarks>
-    public class Application
-    {
-        private static ReleaseMode _status = ReleaseMode.None;
+    using NewReleaseMode = DotNetNuke.Abstractions.Application.ReleaseMode;
 
+    /// <inheritdoc />
+    public class Application : IApplicationInfo
+    {
+        private static NewReleaseMode status = NewReleaseMode.None;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Application"/> class.
+        /// </summary>
         protected internal Application()
         {
         }
 
-        /// <summary>
-        /// Gets the company to which the DotNetNuke application is related.
-        /// </summary>
-        /// <value>Fixed result: DotNetNuke Corporation.</value>
+        /// <inheritdoc />
         public string Company
         {
             get
@@ -35,11 +34,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the version of the currently installed DotNetNuke framework/application
-        /// Can be prior to Version, if the application is pending to be upgraded.
-        /// </summary>
-        /// <value>The version as retreieved from the database version table.</value>
+        /// <inheritdoc />
         public virtual Version CurrentVersion
         {
             get
@@ -48,10 +43,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the description of the application.
-        /// </summary>
-        /// <value>Fixed result: DNN Platform.</value>
+        /// <inheritdoc />
         public virtual string Description
         {
             get
@@ -60,10 +52,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the help URL related to the DotNetNuke application.
-        /// </summary>
-        /// <value>Fixed result: https://dnndocs.com/. </value>
+        /// <inheritdoc />
         public string HelpUrl
         {
             get
@@ -72,10 +61,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the legal copyright.
-        /// </summary>
-        /// <value>Dynamic: DNN Platform is copyright 2002-todays year by .NET Foundation".</value>
+        /// <inheritdoc />
         public string LegalCopyright
         {
             get
@@ -84,10 +70,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the name of the application.
-        /// </summary>
-        /// <value>Fixed result: DNNCORP.CE.</value>
+        /// <inheritdoc />
         public virtual string Name
         {
             get
@@ -96,10 +79,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the SKU (Stock Keeping Unit).
-        /// </summary>
-        /// <value>Fixed result: DNN.</value>
+        /// <inheritdoc />
         public virtual string SKU
         {
             get
@@ -117,11 +97,15 @@ namespace DotNetNuke.Application
         /// <value>
         /// The value can be: None, Alpha, Beta, RC, Stable.
         /// </value>
-        public ReleaseMode Status
+        [Obsolete("Deprecated in Platform 9.7.0. Use 'DotNetNuke.Abstractions.Application.IApplicationInfo' with Dependency Injection instead. Scheduled for removal in v11.0.0.")]
+        public ReleaseMode Status { get => (ReleaseMode)(this as IApplicationInfo).Status; }
+
+        /// <inheritdoc />
+        NewReleaseMode IApplicationInfo.Status
         {
             get
             {
-                if (_status == ReleaseMode.None)
+                if (status == NewReleaseMode.None)
                 {
                     Assembly assy = Assembly.GetExecutingAssembly();
                     if (Attribute.IsDefined(assy, typeof(AssemblyStatusAttribute)))
@@ -129,19 +113,16 @@ namespace DotNetNuke.Application
                         Attribute attr = Attribute.GetCustomAttribute(assy, typeof(AssemblyStatusAttribute));
                         if (attr != null)
                         {
-                            _status = ((AssemblyStatusAttribute)attr).Status;
+                            status = (NewReleaseMode)((AssemblyStatusAttribute)attr).Status;
                         }
                     }
                 }
 
-                return _status;
+                return status;
             }
         }
 
-        /// <summary>
-        /// Gets the title of the application.
-        /// </summary>
-        /// <value>Fixed value: DotNetNuke.</value>
+        /// <inheritdoc />
         public string Title
         {
             get
@@ -150,10 +131,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the trademark.
-        /// </summary>
-        /// <value>Fixed value: DotNetNuke,DNN.</value>
+        /// <inheritdoc />
         public string Trademark
         {
             get
@@ -162,10 +140,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the type of the application.
-        /// </summary>
-        /// <value>Fixed value: Framework.</value>
+        /// <inheritdoc />
         public string Type
         {
             get
@@ -174,10 +149,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the upgrade URL.
-        /// </summary>
-        /// <value>Fixed value: https://dnnplatform.io. </value>
+        /// <inheritdoc />
         public string UpgradeUrl
         {
             get
@@ -192,10 +164,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the URL of the application.
-        /// </summary>
-        /// <value>Fixed value: https://dnncommunity.org.</value>
+        /// <inheritdoc />
         public string Url
         {
             get
@@ -204,10 +173,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        /// Gets the version of the DotNetNuke framework/application.
-        /// </summary>
-        /// <value>The version as retreieved from the Executing assembly.</value>
+        /// <inheritdoc />
         public virtual Version Version
         {
             get
@@ -218,13 +184,7 @@ namespace DotNetNuke.Application
             }
         }
 
-        /// <summary>
-        ///   Determine whether a product specific change is to be applied.
-        /// </summary>
-        /// <param name = "productNames">list of product names.</param>
-        /// <returns>true if product is within list of names.</returns>
-        /// <remarks>
-        /// </remarks>
+        /// <inheritdoc />
         public virtual bool ApplyToProduct(string productNames)
         {
             return productNames.Contains(this.Name);

--- a/DNN Platform/Library/Application/ApplicationStatusInfo.cs
+++ b/DNN Platform/Library/Application/ApplicationStatusInfo.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Application
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ApplicationStatusInfo));
 
         private UpgradeStatus status = UpgradeStatus.Unknown;
-        private string applicationMapPath = string.Empty;
+        private string applicationMapPath;
 
         private IApplicationInfo applicationInfo;
 

--- a/DNN Platform/Library/Application/ApplicationStatusInfo.cs
+++ b/DNN Platform/Library/Application/ApplicationStatusInfo.cs
@@ -1,0 +1,301 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Application
+{
+    using System;
+    using System.IO;
+    using System.Web;
+
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Data;
+    using DotNetNuke.Framework.Providers;
+    using DotNetNuke.Instrumentation;
+    using DotNetNuke.Services.Upgrade;
+
+
+    /// <inheritdoc />
+    public class ApplicationStatusInfo : IApplicationStatusInfo
+    {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ApplicationStatusInfo));
+
+        private UpgradeStatus status = UpgradeStatus.Unknown;
+        private string applicationMapPath = string.Empty;
+
+        private IApplicationInfo applicationInfo;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationStatusInfo"/> class.
+        /// </summary>
+        /// <param name="applicationInfo">The application info.</param>
+        /// <remarks>
+        /// This constructor is designed to be used with Dependency Injection.
+        /// </remarks>
+        public ApplicationStatusInfo(IApplicationInfo applicationInfo)
+        {
+            this.applicationInfo = applicationInfo;
+        }
+
+        /// <inheritdoc />
+        public UpgradeStatus Status
+        {
+            get
+            {
+                if (this.status != UpgradeStatus.Unknown && this.status != UpgradeStatus.Error)
+                {
+                    return this.status;
+                }
+
+                Logger.Trace("Getting application status");
+                var tempStatus = UpgradeStatus.None;
+
+                // first call GetProviderPath - this insures that the Database is Initialised correctly
+                // and also generates the appropriate error message if it cannot be initialised correctly
+                string strMessage = DataProvider.Instance().GetProviderPath();
+
+                // get current database version from DB
+                if (!strMessage.StartsWith("ERROR:"))
+                {
+                    try
+                    {
+                        this.DatabaseVersion = DataProvider.Instance().GetVersion();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex);
+                        strMessage = "ERROR:" + ex.Message;
+                    }
+                }
+
+                if (strMessage.StartsWith("ERROR"))
+                {
+                    if (this.IsInstalled())
+                    {
+                        // Errors connecting to the database after an initial installation should be treated as errors.
+                        tempStatus = UpgradeStatus.Error;
+                    }
+                    else
+                    {
+                        // An error that occurs before the database has been installed should be treated as a new install
+                        tempStatus = UpgradeStatus.Install;
+                    }
+                }
+                else if (this.DatabaseVersion == null)
+                {
+                    // No Db Version so Install
+                    tempStatus = UpgradeStatus.Install;
+                }
+                else
+                {
+                    var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
+                    if (version.Major > this.DatabaseVersion.Major)
+                    {
+                        // Upgrade Required (Major Version Upgrade)
+                        tempStatus = UpgradeStatus.Upgrade;
+                    }
+                    else if (version.Major == this.DatabaseVersion.Major && version.Minor > this.DatabaseVersion.Minor)
+                    {
+                        // Upgrade Required (Minor Version Upgrade)
+                        tempStatus = UpgradeStatus.Upgrade;
+                    }
+                    else if (version.Major == this.DatabaseVersion.Major && version.Minor == this.DatabaseVersion.Minor &&
+                             version.Build > this.DatabaseVersion.Build)
+                    {
+                        // Upgrade Required (Build Version Upgrade)
+                        tempStatus = UpgradeStatus.Upgrade;
+                    }
+                    else if (version.Major == this.DatabaseVersion.Major && version.Minor == this.DatabaseVersion.Minor &&
+                             version.Build == this.DatabaseVersion.Build && this.IncrementalVersionExists(version))
+                    {
+                        // Upgrade Required (Build Version Upgrade)
+                        tempStatus = UpgradeStatus.Upgrade;
+                    }
+                }
+
+                this.status = tempStatus;
+
+                Logger.Trace(string.Format("result of getting providerpath: {0}", strMessage));
+                Logger.Trace("Application status is " + this.status);
+
+                return this.status;
+            }
+        }
+
+        /// <inheritdoc />
+        public Version DatabaseVersion { get; private set; }
+
+        /// <inheritdoc />
+        public string ApplicationMapPath { get => this.applicationMapPath ?? (this.applicationMapPath = this.GetCurrentDomainDirectory()); }
+
+        /// <inheritdoc />
+        public bool IsInstalled()
+        {
+            const int c_PassingScore = 4;
+            int installationdatefactor = Convert.ToInt32(this.HasInstallationDate() ? 1 : 0);
+            int dataproviderfactor = Convert.ToInt32(this.HasDataProviderLogFiles() ? 3 : 0);
+            int htmlmodulefactor = Convert.ToInt32(this.ModuleDirectoryExists("html") ? 2 : 0);
+            int portaldirectoryfactor = Convert.ToInt32(this.HasNonDefaultPortalDirectory() ? 2 : 0);
+            int localexecutionfactor = Convert.ToInt32(HttpContext.Current.Request.IsLocal ? c_PassingScore - 1 : 0);
+
+            // This calculation ensures that you have a more than one item that indicates you have already installed DNN.
+            // While it is possible that you might not have an installation date or that you have deleted log files
+            // it is unlikely that you have removed every trace of an installation and yet still have a working install
+            bool isInstalled = (!this.IsInstallationURL()) && ((installationdatefactor + dataproviderfactor + htmlmodulefactor + portaldirectoryfactor + localexecutionfactor) >= c_PassingScore);
+
+            // we need to tighten this check. We now are enforcing the existence of the InstallVersion value in web.config. If
+            // this value exists, then DNN was previously installed, and we should never try to re-install it
+            return isInstalled || this.HasInstallVersion();
+        }
+
+        /// <inheritdoc />
+        public void UpdateDatabaseVersion(Version version)
+        {
+            // update the version
+            DataProvider.Instance().UpdateDatabaseVersion(version.Major, version.Minor, version.Build, this.applicationInfo.Name);
+            this.DatabaseVersion = version;
+        }
+
+        /// <inheritdoc />
+        public bool IncrementalVersionExists(Version version)
+        {
+            Provider currentdataprovider = Config.GetDefaultProvider("data");
+            string providerpath = currentdataprovider.Attributes["providerPath"];
+
+            // If the provider path does not exist, then there can't be any log files
+            if (!string.IsNullOrEmpty(providerpath))
+            {
+                providerpath = HttpRuntime.AppDomainAppPath + providerpath.Replace("~", string.Empty);
+                if (Directory.Exists(providerpath))
+                {
+                    var incrementalcount = Directory.GetFiles(providerpath, Upgrade.GetStringVersion(version) + ".*." + Upgrade.DefaultProvider).Length;
+
+                    if (incrementalcount > this.GetLastAppliedIteration(version))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public int GetLastAppliedIteration(Version version)
+        {
+            try
+            {
+                return DataProvider.Instance().GetLastAppliedIteration(version.Major, version.Minor, version.Build);
+            }
+            catch (Exception)
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether current request is for install.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if current request is for install; otherwise, <c>false</c>.
+        /// </returns>
+        private bool IsInstallationURL()
+        {
+            string requestURL = HttpContext.Current.Request.RawUrl.ToLowerInvariant().Replace("\\", "/");
+            return requestURL.Contains("/install.aspx") || requestURL.Contains("/installwizard.aspx");
+        }
+
+        /// <summary>
+        /// Determines whether has installation date.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if has installation date; otherwise, <c>false</c>.
+        /// </returns>
+        private bool HasInstallationDate()
+        {
+            return Config.GetSetting("InstallationDate") != null;
+        }
+
+        /// <summary>
+        /// Determines whether has data provider log files.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if has data provider log files; otherwise, <c>false</c>.
+        /// </returns>
+        private bool HasDataProviderLogFiles()
+        {
+            Provider currentdataprovider = Config.GetDefaultProvider("data");
+            string providerpath = currentdataprovider.Attributes["providerPath"];
+
+            // If the provider path does not exist, then there can't be any log files
+            if (!string.IsNullOrEmpty(providerpath))
+            {
+                providerpath = HttpContext.Current.Server.MapPath(providerpath);
+                if (Directory.Exists(providerpath))
+                {
+                    return Directory.GetFiles(providerpath, "*.log.resources").Length > 0;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check whether the modules directory is exists.
+        /// </summary>
+        /// <param name="moduleName">Name of the module.</param>
+        /// <returns>
+        /// <c>true</c> if the module directory exist, otherwise, <c>false</c>.
+        /// </returns>
+        private bool ModuleDirectoryExists(string moduleName)
+        {
+            string dir = this.ApplicationMapPath + "\\desktopmodules\\" + moduleName;
+            return Directory.Exists(dir);
+        }
+
+        /// <summary>
+        /// Determines whether has portal directory except default portal directory in portal path.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if has portal directory except default portal directory in portal path; otherwise, <c>false</c>.
+        /// </returns>
+        private bool HasNonDefaultPortalDirectory()
+        {
+            string dir = this.ApplicationMapPath + "\\portals";
+            if (Directory.Exists(dir))
+            {
+                return Directory.GetDirectories(dir).Length > 1;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether has InstallVersion set.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if has installation date; otherwise, <c>false</c>.
+        /// </returns>
+        private bool HasInstallVersion()
+        {
+            return Config.GetSetting("InstallVersion") != null;
+        }
+
+        /// <summary>
+        /// Get the current domain directory.
+        /// </summary>
+        /// <returns>returns the domain directory.</returns>
+        private string GetCurrentDomainDirectory()
+        {
+            var dir = AppDomain.CurrentDomain.BaseDirectory.Replace("/", "\\");
+            if (dir.Length > 3 && dir.EndsWith("\\"))
+            {
+                dir = dir.Substring(0, dir.Length - 1);
+            }
+
+            return dir;
+        }
+    }
+}

--- a/DNN Platform/Library/Application/ApplicationStatusInfo.cs
+++ b/DNN Platform/Library/Application/ApplicationStatusInfo.cs
@@ -150,11 +150,28 @@ namespace DotNetNuke.Application
             return isInstalled || this.HasInstallVersion();
         }
 
+        /// <summary>
+        /// Sets the status.
+        /// </summary>
+        /// <param name="status">The status.</param>
+        public void SetStatus(UpgradeStatus status)
+        {
+            this.status = status;
+        }
+
         /// <inheritdoc />
         public void UpdateDatabaseVersion(Version version)
         {
             // update the version
             DataProvider.Instance().UpdateDatabaseVersion(version.Major, version.Minor, version.Build, this.applicationInfo.Name);
+            this.DatabaseVersion = version;
+        }
+
+        /// <inheritdoc />
+        public void UpdateDatabaseVersionIncrement(Version version, int increment)
+        {
+            // update the version and increment
+            DataProvider.Instance().UpdateDatabaseVersionIncrement(version.Major, version.Minor, version.Build, increment, DotNetNukeContext.Current.Application.Name);
             this.DatabaseVersion = version;
         }
 

--- a/DNN Platform/Library/Application/DotNetNukeContext.cs
+++ b/DNN Platform/Library/Application/DotNetNukeContext.cs
@@ -34,6 +34,11 @@ namespace DotNetNuke.Application
             : this(Globals.DependencyProvider.GetRequiredService<IApplicationInfo>())
         { }
 
+        [Obsolete("Deprecated in DotNetNuke 9.7.1. This constructor has been replaced by the overload taking an IApplicationInfo, which should be resolved via Dependency Injection. Scheduled removal in v11.0.0.")]
+    protected DotNetNukeContext(Application application)
+        : this((IApplicationInfo)application)
+    { }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetNukeContext" /> class using the provided application as base.
         /// </summary>

--- a/DNN Platform/Library/Application/DotNetNukeContext.cs
+++ b/DNN Platform/Library/Application/DotNetNukeContext.cs
@@ -24,6 +24,17 @@ namespace DotNetNuke.Application
         private readonly IApplicationInfo applicationInfo;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetNukeContext"/> class.
+        /// </summary>
+        /// <remarks>
+        /// Initialize using the public constructor for Dependency Injection, this method will be removed.
+        /// </remarks>
+        [Obsolete("Deprecated in DotNetNuke 9.7.1. This constructor has been replaced by parameterized public constructor which is designed to be used with Dependency Injection. Resolve the new interface 'DotNetNuke.Abstractions.IDnnContext' instead. Scheduled removal in v11.0.0.")]
+        protected DotNetNukeContext()
+            : this(Globals.DependencyProvider.GetRequiredService<IApplicationInfo>())
+        { }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DotNetNukeContext" /> class using the provided application as base.
         /// </summary>
         /// <param name="applicationInfo">The application.</param>

--- a/DNN Platform/Library/Application/DotNetNukeContext.cs
+++ b/DNN Platform/Library/Application/DotNetNukeContext.cs
@@ -61,7 +61,7 @@ namespace DotNetNuke.Application
         /// <summary>
         /// Gets get the application.
         /// </summary>
-        public Application Application { get => this.Application is Application app ? app : new Application(); }
+        public Application Application { get => this.applicationInfo is Application app ? app : new Application(); }
 
         /// <inheritdoc />
         IApplicationInfo IDnnContext.Application { get => this.applicationInfo; }

--- a/DNN Platform/Library/Application/DotNetNukeContext.cs
+++ b/DNN Platform/Library/Application/DotNetNukeContext.cs
@@ -1,41 +1,40 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Application
 {
+    using System;
     using System.Collections.Generic;
 
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Collections.Internal;
+    using DotNetNuke.Common;
     using DotNetNuke.UI.Containers.EventListeners;
     using DotNetNuke.UI.Skins.EventListeners;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     /// Defines the context for the environment of the DotNetNuke application.
     /// </summary>
-    public class DotNetNukeContext
+    public class DotNetNukeContext : IDnnContext
     {
-        private static DotNetNukeContext _current;
-        private readonly Application _application;
-        private readonly IList<ContainerEventListener> _containerEventListeners;
-        private readonly IList<SkinEventListener> _skinEventListeners;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DotNetNukeContext" /> class.
-        /// </summary>
-        protected DotNetNukeContext()
-            : this(new Application())
-        {
-        }
+        private static IDnnContext current;
+        private readonly IApplicationInfo applicationInfo;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetNukeContext" /> class using the provided application as base.
         /// </summary>
-        /// <param name="application">The application.</param>
-        protected DotNetNukeContext(Application application)
+        /// <param name="applicationInfo">The application.</param>
+        /// <remarks>
+        /// This constructor is designed to be used with Dependency Injection.
+        /// </remarks>
+        public DotNetNukeContext(IApplicationInfo applicationInfo)
         {
-            this._application = application;
-            this._containerEventListeners = new NaiveLockingList<ContainerEventListener>();
-            this._skinEventListeners = new NaiveLockingList<SkinEventListener>();
+            this.applicationInfo = applicationInfo;
+            this.ContainerEventListeners = new NaiveLockingList<ContainerEventListener>();
+            this.SkinEventListeners = new NaiveLockingList<SkinEventListener>();
         }
 
         /// <summary>
@@ -45,30 +44,27 @@ namespace DotNetNuke.Application
         {
             get
             {
-                if (_current == null)
+                if (current == null)
                 {
-                    _current = new DotNetNukeContext();
+                    current = Globals.DependencyProvider.GetRequiredService<IDnnContext>();
                 }
 
-                return _current;
+                return current is DotNetNukeContext context ? context : default(DotNetNukeContext);
             }
 
             set
             {
-                _current = value;
+                current = value;
             }
         }
 
         /// <summary>
         /// Gets get the application.
         /// </summary>
-        public Application Application
-        {
-            get
-            {
-                return this._application;
-            }
-        }
+        public Application Application { get => this.Application is Application app ? app : new Application(); }
+
+        /// <inheritdoc />
+        IApplicationInfo IDnnContext.Application { get => this.applicationInfo; }
 
         /// <summary>
         /// Gets the container event listeners. The listeners will be called in each life cycle of load container.
@@ -78,13 +74,7 @@ namespace DotNetNuke.Application
         /// <seealso cref="DotNetNuke.UI.Containers.Container.OnLoad"/>
         /// <seealso cref="DotNetNuke.UI.Containers.Container.OnPreRender"/>
         /// <seealso cref="DotNetNuke.UI.Containers.Container.OnUnload"/>
-        public IList<ContainerEventListener> ContainerEventListeners
-        {
-            get
-            {
-                return this._containerEventListeners;
-            }
-        }
+        public IList<ContainerEventListener> ContainerEventListeners { get; }
 
         /// <summary>
         /// Gets the skin event listeners. The listeners will be called in each life cycle of load skin.
@@ -94,12 +84,6 @@ namespace DotNetNuke.Application
         /// <seealso cref="DotNetNuke.UI.Skins.Skin.OnLoad"/>
         /// <seealso cref="DotNetNuke.UI.Skins.Skin.OnPreRender"/>
         /// <seealso cref="DotNetNuke.UI.Skins.Skin.OnUnload"/>
-        public IList<SkinEventListener> SkinEventListeners
-        {
-            get
-            {
-                return this._skinEventListeners;
-            }
-        }
+        public IList<SkinEventListener> SkinEventListeners { get; }
     }
 }

--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -5,7 +5,6 @@ namespace DotNetNuke.Common
 {
     using System;
     using System.Collections;
-    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Data;
     using System.Diagnostics;
@@ -27,14 +26,11 @@ namespace DotNetNuke.Common
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
-    using DotNetNuke.Application;
     using DotNetNuke.Collections.Internal;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Common.Lists;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
-    using DotNetNuke.Entities;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Modules.Actions;
@@ -47,13 +43,10 @@ namespace DotNetNuke.Common
     using DotNetNuke.Security;
     using DotNetNuke.Security.Permissions;
     using DotNetNuke.Security.Roles;
-    using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.Exceptions;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Localization;
-    using DotNetNuke.Services.Upgrade;
     using DotNetNuke.Services.Url.FriendlyUrl;
-    using DotNetNuke.UI.Skins;
     using DotNetNuke.UI.Utilities;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.VisualBasic.CompilerServices;
@@ -228,6 +221,7 @@ namespace DotNetNuke.Common
 
         private static IServiceProvider dependencyProvider;
         private static IApplicationStatusInfo applicationStatusInfo;
+        private static INavigationManager navigationManager;
 
         // global constants for the life of the application ( set in Application_Start )
 
@@ -2315,7 +2309,6 @@ namespace DotNetNuke.Common
         /// <returns>URL to access denied view.</returns>
         public static string AccessDeniedURL(string Message)
         {
-            var navigationManager = DependencyProvider.GetRequiredService<INavigationManager>();
             string strURL = string.Empty;
             PortalSettings _portalSettings = PortalController.Instance.GetCurrentPortalSettings();
             if (HttpContext.Current.Request.IsAuthenticated)
@@ -2692,7 +2685,6 @@ namespace DotNetNuke.Common
         /// <returns>Formatted URL.</returns>
         public static string LoginURL(string returnUrl, bool overrideSetting, PortalSettings portalSettings)
         {
-            var navigationManager = DependencyProvider.GetRequiredService<INavigationManager>();
             string loginUrl;
             if (!string.IsNullOrEmpty(returnUrl))
             {
@@ -2744,7 +2736,7 @@ namespace DotNetNuke.Common
             string strURL = string.Empty;
             PortalSettings portalSettings = PortalController.Instance.GetCurrentPortalSettings();
 
-            strURL = DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(portalSettings.UserTabId, string.Empty, string.Format("userId={0}", userId));
+            strURL = navigationManager.NavigateURL(portalSettings.UserTabId, string.Empty, string.Format("userId={0}", userId));
 
             return strURL;
         }
@@ -2758,7 +2750,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL()
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL();
+            return navigationManager.NavigateURL();
         }
 
         /// <summary>
@@ -2771,7 +2763,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID);
+            return navigationManager.NavigateURL(tabID);
         }
 
         /// <summary>
@@ -2785,7 +2777,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, bool isSuperTab)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, isSuperTab);
+            return navigationManager.NavigateURL(tabID, isSuperTab);
         }
 
         /// <summary>
@@ -2798,7 +2790,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(string controlKey)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(controlKey);
+            return navigationManager.NavigateURL(controlKey);
         }
 
         /// <summary>
@@ -2812,7 +2804,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(string controlKey, params string[] additionalParameters)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(controlKey, additionalParameters);
+            return navigationManager.NavigateURL(controlKey, additionalParameters);
         }
 
         /// <summary>
@@ -2826,7 +2818,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, string controlKey)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, controlKey);
+            return navigationManager.NavigateURL(tabID, controlKey);
         }
 
         /// <summary>
@@ -2841,7 +2833,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, string controlKey, params string[] additionalParameters)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, controlKey, additionalParameters);
+            return navigationManager.NavigateURL(tabID, controlKey, additionalParameters);
         }
 
         /// <summary>
@@ -2857,7 +2849,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, PortalSettings settings, string controlKey, params string[] additionalParameters)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, settings, controlKey, additionalParameters);
+            return navigationManager.NavigateURL(tabID, settings, controlKey, additionalParameters);
         }
 
         /// <summary>
@@ -2874,7 +2866,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, bool isSuperTab, PortalSettings settings, string controlKey, params string[] additionalParameters)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, isSuperTab, settings, controlKey, additionalParameters);
+            return navigationManager.NavigateURL(tabID, isSuperTab, settings, controlKey, additionalParameters);
         }
 
         /// <summary>
@@ -2890,7 +2882,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, bool isSuperTab, PortalSettings settings, string controlKey, string language, params string[] additionalParameters)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, isSuperTab, settings, controlKey, language, additionalParameters);
+            return navigationManager.NavigateURL(tabID, isSuperTab, settings, controlKey, language, additionalParameters);
         }
 
         /// <summary>
@@ -2907,7 +2899,7 @@ namespace DotNetNuke.Common
         [Obsolete("Deprecated in Platform 9.4.2. Scheduled removal in v11.0.0.")]
         public static string NavigateURL(int tabID, bool isSuperTab, PortalSettings settings, string controlKey, string language, string pageName, params string[] additionalParameters)
         {
-            return DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(tabID, isSuperTab, settings, controlKey, language, pageName, additionalParameters);
+            return navigationManager.NavigateURL(tabID, isSuperTab, settings, controlKey, language, pageName, additionalParameters);
         }
 
         /// <summary>
@@ -2956,7 +2948,6 @@ namespace DotNetNuke.Common
         /// <returns>Formatted url.</returns>
         public static string RegisterURL(string returnURL, string originalURL)
         {
-            var navigationManager = DependencyProvider.GetRequiredService<INavigationManager>();
             string strURL;
             PortalSettings _portalSettings = PortalController.Instance.GetCurrentPortalSettings();
             string extraParams = string.Empty;
@@ -3235,7 +3226,7 @@ namespace DotNetNuke.Common
                 switch (UrlType)
                 {
                     case TabType.Tab:
-                        strLink = DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(int.Parse(Link));
+                        strLink = navigationManager.NavigateURL(int.Parse(Link));
                         break;
                     default:
                         strLink = Link;
@@ -3845,6 +3836,7 @@ namespace DotNetNuke.Common
         private static void OnDependencyProviderChanged(object sender, PropertyChangedEventArgs eventArguments)
         {
             applicationStatusInfo = DependencyProvider?.GetRequiredService<IApplicationStatusInfo>();
+            navigationManager = DependencyProvider?.GetRequiredService<INavigationManager>();
         }
     }
 }

--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -364,7 +364,7 @@ namespace DotNetNuke.Common
         /// <value>
         /// The application map path.
         /// </value>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static string ApplicationMapPath => applicationStatusInfo.ApplicationMapPath;
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace DotNetNuke.Common
         /// <summary>
         /// Gets the database version.
         /// </summary>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static Version DataBaseVersion { get => applicationStatusInfo.DatabaseVersion; }
 
         /// <summary>
@@ -479,7 +479,7 @@ namespace DotNetNuke.Common
         /// Gets the status of application.
         /// </summary>
         /// <seealso cref="GetStatus"/>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static UpgradeStatus Status { get => (UpgradeStatus)applicationStatusInfo.Status; }
 
         /// <summary>
@@ -595,7 +595,7 @@ namespace DotNetNuke.Common
             }
         }
 
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static bool IncrementalVersionExists(Version version) => applicationStatusInfo.IncrementalVersionExists(version);
 
         /// <summary>
@@ -973,7 +973,7 @@ namespace DotNetNuke.Common
         /// Updates the database version.
         /// </summary>
         /// <param name="version">The version.</param>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static void UpdateDataBaseVersion(Version version) => applicationStatusInfo.UpdateDatabaseVersion(version);
 
         /// <summary>
@@ -981,11 +981,11 @@ namespace DotNetNuke.Common
         /// </summary>
         /// <param name="version">The version.</param>
         /// <param name="increment">The increment.</param>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static void UpdateDataBaseVersionIncrement(Version version, int increment) =>
             applicationStatusInfo.UpdateDatabaseVersionIncrement(version, increment);
 
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static int GetLastAppliedIteration(Version version) =>
             applicationStatusInfo.GetLastAppliedIteration(version);
 
@@ -1331,7 +1331,7 @@ namespace DotNetNuke.Common
         /// Sets the status.
         /// </summary>
         /// <param name="status">The status.</param>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         public static void SetStatus(UpgradeStatus status) =>
             applicationStatusInfo.SetStatus((DotNetNuke.Abstractions.Application.UpgradeStatus)status);
 
@@ -3724,7 +3724,7 @@ namespace DotNetNuke.Common
         /// since the connection string may not have been configured yet, which can occur during the installation
         /// wizard.
         /// </remarks>
-        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IApplicationStatusInfo instead.")]
+        [Obsolete("Deprecated in 9.7.1. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead. Scheduled for removal in v11.0.0.")]
         internal static bool IsInstalled() => applicationStatusInfo.IsInstalled();
 
         /// <summary>

--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -227,7 +227,7 @@ namespace DotNetNuke.Common
         private static readonly Stopwatch AppStopwatch = Stopwatch.StartNew();
 
         private static IServiceProvider dependencyProvider;
-        private static IApplicationStatusInfo applicationStatusInfo = new ApplicationStatusInfo(new Application());
+        private static IApplicationStatusInfo applicationStatusInfo;
 
         // global constants for the life of the application ( set in Application_Start )
 
@@ -569,7 +569,13 @@ namespace DotNetNuke.Common
             {
                 dependencyProvider = value;
                 if (dependencyProvider is INotifyPropertyChanged hasPropertyChanged)
+                {
                     hasPropertyChanged.PropertyChanged += OnDependencyProviderChanged;
+                }
+                else
+                {
+                    OnDependencyProviderChanged(null, null);
+                }
             }
         }
 
@@ -3838,7 +3844,7 @@ namespace DotNetNuke.Common
         /// </summary>
         private static void OnDependencyProviderChanged(object sender, PropertyChangedEventArgs eventArguments)
         {
-            applicationStatusInfo = DependencyProvider.GetRequiredService<IApplicationStatusInfo>();
+            applicationStatusInfo = DependencyProvider?.GetRequiredService<IApplicationStatusInfo>();
         }
     }
 }

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Application\Application.cs" />
     <Compile Include="Application\AssemblyStatusAttribute.cs" />
     <Compile Include="Application\DotNetNukeContext.cs" />
+    <Compile Include="Application\ApplicationStatusInfo.cs" />
     <Compile Include="Common\Extensions\HttpContextDependencyInjectionExtensions.cs" />
     <Compile Include="Common\NavigationManager.cs" />
     <Compile Include="Common\Utilities\CryptographyUtils.cs" />

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -6,6 +6,7 @@ namespace DotNetNuke
 {
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Application;
     using DotNetNuke.Common;
     using DotNetNuke.DependencyInjection;
     using DotNetNuke.Entities.Portals;
@@ -25,8 +26,10 @@ namespace DotNetNuke
 
             services.AddTransient(x => PortalController.Instance);
             services.AddTransient<INavigationManager, NavigationManager>();
+
             services.AddTransient<IApplicationInfo, Application.Application>();
-            services.AddTransient<IApplicationStatusInfo, Application.ApplicationStatusInfo>();
+            services.AddTransient<IApplicationStatusInfo, ApplicationStatusInfo>();
+            services.AddTransient<IDnnContext, DotNetNukeContext>();
         }
     }
 }

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -23,13 +23,13 @@ namespace DotNetNuke
             services.AddSingleton<WebFormsModuleControlFactory>();
             services.AddSingleton<Html5ModuleControlFactory>();
             services.AddSingleton<ReflectedModuleControlFactory>();
+            services.AddSingleton<IDnnContext, DotNetNukeContext>();
 
             services.AddTransient(x => PortalController.Instance);
-            services.AddTransient<INavigationManager, NavigationManager>();
+            services.AddScoped<INavigationManager, NavigationManager>();
 
-            services.AddTransient<IApplicationInfo, Application.Application>();
-            services.AddTransient<IApplicationStatusInfo, ApplicationStatusInfo>();
-            services.AddTransient<IDnnContext, DotNetNukeContext>();
+            services.AddScoped<IApplicationInfo, Application.Application>();
+            services.AddScoped<IApplicationStatusInfo, ApplicationStatusInfo>();
         }
     }
 }

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -5,6 +5,7 @@
 namespace DotNetNuke
 {
     using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.DependencyInjection;
     using DotNetNuke.Entities.Portals;
@@ -12,8 +13,10 @@ namespace DotNetNuke
     using DotNetNuke.UI.Modules.Html5;
     using Microsoft.Extensions.DependencyInjection;
 
+    /// <inheritdoc />
     public class Startup : IDnnStartup
     {
+        /// <inheritdoc />
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<WebFormsModuleControlFactory>();
@@ -22,6 +25,8 @@ namespace DotNetNuke
 
             services.AddTransient(x => PortalController.Instance);
             services.AddTransient<INavigationManager, NavigationManager>();
+            services.AddTransient<IApplicationInfo, Application.Application>();
+            services.AddTransient<IApplicationStatusInfo, Application.ApplicationStatusInfo>();
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/AttachmentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/AttachmentControllerTests.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Tests.Content
 {
     using System.Collections.Generic;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -37,6 +37,7 @@ namespace DotNetNuke.Tests.Content
         public void SetUp()
         {
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/AttachmentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/AttachmentControllerTests.cs
@@ -4,22 +4,25 @@
 
 namespace DotNetNuke.Tests.Content
 {
-    using System;
     using System.Collections.Generic;
-    using System.Data;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Content;
-    using DotNetNuke.Entities.Content.Common;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     using FileController = DotNetNuke.Entities.Content.AttachmentController;
@@ -33,6 +36,10 @@ namespace DotNetNuke.Tests.Content
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
             MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
@@ -41,6 +48,7 @@ namespace DotNetNuke.Tests.Content
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
@@ -53,7 +53,6 @@ namespace DotNetNuke.Tests.Content
                 (string searchTypeName) => new SearchType { SearchTypeName = searchTypeName, SearchTypeId = ModuleSearchTypeId });
 
             var serviceCollection = new ServiceCollection();
-
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Tests.Content
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -55,6 +55,8 @@ namespace DotNetNuke.Tests.Content
             var serviceCollection = new ServiceCollection();
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
@@ -9,6 +9,8 @@ namespace DotNetNuke.Tests.Content
     using System.Collections.Specialized;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
@@ -19,7 +21,11 @@ namespace DotNetNuke.Tests.Content
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -45,11 +51,19 @@ namespace DotNetNuke.Tests.Content
 
             this._mockSearchHelper.Setup(x => x.GetSearchTypeByName(It.IsAny<string>())).Returns<string>(
                 (string searchTypeName) => new SearchType { SearchTypeName = searchTypeName, SearchTypeId = ModuleSearchTypeId });
+
+            var serviceCollection = new ServiceCollection();
+
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
         }
 
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentTypeControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentTypeControllerTests.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -35,6 +35,7 @@ namespace DotNetNuke.Tests.Content
         public void SetUp()
         {
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentTypeControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentTypeControllerTests.cs
@@ -7,6 +7,8 @@ namespace DotNetNuke.Tests.Content
     using System;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Content.Data;
@@ -14,7 +16,11 @@ namespace DotNetNuke.Tests.Content
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -28,6 +34,10 @@ namespace DotNetNuke.Tests.Content
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
             MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
@@ -36,6 +46,7 @@ namespace DotNetNuke.Tests.Content
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/DotNetNuke.Tests.Content.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/DotNetNuke.Tests.Content.csproj
@@ -64,6 +64,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.Log4net\bin\dotnetnuke.log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\..\Packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
@@ -100,6 +106,10 @@
     <Compile Include="VocabularyControllerTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928A9B1-F88A-4581-A132-D3EB38669BB0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\DotNetNuke.Log4net\DotNetNuke.Log4Net.csproj">
       <Project>{04f77171-0634-46e0-a95e-d7477c88712e}</Project>
       <Name>DotNetNuke.Log4Net</Name>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ScopeTypeControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ScopeTypeControllerTests.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -35,6 +35,7 @@ namespace DotNetNuke.Tests.Content
         public void SetUp()
         {
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ScopeTypeControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ScopeTypeControllerTests.cs
@@ -7,6 +7,8 @@ namespace DotNetNuke.Tests.Content
     using System;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Entities.Content.Taxonomy;
@@ -14,7 +16,11 @@ namespace DotNetNuke.Tests.Content
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -28,6 +34,10 @@ namespace DotNetNuke.Tests.Content
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
             MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
@@ -36,6 +46,7 @@ namespace DotNetNuke.Tests.Content
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/TermControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/TermControllerTests.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -37,6 +37,7 @@ namespace DotNetNuke.Tests.Content
         public void SetUp()
         {
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/TermControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/TermControllerTests.cs
@@ -7,6 +7,8 @@ namespace DotNetNuke.Tests.Content
     using System;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Content.Data;
@@ -16,7 +18,11 @@ namespace DotNetNuke.Tests.Content
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -30,6 +36,10 @@ namespace DotNetNuke.Tests.Content
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             Mock<IVocabularyController> vocabularyController = MockHelper.CreateMockVocabularyController();
             MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
 
@@ -40,6 +50,7 @@ namespace DotNetNuke.Tests.Content
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/VocabularyControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/VocabularyControllerTests.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -35,6 +35,7 @@ namespace DotNetNuke.Tests.Content
         public void SetUp()
         {
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/VocabularyControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/VocabularyControllerTests.cs
@@ -7,6 +7,8 @@ namespace DotNetNuke.Tests.Content
     using System;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Entities.Content.Taxonomy;
@@ -14,7 +16,11 @@ namespace DotNetNuke.Tests.Content
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -28,6 +34,10 @@ namespace DotNetNuke.Tests.Content
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
             MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
@@ -36,6 +46,7 @@ namespace DotNetNuke.Tests.Content
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Host/HostControllerTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Host/HostControllerTest.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -37,6 +37,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             var serviceCollection = new ServiceCollection();
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Host/HostControllerTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Host/HostControllerTest.cs
@@ -9,13 +9,19 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
     using System.Data;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -28,6 +34,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             this._mockCache = MockComponentProvider.CreateDataCacheProvider();
             MockComponentProvider.CreateEventLogController();
 
@@ -59,6 +71,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
@@ -11,11 +11,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using System.Globalization;
     using System.Text;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Entities.Portals.Internal;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Security.Permissions;
     using DotNetNuke.Security.Roles;
@@ -28,7 +29,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using DotNetNuke.Services.Social.Messaging.Internal;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -66,6 +71,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             ComponentFactory.Container = new SimpleContainer();
             this._mockDataService = new Mock<IDataService>();
             this._dataProvider = MockComponentProvider.CreateDataProvider();
@@ -109,6 +120,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             ComponentFactory.Container = null;
             PortalController.ClearInstance();
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using System.Data;
     using System.Globalization;
     using System.Text;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -75,6 +75,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             ComponentFactory.Container = new SimpleContainer();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/NotificationsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/NotificationsControllerTests.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using System.Data;
     using System.Globalization;
     using System.Text;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -58,6 +58,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             ComponentFactory.Container = new SimpleContainer();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/NotificationsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/NotificationsControllerTests.cs
@@ -11,6 +11,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using System.Globalization;
     using System.Text;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
@@ -25,7 +27,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using DotNetNuke.Services.Social.Notifications.Data;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -48,6 +54,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             ComponentFactory.Container = new SimpleContainer();
 
             this._mockDataService = new Mock<IDataService>();
@@ -79,6 +91,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             ComponentFactory.Container = null;
             MessagingController.ClearInstance();
             PortalController.ClearInstance();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
@@ -98,9 +98,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             MockComponentProvider.ResetContainer();
 
             var serviceCollection = new ServiceCollection();
-            var mockApplicationInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationInfo.Setup(info => info.ApplicationMapPath).Returns("path/to/application");
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationInfo.Object);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             this._mockDataProvider = MockComponentProvider.CreateDataProvider();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.Data;
     using System.IO;
     using System.Threading;
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
@@ -98,6 +99,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             MockComponentProvider.ResetContainer();
 
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
@@ -9,7 +9,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.Data;
     using System.IO;
     using System.Threading;
-
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Controllers;
@@ -19,6 +20,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Services.Search.Internals;
     using DotNetNuke.Tests.Utilities.Mocks;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
 
@@ -95,6 +97,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             ComponentFactory.Container = new SimpleContainer();
             MockComponentProvider.ResetContainer();
 
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationInfo.Setup(info => info.ApplicationMapPath).Returns("path/to/application");
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             this._mockDataProvider = MockComponentProvider.CreateDataProvider();
             this._mockLocaleController = MockComponentProvider.CreateLocaleController();
             this._mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
@@ -125,6 +133,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             SearchHelper.ClearInstance();
             LuceneController.ClearInstance();
             this._luceneController = null;
+            Globals.DependencyProvider = null;
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/LuceneControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/LuceneControllerTests.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.IO;
     using System.Linq;
     using System.Threading;
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
@@ -68,6 +69,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             this._cachingProvider = MockComponentProvider.CreateDataCacheProvider();
 
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/LuceneControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/LuceneControllerTests.cs
@@ -9,7 +9,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.IO;
     using System.Linq;
     using System.Threading;
-
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
@@ -21,6 +22,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using Lucene.Net.Index;
     using Lucene.Net.QueryParsers;
     using Lucene.Net.Search;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
 
@@ -65,6 +67,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             ComponentFactory.Container = new SimpleContainer();
             this._cachingProvider = MockComponentProvider.CreateDataCacheProvider();
 
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             this._mockHostController = new Mock<IHostController>();
             this._mockHostController.Setup(c => c.GetString(Constants.SearchIndexFolderKey, It.IsAny<string>())).Returns(SearchIndexFolder);
             this._mockHostController.Setup(c => c.GetDouble(Constants.SearchReaderRefreshTimeKey, It.IsAny<double>())).Returns(this._readerStaleTimeSpan);
@@ -92,6 +98,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             this._luceneController.Dispose();
             this.DeleteIndexFolder();
             SearchHelper.ClearInstance();
+            Globals.DependencyProvider = null;
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchControllerTests.cs
@@ -10,7 +10,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.IO;
     using System.Linq;
     using System.Threading;
-
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Controllers;
@@ -22,6 +23,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using DotNetNuke.Services.Search.Internals;
     using DotNetNuke.Tests.Utilities.Mocks;
     using Lucene.Net.Documents;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
 
@@ -139,6 +141,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             ComponentFactory.Container = new SimpleContainer();
             MockComponentProvider.ResetContainer();
 
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             this._mockDataProvider = MockComponentProvider.CreateDataProvider();
             this._mockLocaleController = MockComponentProvider.CreateLocaleController();
             this._mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
@@ -168,6 +174,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             SearchHelper.ClearInstance();
             LuceneController.ClearInstance();
             this._luceneController = null;
+            Globals.DependencyProvider = null;
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchControllerTests.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.IO;
     using System.Linq;
     using System.Threading;
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
@@ -142,6 +143,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             MockComponentProvider.ResetContainer();
 
             var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
@@ -8,13 +8,19 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.Data;
     using System.Linq;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.Search.Internals;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -40,12 +46,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             ComponentFactory.Container = new SimpleContainer();
             this._cachingProvider = MockComponentProvider.CreateDataCacheProvider();
             this._dataProvider = MockComponentProvider.CreateDataProvider();
             this.SetupDataProvider();
             this._searchHelper = new SearchHelperImpl();
             DataCache.ClearCache();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Globals.DependencyProvider = null;
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
@@ -7,7 +7,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System;
     using System.Data;
     using System.Linq;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -49,6 +49,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             var serviceCollection = new ServiceCollection();
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
@@ -8,20 +8,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
     using System.Collections.Generic;
     using System.Data;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
-    using DotNetNuke.Entities;
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Entities.Users.Social;
     using DotNetNuke.Entities.Users.Social.Data;
-    using DotNetNuke.Entities.Users.Social.Internal;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>
@@ -42,6 +46,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         [SetUp]
         public void SetUp()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             ComponentFactory.Container = new SimpleContainer();
             var mockDataProvider = MockComponentProvider.CreateDataProvider();
             mockDataProvider.Setup(dp => dp.GetProviderPath()).Returns(string.Empty);
@@ -71,6 +81,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             ComponentFactory.Container = null;
             PortalController.ClearInstance();
             UserController.ClearInstance();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
@@ -7,7 +7,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
     using System;
     using System.Collections.Generic;
     using System.Data;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -50,6 +50,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             ComponentFactory.Container = new SimpleContainer();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -83,6 +83,12 @@
       <HintPath>..\..\Components\Lucene.Net.Contrib\bin\Lucene.Net.Contrib.FastVectorHighlighter.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
     using System.Collections.Generic;
     using System.Reflection;
     using System.Runtime.Serialization;
-
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Controllers;
@@ -17,6 +17,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Tests.Utilities.Mocks;
     using DotNetNuke.UI.Skins;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
 
@@ -44,6 +45,12 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         public void SetUp()
         {
             MockComponentProvider.ResetContainer();
+
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationInfo.Setup(info => info.ApplicationMapPath).Returns("path/to/application");
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
         }
 
         [TearDown]
@@ -51,6 +58,8 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             PortalController.ClearInstance();
             TabController.ClearInstance();
+            Globals.DependencyProvider = null;
+
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
     using System.Collections.Generic;
     using System.Reflection;
     using System.Runtime.Serialization;
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -50,6 +51,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
             var mockApplicationInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationInfo.Setup(info => info.ApplicationMapPath).Returns("path/to/application");
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Tests.Core
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -36,6 +37,7 @@ namespace DotNetNuke.Tests.Core
             var mock = new Mock<IApplicationStatusInfo>();
             mock.Setup(info => info.ApplicationMapPath).Returns(rootPath);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mock.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
@@ -8,13 +8,15 @@ namespace DotNetNuke.Tests.Core
     using System.IO;
     using System.Linq;
     using System.Reflection;
-
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Tests.Utilities.Mocks;
     using ICSharpCode.SharpZipLib.Zip;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
     using NUnit.Framework;
 
     /// <summary>
@@ -26,13 +28,21 @@ namespace DotNetNuke.Tests.Core
         [SetUp]
         public void SetUp()
         {
-            var field = typeof(Globals).GetField("_applicationMapPath", BindingFlags.Static | BindingFlags.NonPublic);
-            field.SetValue(null, null);
+            var applicationStatusInfo = new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>());
+            var rootPath = Path.Combine(applicationStatusInfo.ApplicationMapPath, "FileSystemUtilsTest");
+            this.PrepareRootPath(rootPath, applicationStatusInfo.ApplicationMapPath);
 
-            var rootPath = Path.Combine(Globals.ApplicationMapPath, "FileSystemUtilsTest");
-            this.PrepareRootPath(rootPath);
+            var serviceCollection = new ServiceCollection();
+            var mock = new Mock<IApplicationStatusInfo>();
+            mock.Setup(info => info.ApplicationMapPath).Returns(rootPath);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mock.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        }
 
-            field.SetValue(null, rootPath);
+        [TearDown]
+        public void TearDown()
+        {
+            Globals.DependencyProvider = null;
         }
 
         [TestCase("/")]
@@ -147,14 +157,14 @@ namespace DotNetNuke.Tests.Core
             }
         }
 
-        private void PrepareRootPath(string rootPath)
+        private void PrepareRootPath(string rootPath, string applicationMapPath)
         {
             if (!Directory.Exists(rootPath))
             {
                 Directory.CreateDirectory(rootPath);
             }
 
-            foreach (var file in Directory.GetFiles(Globals.ApplicationMapPath, "*.*", SearchOption.TopDirectoryOnly))
+            foreach (var file in Directory.GetFiles(applicationMapPath, "*.*", SearchOption.TopDirectoryOnly))
             {
                 File.Copy(file, Path.Combine(rootPath, Path.GetFileName(file)), true);
             }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/JavaScriptLibraries/JavaScriptTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/JavaScriptLibraries/JavaScriptTests.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Tests.Core.Framework.JavaScriptLibraries
     using System.Linq;
     using System.Reflection;
     using System.Web;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Application;
     using DotNetNuke.Common;
@@ -46,6 +46,7 @@ namespace DotNetNuke.Tests.Core.Framework.JavaScriptLibraries
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             serviceCollection.AddTransient<IApplicationInfo>(container => mockApplication.Object);
             serviceCollection.AddTransient<IDnnContext>(container => dnnContext);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
 
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/JavaScriptLibraries/JavaScriptTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/JavaScriptLibraries/JavaScriptTests.cs
@@ -9,12 +9,13 @@ namespace DotNetNuke.Tests.Core.Framework.JavaScriptLibraries
     using System.Linq;
     using System.Reflection;
     using System.Web;
-
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Framework.JavaScriptLibraries;
     using DotNetNuke.Tests.Instance.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
 
@@ -29,6 +30,12 @@ namespace DotNetNuke.Tests.Core.Framework.JavaScriptLibraries
         [SetUp]
         public void Setup()
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(container => Mock.Of<IApplicationInfo>());
+            serviceCollection.AddTransient<IDnnContext>(container => (IDnnContext)ActivatorUtilities.GetServiceOrCreateInstance(container, typeof(DotNetNukeContext)));
+
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             // fix Globals.Status
             var status = typeof(Globals).GetField("_status", BindingFlags.Static | BindingFlags.NonPublic);
             status.SetValue(null, Globals.UpgradeStatus.None);
@@ -49,6 +56,7 @@ namespace DotNetNuke.Tests.Core.Framework.JavaScriptLibraries
         {
             UnitTestHelper.ClearHttpContext();
             JavaScriptLibraryController.ClearInstance();
+            Globals.DependencyProvider = null;
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
@@ -5,7 +5,7 @@
 namespace DotNetNuke.Tests.Core.Framework
 {
     using System;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Framework;
@@ -27,6 +27,7 @@ namespace DotNetNuke.Tests.Core.Framework
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             HttpContextHelper.RegisterMockHttpContext();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
@@ -6,9 +6,16 @@ namespace DotNetNuke.Tests.Core.Framework
 {
     using System;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Framework;
     using DotNetNuke.Tests.Instance.Utilities;
     using DotNetNuke.Tests.Utilities;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
     using NUnit.Framework;
 
     public class ServicesFrameworkTests
@@ -16,6 +23,12 @@ namespace DotNetNuke.Tests.Core.Framework
         [SetUp]
         public void Setup()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             HttpContextHelper.RegisterMockHttpContext();
             var simulator = new Instance.Utilities.HttpSimulator.HttpSimulator("/", "c:\\");
             simulator.SimulateRequest(new Uri("http://localhost/dnn/Default.aspx"));
@@ -24,6 +37,7 @@ namespace DotNetNuke.Tests.Core.Framework
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             UnitTestHelper.ClearHttpContext();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FileContentTypeManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FileContentTypeManagerTests.cs
@@ -4,6 +4,7 @@
 
 namespace DotNetNuke.Tests.Core.Providers.Folder
 {
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
@@ -27,6 +28,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             var _mockData = MockComponentProvider.CreateDataProvider();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FileContentTypeManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FileContentTypeManagerTests.cs
@@ -4,28 +4,17 @@
 
 namespace DotNetNuke.Tests.Core.Providers.Folder
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.Drawing;
-    using System.IO;
-    using System.Reflection;
-    using System.Text;
-
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Data;
-    using DotNetNuke.Entities.Content;
-    using DotNetNuke.Entities.Content.Workflow;
-    using DotNetNuke.Entities.Content.Workflow.Entities;
-    using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Security.Permissions;
-    using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.FileSystem;
-    using DotNetNuke.Services.FileSystem.Internal;
-    using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -34,6 +23,12 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [SetUp]
         public void Setup()
         {
+            var serviceCollection = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             var _mockData = MockComponentProvider.CreateDataProvider();
             var _mockCache = MockComponentProvider.CreateDataCacheProvider();
             var _globals = new Mock<IGlobals>();
@@ -48,6 +43,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             TestableGlobals.ClearInstance();
             CBO.ClearInstance();
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using System.Linq;
 
     using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Common.Utilities;
@@ -21,7 +22,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -42,10 +47,23 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [TestFixtureSetUp]
         public void FixtureSetup()
         {
+            var serviceCollection = new ServiceCollection();
+
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+
             var navigationManagerMock = new Mock<INavigationManager>();
-            var containerMock = new Mock<IServiceProvider>();
-            containerMock.Setup(x => x.GetService(typeof(INavigationManager))).Returns(navigationManagerMock.Object);
-            Globals.DependencyProvider = containerMock.Object;
+
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            serviceCollection.AddTransient<INavigationManager>(container => navigationManagerMock.Object);
+
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        }
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Globals.DependencyProvider = null;
         }
 
         [SetUp]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/DotNetNuke.Tests.Web.Mvc.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/DotNetNuke.Tests.Web.Mvc.csproj
@@ -120,6 +120,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928A9B1-F88A-4581-A132-D3EB38669BB0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\DotNetNuke.DependencyInjection\DotNetNuke.DependencyInjection.csproj">
       <Project>{0fca217a-5f9a-4f5b-a31b-86d64ae65198}</Project>
       <Name>DotNetNuke.DependencyInjection</Name>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
@@ -7,13 +7,17 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework
     using System.Linq;
     using System.Web.Mvc;
 
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Web.Mvc.Framework;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using DotNetNuke.Web.Mvc.Framework.Modules;
     using DotNetNuke.Web.Mvc.Routing;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -23,7 +27,12 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework
         public void Setup()
         {
             var services = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+
+            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+
             Globals.DependencyProvider = services.BuildServiceProvider();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework
 {
     using System.Linq;
     using System.Web.Mvc;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Web.Mvc.Framework;
@@ -31,6 +31,7 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
 
             services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            services.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
 
             Globals.DependencyProvider = services.BuildServiceProvider();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
@@ -5,17 +5,21 @@
 namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
 {
     using System;
-    using System.Web;
+
     using System.Web.Mvc;
     using System.Web.Routing;
 
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using DotNetNuke.Web.Mvc.Framework.Modules;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -28,7 +32,12 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
         public void Setup()
         {
             var services = new ServiceCollection();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            
+            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+
             Globals.DependencyProvider = services.BuildServiceProvider();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
 
     using System.Web.Mvc;
     using System.Web.Routing;
-
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Entities.Modules;
@@ -34,8 +34,9 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
             var services = new ServiceCollection();
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-            
+
             services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            services.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
 
             Globals.DependencyProvider = services.BuildServiceProvider();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
@@ -10,11 +10,16 @@ namespace DotNetNuke.Tests.Web.Api
     using System.Linq;
 
     using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Web.Api;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -23,15 +28,19 @@ namespace DotNetNuke.Tests.Web.Api
         [SetUp]
         public void SetUp()
         {
+            var services = new ServiceCollection();
             var navigationManagerMock = new Mock<INavigationManager>();
-            var containerMock = new Mock<IServiceProvider>();
-            containerMock.Setup(x => x.GetService(typeof(INavigationManager))).Returns(navigationManagerMock.Object);
-            Globals.DependencyProvider = containerMock.Object;
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
+            services.AddScoped(typeof(INavigationManager), (x) => navigationManagerMock.Object);
+            Globals.DependencyProvider = services.BuildServiceProvider();
         }
 
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             PortalController.ClearInstance();
             PortalAliasController.ClearInstance();
             TestableGlobals.ClearInstance();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
@@ -32,8 +32,10 @@ namespace DotNetNuke.Tests.Web.Api
             var navigationManagerMock = new Mock<INavigationManager>();
             var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
             mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+
             services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             services.AddScoped(typeof(INavigationManager), (x) => navigationManagerMock.Object);
+            
             Globals.DependencyProvider = services.BuildServiceProvider();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/ServiceRoutingManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/ServiceRoutingManagerTests.cs
@@ -11,8 +11,8 @@ namespace DotNetNuke.Tests.Web.Api
     using System.Web.Routing;
 
     using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
-    using DotNetNuke.DependencyInjection;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework.Internal.Reflection;
     using DotNetNuke.Framework.Reflections;
@@ -42,8 +42,11 @@ namespace DotNetNuke.Tests.Web.Api
             this._portalController = this._mockPortalController.Object;
             PortalController.SetTestableInstance(this._portalController);
 
-            var navigationManagerMock = new Mock<INavigationManager>();
             var services = new ServiceCollection();
+            var navigationManagerMock = new Mock<INavigationManager>();
+            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             services.AddScoped(typeof(INavigationManager), (x) => navigationManagerMock.Object);
             Globals.DependencyProvider = services.BuildServiceProvider();
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/SearchServiceControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/SearchServiceControllerTests.cs
@@ -12,6 +12,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
     using System.Net.Http;
     using System.Web.Http;
     using System.Web.Http.Hosting;
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -100,6 +101,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
 
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
 
             this._mockDataProvider = MockComponentProvider.CreateDataProvider();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/SearchServiceControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/SearchServiceControllerTests.cs
@@ -12,7 +12,8 @@ namespace DotNetNuke.Tests.Web.InternalServices
     using System.Net.Http;
     using System.Web.Http;
     using System.Web.Http.Hosting;
-
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
@@ -30,6 +31,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
     using DotNetNuke.Web.Api;
     using DotNetNuke.Web.InternalServices;
     using DotNetNuke.Web.InternalServices.Views.Search;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
 
@@ -96,6 +98,10 @@ namespace DotNetNuke.Tests.Web.InternalServices
             ComponentFactory.Container = new SimpleContainer();
             MockComponentProvider.ResetContainer();
 
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             this._mockDataProvider = MockComponentProvider.CreateDataProvider();
             this._mockLocaleController = MockComponentProvider.CreateLocaleController();
             this._mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
@@ -138,6 +144,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
         [TearDown]
         public void TearDown()
         {
+            Globals.DependencyProvider = null;
             this._luceneController.Dispose();
             this.DeleteIndexFolder();
             CBO.ClearInstance();


### PR DESCRIPTION
Related to #3985 

## Summary
**This does not close the linked work item, but is required before I can submit a pull request.**

While working on changes to the Client Resource Manager I noticed circular dependency between `DotNetNuke.Libary` and `DotNetNuke.Web.Client`. The `ClientDependencySetting` utilizes reflection to workaround the circular dependency. Dynamically loading types like this is considered an anti-pattern, especially when we can use depenency injection to extract an interface.

This Pull Request extracts 2 interfaces from the Globals.cs
- `IApplicationInfo`
- `IApplicationStatusInfo`