### PR TITLE
Fixes #4003 bug in TokenReplace getting Module by Id

### DIFF
--- a/DNN Platform/Library/Services/Tokens/TokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenReplace.cs
@@ -134,6 +134,15 @@ namespace DotNetNuke.Services.Tokens
             set => TokenContext.Module = GetModule(value);
         }
 
+        /// <summary>
+        /// Load the module for the Module Token Provider
+        /// </summary>
+        /// <param name="moduleId"></param>
+        /// <returns>The populated ModuleInfo or null</returns>
+        /// <remarks>
+        /// This method is called by the Setter of ModuleId.
+        /// Because of this, it may NOT access ModuleId itself (which will still be -1) but use moduleId (lower case)
+        /// </remarks>
         private ModuleInfo GetModule(int moduleId)
         {
             if (moduleId == TokenContext.Module?.ModuleID)
@@ -144,9 +153,9 @@ namespace DotNetNuke.Services.Tokens
 
             var tab = TokenContext.Tab ?? PortalSettings?.ActiveTab;
             if (tab != null && tab.TabID > 0)
-                return ModuleController.Instance.GetModule(ModuleId, tab.TabID, false);
+                return ModuleController.Instance.GetModule(moduleId, tab.TabID, false);
 
-            return ModuleController.Instance.GetModule(ModuleId, Null.NullInteger, true);
+            return ModuleController.Instance.GetModule(moduleId, Null.NullInteger, true);
         }
 
         /// <summary>


### PR DESCRIPTION
https://github.com/dnnsoftware/Dnn.Platform/issues/4003

## Summary
TokenReplace was modified in a recent code change, which broke a functionality where the Module-provider didn't work any more - see #4003. 

There is a funny mechanism in the `TokenReplace` which caused wrong values to be used. The code starts like this:

```
        /// <summary>
        /// Gets or sets /sets the current ModuleID to be used for 'User:' token replacement.
        /// </summary>
        /// <value>ModuleID (Integer).</value>
        public int ModuleId {
            get => TokenContext.Module?.ModuleID ?? Null.NullInteger;
            set => TokenContext.Module = GetModule(value);
        }
```

Then in the GetModule this happens

```
        private ModuleInfo GetModule(int moduleId)
        {
            if (moduleId == TokenContext.Module?.ModuleID)
                return TokenContext.Module;

            if (moduleId <= 0)
                return null;

            var tab = TokenContext.Tab ?? PortalSettings?.ActiveTab;
            if (tab != null && tab.TabID > 0)
                return ModuleController.Instance.GetModule(ModuleId, tab.TabID, false);

            return ModuleController.Instance.GetModule(ModuleId, Null.NullInteger, true);
        }
```

The bug happens on these two lines because of the upper-case `ModuleId` instead of `moduleId`. This accidentally uses the not-yet-set module-id (as it's still in progress of finding it) to find it. Lower-casing it fixes everything:

```
                return ModuleController.Instance.GetModule(ModuleId, tab.TabID, false);

            return ModuleController.Instance.GetModule(ModuleId, Null.NullInteger, true);
```