### PR TITLE
Treat warnings as errors for DotNetNuke.Instrumentation

### DIFF
--- a/DNN Platform/DotNetNuke.Instrumentation/DnnLog.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/DnnLog.cs
@@ -12,6 +12,7 @@ namespace DotNetNuke.Instrumentation
 
     using log4net.Config;
 
+    /// <summary>Provides access to logging methods.  Obsolete, use <see cref="LoggerSource"/> instead.</summary>
     [Obsolete("Deprecated in 7.0.1 due to poor performance, use LoggerSource.Instance. Scheduled removal in v11.0.0.")]
     public static class DnnLog
     {
@@ -19,10 +20,9 @@ namespace DotNetNuke.Instrumentation
         private static readonly DnnLogger Logger = DnnLogger.GetClassLogger(typeof(DnnLog));
 
         private static readonly object ConfigLock = new object();
-        private static bool _configured;
+        private static bool isConfigured;
 
         // use a single static logger to avoid the performance impact of type reflection on every call for logging
-
         private static StackFrame CallingFrame
         {
             get
@@ -68,9 +68,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
-        /// <summary>
-        ///   Standard method to use on method exit.
-        /// </summary>
+        /// <summary>Standard method to use on method exit.</summary>
+        /// <param name="returnObject">The return value of the method.</param>
         public static void MethodExit(object returnObject)
         {
             EnsureConfig();
@@ -99,6 +98,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Logs a message at the Trace log level.</summary>
+        /// <param name="message">The message to log.</param>
         public static void Trace(string message)
         {
             EnsureConfig();
@@ -109,6 +110,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Trace(string format, params object[] args)
         {
             EnsureConfig();
@@ -119,6 +123,10 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Trace(IFormatProvider provider, string format, params object[] args)
         {
             EnsureConfig();
@@ -129,6 +137,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Logs a message at the Debug log level.</summary>
+        /// <param name="message">The message to log.</param>
         public static void Debug(object message)
         {
             EnsureConfig();
@@ -139,6 +149,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Debug log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Debug(string format, params object[] args)
         {
             EnsureConfig();
@@ -156,6 +169,10 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Debug log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Debug(IFormatProvider provider, string format, params object[] args)
         {
             EnsureConfig();
@@ -166,6 +183,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Logs a message at the Info log level.</summary>
+        /// <param name="message">The message to log.</param>
         public static void Info(object message)
         {
             EnsureConfig();
@@ -175,6 +194,10 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Info log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Info(IFormatProvider provider, string format, params object[] args)
         {
             EnsureConfig();
@@ -184,6 +207,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Info log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Info(string format, params object[] args)
         {
             EnsureConfig();
@@ -200,6 +226,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message and exception details at the Warn log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         public static void Warn(string message, Exception exception)
         {
             EnsureConfig();
@@ -209,6 +238,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Logs a message at the Warn log level.</summary>
+        /// <param name="message">The message to log.</param>
         public static void Warn(object message)
         {
             EnsureConfig();
@@ -218,6 +249,10 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Warn log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Warn(IFormatProvider provider, string format, params object[] args)
         {
             EnsureConfig();
@@ -227,6 +262,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Warn log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Warn(string format, params object[] args)
         {
             EnsureConfig();
@@ -243,6 +281,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message and exception details at the Error log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         public static void Error(string message, Exception exception)
         {
             EnsureConfig();
@@ -253,6 +294,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Logs a message at the Error log level.</summary>
+        /// <param name="message">The message to log.</param>
         public static void Error(object message)
         {
             EnsureConfig();
@@ -262,6 +305,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log exception details at the Error log level.</summary>
+        /// <param name="exception">An exception to include in the log.</param>
         public static void Error(Exception exception)
         {
             EnsureConfig();
@@ -271,6 +316,10 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Error log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Error(IFormatProvider provider, string format, params object[] args)
         {
             EnsureConfig();
@@ -280,6 +329,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Error log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Error(string format, params object[] args)
         {
             EnsureConfig();
@@ -296,6 +348,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message and exception details at the Fatal log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         public static void Fatal(string message, Exception exception)
         {
             EnsureConfig();
@@ -305,6 +360,8 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Logs a message at the Fatal log level.</summary>
+        /// <param name="message">The message to log.</param>
         public static void Fatal(object message)
         {
             EnsureConfig();
@@ -314,6 +371,10 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Fatal log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Fatal(IFormatProvider provider, string format, params object[] args)
         {
             EnsureConfig();
@@ -323,6 +384,9 @@ namespace DotNetNuke.Instrumentation
             }
         }
 
+        /// <summary>Log a message at the Fatal log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Fatal(string format, params object[] args)
         {
             EnsureConfig();
@@ -341,11 +405,11 @@ namespace DotNetNuke.Instrumentation
 
         private static void EnsureConfig()
         {
-            if (!_configured)
+            if (!isConfigured)
             {
                 lock (ConfigLock)
                 {
-                    if (!_configured)
+                    if (!isConfigured)
                     {
                         var configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFile);
                         var originalPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config\\" + ConfigFile);
@@ -359,7 +423,7 @@ namespace DotNetNuke.Instrumentation
                             XmlConfigurator.ConfigureAndWatch(new FileInfo(configPath));
                         }
 
-                        _configured = true;
+                        isConfigured = true;
                     }
                 }
             }

--- a/DNN Platform/DotNetNuke.Instrumentation/DnnLogger.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/DnnLogger.cs
@@ -15,23 +15,15 @@ namespace DotNetNuke.Instrumentation
     using log4net.Repository;
     using log4net.Util;
 
-    /// <summary>
-    /// Please use LoggerSource.Instance as a more unit testable way to create loggers.
-    /// </summary>
+    /// <summary>Please use LoggerSource.Instance as a more unit testable way to create loggers.</summary>
     public sealed class DnnLogger : LoggerWrapperImpl
     {
-        internal static Level LevelTrace;
-        internal static Level LevelDebug;
-        internal static Level LevelInfo;
-        internal static Level LevelWarn;
-        internal static Level LevelError;
-        internal static Level LevelFatal;
-
         // add custom logging levels (below trace value of 20000)
-        internal static Level LevelLogInfo = new Level(10001, "LogInfo");
-        internal static Level LevelLogError = new Level(10002, "LogError");
-        private readonly Type _dnnExceptionType = BuildManager.GetType("DotNetNuke.Services.Exceptions.Exceptions", false);
-        private readonly Type _stackBoundary = typeof(DnnLogger);
+        private static Level levelLogInfo = new Level(10001, "LogInfo");
+        private static Level levelLogError = new Level(10002, "LogError");
+
+        private readonly Type dnnExceptionType = BuildManager.GetType("DotNetNuke.Services.Exceptions.Exceptions", false);
+        private readonly Type stackBoundary = typeof(DnnLogger);
 
         private DnnLogger(ILogger logger)
             : base(logger)
@@ -43,28 +35,52 @@ namespace DotNetNuke.Instrumentation
                 int frameDepth = 0;
                 Type methodType = stack[frameDepth].GetMethod().ReflectedType;
 #pragma warning disable 612, 618
-                while (methodType == this._dnnExceptionType || methodType == typeof(DnnLogger) || methodType == typeof(DnnLog) || methodType == typeof(Control))
+                while (methodType == this.dnnExceptionType || methodType == typeof(DnnLogger) || methodType == typeof(DnnLog) || methodType == typeof(Control))
 #pragma warning restore 612, 618
                 {
                     frameDepth++;
                     methodType = stack[frameDepth].GetMethod().ReflectedType;
                 }
 
-                this._stackBoundary = new StackTrace().GetFrame(frameDepth - 1).GetMethod().DeclaringType;
+                this.stackBoundary = new StackTrace().GetFrame(frameDepth - 1).GetMethod().DeclaringType;
             }
             else
             {
-                this._stackBoundary = typeof(DnnLogger);
+                this.stackBoundary = typeof(DnnLogger);
             }
 
             ReloadLevels(logger.Repository);
         }
 
+        /// <summary>Gets the trace log level.</summary>
+        internal static Level LevelTrace { get; private set; }
+
+        /// <summary>Gets the debug log level.</summary>
+        internal static Level LevelDebug { get; private set; }
+
+        /// <summary>Gets the info log level.</summary>
+        internal static Level LevelInfo { get; private set; }
+
+        /// <summary>Gets the warn log level.</summary>
+        internal static Level LevelWarn { get; private set; }
+
+        /// <summary>Gets the error log level.</summary>
+        internal static Level LevelError { get; private set; }
+
+        /// <summary>Gets the fatal log level.</summary>
+        internal static Level LevelFatal { get; private set; }
+
+        /// <summary>Gets the logger for the given <paramref name="type"/>.</summary>
+        /// <param name="type">The type for which to get a logger instance.</param>
+        /// <returns>A new <see cref="DnnLogger"/> instance.</returns>
         public static DnnLogger GetClassLogger(Type type)
         {
             return new DnnLogger(LogManager.GetLogger(Assembly.GetCallingAssembly(), type).Logger);
         }
 
+        /// <summary>Gets the logger for the given <paramref name="name"/>.</summary>
+        /// <param name="name">The name for the logger instance.</param>
+        /// <returns>A new <see cref="DnnLogger"/> instance.</returns>
         public static DnnLogger GetLogger(string name)
         {
             return new DnnLogger(LogManager.GetLogger(name).Logger);
@@ -95,7 +111,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void Debug(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelDebug, message, null);
+            this.Logger.Log(this.stackBoundary, LevelDebug, message, null);
         }
 
         /// <summary>
@@ -122,7 +138,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void DebugFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelDebug, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelDebug, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
         /// <summary>
@@ -145,7 +161,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void DebugFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelDebug, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelDebug, new SystemStringFormat(provider, format, args), null);
         }
 
         /// <summary>
@@ -173,7 +189,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void Info(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelInfo, message, null);
+            this.Logger.Log(this.stackBoundary, LevelInfo, message, null);
         }
 
         /// <summary>
@@ -200,7 +216,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void InfoFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelInfo, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelInfo, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
         /// <summary>
@@ -223,7 +239,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void InfoFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelInfo, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelInfo, new SystemStringFormat(provider, format, args), null);
         }
 
         /// <summary>
@@ -251,7 +267,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void Warn(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelWarn, message, null);
+            this.Logger.Log(this.stackBoundary, LevelWarn, message, null);
         }
 
         /// <summary>
@@ -272,7 +288,7 @@ namespace DotNetNuke.Instrumentation
         /// <seealso cref = "Warn(object)" />
         public void Warn(object message, Exception exception)
         {
-            this.Logger.Log(this._stackBoundary, LevelWarn, message, exception);
+            this.Logger.Log(this.stackBoundary, LevelWarn, message, exception);
         }
 
         /// <summary>
@@ -299,7 +315,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void WarnFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelWarn, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelWarn, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
         /// <summary>
@@ -322,7 +338,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void WarnFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelWarn, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelWarn, new SystemStringFormat(provider, format, args), null);
         }
 
         /// <summary>
@@ -350,7 +366,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void Error(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelError, message, null);
+            this.Logger.Log(this.stackBoundary, LevelError, message, null);
         }
 
         /// <summary>
@@ -371,7 +387,7 @@ namespace DotNetNuke.Instrumentation
         /// <seealso cref = "Error(object)" />
         public void Error(object message, Exception exception)
         {
-            this.Logger.Log(this._stackBoundary, LevelError, message, exception);
+            this.Logger.Log(this.stackBoundary, LevelError, message, exception);
         }
 
         /// <summary>
@@ -398,7 +414,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void ErrorFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelError, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelError, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
         /// <summary>
@@ -421,7 +437,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void ErrorFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelError, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelError, new SystemStringFormat(provider, format, args), null);
         }
 
         /// <summary>
@@ -449,7 +465,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void Fatal(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelFatal, message, null);
+            this.Logger.Log(this.stackBoundary, LevelFatal, message, null);
         }
 
         /// <summary>
@@ -470,7 +486,7 @@ namespace DotNetNuke.Instrumentation
         /// <seealso cref = "Fatal(object)" />
         public void Fatal(object message, Exception exception)
         {
-            this.Logger.Log(this._stackBoundary, LevelFatal, message, exception);
+            this.Logger.Log(this.stackBoundary, LevelFatal, message, exception);
         }
 
         /// <summary>
@@ -497,7 +513,7 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void FatalFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelFatal, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelFatal, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
         /// <summary>
@@ -520,68 +536,93 @@ namespace DotNetNuke.Instrumentation
         /// </remarks>
         public void FatalFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelFatal, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelFatal, new SystemStringFormat(provider, format, args), null);
         }
 
+        /// <summary>Logs an install message at the Error log level.</summary>
+        /// <param name="message">The message to log.</param>
         public void InstallLogError(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogError, message, null);
+            this.Logger.Log(this.stackBoundary, levelLogError, message, null);
         }
 
+        /// <summary>Log an install message and exception details at the Error log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         public void InstallLogError(string message, Exception exception)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogError, message, exception);
+            this.Logger.Log(this.stackBoundary, levelLogError, message, exception);
         }
 
+        /// <summary>Log an install message at the Error log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public void InstallLogErrorFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogError, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, levelLogError, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
+        /// <summary>Log an install message at the Error log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public void InstallLogErrorFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogError, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, levelLogError, new SystemStringFormat(provider, format, args), null);
         }
 
+        /// <summary>Logs an install message at the Info log level.</summary>
+        /// <param name="message">The message to log.</param>
         public void InstallLogInfo(object message)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogInfo, message, null);
+            this.Logger.Log(this.stackBoundary, levelLogInfo, message, null);
         }
 
+        /// <summary>Log an install message at the Info log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public void InstallLogInfoFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogInfo, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, levelLogInfo, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
+        /// <summary>Log an install message at the Info log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         public void InstallLogInfoFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelLogInfo, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, levelLogInfo, new SystemStringFormat(provider, format, args), null);
         }
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         internal void TraceFormat(string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelTrace, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelTrace, new SystemStringFormat(CultureInfo.InvariantCulture, format, args), null);
         }
 
