### PR TITLE
Improves GitVersion speed

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -3,7 +3,7 @@ commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment
 ignore:
-  commits-before: 2019-01-01T00:00:00
+  commits-before: 2020-01-01T00:00:00
 branches:
   future:
     regex: future?[/-]

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -2,8 +2,10 @@ next-version: 9.6.0
 commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment
+ignore:
+  commits-before:
+    - 2019-01-01T00:00:00
 branches:
-
   future:
     regex: future?[/-]
     tag: 'alpha'

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -3,8 +3,7 @@ commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment
 ignore:
-  commits-before:
-    - 2019-01-01T00:00:00
+  commits-before: 2019-01-01T00:00:00
 branches:
   future:
     regex: future?[/-]


### PR DESCRIPTION
Sets the maximum GitVersion lookup date to january 1st 2020 thus speeding up GitVersion calculations a lot. This means GitVersion will only look at commits from this year instead of well all the project history to find tags and read commit messages, etc.