### PR TITLE
Fixed bug with hierarchical vocabularies

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Vocabularies.Web/src/components/VocabularyList/RightPane/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Vocabularies.Web/src/components/VocabularyList/RightPane/index.jsx
@@ -10,20 +10,15 @@ import { GridCell, SvgIcons } from "@dnnsoftware/dnn-react-common";
 
 function findInChildren(list, parentTermId) {
     if (!list) {
-        return;
+        return null;
     }
-    let parentTerm = {};
-    list.forEach((_term) => {
-        if (_term.TermId === parentTermId) {
-            parentTerm = _term;
-            return parentTerm;
-        } else {
-            if (findInChildren(_term.ChildTerms, parentTermId)) {
-                parentTerm = findInChildren(_term.ChildTerms, parentTermId);
-                return parentTerm;
-            }
-        }
-    });
+    let parentTerm = null;
+    for (let i = 0; i < list.length && !parentTerm; i++) {
+        const term = list[i];
+        parentTerm = term.TermId === parentTermId
+            ? term
+            : findInChildren(term.ChildTerms, parentTermId);
+    }
     return parentTerm;
 }
 


### PR DESCRIPTION
Fixes #4047

## Summary
Several problems in this `findInChildren` function.
1) The `forEach` loop cannot be broken, so the `return` statement at line 19 was not actually exiting the function.
2) The initial value of `parentTerm` was an empty object, so if the item was not found, an empty object was being returned by the function. However, empty objects evaluate to `true`, not to `false`.
3) Since this is a recursive function, and because of 2), line 21 was deciding to continue instead of deciding to stop. This was causing the `parentTerm` variable to get incorrectly overwritten in following cycles.

I replaced this buggy function with a more clear implementation that immediately breaks the loop if the item is found, or returns `null` otherwise.