### PR TITLE
Fixed an issue where a new page was created by "Add page", the "Advanced/More/Secure Connection" property was always stored as "Off", regardless of the setting in the UI

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1367,7 +1367,6 @@ namespace Dnn.PersonaBar.Pages.Components
             tab.IconFileLarge = sourceTab.IconFileLarge;
             tab.PageHeadText = sourceTab.PageHeadText;
             tab.RefreshInterval = sourceTab.RefreshInterval;
-            tab.IsSecure = sourceTab.IsSecure;
             this._tabController.UpdateTab(tab);
 
             //update need tab settings.


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #4058 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
IsSecure property of the new page was getting overwritten by the source page's IsSecure property which made the UI component for IsSecure unusable. The overwritten code is deleted now so that the value of the UI component can be used.

Demo: https://drive.google.com/file/d/1ucKIZ0S4H4vwJRie3kRF_03HaQbcGeXm/view?usp=sharing