### PR TITLE
Resolve styling issue for checked Accept License checkbox in Extension installer

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/Checkbox/style.less
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/Checkbox/style.less
@@ -21,7 +21,7 @@
     .checkbox {
         position: relative;
         display: inline;
-        margin-right: 15px;
+        margin-right: 20px;
         > label {
             width: 13px;
             height: 13px;
@@ -34,7 +34,6 @@
             & + label {
                 position: absolute;
                 top: 0px;
-                left: 0px;
                 background: white;
                 border: 1px solid @thunder;
                 cursor: pointer;


### PR DESCRIPTION
Resolves #3912 

## Summary
This PR resolves an annoying quirk where the `Accept License` checkbox jumps when checked (Extensions > Install Extensions).

### Accept License Unchecked
![image](https://user-images.githubusercontent.com/4568451/93693133-baf1ca00-fac9-11ea-83ac-8aad24ec1659.png)

### Accept License Checked
![image](https://user-images.githubusercontent.com/4568451/93693137-cb09a980-fac9-11ea-8eab-53d430719972.png)
