### PR TITLE
Updated IHostSettingsService to use IDictionary instead of Dictionary

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Application/IHostSettingsService.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IHostSettingsService.cs
@@ -92,13 +92,13 @@ namespace DotNetNuke.Abstractions.Application
         /// Gets all host settings.
         /// </summary>
         /// <returns>host setting.</returns>
-        Dictionary<string, IConfigurationSetting> GetSettings();
+        IDictionary<string, IConfigurationSetting> GetSettings();
 
         /// <summary>
         /// Gets all host settings as dictionary.
         /// </summary>
         /// <returns>host setting's value.</returns>
-        Dictionary<string, string> GetSettingsDictionary();
+        IDictionary<string, string> GetSettingsDictionary();
 
         /// <summary>
         /// Gets the setting value by the specific key.
@@ -140,7 +140,7 @@ namespace DotNetNuke.Abstractions.Application
         /// Updates the specified settings.
         /// </summary>
         /// <param name="settings">The settings.</param>
-        void Update(Dictionary<string, string> settings);
+        void Update(IDictionary<string, string> settings);
 
         /// <summary>
         /// Updates the setting for a specified key.

--- a/DNN Platform/Library/Entities/Controllers/HostController.cs
+++ b/DNN Platform/Library/Entities/Controllers/HostController.cs
@@ -116,7 +116,7 @@ namespace DotNetNuke.Entities.Controllers
         }
 
         /// <inheritdoc/>
-        Dictionary<string, IConfigurationSetting> IHostSettingsService.GetSettings()
+        IDictionary<string, IConfigurationSetting> IHostSettingsService.GetSettings()
         {
             return CBO.GetCachedObject<Dictionary<string, IConfigurationSetting>>(
                                             new CacheItemArgs(
@@ -128,9 +128,10 @@ namespace DotNetNuke.Entities.Controllers
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, string> GetSettingsDictionary()
+        IDictionary<string, string> IHostSettingsService.GetSettingsDictionary()
         {
-            return this.GetSettings().ToDictionary(c => c.Key, c => c.Value.Value);
+            return ((IHostSettingsService)this).GetSettings()
+                .ToDictionary(c => c.Key, c => c.Value.Value);
         }
 
         /// <inheritdoc/>
@@ -162,7 +163,7 @@ namespace DotNetNuke.Entities.Controllers
         }
 
         /// <inheritdoc/>
-        public void Update(Dictionary<string, string> settings)
+        void IHostSettingsService.Update(IDictionary<string, string> settings)
         {
             foreach (KeyValuePair<string, string> settingKvp in settings)
             {

--- a/DNN Platform/Library/Obsolete/HostController.cs
+++ b/DNN Platform/Library/Obsolete/HostController.cs
@@ -32,12 +32,16 @@ namespace DotNetNuke.Entities.Controllers
             }
         }
 
-        /// <inheritdoc/>
         [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IHostSettingsService instead.")]
         public Dictionary<string, ConfigurationSetting> GetSettings() =>
             ((IHostSettingsService)this).GetSettings()
                 .Where(setting => setting.Value is ConfigurationSetting)
                 .Select(setting => new KeyValuePair<string, ConfigurationSetting>(setting.Key, (ConfigurationSetting)setting.Value))
+                .ToDictionary(setting => setting.Key, setting => setting.Value);
+
+        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IHostSettingsService instead.")]
+        public Dictionary<string, string> GetSettingsDictionary() =>
+            ((IHostSettingsService)this).GetSettingsDictionary()
                 .ToDictionary(setting => setting.Key, setting => setting.Value);
 
         /// <inheritdoc/>
@@ -49,5 +53,9 @@ namespace DotNetNuke.Entities.Controllers
         [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IHostSettingsService instead.")]
         public void Update(ConfigurationSetting config, bool clearCache) =>
             ((IHostSettingsService)this).Update(config, clearCache);
+
+        [Obsolete("Deprecated in 9.7.1. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.IHostSettingsService instead.")]
+        public void Update(Dictionary<string, string> settings) =>
+            ((IHostSettingsService)this).Update(settings);
     }
 }


### PR DESCRIPTION
Fixes: #4051 

## Summary
Updated `Dictionary<>` references in the `IHostSettingsService` to use `IDictionary<>`
