### PR TITLE
Update SMTP Test Email Logic

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
@@ -102,7 +102,8 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                var mailFrom = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.Email;
+                var smtpHostMode = request.SmtpServerMode == "h";
+                var mailFrom = smtpHostMode ? Host.HostEmail : this.PortalSettings.Email;
                 var mailTo = this.UserInfo.Email;
 
                 var errMessage = Mail.SendMail(mailFrom,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
@@ -102,8 +102,7 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                var smtpHostMode = request.SmtpServerMode == "h";
-                var mailFrom = smtpHostMode ? Host.HostEmail : this.PortalSettings.Email;
+                var mailFrom = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.Email;
                 var mailTo = this.UserInfo.Email;
 
                 var errMessage = Mail.SendMail(mailFrom,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
@@ -69,7 +69,7 @@ namespace Dnn.PersonaBar.Servers.Services
                 var portalId = PortalSettings.Current.PortalId;
                 PortalController.UpdatePortalSetting(portalId, "SMTPmode", request.SmtpServerMode, false);
 
-                //admins can only change site settings
+                // admins can only change site settings
                 PortalController.UpdatePortalSetting(portalId, "SMTPServer", request.SmtpServer, false);
                 PortalController.UpdatePortalSetting(portalId, "SMTPConnectionLimit", request.SmtpConnectionLimit, false);
                 PortalController.UpdatePortalSetting(portalId, "SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
@@ -128,8 +128,12 @@ namespace Dnn.PersonaBar.Servers.Services
                     success,
                     errMessage,
                     confirmationMessage =
-                        string.Format(Localization.GetString("EmailSentMessage", Components.Constants.ServersResourcersPath),
-                        mailFrom, mailTo)
+                        string.Format(
+                            Localization.GetString(
+                                "EmailSentMessage",
+                                Components.Constants.ServersResourcersPath),
+                            mailFrom,
+                            mailTo),
                 });
             }
             catch (Exception exc)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -127,8 +127,8 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                var mailFrom = Host.HostEmail;
-                var mailTo = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.UserInfo.Email;
+                var mailFrom = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.Email;
+                var mailTo = this.UserInfo.Email;
 
                 var errMessage = Mail.SendMail(mailFrom,
                     mailTo,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -127,7 +127,8 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                var mailFrom = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.Email;
+                var smtpHostMode = request.SmtpServerMode == "h";
+                var mailFrom = smtpHostMode ? Host.HostEmail : this.PortalSettings.Email;
                 var mailTo = this.UserInfo.Email;
 
                 var errMessage = Mail.SendMail(mailFrom,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -127,8 +127,7 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                var smtpHostMode = request.SmtpServerMode == "h";
-                var mailFrom = smtpHostMode ? Host.HostEmail : this.PortalSettings.Email;
+                var mailFrom = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.Email;
                 var mailTo = this.UserInfo.Email;
 
                 var errMessage = Mail.SendMail(mailFrom,
@@ -141,20 +140,24 @@ namespace Dnn.PersonaBar.Servers.Services
                     Encoding.UTF8,
                     "",
                     "",
-                    smtpHostMode ? HostController.Instance.GetString("SMTPServer") : request.SmtpServer,
-                    smtpHostMode ? HostController.Instance.GetString("SMTPAuthentication") : request.SmtpAuthentication.ToString(),
-                    smtpHostMode ? HostController.Instance.GetString("SMTPUsername") : request.SmtpUsername,
-                    smtpHostMode ? HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey()) : request.SmtpPassword,
-                    smtpHostMode ? HostController.Instance.GetBoolean("SMTPEnableSSL", false) : request.EnableSmtpSsl);
+                    request.SmtpServer,
+                    request.SmtpAuthentication.ToString(),
+                    request.SmtpUsername,
+                    request.SmtpPassword,
+                    request.EnableSmtpSsl);
 
                 var success = string.IsNullOrEmpty(errMessage);
                 return this.Request.CreateResponse(success ? HttpStatusCode.OK : HttpStatusCode.BadRequest, new
                 {
                     success,
                     errMessage,
-                    confirmationMessage = success ?
-                        string.Format(Localization.GetString("EmailSentMessage", Components.Constants.ServersResourcersPath),
-                        mailFrom, mailTo) : Localization.GetString("errorMessageSendingTestEmail")
+                    confirmationMessage =
+                        string.Format(
+                            Localization.GetString(
+                                "EmailSentMessage",
+                                Components.Constants.ServersResourcersPath),
+                            mailFrom,
+                            mailTo),
                 });
             }
             catch (Exception exc)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -141,11 +141,11 @@ namespace Dnn.PersonaBar.Servers.Services
                     Encoding.UTF8,
                     "",
                     "",
