### PR TITLE
Prevents creation of custom registration form without DisplayName and no DisplayNameFormat

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Attributes/RegistrationFieldsAttribute.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Attributes/RegistrationFieldsAttribute.cs
@@ -16,14 +16,16 @@ namespace Dnn.PersonaBar.Security.Attributes
     [AttributeUsage(AttributeTargets.Property)]
     class RegistrationFieldsAttribute : ValidationAttribute
     {
-        public RegistrationFieldsAttribute(string registrationFormType, string requireUniqueDisplayName)
+        public RegistrationFieldsAttribute(string registrationFormType, string requireUniqueDisplayName, string displayNameFormat)
         {
             this.RegistrationFormTypePropertyName = registrationFormType;
             this.RequireUniqueDisplayNamePropertyName = requireUniqueDisplayName;
+            this.DisplayNameFormatPropertyName = displayNameFormat;
         }
 
         public string RegistrationFormTypePropertyName { get; private set; }
         public string RequireUniqueDisplayNamePropertyName { get; private set; }
+        public string DisplayNameFormatPropertyName { get; private set; }
 
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
@@ -96,6 +98,22 @@ namespace Dnn.PersonaBar.Security.Attributes
                 {
                     PortalController.UpdatePortalSetting(portalId, "Registration_RegistrationFormType", "0", false);
                     return new ValidationResult(Localization.GetString(Constants.NoDisplayName, Constants.LocalResourcesFile));
+                }
+
+                var displayNameFormatValue = string.Empty;
+
+                try
+                {
+                    displayNameFormatValue = validationContext.ObjectType.GetProperty(this.DisplayNameFormatPropertyName).GetValue(validationContext.ObjectInstance, null).ToString();
+                }
+                catch
+                {
+                    return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid, Constants.LocalResourcesFile), this.DisplayNameFormatPropertyName, displayNameFormatValue));
+                }
+
+                if (!registrationFields.Contains("DisplayName") && string.IsNullOrWhiteSpace(displayNameFormatValue))
+                {
+                    return new ValidationResult(Localization.GetString(Constants.IncorrectDisplayNameConfiguration, Constants.LocalResourcesFile));
                 }
             }
 

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Constants.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Constants.cs
@@ -23,6 +23,7 @@ namespace Dnn.PersonaBar.Security.Components
         public const string ContainsDuplicateAddresses = "ContainsDuplicateAddresses";
         public const string DeletedTab = "DeletedTab";
         public const string DisabledTab = "DisabledTab";
+        public const string IncorrectDisplayNameConfiguration = "IncorrectDisplayNameConfiguration";
         public const string LocalResourcesFile = "~/DesktopModules/admin/Dnn.PersonaBar/Modules/Dnn.Security/App_LocalResources/Security.resx";
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/DTO/UpdateRegistrationSettingsRequest.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/DTO/UpdateRegistrationSettingsRequest.cs
@@ -20,7 +20,7 @@ namespace Dnn.PersonaBar.Security.Services.Dto
         [RegistrationFormTypeOption]
         public int RegistrationFormType { get; set; }
 
-        [RegistrationFields("RegistrationFormType", "RequireUniqueDisplayName")]
+        [RegistrationFields("RegistrationFormType", "RequireUniqueDisplayName", "DisplayNameFormat")]
         public string RegistrationFields { get; set; }
 
         public bool RequireUniqueDisplayName { get; set; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -1147,4 +1147,7 @@
   <data name="RedirectionMovedToSiteSettings.Text" xml:space="preserve">
     <value>Redirection has been moved to Site Settings</value>
   </data>
+  <data name="IncorrectDisplayNameConfiguration.Text" xml:space="preserve">
+    <value>The Display Name configuration is not correct. Either provide Display Name Format or include Display Name in the list of fields.</value>
+  </data>
 </root>


### PR DESCRIPTION
DNN-41046: disallowed custom form without DisplayName and lacking a DisplayNameFormat

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3971 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Custom Registration Form without DisplayName field on it and lacking Display Name Format is no longer allowed and considered as incorrect configuration.