### PR TITLE
Fixes 2 wrong svg imports in resource-manager

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderSelector.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderSelector.jsx
@@ -4,7 +4,7 @@ import Folders from "./Folders";
 import { Scrollbars } from "react-custom-scrollbars";
 import "./style.less";
 
-const searchIconImage = require("./img/search.svg").default;
+const searchIconImage = require("!raw-loader!./img/search.svg").default;
 
 export default class FolderSelector extends Component {
 

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderSelector.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderSelector.jsx
@@ -4,7 +4,7 @@ import Folders from "./Folders";
 import { Scrollbars } from "react-custom-scrollbars";
 import "./style.less";
 
-const searchIconImage = require("!raw-loader!./img/search.svg");
+const searchIconImage = require("./img/search.svg").default;
 
 export default class FolderSelector extends Component {
 

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/Folders.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/Folders.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { PropTypes } from "prop-types";
 import "./style.less";
 
-const folderIcon = require("!raw-loader!./img/folder.svg");
+const folderIcon = require("./img/folder.svg").default;
 
 export default class Folders extends Component {
 

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/Folders.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/Folders.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { PropTypes } from "prop-types";
 import "./style.less";
 
-const folderIcon = require("./img/folder.svg").default;
+const folderIcon = require("!raw-loader!./img/folder.svg").default;
 
 export default class Folders extends Component {
 


### PR DESCRIPTION
Somewhere in god knows which update of which dependency, the way to import svgs using raw-loaders changed and we have to add .default to the import. This PR solves that in the resource-manager module.

![image](https://user-images.githubusercontent.com/6371568/91816547-0b7cb280-ec03-11ea-8f20-e28bb4dc1048.png)


<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