+        /// <summary>Logs a message at the Trace log level.</summary>
+        /// <param name="message">The message to log.</param>
         internal void Trace(string message)
         {
-            this.Logger.Log(this._stackBoundary, LevelTrace, message, null);
+            this.Logger.Log(this.stackBoundary, LevelTrace, message, null);
         }
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         internal void TraceFormat(IFormatProvider provider, string format, params object[] args)
         {
-            this.Logger.Log(this._stackBoundary, LevelTrace, new SystemStringFormat(provider, format, args), null);
+            this.Logger.Log(this.stackBoundary, LevelTrace, new SystemStringFormat(provider, format, args), null);
         }
 
         /// <summary>
         ///   Virtual method called when the configuration of the repository changes.
         /// </summary>
         /// <param name = "repository">the repository holding the levels.</param>
-        /// <remarks>
-        ///   <para>
-        ///     Virtual method called when the configuration of the repository changes.
-        ///   </para>
-        /// </remarks>
         private static void ReloadLevels(ILoggerRepository repository)
         {
             LevelMap levelMap = repository.LevelMap;
@@ -592,12 +633,12 @@ namespace DotNetNuke.Instrumentation
             LevelWarn = levelMap.LookupWithDefault(Level.Warn);
             LevelError = levelMap.LookupWithDefault(Level.Error);
             LevelFatal = levelMap.LookupWithDefault(Level.Fatal);
-            LevelLogError = levelMap.LookupWithDefault(LevelLogError);
-            LevelLogInfo = levelMap.LookupWithDefault(LevelLogInfo);
+            levelLogError = levelMap.LookupWithDefault(levelLogError);
+            levelLogInfo = levelMap.LookupWithDefault(levelLogInfo);
 
-            //// Register custom logging levels with the default LoggerRepository
-            LogManager.GetRepository().LevelMap.Add(LevelLogInfo);
-            LogManager.GetRepository().LevelMap.Add(LevelLogError);
+            // Register custom logging levels with the default LoggerRepository
+            LogManager.GetRepository().LevelMap.Add(levelLogInfo);
+            LogManager.GetRepository().LevelMap.Add(levelLogError);
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Instrumentation/DotNetNuke.Instrumentation.csproj
+++ b/DNN Platform/DotNetNuke.Instrumentation/DotNetNuke.Instrumentation.csproj
@@ -25,6 +25,7 @@
     <DocumentationFile>bin\DotNetNuke.Instrumentation.xml</DocumentationFile>
     <NoWarn>1591, 0649</NoWarn>
     <LangVersion>7</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +37,7 @@
     <DocumentationFile>bin\DotNetNuke.Instrumentation.xml</DocumentationFile>
     <NoWarn>1591, 0649</NoWarn>
     <LangVersion>7</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetNuke.log4net">

--- a/DNN Platform/DotNetNuke.Instrumentation/ILog.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/ILog.cs
@@ -1,71 +1,149 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Instrumentation
 {
     using System;
 
+    /// <summary>A contract specifying the ability to log information.</summary>
     public interface ILog
     {
+        /// <summary>Gets a value indicating whether the Debug log level is enabled.</summary>
         bool IsDebugEnabled { get; }
 
+        /// <summary>Gets a value indicating whether the Info log level is enabled.</summary>
         bool IsInfoEnabled { get; }
 
+        /// <summary>Gets a value indicating whether the Trace log level is enabled.</summary>
         bool IsTraceEnabled { get; }
 
+        /// <summary>Gets a value indicating whether the Warn log level is enabled.</summary>
         bool IsWarnEnabled { get; }
 
+        /// <summary>Gets a value indicating whether the Error log level is enabled.</summary>
         bool IsErrorEnabled { get; }
 
+        /// <summary>Gets a value indicating whether the Fatal log level is enabled.</summary>
         bool IsFatalEnabled { get; }
 
+        /// <summary>Log a message at the Debug log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
         void Debug(object message);
 
+        /// <summary>Log a message and exception details at the Debug log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         void Debug(object message, Exception exception);
 
+        /// <summary>Log a message at the Debug log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void DebugFormat(string format, params object[] args);
 
+        /// <summary>Log a message at the Debug log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void DebugFormat(IFormatProvider provider, string format, params object[] args);
 
+        /// <summary>Log a message at the Info log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
         void Info(object message);
 
+        /// <summary>Log a message and exception details at the Info log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         void Info(object message, Exception exception);
 
+        /// <summary>Log a message at the Info log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void InfoFormat(string format, params object[] args);
 
+        /// <summary>Log a message at the Info log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void InfoFormat(IFormatProvider provider, string format, params object[] args);
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
         void Trace(object message);
 
+        /// <summary>Log a message and exception details at the Trace log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         void Trace(object message, Exception exception);
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void TraceFormat(string format, params object[] args);
 
+        /// <summary>Log a message at the Trace log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void TraceFormat(IFormatProvider provider, string format, params object[] args);
 
+        /// <summary>Log a message at the Warn log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
         void Warn(object message);
 
+        /// <summary>Log a message and exception details at the Warn log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         void Warn(object message, Exception exception);
 
+        /// <summary>Log a message at the Warn log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void WarnFormat(string format, params object[] args);
 
+        /// <summary>Log a message at the Warn log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void WarnFormat(IFormatProvider provider, string format, params object[] args);
 
+        /// <summary>Log a message at the Error log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
         void Error(object message);
 
+        /// <summary>Log a message and exception details at the Error log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         void Error(object message, Exception exception);
 
+        /// <summary>Log a message at the Error log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void ErrorFormat(string format, params object[] args);
 
+        /// <summary>Log a message at the Error log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void ErrorFormat(IFormatProvider provider, string format, params object[] args);
 
+        /// <summary>Log a message at the Fatal log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
         void Fatal(object message);
 
+        /// <summary>Log a message and exception details at the Fatal log level.</summary>
+        /// <param name="message">An object to display as the message.</param>
+        /// <param name="exception">An exception to include in the log.</param>
         void Fatal(object message, Exception exception);
 
+        /// <summary>Log a message at the Fatal log level.</summary>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void FatalFormat(string format, params object[] args);
 
+        /// <summary>Log a message at the Fatal log level.</summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A <see href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting">composite format string</see>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
         void FatalFormat(IFormatProvider provider, string format, params object[] args);
     }
 }

--- a/DNN Platform/DotNetNuke.Instrumentation/ILoggerSource.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/ILoggerSource.cs
@@ -1,15 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Instrumentation
 {
     using System;
 
+    /// <summary>A contract specifying the ability to provide <see cref="ILog"/> instances.</summary>
     public interface ILoggerSource
     {
+        /// <summary>Gets the logger for the given <paramref name="type"/>.</summary>
+        /// <param name="type">The type providing the name for the logger instance.</param>
+        /// <returns>An <see cref="ILog"/> instance.</returns>
         ILog GetLogger(Type type);
 
+        /// <summary>Gets the logger for the given <paramref name="name"/>.</summary>
+        /// <param name="name">The name for the logger instance.</param>
+        /// <returns>An <see cref="ILog"/> instance.</returns>
         ILog GetLogger(string name);
     }
 }

--- a/DNN Platform/DotNetNuke.Instrumentation/LoggerSource.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/LoggerSource.cs
@@ -4,18 +4,17 @@
 
 namespace DotNetNuke.Instrumentation
 {
+    /// <summary>Provides access to an <see cref="ILoggerSource"/> instance.</summary>
     public static class LoggerSource
     {
-        private static ILoggerSource _instance = new LoggerSourceImpl();
+        /// <summary>Gets the instance.</summary>
+        public static ILoggerSource Instance { get; private set; } = new LoggerSourceImpl();
 
-        public static ILoggerSource Instance
-        {
-            get { return _instance; }
-        }
-
+        /// <summary>Overrides the <see cref="Instance"/> for testing.</summary>
+        /// <param name="loggerSource">A test <see cref="ILoggerSource"/> instance.</param>
         public static void SetTestableInstance(ILoggerSource loggerSource)
         {
-            _instance = loggerSource;
+            Instance = loggerSource;
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Instrumentation/LoggerSourceImpl.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/LoggerSourceImpl.cs
@@ -17,13 +17,16 @@ namespace DotNetNuke.Instrumentation
     using log4net.Repository;
     using log4net.Util;
 
+    /// <summary>An <see cref="ILoggerSource"/> implementation.</summary>
     public class LoggerSourceImpl : ILoggerSource
     {
+        /// <inheritdoc/>
         public ILog GetLogger(Type type)
         {
             return new Logger(LogManager.GetLogger(type).Logger, type);
         }
 
+        /// <inheritdoc/>
         public ILog GetLogger(string name)
         {
             return new Logger(LogManager.GetLogger(name).Logger, null);
@@ -33,55 +36,55 @@ namespace DotNetNuke.Instrumentation
         {
             private const string ConfigFile = "DotNetNuke.log4net.config";
             private static readonly object ConfigLock = new object();
-            private static Level _levelTrace;
-            private static Level _levelDebug;
-            private static Level _levelInfo;
-            private static Level _levelWarn;
-            private static Level _levelError;
-            private static Level _levelFatal;
-            private static bool _configured;
+            private static Level levelTrace;
+            private static Level levelDebug;
+            private static Level levelInfo;
+            private static Level levelWarn;
+            private static Level levelError;
+            private static Level levelFatal;
+            private static bool configured;
 
             // add custom logging levels (below trace value of 20000)
             //            internal static Level LevelLogInfo = new Level(10001, "LogInfo");
             //            internal static Level LevelLogError = new Level(10002, "LogError");
-            private readonly Type _stackBoundary = typeof(DnnLogger);
+            private readonly Type stackBoundary = typeof(DnnLogger);
 
             internal Logger(ILogger logger, Type type)
                 : base(logger)
             {
-                this._stackBoundary = type ?? typeof(Logger);
+                this.stackBoundary = type ?? typeof(Logger);
                 EnsureConfig();
                 ReloadLevels(logger.Repository);
             }
 
             public bool IsDebugEnabled
             {
-                get { return this.Logger.IsEnabledFor(_levelDebug); }
+                get { return this.Logger.IsEnabledFor(levelDebug); }
             }
 
             public bool IsInfoEnabled
             {
-                get { return this.Logger.IsEnabledFor(_levelInfo); }
+                get { return this.Logger.IsEnabledFor(levelInfo); }
             }
 
             public bool IsTraceEnabled
             {
-                get { return this.Logger.IsEnabledFor(_levelTrace); }
+                get { return this.Logger.IsEnabledFor(levelTrace); }
             }
 
             public bool IsWarnEnabled
             {
-                get { return this.Logger.IsEnabledFor(_levelWarn); }
+                get { return this.Logger.IsEnabledFor(levelWarn); }
             }
 
             public bool IsErrorEnabled
             {
-                get { return this.Logger.IsEnabledFor(_levelError); }
+                get { return this.Logger.IsEnabledFor(levelError); }
             }
 
             public bool IsFatalEnabled
             {
-                get { return this.Logger.IsEnabledFor(_levelFatal); }
+                get { return this.Logger.IsEnabledFor(levelFatal); }
             }
 
             public void Debug(object message)
@@ -91,7 +94,7 @@ namespace DotNetNuke.Instrumentation
 
             public void Debug(object message, Exception exception)
             {
-                this.Logger.Log(this._stackBoundary, _levelDebug, message, exception);
+                this.Logger.Log(this.stackBoundary, levelDebug, message, exception);
             }
 
             public void DebugFormat(string format, params object[] args)
@@ -101,7 +104,7 @@ namespace DotNetNuke.Instrumentation
 
             public void DebugFormat(IFormatProvider provider, string format, params object[] args)
             {
-                this.Logger.Log(this._stackBoundary, _levelDebug, new SystemStringFormat(provider, format, args), null);
+                this.Logger.Log(this.stackBoundary, levelDebug, new SystemStringFormat(provider, format, args), null);
             }
 
             public void Info(object message)
@@ -111,7 +114,7 @@ namespace DotNetNuke.Instrumentation
 
             public void Info(object message, Exception exception)
             {
-                this.Logger.Log(this._stackBoundary, _levelInfo, message, exception);
+                this.Logger.Log(this.stackBoundary, levelInfo, message, exception);
             }
 
             public void InfoFormat(string format, params object[] args)
@@ -121,7 +124,7 @@ namespace DotNetNuke.Instrumentation
 
             public void InfoFormat(IFormatProvider provider, string format, params object[] args)
             {
-                this.Logger.Log(this._stackBoundary, _levelInfo, new SystemStringFormat(provider, format, args), null);
+                this.Logger.Log(this.stackBoundary, levelInfo, new SystemStringFormat(provider, format, args), null);
             }
 
             public void Trace(object message)
@@ -131,7 +134,7 @@ namespace DotNetNuke.Instrumentation
 
             public void Trace(object message, Exception exception)
             {
-                this.Logger.Log(this._stackBoundary, _levelTrace, message, exception);
+                this.Logger.Log(this.stackBoundary, levelTrace, message, exception);
             }
 
             public void TraceFormat(string format, params object[] args)
@@ -141,7 +144,7 @@ namespace DotNetNuke.Instrumentation
 
             public void TraceFormat(IFormatProvider provider, string format, params object[] args)
             {
-                this.Logger.Log(this._stackBoundary, _levelTrace, new SystemStringFormat(provider, format, args), null);
+                this.Logger.Log(this.stackBoundary, levelTrace, new SystemStringFormat(provider, format, args), null);
             }
 
             public void Warn(object message)
@@ -151,7 +154,7 @@ namespace DotNetNuke.Instrumentation
 
             public void Warn(object message, Exception exception)
             {
-                this.Logger.Log(this._stackBoundary, _levelWarn, message, exception);
+                this.Logger.Log(this.stackBoundary, levelWarn, message, exception);
             }
 
             public void WarnFormat(string format, params object[] args)
@@ -161,7 +164,7 @@ namespace DotNetNuke.Instrumentation
 
             public void WarnFormat(IFormatProvider provider, string format, params object[] args)
             {
-                this.Logger.Log(this._stackBoundary, _levelWarn, new SystemStringFormat(provider, format, args), null);
+                this.Logger.Log(this.stackBoundary, levelWarn, new SystemStringFormat(provider, format, args), null);
             }
 
             public void Error(object message)
@@ -171,7 +174,7 @@ namespace DotNetNuke.Instrumentation
 
             public void Error(object message, Exception exception)
             {
-                this.Logger.Log(this._stackBoundary, _levelError, message, exception);
+                this.Logger.Log(this.stackBoundary, levelError, message, exception);
             }
 
             public void ErrorFormat(string format, params object[] args)
@@ -181,7 +184,7 @@ namespace DotNetNuke.Instrumentation
 
             public void ErrorFormat(IFormatProvider provider, string format, params object[] args)
             {
-                this.Logger.Log(this._stackBoundary, _levelError, new SystemStringFormat(provider, format, args), null);
+                this.Logger.Log(this.stackBoundary, levelError, new SystemStringFormat(provider, format, args), null);
             }
 
             public void Fatal(object message)
@@ -191,7 +194,7 @@ namespace DotNetNuke.Instrumentation
 
             public void Fatal(object message, Exception exception)
             {
-                this.Logger.Log(this._stackBoundary, _levelFatal, message, exception);
+                this.Logger.Log(this.stackBoundary, levelFatal, message, exception);
             }
 
             public void FatalFormat(string format, params object[] args)
@@ -201,16 +204,16 @@ namespace DotNetNuke.Instrumentation
 
             public void FatalFormat(IFormatProvider provider, string format, params object[] args)
             {
-                this.Logger.Log(this._stackBoundary, _levelFatal, new SystemStringFormat(provider, format, args), null);
+                this.Logger.Log(this.stackBoundary, levelFatal, new SystemStringFormat(provider, format, args), null);
             }
 
             private static void EnsureConfig()
             {
-                if (!_configured)
+                if (!configured)
                 {
                     lock (ConfigLock)
                     {
-                        if (!_configured)
+                        if (!configured)
                         {
                             var configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFile);
                             var originalPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config\\" + ConfigFile);
@@ -225,7 +228,7 @@ namespace DotNetNuke.Instrumentation
                                 XmlConfigurator.ConfigureAndWatch(new FileInfo(configPath));
                             }
 
-                            _configured = true;
+                            configured = true;
                         }
                     }
                 }
@@ -235,19 +238,12 @@ namespace DotNetNuke.Instrumentation
             {
                 LevelMap levelMap = repository.LevelMap;
 
-                _levelTrace = levelMap.LookupWithDefault(Level.Trace);
-                _levelDebug = levelMap.LookupWithDefault(Level.Debug);
-                _levelInfo = levelMap.LookupWithDefault(Level.Info);
-                _levelWarn = levelMap.LookupWithDefault(Level.Warn);
-                _levelError = levelMap.LookupWithDefault(Level.Error);
-                _levelFatal = levelMap.LookupWithDefault(Level.Fatal);
-
-                // LevelLogError = levelMap.LookupWithDefault(LevelLogError);
-                //                LevelLogInfo = levelMap.LookupWithDefault(LevelLogInfo);
-
-                //// Register custom logging levels with the default LoggerRepository
-                //                LogManager.GetRepository().LevelMap.Add(LevelLogInfo);
-                //                LogManager.GetRepository().LevelMap.Add(LevelLogError);
+                levelTrace = levelMap.LookupWithDefault(Level.Trace);
+                levelDebug = levelMap.LookupWithDefault(Level.Debug);
+                levelInfo = levelMap.LookupWithDefault(Level.Info);
+                levelWarn = levelMap.LookupWithDefault(Level.Warn);
+                levelError = levelMap.LookupWithDefault(Level.Error);
+                levelFatal = levelMap.LookupWithDefault(Level.Fatal);
             }
 
             private static void AddGlobalContext()
@@ -255,29 +251,8 @@ namespace DotNetNuke.Instrumentation
                 try
                 {
                     GlobalContext.Properties["appdomain"] = AppDomain.CurrentDomain.Id.ToString("D");
-
-                    // bool isFullTrust = false;
-                    // try
-                    // {
-                    //    CodeAccessPermission securityTest = new AspNetHostingPermission(AspNetHostingPermissionLevel.Unrestricted);
-                    //    securityTest.Demand();
-                    //    isFullTrust = true;
-                    // }
-                    // catch
-                    // {
-                    //    //code access security error
-                    //    isFullTrust = false;
-                    // }
-                    // if (isFullTrust)
-                    // {
-                    //    GlobalContext.Properties["processid"] = Process.GetCurrentProcess().Id.ToString("D");
-                    // }
                 }
-
-                // ReSharper disable EmptyGeneralCatchClause
                 catch
-
-                    // ReSharper restore EmptyGeneralCatchClause
                 {
                     // do nothing but just make sure no exception here.
                 }


### PR DESCRIPTION
* Adds missing documentation
* Removes `internal` fields (changing to `private` or properties as appropriate)
* Remove underscores from field names