### PR TITLE
Add host setting option and ability to use settings outside module context

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Entities\Modules\InstalledModulesController.cs" />
     <Compile Include="Entities\Modules\Prompt\ListModules.cs" />
     <Compile Include="Entities\Modules\Prompt\PromptModuleInfo.cs" />
+    <Compile Include="Entities\Modules\Settings\HostSettingAttribute.cs" />
     <Compile Include="Entities\Modules\Settings\ISettingsRepository.cs" />
     <Compile Include="Entities\Modules\Settings\ISettingsSerializer.cs" />
     <Compile Include="Entities\Modules\Settings\ModuleSettingAttribute.cs" />

--- a/DNN Platform/Library/Entities/Modules/Settings/HostSettingAttribute.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/HostSettingAttribute.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Entities.Modules.Settings
+{
+    using System;
+
+    /// <summary>
+    /// When applied to a property this attribute persists the value of the property in the DNN HostSettings table.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class HostSettingAttribute : ParameterAttributeBase
+    {
+    }
+}

--- a/DNN Platform/Library/Entities/Modules/Settings/ISettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/ISettingsRepository.cs
@@ -7,8 +7,36 @@ namespace DotNetNuke.Entities.Modules.Settings
     public interface ISettingsRepository<T>
         where T : class
     {
+        /// <summary>
+        /// Retrieve module settings. This can optionally include TabModule settings, Portal settings and
+        /// host settings as well. Note the result is cached.
+        /// </summary>
+        /// <param name="moduleContext">Your module's context.</param>
+        /// <returns>Your settings class.</returns>
         T GetSettings(ModuleInfo moduleContext);
 
+        /// <summary>
+        /// Retrieve portal/host settings. This will ignore Module and TabModule settings.
+        /// Note the result is cached.
+        /// </summary>
+        /// <param name="portalId">The portal ID for which to retrieve the settings.</param>
+        /// <returns>Your settings class.</returns>
+        T GetSettings(int portalId);
+
+        /// <summary>
+        /// Save your module's settings. This can optionally include TabModule settings, Portal settings and
+        /// host settings as well.
+        /// </summary>
+        /// <param name="moduleContext">Your module's context.</param>
+        /// <param name="settings">Your settings class.</param>
         void SaveSettings(ModuleInfo moduleContext, T settings);
+
+        /// <summary>
+        /// Save your settings. Module and TabModule settings will be ignored. Only Portal settings and
+        /// host settings will be saved.
+        /// </summary>
+        /// <param name="portalId">Your portal Id for these settings.</param>
+        /// <param name="settings">Your settings class.</param>
+        void SaveSettings(int portalId, T settings);
     }
 }

--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -1,77 +1,81 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Entities.Modules.Settings
 {
     using System;
     using System.Collections.Generic;
     using System.Reflection;
     using System.Web.Caching;
+
     using DotNetNuke.Collections;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Services.Cache;
-    public abstract class SettingsRepository<T> : ISettingsRepository<T> where T : class, new()
+
+    /// <inheritdoc/>
+    public abstract class SettingsRepository<T> : ISettingsRepository<T>
+        where T : class, new()
     {
-        public const string CachePrefix = "ModuleSettingsPersister_";
+        private readonly IModuleController moduleController;
 
-        private readonly IModuleController _moduleController;
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SettingsRepository{T}"/> class.
+        /// </summary>
         protected SettingsRepository()
         {
             this.Mapping = this.LoadMapping();
-            this._moduleController = ModuleController.Instance;
+            this.moduleController = ModuleController.Instance;
         }
+
+        /// <summary>
+        /// Gets cache key for this class. Used for parameter mapping storage as well as entire class persistence.
+        /// </summary>
         protected virtual string MappingCacheKey
         {
             get
             {
                 var type = typeof(T);
-                return CachePrefix + type.FullName.Replace(".", "_");
+                return "SettingsRepository_" + type.FullName.Replace(".", "_");
             }
         }
 
         private IList<ParameterMapping> Mapping { get; }
 
+        /// <inheritdoc/>
         public T GetSettings(ModuleInfo moduleContext)
         {
             return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(moduleContext.TabModuleID), 20, CacheItemPriority.AboveNormal, moduleContext), this.Load, false);
         }
 
