### PR TITLE
Enabled StyleCop & Fixed All Build Errors/Warnings

### DIFF
--- a/DNN Platform/Modules/ResourceManager/Components/Common/Utils.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/Common/Utils.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components.Common
 {
     using System;
@@ -10,21 +9,21 @@ namespace Dnn.Modules.ResourceManager.Components.Common
     using DotNetNuke.Services.FileSystem;
 
     /// <summary>
-    /// Various utilities.
+    /// General utilities for the Resource Manager.
     /// </summary>
     public class Utils
     {
         /// <summary>
-        ///     Obtains a human friendly description from an enum value using the
-        ///     <see cref="System.ComponentModel.DescriptionAttribute" /> attribute to get a proper name.
+        /// Obtains a human friendly description from an enum value using the
+        /// <see cref="System.ComponentModel.DescriptionAttribute" /> attribute to get a proper name.
         /// </summary>
         /// <param name="enumValue">The enum value to lookup.</param>
         /// <returns>The specified description attribute name or the value of the enum as a string.</returns>
         public static string GetEnumDescription(Enum enumValue)
         {
             var fi = enumValue.GetType().GetField(enumValue.ToString());
-            var descriptionAttributes =
-                (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+            var descriptionAttributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+
             if (descriptionAttributes.Length > 0)
             {
                 return descriptionAttributes[0].Description;

--- a/DNN Platform/Modules/ResourceManager/Components/Constants.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/Constants.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;

--- a/DNN Platform/Modules/ResourceManager/Components/GroupManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/GroupManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;

--- a/DNN Platform/Modules/ResourceManager/Components/IGroupManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/IGroupManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using DotNetNuke.Services.FileSystem;

--- a/DNN Platform/Modules/ResourceManager/Components/IItemsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/IItemsManager.cs
@@ -1,12 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System.IO;
 
     using Dnn.Modules.ResourceManager.Services.Dto;
+
     using DotNetNuke.Services.Assets;
     using DotNetNuke.Services.FileSystem;
 
@@ -44,12 +44,7 @@ namespace Dnn.Modules.ResourceManager.Components
         /// <param name="mappedName">Mapped name.</param>
         /// <param name="moduleMode">Current mode of the module instance.</param>
         /// <returns>Folder info object of the new created folder.</returns>
-        IFolderInfo CreateNewFolder(
-            string folderName,
-            int parentFolderId,
-            int folderMappingId,
-            string mappedName,
-            int moduleMode);
+        IFolderInfo CreateNewFolder(string folderName, int parentFolderId, int folderMappingId, string mappedName, int moduleMode);
 
         /// <summary>
         /// Update the asset details of a file.

--- a/DNN Platform/Modules/ResourceManager/Components/IPermissionsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/IPermissionsManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Components/ISearchController.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/ISearchController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System.Collections.Generic;
@@ -26,15 +25,6 @@ namespace Dnn.Modules.ResourceManager.Components
         /// <param name="moduleMode">Module Mode.</param>
         /// <param name="totalCount">Returns the total count (out parameter).</param>
         /// <returns>Result set of the file search page.</returns>
-        IList<IFileInfo> SearchFolderContent(
-            int moduleId,
-            IFolderInfo folder,
-            bool recursive,
-            string search,
-            int pageIndex,
-            int pageSize,
-            string sorting,
-            int moduleMode,
-            out int totalCount);
+        IList<IFileInfo> SearchFolderContent(int moduleId, IFolderInfo folder, bool recursive, string search, int pageIndex, int pageSize, string sorting, int moduleMode, out int totalCount);
     }
 }

--- a/DNN Platform/Modules/ResourceManager/Components/IThumbnailsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/IThumbnailsManager.cs
@@ -1,12 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System.Drawing;
 
     using Dnn.Modules.ResourceManager.Components.Models;
+
     using DotNetNuke.Services.FileSystem;
 
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Components/ItemsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/ItemsManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;
@@ -12,6 +11,7 @@ namespace Dnn.Modules.ResourceManager.Components
     using Dnn.Modules.ResourceManager.Exceptions;
     using Dnn.Modules.ResourceManager.Helpers;
     using Dnn.Modules.ResourceManager.Services.Dto;
+
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Portals;
@@ -29,7 +29,6 @@ namespace Dnn.Modules.ResourceManager.Components
     public class ItemsManager : ServiceLocator<IItemsManager, ItemsManager>, IItemsManager
     {
         private const int MaxDescriptionLength = 500;
-        private readonly IContentController contentController;
         private readonly IRoleController roleController;
         private readonly IFileManager fileManager;
         private readonly IAssetManager assetManager;
@@ -40,14 +39,13 @@ namespace Dnn.Modules.ResourceManager.Components
         /// </summary>
         public ItemsManager()
         {
-            this.contentController = ContentController.Instance;
             this.roleController = RoleController.Instance;
             this.fileManager = FileManager.Instance;
             this.assetManager = AssetManager.Instance;
             this.permissionsManager = PermissionsManager.Instance;
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public ContentPage GetFolderContent(int folderId, int startIndex, int numItems, string sorting, int moduleMode)
         {
             var noPermissionMessage = Localization.GetExceptionMessage(
@@ -69,7 +67,7 @@ namespace Dnn.Modules.ResourceManager.Components
             }
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public Stream GetFileContent(int fileId, out string fileName, out string contentType)
         {
             var file = this.fileManager.GetFile(fileId, true);
@@ -91,13 +89,8 @@ namespace Dnn.Modules.ResourceManager.Components
             return content;
         }
 
-        /// <inheritdoc/>
-        public IFolderInfo CreateNewFolder(
-            string folderName,
-            int parentFolderId,
-            int folderMappingId,
-            string mappedName,
-            int moduleMode)
+        /// <inheritdoc />
+        public IFolderInfo CreateNewFolder(string folderName, int parentFolderId, int folderMappingId, string mappedName, int moduleMode)
         {
             if (!this.permissionsManager.HasAddFoldersPermission(moduleMode, parentFolderId))
             {
@@ -107,7 +100,7 @@ namespace Dnn.Modules.ResourceManager.Components
             return AssetManager.Instance.CreateFolder(folderName, parentFolderId, folderMappingId, mappedName);
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public void SaveFileDetails(IFileInfo file, FileDetailsRequest fileDetails)
         {
             var propertyChanged = false;
@@ -136,7 +129,7 @@ namespace Dnn.Modules.ResourceManager.Components
             }
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public void SaveFolderDetails(IFolderInfo folder, FolderDetailsRequest folderDetails)
         {
             this.assetManager.RenameFolder(folderDetails.FolderId, folderDetails.FolderName);
@@ -146,7 +139,7 @@ namespace Dnn.Modules.ResourceManager.Components
             FolderManager.Instance.UpdateFolder(folder);
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public void DeleteFile(int fileId, int moduleMode, int groupId)
         {
             var file = FileManager.Instance.GetFile(fileId);
@@ -168,7 +161,7 @@ namespace Dnn.Modules.ResourceManager.Components
             AssetManager.Instance.DeleteFile(fileId);
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public void DeleteFolder(int folderId, bool unlinkAllowedStatus, int moduleMode)
         {
             var folder = FolderManager.Instance.GetFolder(folderId);
@@ -186,7 +179,7 @@ namespace Dnn.Modules.ResourceManager.Components
             AssetManager.Instance.DeleteFolder(folderId, unlinkAllowedStatus, nonDeletedSubfolders);
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         protected override Func<IItemsManager> GetFactory()
         {
             return () => new ItemsManager();

--- a/DNN Platform/Modules/ResourceManager/Components/LocalizationController.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/LocalizationController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;
@@ -13,6 +12,7 @@ namespace Dnn.Modules.ResourceManager.Components
     using System.Xml;
 
     using Dnn.Modules.ResourceManager.Components.Models;
+
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Framework;
@@ -26,48 +26,46 @@ namespace Dnn.Modules.ResourceManager.Components
         /// <inheritdoc/>
         public string CultureName => Instance.CultureName;
 
-        /// <inheritdoc/>
-        public Dictionary<string, string> GetLocalizedDictionary(string resourceFile, string culture)
-            => Instance.GetLocalizedDictionary(resourceFile, culture);
+        /// <inheritdoc />
+        public Dictionary<string, string> GetLocalizedDictionary(string resourceFile, string culture) =>
+            Instance.GetLocalizedDictionary(resourceFile, culture);
 
-        /// <inheritdoc/>
-        public Dictionary<string, string> GetLocalizedDictionary(
-            string resourceFile,
-            string culture,
-            Localization localization) => Instance.GetLocalizedDictionary(resourceFile, culture, localization);
+        /// <inheritdoc />
+        public Dictionary<string, string> GetLocalizedDictionary(string resourceFile, string culture, Localization localization) =>
+            Instance.GetLocalizedDictionary(resourceFile, culture, localization);
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public long GetResxTimeStamp(string resourceFile, Localization localization)
             => Instance.GetResxTimeStamp(resourceFile, localization);
 
-        /// <summary>
-        /// Provides a method to override Service Locator's GetFactory method.
-        /// </summary>
-        /// <returns>A <see cref="LocalizationControllerImpl"/>" instance.</returns>
+        /// <inheritdoc />
         protected override Func<ILocalizationController> GetFactory()
         {
-            return () => new LocalizationControllerImpl();
+            return () => new LocalizationControllerImplementation();
         }
 
-        private class LocalizationControllerImpl : ILocalizationController
+        /// <summary>
+        /// The localization controller implementation.
+        /// </summary>
+        private class LocalizationControllerImplementation : ILocalizationController
         {
             private static readonly TimeSpan FiveMinutes = TimeSpan.FromMinutes(5);
             private static readonly TimeSpan OneHour = TimeSpan.FromHours(1);
 
+            /// <inheritdoc />
             public string CultureName
             {
                 get { return Thread.CurrentThread.CurrentUICulture.Name; }
             }
 
+            /// <inheritdoc />
             public long GetResxTimeStamp(string resourceFile, Localization localization)
             {
                 return this.GetLastModifiedTime(resourceFile, this.CultureName, localization).Ticks;
             }
 
-            public Dictionary<string, string> GetLocalizedDictionary(
-                string resourceFile,
-                string culture,
-                Localization localization)
+            /// <inheritdoc />
+            public Dictionary<string, string> GetLocalizedDictionary(string resourceFile, string culture, Localization localization)
             {
                 Requires.NotNullOrEmpty("resourceFile", resourceFile);
                 Requires.NotNullOrEmpty("culture", culture);
@@ -91,7 +89,7 @@ namespace Dnn.Modules.ResourceManager.Components
                 DataCache.SetCache(
                     cacheKey,
                     dictionary,
-                    (DNNCacheDependency)null,
+                    default(DNNCacheDependency),
                     Cache.NoAbsoluteExpiration,
                     FiveMinutes,
                     CacheItemPriority.Normal,
@@ -100,15 +98,7 @@ namespace Dnn.Modules.ResourceManager.Components
                 return dictionary;
             }
 
-            /// <summary>
-            /// Gets a dictionary of localization keys and values.
-            /// </summary>
-            /// <param name="resourceFile">The resource file from which to get the localization values.</param>
-            /// <param name="culture">The culture to use.</param>
-            /// <returns>
-            /// A <see cref="Dictionary{TKey, TValue}"/> where the key is a string representing
-            /// the localization key and the value is a string containing the localized text.
-            /// </returns>
+            /// <inheritdoc />
             public Dictionary<string, string> GetLocalizedDictionary(string resourceFile, string culture)
             {
                 Requires.NotNullOrEmpty("resourceFile", resourceFile);
@@ -132,7 +122,7 @@ namespace Dnn.Modules.ResourceManager.Components
                 DataCache.SetCache(
                     cacheKey,
                     dictionary,
-                    (DNNCacheDependency)null,
+                    default(DNNCacheDependency),
                     Cache.NoAbsoluteExpiration,
                     Constants.FiveMinutes,
                     CacheItemPriority.Normal,
@@ -185,7 +175,6 @@ namespace Dnn.Modules.ResourceManager.Components
                     document.Load(stream);
 
                     var headers = document.SelectNodes(@"/root/resheader").Cast<XmlNode>().ToArray();
-
                     AssertHeaderValue(headers, "resmimetype", "text/microsoft-resx");
 
                     foreach (var xmlNode in document.SelectNodes("/root/data").Cast<XmlNode>())
@@ -232,7 +221,7 @@ namespace Dnn.Modules.ResourceManager.Components
                 DataCache.SetCache(
                     cacheKey,
                     lastModifiedDate,
-                    (DNNCacheDependency)null,
+                    default(DNNCacheDependency),
                     Cache.NoAbsoluteExpiration,
                     OneHour,
                     CacheItemPriority.Normal,
@@ -243,8 +232,8 @@ namespace Dnn.Modules.ResourceManager.Components
 
             private DateTime GetLastModifiedTimeInternal(string resourceFile, string culture)
             {
-                var cultureSpecificFile =
-                    System.Web.HttpContext.Current.Server.MapPath(resourceFile.Replace(".resx", string.Empty) + "." + culture + ".resx");
+                var cultureSpecificFile = System.Web.HttpContext.Current.Server.MapPath(
+                    resourceFile.Replace(".resx", string.Empty) + "." + culture + ".resx");
                 var lastModifiedDate = DateTime.MinValue;
 
                 if (File.Exists(cultureSpecificFile))

--- a/DNN Platform/Modules/ResourceManager/Components/Models/Localization.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/Models/Localization.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components.Models
 {
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Components/Models/ThumbnailContent.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/Models/ThumbnailContent.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components.Models
 {
     using System.Net.Http;

--- a/DNN Platform/Modules/ResourceManager/Components/PermissionHelper.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/PermissionHelper.cs
@@ -9,6 +9,7 @@ namespace Dnn.Modules.ResourceManager.Components
     using System.Linq;
 
     using Dnn.Modules.ResourceManager.Services.Dto;
+
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;

--- a/DNN Platform/Modules/ResourceManager/Components/PermissionsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/PermissionsManager.cs
@@ -1,12 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;
 
     using Dnn.Modules.ResourceManager.Components.Common;
+
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Framework;

--- a/DNN Platform/Modules/ResourceManager/Components/SearchController.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/SearchController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;
@@ -9,6 +8,7 @@ namespace Dnn.Modules.ResourceManager.Components
     using System.Linq;
 
     using Dnn.Modules.ResourceManager.Exceptions;
+
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Services.Assets;
     using DotNetNuke.Services.FileSystem;

--- a/DNN Platform/Modules/ResourceManager/Components/SettingsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/SettingsManager.cs
@@ -1,12 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System.Collections;
 
     using Dnn.Modules.ResourceManager.Exceptions;
+
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
@@ -32,8 +32,8 @@ namespace Dnn.Modules.ResourceManager.Components
             this.groupId = groupId;
             var moduleController = new ModuleController();
             var module = moduleController.GetModule(moduleId);
-            this.moduleSettingsDictionary = module.ModuleSettings;
 
+            this.moduleSettingsDictionary = module.ModuleSettings;
             this.LoadSettings();
         }
 

--- a/DNN Platform/Modules/ResourceManager/Components/ThumbnailsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/ThumbnailsManager.cs
@@ -11,6 +11,7 @@ namespace Dnn.Modules.ResourceManager.Components
     using System.Net.Http;
 
     using Dnn.Modules.ResourceManager.Components.Models;
+
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Framework;

--- a/DNN Platform/Modules/ResourceManager/Components/ThumbnailsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/ThumbnailsManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Components
 {
     using System;
@@ -12,7 +11,6 @@ namespace Dnn.Modules.ResourceManager.Components
 
     using Dnn.Modules.ResourceManager.Components.Models;
 
-    using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Framework;
     using DotNetNuke.Services.FileSystem;
@@ -39,9 +37,24 @@ namespace Dnn.Modules.ResourceManager.Components
         /// </summary>
         private enum ThumbnailExtensions
         {
+            /// <summary>
+            /// A JPEG thumbnail.
+            /// </summary>
             JPEG,
+
+            /// <summary>
+            /// A JPG thumbnail.
+            /// </summary>
             JPG,
+
+            /// <summary>
+            /// A PNG thumbnail.
+            /// </summary>
             PNG,
+
+            /// <summary>
+            /// A GIF thumbnail.
+            /// </summary>
             GIF,
         }
 

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -32,6 +32,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>7</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -44,6 +45,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>7</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -260,6 +260,13 @@
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
     <None Include="packages.config" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -254,11 +254,6 @@
     <Content Include="App_LocalResources\EditFolderMapping.ascx.resx" />
   </ItemGroup>
   <ItemGroup>
-    <AdditionalFiles Include="..\..\..\stylecop.json">
-      <Link>stylecop.json</Link>
-    </AdditionalFiles>
-  </ItemGroup>
-  <ItemGroup>
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
     <None Include="packages.config" />

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -31,6 +31,7 @@
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>7</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -42,6 +43,7 @@
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>7</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -254,8 +254,6 @@
     <Content Include="App_LocalResources\EditFolderMapping.ascx.resx" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
     <None Include="packages.config" />
     <Content Include="web.config" />
     <None Include="web.Debug.config">

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -56,9 +56,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\Packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -55,6 +55,8 @@
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\Packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
@@ -255,6 +257,7 @@
   <ItemGroup>
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <None Include="packages.config" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -155,6 +155,9 @@
     <Compile Include="View.ascx.designer.cs">
       <DependentUpon>View.ascx</DependentUpon>
     </Compile>
+    <AdditionalFiles Include="..\..\..\stylecop.json">
+      <Link>stylecop.json</Link>
+    </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
     <Content Include="EditFolderMapping.ascx" />
@@ -269,6 +272,10 @@
     <None Include="web.Release.config">
       <DependentUpon>web.config</DependentUpon>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DNN Platform/Modules/ResourceManager/Exceptions/FolderPermissionNotMetException.cs
+++ b/DNN Platform/Modules/ResourceManager/Exceptions/FolderPermissionNotMetException.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Exceptions
 {
     using System;

--- a/DNN Platform/Modules/ResourceManager/Exceptions/ModeValidationException.cs
+++ b/DNN Platform/Modules/ResourceManager/Exceptions/ModeValidationException.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Exceptions
 {
     using System;

--- a/DNN Platform/Modules/ResourceManager/Exceptions/NotFoundException.cs
+++ b/DNN Platform/Modules/ResourceManager/Exceptions/NotFoundException.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Exceptions
 {
     using System;

--- a/DNN Platform/Modules/ResourceManager/Helpers/LocalizationHelper.cs
+++ b/DNN Platform/Modules/ResourceManager/Helpers/LocalizationHelper.cs
@@ -1,10 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Helpers
 {
     using Dnn.Modules.ResourceManager.Components;
+
     using DotNetNuke.Services.Localization;
 
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Modules/ResourceManager/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/DNN Platform/Modules/ResourceManager/Services/Attributes/ResourceManagerExceptionFilter.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Attributes/ResourceManagerExceptionFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Attributes
 {
     using System.Net;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/CreateNewFolderRequest.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/CreateNewFolderRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/DeleteFileRequest.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/DeleteFileRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/DeleteFolderRequest.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/DeleteFolderRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/FileDetailsRequest.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/FileDetailsRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Runtime.Serialization;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/FolderDetailsRequest.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/FolderDetailsRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Runtime.Serialization;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/FolderPermissions.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/FolderPermissions.cs
@@ -1,12 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Linq;
 
     using Dnn.Modules.ResourceManager.Components;
+
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Security.Permissions;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/Permission.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/Permission.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Runtime.Serialization;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/Permissions.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/Permissions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Collections.Generic;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/RolePermission.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/RolePermission.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Collections.Generic;

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/ThumbnailDownloadRequest.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/ThumbnailDownloadRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     /// <summary>

--- a/DNN Platform/Modules/ResourceManager/Services/Dto/UserPermission.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/Dto/UserPermission.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services.Dto
 {
     using System.Collections.Generic;

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services
 {
     using System;
@@ -17,6 +16,7 @@ namespace Dnn.Modules.ResourceManager.Services
     using Dnn.Modules.ResourceManager.Helpers;
     using Dnn.Modules.ResourceManager.Services.Attributes;
     using Dnn.Modules.ResourceManager.Services.Dto;
+
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Icons;
@@ -24,7 +24,6 @@ namespace Dnn.Modules.ResourceManager.Services
     using DotNetNuke.Security.Permissions;
     using DotNetNuke.Services.Assets;
     using DotNetNuke.Services.FileSystem;
-    using DotNetNuke.UI.Modules;
     using DotNetNuke.Web.Api;
 
     using CreateNewFolderRequest = Dnn.Modules.ResourceManager.Services.Dto.CreateNewFolderRequest;
@@ -158,8 +157,9 @@ namespace Dnn.Modules.ResourceManager.Services
             var isSuperTab = this.PortalSettings.ActiveTab != null && this.PortalSettings.ActiveTab.IsSuperTab;
 
             var mappings = FolderMappingController.Instance.GetFolderMappings(
-                isSuperTab && this.UserInfo.IsSuperUser ? Null.NullInteger : this.PortalSettings.PortalId);
-            var moduleContext = this.GetModuleContext();
+                isSuperTab && UserInfo.IsSuperUser ? 
+                    Null.NullInteger : 
+                    PortalSettings.PortalId);
 
             var r = from m in mappings
                     select new

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -165,6 +165,7 @@ namespace Dnn.Modules.ResourceManager.Services
         {
             var isSuperTab = this.PortalSettings.ActiveTab != null && this.PortalSettings.ActiveTab.IsSuperTab;
 
+            var moduleContext = this.GetModuleContext();
             var mappings = FolderMappingController.Instance.GetFolderMappings(
                 isSuperTab && this.UserInfo.IsSuperUser ?
                     Null.NullInteger :
@@ -179,7 +180,7 @@ namespace Dnn.Modules.ResourceManager.Services
                         IsDefault =
                         m.MappingName == "Standard" || m.MappingName == "Secure" || m.MappingName == "Database",
                         editUrl = this.UserInfo.IsAdmin ?
-                            this.GetModuleContext().EditUrl(
+                            moduleContext.EditUrl(
                                 "ItemID",
                                 m.FolderMappingID.ToString(),
                                 "EditFolderMapping",

--- a/DNN Platform/Modules/ResourceManager/Services/LocalizationController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/LocalizationController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services
 {
     using System.Net;

--- a/DNN Platform/Modules/ResourceManager/Services/RouteMapper.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/RouteMapper.cs
@@ -1,17 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager.Services
 {
     using DotNetNuke.Web.Api;
 
-    /// <summary>
-    /// Registers the WebApi routes for the resource manager module.
-    /// </summary>
+    /// <inheritdoc />
     public class RouteMapper : IServiceRouteMapper
     {
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public void RegisterRoutes(IMapRoute mapRouteManager)
         {
             mapRouteManager.MapHttpRoute("ResourceManager", "default", "{controller}/{action}", new[] { "Dnn.Modules.ResourceManager.Services" });

--- a/DNN Platform/Modules/ResourceManager/Settings.ascx.cs
+++ b/DNN Platform/Modules/ResourceManager/Settings.ascx.cs
@@ -54,7 +54,6 @@ namespace Dnn.Modules.ResourceManager
             }
             catch (Exception exc)
             {
-                // Module failed to load
                 DnnExceptions.ProcessModuleLoadException(this, exc);
             }
         }
@@ -71,7 +70,6 @@ namespace Dnn.Modules.ResourceManager
             }
             catch (Exception exc)
             {
-                // Module failed to load
                 DnnExceptions.ProcessModuleLoadException(this, exc);
             }
         }

--- a/DNN Platform/Modules/ResourceManager/Settings.ascx.cs
+++ b/DNN Platform/Modules/ResourceManager/Settings.ascx.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager
 {
     using System;
@@ -55,6 +54,7 @@ namespace Dnn.Modules.ResourceManager
             }
             catch (Exception exc)
             {
+                // Module failed to load
                 DnnExceptions.ProcessModuleLoadException(this, exc);
             }
         }
@@ -71,6 +71,7 @@ namespace Dnn.Modules.ResourceManager
             }
             catch (Exception exc)
             {
+                // Module failed to load
                 DnnExceptions.ProcessModuleLoadException(this, exc);
             }
         }

--- a/DNN Platform/Modules/ResourceManager/View.ascx.cs
+++ b/DNN Platform/Modules/ResourceManager/View.ascx.cs
@@ -105,7 +105,7 @@ namespace Dnn.Modules.ResourceManager
         /// <summary>
         /// Gets the timestamp of the localization resource file.
         /// </summary>
-        protected string ResxTimeStamp => 
+        protected string ResxTimeStamp =>
             LocalizationController.Instance.GetResxTimeStamp(Constants.ViewResourceFileName, Constants.ResourceManagerLocalization).ToString();
 
         /// <summary>

--- a/DNN Platform/Modules/ResourceManager/View.ascx.cs
+++ b/DNN Platform/Modules/ResourceManager/View.ascx.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.Modules.ResourceManager
 {
     using System;
@@ -106,9 +105,8 @@ namespace Dnn.Modules.ResourceManager
         /// <summary>
         /// Gets the timestamp of the localization resource file.
         /// </summary>
-        protected string ResxTimeStamp => LocalizationController.Instance.GetResxTimeStamp(
-            Constants.ViewResourceFileName,
-            Constants.ResourceManagerLocalization).ToString();
+        protected string ResxTimeStamp => 
+            LocalizationController.Instance.GetResxTimeStamp(Constants.ViewResourceFileName, Constants.ResourceManagerLocalization).ToString();
 
         /// <summary>
         /// Gets the id of the home folder.
@@ -217,6 +215,7 @@ namespace Dnn.Modules.ResourceManager
             }
             catch (Exception exc)
             {
+                // Module failed to load
                 DnnExceptions.ProcessModuleLoadException(exc.Message, this, exc);
             }
         }

--- a/DNN Platform/Modules/ResourceManager/View.ascx.cs
+++ b/DNN Platform/Modules/ResourceManager/View.ascx.cs
@@ -215,7 +215,6 @@ namespace Dnn.Modules.ResourceManager
             }
             catch (Exception exc)
             {
-                // Module failed to load
                 DnnExceptions.ProcessModuleLoadException(exc.Message, this, exc);
             }
         }

--- a/DNN Platform/Modules/ResourceManager/packages.config
+++ b/DNN Platform/Modules/ResourceManager/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net472" />
+</packages>

--- a/DNN Platform/Modules/ResourceManager/packages.config
+++ b/DNN Platform/Modules/ResourceManager/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net472" />
+  <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/DNN Platform/Modules/ResourceManager/web.Debug.config
+++ b/DNN Platform/Modules/ResourceManager/web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/DNN Platform/Modules/ResourceManager/web.Release.config
+++ b/DNN Platform/Modules/ResourceManager/web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/DNN Platform/Modules/ResourceManager/web.config
+++ b/DNN Platform/Modules/ResourceManager/web.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<configuration>
+
+  <system.web>
+    <compilation debug="true" targetFramework="4.7.2"/>
+    <httpRuntime targetFramework="4.7.2"/>
+  </system.web>
+
+	<runtime>
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>

--- a/DNN Platform/Modules/ResourceManager/web.config
+++ b/DNN Platform/Modules/ResourceManager/web.config
@@ -9,10 +9,6 @@
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
 			</dependentAssembly>

--- a/DNN Platform/Modules/ResourceManager/web.config
+++ b/DNN Platform/Modules/ResourceManager/web.config
@@ -1,16 +1,20 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2"/>
-    <httpRuntime targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.7.2" />
+    <httpRuntime targetFramework="4.7.2" />
   </system.web>
 
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>


### PR DESCRIPTION
## Summary
- Added necessary files and NuGet packages to enable StyleCop
- Enabled `TreatBuildWarningsAsErrors` for both Debug and Release Modes
- Fixed build warnings with Newtonsoft.json - There needs to be a local web.config file to build correctly, let's make sure we keep that in there even if it isn't used as part of the build.
- Updated the entire module to meet our coding standards set by stylecop

cc: @valadas @bdukes @mitchelsellers 