-                    request.SmtpServer,
-                    request.SmtpAuthentication.ToString(),
-                    request.SmtpUsername,
-                    request.SmtpPassword,
-                    request.EnableSmtpSsl);
+                    smtpHostMode ? HostController.Instance.GetString("SMTPServer") : request.SmtpServer,
+                    smtpHostMode ? HostController.Instance.GetString("SMTPAuthentication") : request.SmtpAuthentication.ToString(),
+                    smtpHostMode ? HostController.Instance.GetString("SMTPUsername") : request.SmtpUsername,
+                    smtpHostMode ? HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey()) : request.SmtpPassword,
+                    smtpHostMode ? HostController.Instance.GetBoolean("SMTPEnableSSL", false) : request.EnableSmtpSsl);
 
                 var success = string.IsNullOrEmpty(errMessage);
                 return this.Request.CreateResponse(success ? HttpStatusCode.OK : HttpStatusCode.BadRequest, new

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -86,20 +86,17 @@ namespace Dnn.PersonaBar.Servers.Services
                     HostController.Instance.Update("SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
                     HostController.Instance.Update("SMTPAuthentication", request.SmtpAuthentication.ToString(), false);
                     HostController.Instance.Update("SMTPUsername", request.SmtpUsername, false);
-                    HostController.Instance.UpdateEncryptedString("SMTPPassword", request.SmtpPassword,
-                        Config.GetDecryptionkey());
+                    HostController.Instance.UpdateEncryptedString("SMTPPassword", request.SmtpPassword, Config.GetDecryptionkey());
                     HostController.Instance.Update("HostEmail", request.SmtpHostEmail);
                     HostController.Instance.Update("SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
-                    HostController.Instance.Update("MessageSchedulerBatchSize",
-                        request.MessageSchedulerBatchSize.ToString(), false);
+                    HostController.Instance.Update("MessageSchedulerBatchSize", request.MessageSchedulerBatchSize.ToString(), false);
                 }
                 else
                 {
                     PortalController.UpdatePortalSetting(portalId, "SMTPServer", request.SmtpServer, false);
                     PortalController.UpdatePortalSetting(portalId, "SMTPConnectionLimit", request.SmtpConnectionLimit, false);
                     PortalController.UpdatePortalSetting(portalId, "SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
-                    PortalController.UpdatePortalSetting(portalId, "SMTPAuthentication",
-                        request.SmtpAuthentication.ToString(), false);
+                    PortalController.UpdatePortalSetting(portalId, "SMTPAuthentication", request.SmtpAuthentication.ToString(), false);
                     PortalController.UpdatePortalSetting(portalId, "SMTPUsername", request.SmtpUsername, false);
                     PortalController.UpdateEncryptedString(portalId, "SMTPPassword", request.SmtpPassword, Config.GetDecryptionkey());
                     PortalController.UpdatePortalSetting(portalId, "SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
@@ -176,7 +173,7 @@ namespace Dnn.PersonaBar.Servers.Services
             }
             catch (Exception)
             {
-                //fixes case where smtppassword failed to encrypt due to failing upgrade
+                // fixes case where smtppassword failed to encrypt due to failing upgrade
                 var current = HostController.Instance.GetString("SMTPPassword");
                 if (!string.IsNullOrEmpty(current))
                 {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -149,12 +149,14 @@ namespace Dnn.PersonaBar.Servers.Services
                     success,
                     errMessage,
                     confirmationMessage =
-                        string.Format(
-                            Localization.GetString(
-                                "EmailSentMessage",
-                                Components.Constants.ServersResourcersPath),
-                            mailFrom,
-                            mailTo),
+                        success
+                            ? string.Format(
+                                Localization.GetString(
+                                    "EmailSentMessage",
+                                    Components.Constants.ServersResourcersPath),
+                                mailFrom,
+                                mailTo)
+                            : Localization.GetString("errorMessageSendingTestEmail"),
                 });
             }
             catch (Exception exc)


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #3813 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Simplifies and makes the logic for TEST SMTP emails used **FROM** and **TO** and utilizes newer logic for both a Host or an Administrator when sending a test email.

Somehow the previous didnt get merged.  I think this code change refines things a bit to get the job done as expected.