+        /// <inheritdoc/>
+        public T GetSettings(int portalId)
+        {
+            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(portalId), 20, CacheItemPriority.AboveNormal, null, portalId), this.Load, false);
+        }
+
+        /// <inheritdoc/>
         public void SaveSettings(ModuleInfo moduleContext, T settings)
         {
             Requires.NotNull("settings", settings);
             Requires.NotNull("ctlModule", moduleContext);
-
-            this.Mapping.ForEach(mapping =>
-            {
-                var attribute = mapping.Attribute;
-                var property = mapping.Property;
-
-                if (property.CanRead) // Should be, because we asked for properties with a Get accessor.
-                {
-                    var settingValueAsString = SerializationController.SerializeProperty(settings, property, attribute.Serializer);
-
-                    if (attribute is ModuleSettingAttribute)
-                    {
-                        this._moduleController.UpdateModuleSetting(moduleContext.ModuleID, mapping.FullParameterName, settingValueAsString);
-                        moduleContext.ModuleSettings[mapping.FullParameterName] = settingValueAsString; // temporary fix for issue 3692
-                    }
-                    else if (attribute is TabModuleSettingAttribute)
-                    {
-                        this._moduleController.UpdateTabModuleSetting(moduleContext.TabModuleID, mapping.FullParameterName, settingValueAsString);
-                        moduleContext.TabModuleSettings[mapping.FullParameterName] = settingValueAsString; // temporary fix for issue 3692
-                    }
-                    else if (attribute is PortalSettingAttribute)
-                    {
-                        PortalController.UpdatePortalSetting(moduleContext.PortalID, mapping.FullParameterName, settingValueAsString);
-                    }
-                }
-            });
-            DataCache.SetCache(this.CacheKey(moduleContext.TabModuleID), settings);
+            this.SaveSettings(moduleContext.PortalID, moduleContext, settings);
         }
 
+        /// <inheritdoc/>
+        public void SaveSettings(int portalId, T settings)
+        {
+            Requires.NotNull("settings", settings);
+            this.SaveSettings(portalId, null, settings);
+        }
+
+        /// <summary>
+        /// Retrieves the parameter mapping from cache if still there, otherwise recreates it.
+        /// </summary>
+        /// <returns>List of parameters.</returns>
         protected IList<ParameterMapping> LoadMapping()
         {
             var cacheKey = this.MappingCacheKey;
@@ -88,6 +92,10 @@ namespace DotNetNuke.Entities.Modules.Settings
             return mapping;
         }
 
+        /// <summary>
+        /// Rebuilds parameter mapping of the class.
+        /// </summary>
+        /// <returns>List of parameters.</returns>
         protected virtual IList<ParameterMapping> CreateMapping()
         {
             var mapping = new List<ParameterMapping>();
@@ -103,9 +111,44 @@ namespace DotNetNuke.Entities.Modules.Settings
             return mapping;
         }
 
