### PR TITLE
Removes svg from resource-manager build

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/webpack.config.js
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/webpack.config.js
@@ -96,9 +96,15 @@ module.exports = {
                 }
             },
             {
-                test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+                test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/,
                 use: {
                     loader: "file-loader?name=[name].[ext]"
+                }
+            },
+            {
+                test: /\.(svg)/,
+                use: {
+                    loader: "raw-loader"
                 }
             }
         ]


### PR DESCRIPTION
SVG files where present in the scripts folder on every build, those files should use raw-loader as the rest of our projects.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
