### PR TITLE
change "dnn" to "app" in dnn_IsMobile cookie

### DIFF
--- a/DNN Platform/Library/Entities/Urls/FriendlyUrlController.cs
+++ b/DNN Platform/Library/Entities/Urls/FriendlyUrlController.cs
@@ -30,8 +30,8 @@ namespace DotNetNuke.Entities.Urls
         private const string DisableMobileRedirectQueryStringName = "nomo";
 
         // google uses the same name nomo=1 means do not redirect to mobile
-        private const string MobileViewSiteCookieName = "dnn_IsMobile";
-        private const string DisableMobileViewCookieName = "dnn_NoMobile";
+        private const string MobileViewSiteCookieName = "app_IsMobile";
+        private const string DisableMobileViewCookieName = "app_NoMobile";
 
         public static FriendlyUrlSettings GetCurrentSettings(int portalId)
         {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
 Fixes #4044 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

Small fix to help hide the app being used for the site by changing the cookie name used from `dnn_IsMobile` and `dnn_NoMobile` to `app_IsMobile` and `app_NoMobile` in FriendlyUrlController.cs file.