### PR TITLE
Removal of references to the Dashboard Project Type

### DIFF
--- a/DNN Platform/Library/Services/Installer/Util.cs
+++ b/DNN Platform/Library/Services/Installer/Util.cs
@@ -616,12 +616,6 @@ namespace DotNetNuke.Services.Installer
         public static string CONFIG_Committed = GetLocalizedString("CONFIG_Committed");
         public static string CONFIG_RolledBack = GetLocalizedString("CONFIG_RolledBack");
         public static string CONFIG_Updated = GetLocalizedString("CONFIG_Updated");
-        public static string DASHBOARD_ReadSuccess = GetLocalizedString("DASHBOARD_ReadSuccess");
-        public static string DASHBOARD_SrcMissing = GetLocalizedString("DASHBOARD_SrcMissing");
-        public static string DASHBOARD_Registered = GetLocalizedString("DASHBOARD_Registered");
-        public static string DASHBOARD_KeyMissing = GetLocalizedString("DASHBOARD_KeyMissing");
-        public static string DASHBOARD_LocalResourcesMissing = GetLocalizedString("DASHBOARD_LocalResourcesMissing");
-        public static string DASHBOARD_UnRegistered = GetLocalizedString("DASHBOARD_UnRegistered");
         public static string DNN_Reading = GetLocalizedString("DNN_Reading");
         public static string DNN_ReadingComponent = GetLocalizedString("DNN_ReadingComponent");
         public static string DNN_ReadingPackage = GetLocalizedString("DNN_ReadingPackage");

--- a/DNN Platform/Website/App_GlobalResources/SharedResources.resx
+++ b/DNN Platform/Website/App_GlobalResources/SharedResources.resx
@@ -1404,24 +1404,6 @@
   <data name="TokenReplaceUnknownObject.Text" xml:space="preserve">
     <value>Error accessing [{0}:{1}], {0} is an unknown datasource.</value>
   </data>
-  <data name="DASHBOARD_KeyMissing.Text" xml:space="preserve">
-    <value>Required field Key is missing from Manifest.</value>
-  </data>
-  <data name="DASHBOARD_LocalResourcesMissing.Text" xml:space="preserve">
-    <value>Required field LocalResources is missing from Manifest.</value>
-  </data>
-  <data name="DASHBOARD_ReadSuccess.Text" xml:space="preserve">
-    <value>Parsed Dashboard Control Manifest successfully.</value>
-  </data>
-  <data name="DASHBOARD_Registered.Text" xml:space="preserve">
-    <value>Dashboard Control registered successfully.</value>
-  </data>
-  <data name="DASHBOARD_SrcMissing.Text" xml:space="preserve">
-    <value>Required field Src is missing from Manifest.</value>
-  </data>
-  <data name="DASHBOARD_UnRegistered.Text" xml:space="preserve">
-    <value>Dashboard Control unregistered successfully.</value>
-  </data>
   <data name="SKIN_Installed.Text" xml:space="preserve">
     <value>Theme already installed with a different Package Name.</value>
   </data>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Constants.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Constants.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
+using System;
+
 namespace Dnn.PersonaBar.Extensions.Components
 {
     public enum PackageTypes
@@ -12,7 +14,6 @@ namespace Dnn.PersonaBar.Extensions.Components
         Auth_System = AuthSystem,
         Container,
         CoreLanguagePack,
-        DashboardControl,
         ExtensionLanguagePack,
         EvoqConnector,
         JavascriptLibrary,
@@ -51,8 +52,6 @@ namespace Dnn.PersonaBar.Extensions.Components
         internal const string DefaultProviderImage = "icon_provider.gif";
         internal const string DefaultLibraryImage = "icon_library.png";
         internal const string DefaultWidgetImage = "icon_widget.png";
-        internal const string DefaultDashboardImage = "icon_dashboard.png";
-
         internal const string DnnAuthTypeName = "DNN";
         internal const string SharedResources = Library.Constants.PersonaBarRelativePath + "/Modules/Dnn.Extensions/App_LocalResources/Extensions.resx";
     }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/ExtensionsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/ExtensionsController.cs
@@ -250,8 +250,6 @@ namespace Dnn.PersonaBar.Extensions.Components
                     return IconExists(package.IconFile) ? FixIconUrl(package.IconFile) : Globals.ImagePath + Constants.DefaultProviderImage;
                 case "widget":
                     return IconExists(package.IconFile) ? FixIconUrl(package.IconFile) : Globals.ImagePath + Constants.DefaultWidgetImage;
-                case "dashboardcontrol":
-                    return IconExists(package.IconFile) ? FixIconUrl(package.IconFile) : Globals.ImagePath + Constants.DefaultDashboardImage;
                 case "library":
                     return IconExists(package.IconFile) ? FixIconUrl(package.IconFile) : Globals.ImagePath + Constants.DefaultLibraryImage;
                 default:

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Extensions/App_LocalResources/Extensions.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Extensions/App_LocalResources/Extensions.resx
@@ -249,9 +249,6 @@
   <data name="CoreLanguagePack.Type" xml:space="preserve">
     <value>Core Language Packs</value>
   </data>
-  <data name="DashboardControl.Type" xml:space="preserve">
-    <value>Dashboard Controls</value>
-  </data>
   <data name="ExtensionLanguagePack.Type" xml:space="preserve">
     <value>Extension Language Packs</value>
   </data>


### PR DESCRIPTION
Fixes #4114 

Upon further review, since version 8.0.0 it has been impossible to install, or uninstall Dashboard components.  However, there were lingering references.  Given this, I have opted in this PR to remove the references rather than simply flagging as there wasn't anything easily flaggable.  I can adjust if needed.
