### PR TITLE
Hide new members that differ only by case

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalAliasController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasController.cs
@@ -22,17 +22,19 @@ namespace DotNetNuke.Entities.Portals
     /// </summary>
     /// <remarks>
     /// For DotNetNuke to know what site a request should load, it uses a system of portal aliases.
-    /// When a request is recieved by DotNetNuke from IIS, it extracts the domain name portion and does a comparison against
-    /// the list of portal aliases and then redirects to the relevant portal to load the approriate page.
+    /// When a request is received by DotNetNuke from IIS, it extracts the domain name portion and does a comparison against
+    /// the list of portal aliases and then redirects to the relevant portal to load the appropriate page.
     /// </remarks>
     public partial class PortalAliasController : IPortalAliasService
     {
+        private IPortalAliasService ThisAsInterface => this;
+
         /// <inheritdoc/>
         string IPortalAliasService.GetPortalAliasByPortal(int portalId, string portalAlias)
         {
             string retValue = string.Empty;
             bool foundAlias = false;
-            PortalAliasInfo portalAliasInfo = this.GetPortalAlias(portalAlias, portalId);
+            var portalAliasInfo = this.ThisAsInterface.GetPortalAlias(portalAlias, portalId);
             if (portalAliasInfo != null)
             {
                 retValue = portalAliasInfo.HttpAlias;
@@ -54,17 +56,18 @@ namespace DotNetNuke.Entities.Portals
                     // StartsWith because child portals are redirected to the parent portal domain name
                     // eg. child = 'www.domain.com/child' and parent is 'www.domain.com'
                     // this allows the parent domain name to resolve to the child alias ( the tabid still identifies the child portalid )
-                    string httpAlias = currentAlias.Value.HttpAlias.ToLowerInvariant();
-                    if (httpAlias.StartsWith(portalAlias.ToLowerInvariant()) && currentAlias.Value.PortalId == portalId)
+                    IPortalAliasInfo currentAliasInfo = currentAlias.Value;
+                    string httpAlias = currentAliasInfo.HttpAlias.ToLowerInvariant();
+                    if (httpAlias.StartsWith(portalAlias.ToLowerInvariant()) && currentAliasInfo.PortalId == portalId)
                     {
-                        retValue = currentAlias.Value.HttpAlias;
+                        retValue = currentAliasInfo.HttpAlias;
                         break;
                     }
 
                     httpAlias = httpAlias.StartsWith("www.") ? httpAlias.Replace("www.", string.Empty) : string.Concat("www.", httpAlias);
-                    if (httpAlias.StartsWith(portalAlias.ToLowerInvariant()) && currentAlias.Value.PortalId == portalId)
+                    if (httpAlias.StartsWith(portalAlias.ToLowerInvariant()) && currentAliasInfo.PortalId == portalId)
                     {
-                        retValue = currentAlias.Value.HttpAlias;
+                        retValue = currentAliasInfo.HttpAlias;
                         break;
                     }
                 }
@@ -99,7 +102,7 @@ namespace DotNetNuke.Entities.Portals
                     retValue = portalAlias;
                     break;
                 default: // portal tab
-                    retValue = GetPortalAliasByPortal(intPortalId, portalAlias);
+                    retValue = this.ThisAsInterface.GetPortalAliasByPortal(intPortalId, portalAlias);
                     break;
             }
 
@@ -167,18 +170,20 @@ namespace DotNetNuke.Entities.Portals
         /// <inheritdoc />
         IPortalAliasInfo IPortalAliasService.GetPortalAlias(string alias, int portalId) =>
             this.GetPortalAliasesInternal()
-                .SingleOrDefault(portalAliasInfo => portalAliasInfo.Key.Equals(alias, StringComparison.InvariantCultureIgnoreCase) && portalAliasInfo.Value.PortalID == portalId).Value;
+                .SingleOrDefault((portalAliasInfo) => portalAliasInfo.Key.Equals(alias, StringComparison.InvariantCultureIgnoreCase) && ((IPortalAliasInfo)portalAliasInfo.Value).PortalId == portalId).Value;
 
         /// <inheritdoc />
         IPortalAliasInfo IPortalAliasService.GetPortalAliasByPortalAliasId(int portalAliasId) =>
             this.GetPortalAliasesInternal()
-                .SingleOrDefault(portalAliasInfo => portalAliasInfo.Value.PortalAliasId == portalAliasId).Value;
+                .Values
+                .Cast<IPortalAliasInfo>()
+                .SingleOrDefault(portalAliasInfo => portalAliasInfo.PortalAliasId == portalAliasId);
 
         /// <inheritdoc />
         IDictionary<string, IPortalAliasInfo> IPortalAliasService.GetPortalAliases()
         {
             var aliasCollection = new Dictionary<string, IPortalAliasInfo>();
-            foreach (var alias in this.GetPortalAliasesInternal().Values)
+            foreach (IPortalAliasInfo alias in this.GetPortalAliasesInternal().Values)
             {
                 aliasCollection.Add(alias.HttpAlias, alias);
             }
@@ -188,7 +193,7 @@ namespace DotNetNuke.Entities.Portals
 
         /// <inheritdoc />
         IEnumerable<IPortalAliasInfo> IPortalAliasService.GetPortalAliasesByPortalId(int portalId) =>
-            this.GetPortalAliasesInternal().Values.Where(alias => alias.PortalId == portalId).ToList();
+            this.GetPortalAliasesInternal().Values.Cast<IPortalAliasInfo>().Where(alias => alias.PortalId == portalId).ToList();
 
         /// <inheritdoc />
         IPortalInfo IPortalAliasService.GetPortalByPortalAliasId(int portalAliasId) =>
@@ -256,7 +261,7 @@ namespace DotNetNuke.Entities.Portals
         private static void LogEvent(IPortalAliasInfo portalAlias, EventLogController.EventLogType logType)
         {
             int userId = UserController.Instance.GetCurrentUserInfo().UserID;
-            EventLogController.Instance.AddLog(portalAlias, PortalController.Instance.GetCurrentPortalSettings(), userId, string.Empty, logType);
+            EventLogController.Instance.AddLog(portalAlias, PortalController.Instance.GetCurrentSettings(), userId, string.Empty, logType);
         }
 
         private static bool ValidateAlias(string portalAlias, bool ischild, bool isDomain)
@@ -340,7 +345,7 @@ namespace DotNetNuke.Entities.Portals
                     EventLogController.Instance.AddLog(
                         "PortalAlias",
                         httpAlias,
-                        PortalController.Instance.GetCurrentPortalSettings(),
+                        PortalController.Instance.GetCurrentSettings(),
                         UserController.Instance.GetCurrentUserInfo().UserID,
                         EventLogController.EventLogType.PORTALALIAS_UPDATED);
 

--- a/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
@@ -25,46 +25,51 @@ namespace DotNetNuke.Entities.Portals
         {
         }
 
-        public PortalAliasInfo(PortalAliasInfo alias)
+        public PortalAliasInfo(PortalAliasInfo alias) 
+            : this((IPortalAliasInfo)alias)
         {
-            this.HttpAlias = alias.HttpAlias;
-            this.PortalAliasId = alias.PortalAliasId;
-            this.PortalId = alias.PortalId;
+        }
+
+        public PortalAliasInfo(IPortalAliasInfo alias)
+        {
+            this.ThisAsInterface.HttpAlias = alias.HttpAlias;
+            this.ThisAsInterface.PortalAliasId = alias.PortalAliasId;
+            this.ThisAsInterface.PortalId = alias.PortalId;
             this.IsPrimary = alias.IsPrimary;
             this.Redirect = alias.Redirect;
-            ((IPortalAliasInfo)this).BrowserType = ((IPortalAliasInfo)alias).BrowserType;
+            this.ThisAsInterface.BrowserType = alias.BrowserType;
             this.CultureCode = alias.CultureCode;
             this.Skin = alias.Skin;
         }
 
         /// <inheritdoc />
-        public string HttpAlias { get; set; }
+        string IPortalAliasInfo.HttpAlias { get; set; }
 
         [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalAliasInfo.HttpAlias instead.")]
         public string HTTPAlias
         {
-            get => this.HttpAlias;
-            set => this.HttpAlias = value;
+            get => this.ThisAsInterface.HttpAlias;
+            set => this.ThisAsInterface.HttpAlias = value;
         }
 
         /// <inheritdoc />
-        public int PortalAliasId { get; set; }
+        int IPortalAliasInfo.PortalAliasId { get; set; }
 
         [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalAliasInfo.PortalAliasId instead.")]
         public int PortalAliasID
         {
-            get => this.PortalAliasId;
-            set => this.PortalAliasId = value;
+            get => this.ThisAsInterface.PortalAliasId;
+            set => this.ThisAsInterface.PortalAliasId = value;
         }
 
         /// <inheritdoc />
-        public int PortalId { get; set; }
+        int IPortalAliasInfo.PortalId { get; set; }
 
         [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalAliasInfo.PortalId instead.")]
         public int PortalID
         {
-            get => this.PortalId;
-            set => this.PortalId = value;
+            get => this.ThisAsInterface.PortalId;
+            set => this.ThisAsInterface.PortalId = value;
         }
 
         /// <inheritdoc />
@@ -79,8 +84,8 @@ namespace DotNetNuke.Entities.Portals
         [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalAliasInfo.BrowserType instead.")]
         public BrowserTypes BrowserType
         {
-            get => (BrowserTypes)((IPortalAliasInfo)this).BrowserType;
-            set => ((IPortalAliasInfo)this).BrowserType = (NewBrowserType)value;
+            get => (BrowserTypes)this.ThisAsInterface.BrowserType;
+            set => this.ThisAsInterface.BrowserType = (NewBrowserType)value;
         }
 
         /// <inheritdoc />
@@ -95,17 +100,19 @@ namespace DotNetNuke.Entities.Portals
         /// <inheritdoc />
         public int KeyID
         {
-            get { return this.PortalAliasId; }
-            set { this.PortalAliasId = value; }
+            get { return this.ThisAsInterface.PortalAliasId; }
+            set { this.ThisAsInterface.PortalAliasId = value; }
         }
+
+        private IPortalAliasInfo ThisAsInterface => this;
 
         public void Fill(IDataReader dr)
         {
             this.FillInternal(dr);
 
-            this.PortalAliasId = Null.SetNullInteger(dr["PortalAliasID"]);
-            this.PortalId = Null.SetNullInteger(dr["PortalID"]);
-            this.HttpAlias = Null.SetNullString(dr["HTTPAlias"]);
+            this.ThisAsInterface.PortalAliasId = Null.SetNullInteger(dr["PortalAliasID"]);
+            this.ThisAsInterface.PortalId = Null.SetNullInteger(dr["PortalID"]);
+            this.ThisAsInterface.HttpAlias = Null.SetNullString(dr["HTTPAlias"]);
             this.IsPrimary = Null.SetNullBoolean(dr["IsPrimary"]);
             var browserType = Null.SetNullString(dr["BrowserType"]);
             this.BrowserType = string.IsNullOrEmpty(browserType) || browserType.Equals("normal", StringComparison.OrdinalIgnoreCase)
@@ -139,13 +146,13 @@ namespace DotNetNuke.Entities.Portals
                     case "portalAlias":
                         break;
                     case "portalID":
-                        this.PortalId = reader.ReadElementContentAsInt();
+                        this.ThisAsInterface.PortalId = reader.ReadElementContentAsInt();
                         break;
                     case "portalAliasID":
-                        this.PortalAliasId = reader.ReadElementContentAsInt();
+                        this.ThisAsInterface.PortalAliasId = reader.ReadElementContentAsInt();
                         break;
                     case "HTTPAlias":
-                        this.HttpAlias = reader.ReadElementContentAsString();
+                        this.ThisAsInterface.HttpAlias = reader.ReadElementContentAsString();
                         break;
                     case "skin":
                         this.Skin = reader.ReadElementContentAsString();
@@ -177,9 +184,9 @@ namespace DotNetNuke.Entities.Portals
             writer.WriteStartElement("portalAlias");
 
             // write out properties
-            writer.WriteElementString("portalID", this.PortalId.ToString());
-            writer.WriteElementString("portalAliasID", this.PortalAliasId.ToString());
-            writer.WriteElementString("HTTPAlias", this.HttpAlias);
+            writer.WriteElementString("portalID", this.ThisAsInterface.PortalId.ToString());
+            writer.WriteElementString("portalAliasID", this.ThisAsInterface.PortalAliasId.ToString());
+            writer.WriteElementString("HTTPAlias", this.ThisAsInterface.HttpAlias);
             writer.WriteElementString("skin", this.Skin);
             writer.WriteElementString("cultureCode", this.CultureCode);
             writer.WriteElementString("browserType", this.BrowserType.ToString().ToLowerInvariant());


### PR DESCRIPTION
Addresses [CA1708](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1708)
>Identifiers for namespaces, types, members, and parameters cannot
>differ only by case because languages that target the common language
>runtime are not required to be case-sensitive. For example, Visual
>Basic is a widely used case-insensitive language.

Fixes #4138