+        private void SaveSettings(int portalId, ModuleInfo moduleContext, T settings)
+        {
+            this.Mapping.ForEach(mapping =>
+            {
+                var attribute = mapping.Attribute;
+                var property = mapping.Property;
+
+                if (property.CanRead) // Should be, because we asked for properties with a Get accessor.
+                {
+                    var settingValueAsString = SerializationController.SerializeProperty(settings, property, attribute.Serializer);
+
+                    if (attribute is ModuleSettingAttribute && moduleContext != null)
+                    {
+                        this.moduleController.UpdateModuleSetting(moduleContext.ModuleID, mapping.FullParameterName, settingValueAsString);
+                        moduleContext.ModuleSettings[mapping.FullParameterName] = settingValueAsString; // temporary fix for issue 3692
+                    }
+                    else if (attribute is TabModuleSettingAttribute && moduleContext != null)
+                    {
+                        this.moduleController.UpdateTabModuleSetting(moduleContext.TabModuleID, mapping.FullParameterName, settingValueAsString);
+                        moduleContext.TabModuleSettings[mapping.FullParameterName] = settingValueAsString; // temporary fix for issue 3692
+                    }
+                    else if (attribute is PortalSettingAttribute && portalId != -1)
+                    {
+                        PortalController.UpdatePortalSetting(portalId, mapping.FullParameterName, settingValueAsString);
+                    }
+                    else if (attribute is HostSettingAttribute)
+                    {
+                        HostController.Instance.Update(mapping.FullParameterName, settingValueAsString);
+                    }
+                }
+            });
+            DataCache.SetCache(this.CacheKey(moduleContext == null ? portalId : moduleContext.TabModuleID), settings);
+        }
+
         private T Load(CacheItemArgs args)
         {
             var ctlModule = (ModuleInfo)args.ParamList[0];
+            var portalId = ctlModule == null ? (int)args.ParamList[1] : ctlModule.PortalID;
             var settings = new T();
 
             this.Mapping.ForEach(mapping =>
@@ -116,15 +159,19 @@ namespace DotNetNuke.Entities.Modules.Settings
                 var property = mapping.Property;
 
                 // TODO: Make more extensible, enable other attributes to be defined
-                if (attribute is PortalSettingAttribute && PortalController.Instance.GetPortalSettings(ctlModule.PortalID).ContainsKey(mapping.FullParameterName))
+                if (attribute is HostSettingAttribute && HostController.Instance.GetSettings().ContainsKey(mapping.FullParameterName))
                 {
-                    settingValue = PortalController.Instance.GetPortalSettings(ctlModule.PortalID)[mapping.FullParameterName];
+                    settingValue = HostController.Instance.GetSettings()[mapping.FullParameterName].Value;
                 }
-                else if (attribute is TabModuleSettingAttribute && ctlModule.TabModuleSettings.ContainsKey(mapping.FullParameterName))
+                else if (attribute is PortalSettingAttribute && portalId != -1 && PortalController.Instance.GetPortalSettings(portalId).ContainsKey(mapping.FullParameterName))
+                {
+                    settingValue = PortalController.Instance.GetPortalSettings(portalId)[mapping.FullParameterName];
+                }
+                else if (attribute is TabModuleSettingAttribute && ctlModule != null && ctlModule.TabModuleSettings.ContainsKey(mapping.FullParameterName))
                 {
                     settingValue = (string)ctlModule.TabModuleSettings[mapping.FullParameterName];
                 }
-                else if (attribute is ModuleSettingAttribute && ctlModule.ModuleSettings.ContainsKey(mapping.FullParameterName))
+                else if (attribute is ModuleSettingAttribute && ctlModule != null && ctlModule.ModuleSettings.ContainsKey(mapping.FullParameterName))
                 {
                     settingValue = (string)ctlModule.ModuleSettings[mapping.FullParameterName];
                 }
@@ -138,10 +185,7 @@ namespace DotNetNuke.Entities.Modules.Settings
             return settings;
         }
 
-        private string CacheKey(int moduleId)
-        {
-            return string.Format("SettingsModule{0}", moduleId);
-        }
+        private string CacheKey(int id) => $"Settings{this.MappingCacheKey}_{id}";
 
         /// <summary>
         /// Deserializes the property.
@@ -149,7 +193,7 @@ namespace DotNetNuke.Entities.Modules.Settings
         /// <param name="settings">The settings.</param>
         /// <param name="property">The property.</param>
         /// <param name="propertyValue">The property value.</param>
-        /// <exception cref="System.InvalidCastException"></exception>
+        /// <exception cref="InvalidCastException">Thrown if string value cannot be deserialized to desired type.</exception>
         private void DeserializeProperty(T settings, PropertyInfo property, ParameterAttributeBase attribute, string propertyValue)
         {
             SerializationController.DeserializeProperty(settings, property, propertyValue, attribute.Serializer);


### PR DESCRIPTION
This PR does two things:

1. It adds the (IMO missing) HostSettingsAttribute which persists the value to the HostSettings table
2. It allows you to construct the settings repository with a simple PortalId to retrieve a settings class with only portal/host settings

Because of #2 you can also create a settings class using -1 for portal ID which allows you to use only HostSettings.