### PR TITLE
Treat Build Warnings as Errors for Abstractions & DependencyInjection Projects

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Application
 {
     using System;

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
@@ -106,8 +106,6 @@ namespace DotNetNuke.Abstractions.Application
         /// </summary>
         /// <param name = "productNames">list of product names.</param>
         /// <returns>true if product is within list of names.</returns>
-        /// <remarks>
-        /// </remarks>
         bool ApplyToProduct(string productNames);
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationStatusInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationStatusInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Application
 {
     using System;

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IDnnContext.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IDnnContext.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Application
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IHostSettingsService.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IHostSettingsService.cs
@@ -13,7 +13,6 @@ namespace DotNetNuke.Abstractions.Application
     /// Entity.
     /// </summary>
     /// <example>
-    /// 
     /// <code lang="C#">
     /// public class MySampleClass
     /// {

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IHostSettingsService.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IHostSettingsService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Application
 {
     using System.Collections.Generic;

--- a/DNN Platform/DotNetNuke.Abstractions/Application/ReleaseMode.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/ReleaseMode.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Application
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Application/UpgradeStatus.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/UpgradeStatus.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Application
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
+++ b/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
@@ -1,16 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\DNN_Platform.build" />
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
+    <DocumentationFile>bin/$(Configuration)/$(TargetFramework)/DotNetNuke.Abstractions.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -20,12 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+  <Import Project="..\..\DNN_Platform.build" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.Abstractions*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />
   </Target>

--- a/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
+++ b/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
-  </PropertyGroup>
   <Import Project="..\..\DNN_Platform.build" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.Abstractions/INavigationManager.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/INavigationManager.cs
@@ -105,7 +105,7 @@ namespace DotNetNuke.Abstractions
         /// <param name="settings">The portal settings.</param>
         /// <param name="controlKey">The control key, or <see cref="string.Empty"/> or <c>null</c>.</param>
         /// <param name="language">The language code.</param>
-        /// <param name="pageName">The page name to pass to <see cref="FriendlyUrl(DotNetNuke.Entities.Tabs.TabInfo,string,string)"/>.</param>
+        /// <param name="pageName">The page name to pass.</param>
         /// <param name="additionalParameters">Any additional parameters.</param>
         /// <returns>Formatted url.</returns>
         string NavigateURL(int tabID, bool isSuperTab, IPortalSettings settings, string controlKey, string language, string pageName, params string[] additionalParameters);

--- a/DNN Platform/DotNetNuke.Abstractions/INavigationManager.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/INavigationManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions
 {
     using DotNetNuke.Abstractions.Portals;

--- a/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalAliasInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalAliasInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Portals
 {
     using DotNetNuke.Abstractions.Urls;

--- a/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalAliasService.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalAliasService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Portals
 {
     using System.Collections.Generic;

--- a/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Portals
 {
     using System;

--- a/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalSettings.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalSettings.cs
@@ -333,54 +333,207 @@ namespace DotNetNuke.Abstractions.Portals
         /// which update the database should be disabled.
         /// </summary>
         bool IsLocked { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether get a value indicating whether
+        /// the current portal is in maintenance mode (note, the entire
+        /// instance may still be locked, this only indicates whether this
+        /// portal is specifically locked). If locked, any actions which
+        /// update the database should be disabled.
+        /// </summary>
         bool IsThisPortalLocked { get; }
+
+        /// <summary>
+        /// Gets or sets the portal keywords.
+        /// </summary>
         string KeyWords { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals login tab id.
+        /// </summary>
         int LoginTabId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals logo file.
+        /// </summary>
         string LogoFile { get; set; }
+
+        /// <summary>
+        /// Gets the portals page head text.
+        /// </summary>
         string PageHeadText { get; }
+
+        /// <summary>
+        /// Gets or sets the portals page quota.
+        /// </summary>
         int PageQuota { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals pages.
+        /// </summary>
         int Pages { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether gets whether enable url language.
+        /// </summary>
+        /// <remarks>Defaults to True.</remarks>
         bool EnableUrlLanguage { get; }
-        //IPortalAliasInfo PortalAlias { get; set; }
-        //PortalSettings.PortalAliasMapping PortalAliasMappingMode { get; }
+
+        /// <summary>
+        /// Gets or sets the portal id.
+        /// </summary>
         int PortalId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portal name.
+        /// </summary>
         string PortalName { get; set; }
-        //IPortalAliasInfo PrimaryAlias { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals privacy tab id.
+        /// </summary>
         int PrivacyTabId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals registered role id.
+        /// </summary>
         int RegisteredRoleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals registered role name.
+        /// </summary>
         string RegisteredRoleName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portals register tab id.
+        /// </summary>
         int RegisterTabId { get; set; }
-        //RegistrationSettings Registration { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether to inlcude Common Words in the Search Index.
+        /// </summary>
+        /// <remarks>Defaults to False.</remarks>
         bool SearchIncludeCommon { get; }
+
+        /// <summary>
+        /// Gets the filter used for inclusion of tag info.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to "".
+        /// </remarks>
         string SearchIncludedTagInfoFilter { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether to inlcude Numbers in the Search Index.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to False.
+        /// </remarks>
         bool SearchIncludeNumeric { get; }
+
+        /// <summary>
+        /// Gets the maximum Search Word length to index.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 3.
+        /// </remarks>
         int SearchMaxWordlLength { get; }
+
+        /// <summary>
+        /// Gets the minum Search Word length to index.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 3.
+        /// </remarks>
         int SearchMinWordlLength { get; }
+
+        /// <summary>
+        /// Gets or sets the portals search tab id.
+        /// </summary>
         int SearchTabId { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether a cookie consent popup should be shown.
+        /// </summary>
+        /// <remarks>Defaults to False.</remarks>
         bool ShowCookieConsent { get; }
-        int SiteLogHistory { get; set; }
+
+        /// <summary>
+        /// Gets the portals SMTP connection limit.
+        /// </summary>
         int SMTPConnectionLimit { get; }
+
+        /// <summary>
+        /// Gets the portals SMPT max idle time.
+        /// </summary>
         int SMTPMaxIdleTime { get; }
+
+        /// <summary>
+        /// Gets or sets the portals splash tab id.
+        /// </summary>
         int SplashTabId { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether SSL is enabled for the portal.
+        /// </summary>
         bool SSLEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether SLL is enforced for the portal.
+        /// </summary>
         bool SSLEnforced { get; }
 
+        /// <summary>
+        /// Gets the SSL url for the portal.
+        /// </summary>
         string SSLURL { get; }
-        string STDURL { get; }
-        int SuperTabId { get; set; }
-        int TermsTabId { get; set; }
-        TimeZoneInfo TimeZone { get; set; }
-        int UserId { get; }
-        //IUserInfo UserInfo { get; }
-        //PortalSettings.Mode UserMode { get; }
-        int UserQuota { get; set; }
-        int UserRegistration { get; set; }
-        int Users { get; set; }
-        int UserTabId { get; set; }
 
-        //IPortalSettings Clone();
-        //string GetProperty(string propertyName, string format, CultureInfo formatProvider, UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound);
+        /// <summary>
+        /// Gets the standard url for the portal.
+        /// </summary>
+        string STDURL { get; }
+
+        /// <summary>
+        /// Gets or sets the super tab id.
+        /// </summary>
+        int SuperTabId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the terms and conditions tab id.
+        /// </summary>
+        int TermsTabId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timezone for the portal.
+        /// </summary>
+        TimeZoneInfo TimeZone { get; set; }
+
+        /// <summary>
+        /// Gets the currently logged in user identifier.
+        /// </summary>
+        /// <value>
+        /// The user identifier.
+        /// </value>
+        int UserId { get; }
+
+        /// <summary>
+        /// Gets or sets the user quota for the portal.
+        /// </summary>
+        int UserQuota { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user registration for the portal.
+        /// </summary>
+        int UserRegistration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the users for the portal.
+        /// </summary>
+        int Users { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user tab id for the portal.
+        /// </summary>
+        int UserTabId { get; set; }
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalSettings.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Portals/IPortalSettings.cs
@@ -5,72 +5,333 @@ namespace DotNetNuke.Abstractions.Portals
 {
     using System;
 
+    /// <summary>
+    /// The PortalSettings class encapsulates all of the settings for the Portal,
+    /// as well as the configuration settings required to execute the current tab
+    /// view within the portal.
+    /// </summary>
     public interface IPortalSettings
     {
-        //TabInfo ActiveTab { get; set; }
+        /// <summary>
+        /// Gets a value indicating whether if true then add a cachebuster parameter to generated file URI's.
+        /// </summary>
         bool AddCachebusterToResourceUris { get; }
+
+        /// <summary>
+        /// Gets a compatible page header.
+        /// </summary>
+        /// <remarks>
+        /// generates a : Page.Response.AddHeader("X-UA-Compatible", "").
+        /// </remarks>
         string AddCompatibleHttpHeader { get; }
+
+        /// <summary>
+        /// Gets or sets the administrator id.
+        /// </summary>
         int AdministratorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the administrator role id.
+        /// </summary>
         int AdministratorRoleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the administrator role name.
+        /// </summary>
         string AdministratorRoleName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the admin tab id.
+        /// </summary>
         int AdminTabId { get; set; }
-        //FileExtensionWhitelist AllowedExtensionsWhitelist { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether allows users to select their own UI culture.
+        /// When set to false (default) framework will allways same culture for both
+        /// CurrentCulture (content) and CurrentUICulture (interface).
+        /// </summary>
+        /// <remarks>Defaults to False.</remarks>
         bool AllowUserUICulture { get; }
+
+        /// <summary>
+        /// Gets or sets the background file.
+        /// </summary>
         string BackgroundFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the banner advertising.
+        /// </summary>
         int BannerAdvertising { get; set; }
-        //CacheLevel Cacheability { get; }
+
+        /// <summary>
+        /// Gets the CDF version.
+        /// </summary>
         int CdfVersion { get; }
-        //PortalSettings.ControlPanelPermission ControlPanelSecurity { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the control panel is visible.
+        /// </summary>
         bool ControlPanelVisible { get; }
+
+        /// <summary>
+        /// Gets link for the user to find out more about cookies. If not specified the link
+        /// shown will point to cookiesandyou.com.
+        /// </summary>
         string CookieMoreLink { get; }
+
+        /// <summary>
+        /// Gets or sets the culture code.
+        /// </summary>
         string CultureCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the currency.
+        /// </summary>
         string Currency { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether if true then all users will be pushed through the data consent workflow.
+        /// </summary>
         bool DataConsentActive { get; }
+
+        /// <summary>
+        /// Gets if set this is a tab id of a page where the user will be redirected to for consent. If not set then
+        /// the platform's default logic is used.
+        /// </summary>
         int DataConsentConsentRedirect { get; }
+
+        /// <summary>
+        /// Gets the delay time (in conjunction with DataConsentDelayMeasurement) for the DataConsentUserDeleteAction.
+        /// </summary>
         int DataConsentDelay { get; }
+
+        /// <summary>
+        /// Gets units for DataConsentDelay.
+        /// </summary>
         string DataConsentDelayMeasurement { get; }
+
+        /// <summary>
+        /// Gets last time the terms and conditions have been changed. This will determine if the user needs to
+        /// reconsent or not. Legally once the terms have changed, users need to sign again. This value is set
+        /// by the "reset consent" button on the UI.
+        /// </summary>
         DateTime DataConsentTermsLastChange { get; }
-        //PortalSettings.UserDeleteAction DataConsentUserDeleteAction { get; }
+
+        /// <summary>
+        /// Gets the default admin container.
+        /// </summary>
         string DefaultAdminContainer { get; }
+
+        /// <summary>
+        /// Gets the default admin skin.
+        /// </summary>
         string DefaultAdminSkin { get; }
+
+        /// <summary>
+        /// Gets the default authentication provider.
+        /// </summary>
         string DefaultAuthProvider { get; }
-        //PortalSettings.Mode DefaultControlPanelMode { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the default control panel is visible.
+        /// </summary>
         bool DefaultControlPanelVisibility { get; }
+
+        /// <summary>
+        /// Gets the default icon location.
+        /// </summary>
         string DefaultIconLocation { get; }
+
+        /// <summary>
+        /// Gets or sets the default location.
+        /// </summary>
         string DefaultLanguage { get; set; }
+
+        /// <summary>
+        /// Gets the default module action menu.
+        /// </summary>
         string DefaultModuleActionMenu { get; }
+
+        /// <summary>
+        /// Gets the Default Module Id.
+        /// </summary>
+        /// <remarks>Defaults to Null.NullInteger.</remarks>
         int DefaultModuleId { get; }
+
+        /// <summary>
+        /// Gets the default portal alias.
+        /// </summary>
         string DefaultPortalAlias { get; }
+
+        /// <summary>
+        /// Gets the default portal container.
+        /// </summary>
         string DefaultPortalContainer { get; }
+
+        /// <summary>
+        /// Gets the default portal skin.
+        /// </summary>
         string DefaultPortalSkin { get; }
+
+        /// <summary>
+        /// Gets the Default Tab Id.
+        /// </summary>
+        /// <remarks>Defaults to Null.NullInteger.</remarks>
         int DefaultTabId { get; }
+
+        /// <summary>
+        /// Gets or sets the portal description.
+        /// </summary>
         string Description { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether if this is true, then regular users can't send message to specific user/group.
+        /// </summary>
         bool DisablePrivateMessage { get; }
+
+        /// <summary>
+        /// Gets or sets the portal email.
+        /// </summary>
         string Email { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether Browser Language Detection is Enabled.
+        /// </summary>
+        /// <remarks>Defaults to True.</remarks>
         bool EnableBrowserLanguage { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the composite files for client scripts is enabled.
+        /// </summary>
         bool EnableCompositeFiles { get; }
-        bool EnableModuleEffect { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether to use the popup.
+        /// </summary>
+        /// <remarks>Defaults to True.</remarks>
         bool EnablePopUps { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether website Administrator whether receive the notification email when new user register.
+        /// </summary>
         bool EnableRegisterNotification { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether the Skin Widgets are enabled/supported.
+        /// </summary>
+        /// <remarks>Defaults to True.</remarks>
         bool EnableSkinWidgets { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the content is localized.
+        /// </summary>
         bool ContentLocalizationEnabled { get; }
+
+        /// <summary>
+        /// Gets the error page 404.
+        /// </summary>
         int ErrorPage404 { get; }
+
+        /// <summary>
+        /// Gets the error page 500.
+        /// </summary>
         int ErrorPage500 { get; }
+
+        /// <summary>
+        /// Gets or sets the expiry date.
+        /// </summary>
         DateTime ExpiryDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portal footer text.
+        /// </summary>
         string FooterText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the portal GUID.
+        /// </summary>
         Guid GUID { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether folders which are hidden or whose name begins with underscore
+        /// are included in folder synchronization.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to True.
+        /// </remarks>
         bool HideFoldersEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether hide the login link.
+        /// </summary>
+        /// <remarks>Defaults to False.</remarks>
         bool HideLoginControl { get; }
+
+        /// <summary>
+        /// Gets or sets the portal home directory.
+        /// </summary>
         string HomeDirectory { get; set; }
+
+        /// <summary>
+        /// Gets the portals home directory mapped path.
+        /// </summary>
         string HomeDirectoryMapPath { get; }
+
+        /// <summary>
+        /// Gets or sets the portals home system directory.
+        /// </summary>
         string HomeSystemDirectory { get; set; }
+
+        /// <summary>
+        /// Gets the portals home directory mapped path.
+        /// </summary>
         string HomeSystemDirectoryMapPath { get; }
+
+        /// <summary>
+        /// Gets or sets the portals home tab id.
+        /// </summary>
         int HomeTabId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the host fee.
+        /// </summary>
         float HostFee { get; set; }
+
+        /// <summary>
+        /// Gets or sets the host space.
+        /// </summary>
         int HostSpace { get; set; }
+
+        /*
+         * add <a name="[moduleid]"></a> on the top of the module
+         *
+         * Desactivate this remove the html5 compatibility warnings
+         * (and make the output smaller)
+         *
+         */
+
+        /// <summary>
+        /// Gets a value indicating whether a module can inject a hyperlink.
+        /// </summary>
+        /// <remarks>
+        /// add <![CDATA[<a name="[moduleid]"></a>]]> on the top of the module.
+        /// Desactivate this remove the html5 compatibility warnings
+        /// (and make the output smaller).
+        /// </remarks>
         bool InjectModuleHyperLink { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether the Inline Editor is enabled.
+        /// </summary>
+        /// <remarks>Defaults to True.</remarks>
         bool InlineEditorEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether get a value indicating whether
+        /// the current portal is in maintenance mode (if either this specific
+        /// portal or the entire instance is locked). If locked, any actions
+        /// which update the database should be disabled.
+        /// </summary>
         bool IsLocked { get; }
         bool IsThisPortalLocked { get; }
         string KeyWords { get; set; }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
@@ -21,6 +21,7 @@ namespace DotNetNuke.Abstractions.Prompt
 
         /// <summary>
         /// Gets or sets thecategory to which this command belongs.
+        /// </summary>
         /// <remarks>
         /// This is used to group the list of commands when a user requests this.
         /// </remarks>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
@@ -1,37 +1,44 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>
-    /// This is used to retrieve and keep a list of all commands found in the installation
+    /// This is used to retrieve and keep a list of all commands found in the installation.
     /// </summary>
     public interface ICommand
     {
         /// <summary>
-        /// Name of the command
+        /// Gets or sets the name of the command.
         /// </summary>
         string Name { get; set; }
+
         /// <summary>
-        /// Description of the command
+        /// Gets or sets the description of the command.
         /// </summary>
         string Description { get; set; }
+
         /// <summary>
-        /// Category to which this command belongs. This is used to 
-        /// group the list of commands when a user requests this.
-        /// </summary>
+        /// Gets or sets thecategory to which this command belongs.
+        /// <remarks>
+        /// This is used to group the list of commands when a user requests this.
+        /// </remarks>
         string Category { get; set; }
+
         /// <summary>
-        /// Key that is used to lookup the command internally 
-        /// (= upper cased command name)
+        /// Gets or sets the key that is used to lookup the command internally
+        /// (= upper cased command name).
         /// </summary>
         string Key { get; set; }
+
         /// <summary>
-        /// Assembly version of the assembly containing the command
+        /// Gets or sets the assembly version of the assembly containing the command.
         /// </summary>
         string Version { get; set; }
+
         /// <summary>
-        /// Full name of the class of the command
+        /// Gets or sets the full name of the class of the command.
         /// </summary>
         string TypeFullName { get; set; }
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Prompt
 {
     using System.Collections.Generic;

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
@@ -1,33 +1,38 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Prompt
 {
     using System.Collections.Generic;
 
     /// <summary>
-    /// This is used to send the result back to the client when a user asks help for a command
+    /// This is used to send the result back to the client when a user asks help for a command.
     /// </summary>
     public interface ICommandHelp
     {
         /// <summary>
-        /// Name of the command
+        /// Gets or sets the name of the command.
         /// </summary>
         string Name { get; set; }
+
         /// <summary>
-        /// Description of the command
+        /// Gets or sets the description of the command.
         /// </summary>
         string Description { get; set; }
+
         /// <summary>
-        /// Command parameter list, each with their own help text
+        /// Gets or sets the Command parameter list, each with their own help text.
         /// </summary>
         IEnumerable<ICommandOption> Options { get; set; }
+
         /// <summary>
-        /// Html formatted block of text that describes what this command does
+        /// Gets or sets the html formatted block of text that describes what this command does.
         /// </summary>
         string ResultHtml { get; set; }
+
         /// <summary>
-        /// Any error produced while trying to retrieve help for this command
+        /// Gets or sets any error produced while trying to retrieve help for this command.
         /// </summary>
         string Error { get; set; }
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
@@ -1,27 +1,31 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>
-    /// This is used in the ICommandHelp to send a list of command parameters to the client for explanatory help
+    /// This is used in the ICommandHelp to send a list of command parameters to the client for explanatory help.
     /// </summary>
     public interface ICommandOption
     {
         /// <summary>
-        /// Name of the parameter
+        /// Gets or sets the name of the parameter.
         /// </summary>
         string Name { get; set; }
+
         /// <summary>
-        /// Description of what this parameter is for
+        /// Gets or sets the description of what this parameter is for.
         /// </summary>
         string Description { get; set; }
+
         /// <summary>
-        /// Default serialized value if it is specified
+        /// Gets or sets the default serialized value if it is specified.
         /// </summary>
         string DefaultValue { get; set; }
+
         /// <summary>
-        /// Whether the parameter is required
+        /// Gets or sets a value indicating whether the parameter is required.
         /// </summary>
         bool Required { get; set; }
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
@@ -6,26 +6,28 @@ namespace DotNetNuke.Abstractions.Prompt
     using System.Collections.Generic;
 
     /// <summary>
-    /// The repository handles retrieving of commands from the entire DNN installation
+    /// The repository handles retrieving of commands from the entire DNN installation.
     /// </summary>
     public interface ICommandRepository
     {
         /// <summary>
         /// Gets a list of all found commands.
         /// </summary>
-        /// <returns>List of ICommand</returns>
+        /// <returns>List of ICommand.</returns>
         IEnumerable<ICommand> GetCommands();
+
         /// <summary>
         /// Get the command. Returns null if no command found for the name.
         /// </summary>
-        /// <param name="commandName">Name of the command (commonly in verb-noun format)</param>
-        /// <returns>An IConsoleCommand or null</returns>
+        /// <param name="commandName">Name of the command (commonly in verb-noun format).</param>
+        /// <returns>An IConsoleCommand or null.</returns>
         IConsoleCommand GetCommand(string commandName);
+
         /// <summary>
-        /// Get help for the specified command
+        /// Get help for the specified command.
         /// </summary>
-        /// <param name="consoleCommand">Command to get help for</param>
-        /// <returns>ICommandHelp class that can be used by the client to compile a help text</returns>
+        /// <param name="consoleCommand">Command to get help for.</param>
+        /// <returns>ICommandHelp class that can be used by the client to compile a help text.</returns>
         ICommandHelp GetCommandHelp(IConsoleCommand consoleCommand);
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleCommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleCommand.cs
@@ -1,45 +1,51 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Prompt
 {
     using DotNetNuke.Abstractions.Users;
 
     /// <summary>
-    /// Interface implemented by all commands
+    /// Interface implemented by all commands.
     /// </summary>
     public interface IConsoleCommand
     {
         /// <summary>
+        /// Gets the validation message for the user input. If the user input is invalid, specify what is wrong with it.
+        /// </summary>
+        string ValidationMessage { get; }
+
+        /// <summary>
+        /// Gets the local resx file to use to retrieve command description, help text and parameter descriptions.
+        /// </summary>
+        string LocalResourceFile { get; }
+
+        /// <summary>
+        /// Gets the help text for the command. This is used when retrieving help for the command.
+        /// </summary>
+        string ResultHtml { get; }
+
+        /// <summary>
         /// Initializes the command when invoked by the client. Note that you can opt to override this but you should
         /// call base.Initialize() to ensure all base values are loaded.
         /// </summary>
-        /// <param name="args">Raw argument list passed by the client</param>
+        /// <param name="args">Raw argument list passed by the client.</param>
         /// <param name="portalSettings">PortalSettings for the portal we're operating under or if PortalId is specified, that portal.</param>
-        /// <param name="userInfo">Current user</param>
-        /// <param name="activeTabId">Current page/tab</param>
+        /// <param name="userInfo">Current user.</param>
+        /// <param name="activeTabId">Current page/tab.</param>
         void Initialize(string[] args, Portals.IPortalSettings portalSettings, IUserInfo userInfo, int activeTabId);
+
         /// <summary>
-        /// The main method of the command which executes it
+        /// The main method of the command which executes it.
         /// </summary>
-        /// <returns>A class used by the client to display results</returns>
+        /// <returns>A class used by the client to display results.</returns>
         IConsoleResultModel Run();
+
         /// <summary>
-        /// Specify whether the user input for the command is valid
+        /// Specify whether the user input for the command is valid.
         /// </summary>
-        /// <returns>True is the command can execute</returns>
+        /// <returns>True is the command can execute.</returns>
         bool IsValid();
-        /// <summary>
-        /// If the user input is invalid, specify what is wrong with it
-        /// </summary>
-        string ValidationMessage { get; }
-        /// <summary>
-        /// Resx file to use to retrieve command description, help text and parameter descriptions.
-        /// </summary>
-        string LocalResourceFile { get; }
-        /// <summary>
-        /// Help text for the command. This is used when retrieving help for the command.
-        /// </summary>
-        string ResultHtml { get; }
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleCommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Prompt
 {
     using DotNetNuke.Abstractions.Users;

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleResultModel.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleResultModel.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleResultModel.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IConsoleResultModel.cs
@@ -1,49 +1,73 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>
-    /// This is used to return the results of the execution of a command to the client
+    /// This is used to return the results of the execution of a command to the client.
     /// </summary>
     public interface IConsoleResultModel
     {
         /// <summary>
-        /// The returned result - text or HTML 
+        /// Gets or sets the returned result - text or HTML.
         /// </summary>
         string Output { get; set; }
+
         /// <summary>
-        /// Is the output an error message?
+        /// Gets or sets a value indicating whether the output message is an error message.
         /// </summary>
         bool IsError { get; set; }
+
         /// <summary>
-        /// Let the client know if the output is HTML or not
+        /// Gets or sets a value indicating whether output is HTML.
         /// </summary>
+        /// <remarks>
+        /// Let the client know if the output is HTML or not.
+        /// </remarks>
         bool IsHtml { get; set; }
+
         /// <summary>
-        /// Should the client reload after processing the command
+        /// Gets or sets a value indicating whether the prompt must reload.
         /// </summary>
+        /// <remarks>
+        /// Should the client reload after processing the command.
+        /// </remarks>
         bool MustReload { get; set; }
+
         /// <summary>
-        /// The response contains data to be formatted by the client
+        /// Gets or sets if the response contains data to be formatted by the client.
         /// </summary>
         object Data { get; set; }
+
         /// <summary>
-        /// Optionally tell the client in what order the fields should be displayed
+        /// Gets or sets the field order.
         /// </summary>
+        /// <remarks>
+        /// Optionally tell the client in what order the fields should be displayed.
+        /// </remarks>
         string[] FieldOrder { get; set; }
+
         /// <summary>
+        /// Gets or sets the <see cref="IPagingInfo"/>.
+        /// </summary>
+        /// <remarks>
         /// Information about paging of data. This allows the client to prompt the user
         /// to load the next page of data.
-        /// </summary>
+        /// </remarks>
         IPagingInfo PagingInfo { get; set; }
+
         /// <summary>
+        /// Gets or sets the next page command.
+        /// </summary>
+        /// <remarks>
         /// Command to be used to display the next page of data. This is set in the
         /// WebAPI handler.
-        /// </summary>
+        /// </remarks>
         string NextPageCommand { get; set; }
+
         /// <summary>
-        /// Nr of records retrieved (for this page).
+        /// Gets or sets the number of records retrieved (for this page).
         /// </summary>
         int Records { get; set; }
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IPagingInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IPagingInfo.cs
@@ -1,27 +1,31 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>
-    /// Used to page long lists of data to the client
+    /// Used to page long lists of data to the client.
     /// </summary>
     public interface IPagingInfo
     {
         /// <summary>
-        /// Current page nr
+        /// Gets or sets the current page nr.
         /// </summary>
         int PageNo { get; set; }
+
         /// <summary>
-        /// Page size
+        /// Gets or sets the Page size.
         /// </summary>
         int PageSize { get; set; }
+
         /// <summary>
-        /// Total nr of pages
+        /// Gets or sets the total nr of pages.
         /// </summary>
         int TotalPages { get; set; }
+
         /// <summary>
-        /// Total nr of records
+        /// Gets or sets the total nr of records.
         /// </summary>
         int TotalRecords { get; set; }
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IPagingInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IPagingInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Settings/IConfigurationSetting.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Settings/IConfigurationSetting.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Settings
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Urls/BrowserTypes.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Urls/BrowserTypes.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Urls
 {
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Urls/BrowserTypes.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Urls/BrowserTypes.cs
@@ -5,7 +5,7 @@
 namespace DotNetNuke.Abstractions.Urls
 {
     /// <summary>
-    /// Browser Types
+    /// Enumeration values for Browser Types. (Normal or desktop, mobile, etc.)
     /// </summary>
     public enum BrowserTypes
     {

--- a/DNN Platform/DotNetNuke.Abstractions/Users/IUserInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Users/IUserInfo.cs
@@ -1,42 +1,135 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Abstractions.Users
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
 
+    /// <summary>
+    /// The UserInfo class provides Business Layer model for Users.
+    /// </summary>
     public interface IUserInfo
     {
+        /// <summary>
+        /// Gets or sets and sets the AffiliateId for this user.
+        /// </summary>
         int AffiliateID { get; set; }
-        //CacheLevel Cacheability { get; }
+
+        /// <summary>
+        /// Gets or sets and sets the Display Name.
+        /// </summary>
         string DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the Email Address.
+        /// </summary>
         string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the First Name.
+        /// </summary>
         string FirstName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets and sets whether the user has agreed to the terms and conditions.
+        /// </summary>
         bool HasAgreedToTerms { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets when the user last agreed to the terms and conditions.
+        /// </summary>
         DateTime HasAgreedToTermsOn { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether gets whether the user is in the portal's administrators role.
+        /// </summary>
         bool IsAdmin { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets and sets whether the User is deleted.
+        /// </summary>
         bool IsDeleted { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets and sets whether the User is a SuperUser.
+        /// </summary>
         bool IsSuperUser { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the Last IP address used by user.
+        /// </summary>
         string LastIPAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the Last Name.
+        /// </summary>
         string LastName { get; set; }
-        //UserMembership Membership { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the datetime that the PasswordResetToken is valid.
+        /// </summary>
         DateTime PasswordResetExpiration { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the token created for resetting passwords.
+        /// </summary>
         Guid PasswordResetToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the PortalId.
+        /// </summary>
         int PortalID { get; set; }
-        //UserProfile Profile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets and sets whether the user has requested they be removed from the site.
+        /// </summary>
         bool RequestsRemoval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the roles.
+        /// </summary>
         string[] Roles { get; set; }
-        //UserSocial Social { get; }
+
+        /// <summary>
+        /// Gets or sets and sets the User Id.
+        /// </summary>
         int UserID { get; set; }
+
+        /// <summary>
+        /// Gets or sets and sets the User Name.
+        /// </summary>
         string Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the vanity url.
+        /// </summary>
         string VanityUrl { get; set; }
 
-        //string GetProperty(string propertyName, string format, CultureInfo formatProvider, UserInfo accessingUser, Scope currentScope, ref bool propertyNotFound);
+        /// <summary>
+        /// IsInRole determines whether the user is in the role passed.
+        /// </summary>
+        /// <param name="role">The role to check.</param>
+        /// <returns>A Boolean indicating success or failure.</returns>
         bool IsInRole(string role);
+
+        /// <summary>
+        /// Gets current time in User's timezone.
+        /// </summary>
+        /// <returns>The local time for the user.</returns>
         DateTime LocalTime();
+
+        /// <summary>
+        /// Convert utc time in User's timezone.
+        /// </summary>
+        /// <param name="utcTime">Utc time to convert.</param>
+        /// <returns>The local time for the user.</returns>
         DateTime LocalTime(DateTime utcTime);
+
+        /// <summary>
+        /// UpdateDisplayName updates the displayname to the format provided.
+        /// </summary>
+        /// <param name="format">The format to use.</param>
         void UpdateDisplayName(string format);
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Users/IUserInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Users/IUserInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Abstractions.Users
 {
     using System;

--- a/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
+++ b/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
@@ -1,18 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
-  </PropertyGroup>
-  <Import Project="..\..\DNN_Platform.build" />
-
-  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
+    <DocumentationFile>bin/$(Configuration)/$(TargetFramework)/DotNetNuke.DependencyInjection.xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
@@ -28,6 +22,11 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <Import Project="..\..\DNN_Platform.build" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.DependencyInjection*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />
   </Target>

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.DependencyInjection.Extensions
 {
     using System;

--- a/DNN Platform/DotNetNuke.DependencyInjection/IDnnStartup.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/IDnnStartup.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.DependencyInjection
 {
     using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Fixes #4040 

## Summary
This PR updates `DotNetNuke.Abstractions` and `DotNetNuke.DependencyInjection` to treat all build warnings as errors. This will help ensure a high level of code quality in these new projects.