### PR TITLE
Fixed an issue where the React common components would interfere with container css class

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/ScrollBar/styles.less
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/ScrollBar/styles.less
@@ -1,18 +1,18 @@
-.container {
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  position: relative;
-  background: white;
-
-  padding: 0px;
-}
 
 .area {
   margin: 0 auto;
   width: 175px;
   min-height: 109px;
   background: white;
+  .container {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    position: relative;
+    background: white;
+  
+    padding: 0px;
+  }
 
   .content {
     width: 400px;


### PR DESCRIPTION
Closes #4107
This scopes the `container` styles inside the `area` class for the Scrollbars common component. It looks like this component is only used once in all our modules in the Pages module for the list of pages scroll area. I have done some testing and it looks all like before.

Before:
![image](https://user-images.githubusercontent.com/6371568/93724570-27c29e00-fb76-11ea-853c-bf968b57924c.png)

After:
![image](https://user-images.githubusercontent.com/6371568/93724573-34df8d00-fb76-11ea-8e26-ae6b741619a4.png)
