### PR TITLE
Resolves an infinite redirect loop issue

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -254,7 +254,7 @@ namespace DotNetNuke.Entities.Urls
             {
                 var portalAliases = PortalAliasController.Instance.GetPortalAliasesByPortalId(result.PortalId).ToList();
 
-                if (queryStringCol != null && queryStringCol["forceAlias"] != "true")
+                if (queryStringCol != null && queryStringCol["forceAlias"] != null && queryStringCol["forceAlias"] != "true")
                 {
                     if (portalAliases.Count > 0)
                     {


### PR DESCRIPTION
Closes #4157

An infinite redirect loop could occur even in situations where the portal aliasses where setup in canonical mode.

Relates to this discussion: https://github.com/dnnsoftware/Dnn.Platform/discussions/4137

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
