### PR TITLE
Use request scope in PortalModuleBase

### DIFF
--- a/DNN Platform/Library/Common/ServiceScopeContainer.cs
+++ b/DNN Platform/Library/Common/ServiceScopeContainer.cs
@@ -32,7 +32,7 @@ namespace DotNetNuke.Common
         /// </summary>
         public static ServiceScopeContainer GetRequestOrCreateScope()
         {
-            var requestScope = HttpContext.Current?.GetScope();
+            var requestScope = HttpContextSource.Current?.GetScope();
 
             if (requestScope != null)
             {

--- a/DNN Platform/Library/Common/ServiceScopeContainer.cs
+++ b/DNN Platform/Library/Common/ServiceScopeContainer.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Common
+{
+    using System;
+    using System.Web;
+    using DotNetNuke.Common.Extensions;
+    using Microsoft.Extensions.DependencyInjection;
+
+    internal struct ServiceScopeContainer : IDisposable
+    {
+        public ServiceScopeContainer(IServiceScope serviceScope, bool shouldDispose)
+        {
+            ServiceScope = serviceScope;
+            ShouldDispose = shouldDispose;
+        }
+
+        /// <summary>
+        ///     Service scope that the container holds.
+        /// </summary>
+        public IServiceScope ServiceScope { get; }
+
+        /// <summary>
+        ///     True if the <see cref="ServiceScope"/> should be disposed.
+        /// </summary>
+        public bool ShouldDispose { get; }
+
+        /// <summary>
+        ///     Get the service scope from <see cref="HttpContext"/> or create a new scope from <see cref="Globals.DependencyProvider"/> when the scope doesn't exists.
+        /// </summary>
+        public static ServiceScopeContainer GetRequestOrCreateScope()
+        {
+            var requestScope = HttpContext.Current?.GetScope();
+
+            if (requestScope != null)
+            {
+                return new ServiceScopeContainer(requestScope, false);
+            }
+
+            return new ServiceScopeContainer(Globals.DependencyProvider.CreateScope(), true);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (ShouldDispose)
+            {
+                ServiceScope.Dispose();
+            }
+        }
+    }
+}

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Application\ApplicationStatusInfo.cs" />
     <Compile Include="Common\Extensions\HttpContextDependencyInjectionExtensions.cs" />
     <Compile Include="Common\NavigationManager.cs" />
+    <Compile Include="Common\ServiceScopeContainer.cs" />
     <Compile Include="Common\Utilities\CryptographyUtils.cs" />
     <Compile Include="Common\Utilities\FileSystemExtensions.cs" />
     <Compile Include="Common\Utilities\RegexUtils.cs" />

--- a/DNN Platform/Library/Entities/Modules/PortalModuleBase.cs
+++ b/DNN Platform/Library/Entities/Modules/PortalModuleBase.cs
@@ -43,7 +43,7 @@ namespace DotNetNuke.Entities.Modules
             RegexOptions.IgnoreCase | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         private readonly ILog _tracelLogger = LoggerSource.Instance.GetLogger("DNN.Trace");
-        private readonly Lazy<IServiceScope> _serviceScope = new Lazy<IServiceScope>(Globals.DependencyProvider.CreateScope);
+        private readonly Lazy<ServiceScopeContainer> _serviceScopeContainer = new Lazy<ServiceScopeContainer>(ServiceScopeContainer.GetRequestOrCreateScope);
         private string _localResourceFile;
         private ModuleInstanceContext _moduleContext;
 
@@ -365,7 +365,7 @@ namespace DotNetNuke.Entities.Modules
         /// <value>
         /// The Dependency Service.
         /// </value>
-        protected IServiceProvider DependencyProvider => this._serviceScope.Value.ServiceProvider;
+        protected IServiceProvider DependencyProvider => this._serviceScopeContainer.Value.ServiceScope.ServiceProvider;
 
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -418,9 +418,9 @@ namespace DotNetNuke.Entities.Modules
         public override void Dispose()
         {
             base.Dispose();
-            if (this._serviceScope.IsValueCreated)
+            if (this._serviceScopeContainer.IsValueCreated)
             {
-                this._serviceScope.Value.Dispose();
+                this._serviceScopeContainer.Value.Dispose();
             }
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/ServiceContainerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/ServiceContainerTests.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Web.Api.Internals
+{
+    using System.Web;
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
+    using DotNetNuke.Common.Extensions;
+    using DotNetNuke.Tests.Instance.Utilities.HttpSimulator;
+    using Moq;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ServiceContainerTests
+    {
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
+            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        }
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Globals.DependencyProvider = null;
+        }
+
+        [Test]
+        public void CreateScopeWhenRequestDoesNotExists()
+        {
+            Assert.Null(HttpContext.Current?.GetScope());
+
+            var container = ServiceScopeContainer.GetRequestOrCreateScope();
+
+            Assert.True(container.ShouldDispose);
+        }
+
+        [Test]
+        public void UseRequestScopeWhenPossible()
+        {
+            using (var simulator = new HttpSimulator())
+            {
+                simulator.SimulateRequest();
+
+                var scope = Globals.DependencyProvider.CreateScope();
+
+                HttpContext.Current.SetScope(scope);
+
+                Assert.NotNull(HttpContext.Current?.GetScope());
+
+                var container = ServiceScopeContainer.GetRequestOrCreateScope();
+
+                Assert.False(container.ShouldDispose);
+                Assert.AreEqual(scope, container.ServiceScope);
+            }
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/ServiceContainerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/ServiceContainerTests.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Extensions;
-    using DotNetNuke.Tests.Instance.Utilities.HttpSimulator;
+    using DotNetNuke.Tests.Utilities;
     using Moq;
     using Microsoft.Extensions.DependencyInjection;
     using NUnit.Framework;
@@ -37,7 +37,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void CreateScopeWhenRequestDoesNotExists()
         {
-            Assert.Null(HttpContext.Current?.GetScope());
+            Assert.Null(HttpContextSource.Current?.GetScope());
 
             var container = ServiceScopeContainer.GetRequestOrCreateScope();
 
@@ -47,21 +47,17 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void UseRequestScopeWhenPossible()
         {
-            using (var simulator = new HttpSimulator())
-            {
-                simulator.SimulateRequest();
+            var scope = Globals.DependencyProvider.CreateScope();
 
-                var scope = Globals.DependencyProvider.CreateScope();
+            HttpContextHelper.RegisterMockHttpContext();
+            HttpContextSource.Current.SetScope(scope);
 
-                HttpContext.Current.SetScope(scope);
+            Assert.NotNull(HttpContextSource.Current?.GetScope());
 
-                Assert.NotNull(HttpContext.Current?.GetScope());
+            var container = ServiceScopeContainer.GetRequestOrCreateScope();
 
-                var container = ServiceScopeContainer.GetRequestOrCreateScope();
-
-                Assert.False(container.ShouldDispose);
-                Assert.AreEqual(scope, container.ServiceScope);
-            }
+            Assert.False(container.ShouldDispose);
+            Assert.AreEqual(scope, container.ServiceScope);
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
@@ -91,6 +91,7 @@
   <ItemGroup>
     <Compile Include="Api\BasicAuthMessageHandlerTests.cs" />
     <Compile Include="Api\Internals\DnnDependencyResolverTests.cs" />
+    <Compile Include="Api\Internals\ServiceContainerTests.cs" />
     <Compile Include="Api\JwtAuthMessageHandlerTests.cs" />
     <Compile Include="Api\DigestAuthMessageHandlerTests.cs" />
     <Compile Include="Api\DnnActionFilterProviderTests.cs" />


### PR DESCRIPTION
Fixes #4046

## Summary
Currently every PortalModule create its own service scope. This PR changes this behaviour by using the request scope when possible.

If a PortalModule is created outside ASP.Net (or the HttpContext was not available) it'll still create a new scope.

I've placed the unit test in the same directory as `DnnDependencyResolverTests` since I was not sure where to place it. If this is incorrect, place a comment and I'll move it 😄.