### PR TITLE
Error message to use correct error icon

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/App.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/App.jsx
@@ -159,7 +159,7 @@ class App extends Component {
     componentDidUpdate(prevProps) {
         if (this.props.error && this.props.error && this.props.error !== prevProps.error){
             const errorMessage = (this.props.error && this.props.error.message) || Localization.get("AnErrorOccurred");
-            utils.notify(errorMessage);
+            utils.notifyError(errorMessage);
         }
         window.dnn.utility.closeSocialTasks();
         const { selectedPage } = this.props;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #4123 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
The error path was using notify method to show error instead of notifyError method which results in showing incorrect notification icon. Fixed it to use correct method.