### PR TITLE
Properly named CSS class & keeps the other for compatibility for now

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/UserControls/PersonaBarContainer.ascx
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/UserControls/PersonaBarContainer.ascx
@@ -1,6 +1,6 @@
 <%@ Control language="C#" Inherits="Dnn.PersonaBar.UI.UserControls.PersonaBarContainer" AutoEventWireup="false"  Codebehind="PersonaBarContainer.ascx.cs" %>
 <%@ Register TagPrefix="dnnweb" Namespace="DotNetNuke.Web.UI.WebControls" Assembly="DotNetNuke.Web" %>
-<asp:Panel runat="server" ID="PersonaBarPanel" Visible="False" CssClass="personalBarContainer">
+<asp:Panel runat="server" ID="PersonaBarPanel" Visible="False" CssClass="personaBarContainer personalBarContainer">
     <div id="personabar-placeholder" class="personabar-placeholder">
         <!--
             A temporary UI placeholder to avoid the sliding effect when PersonaBar loads


### PR DESCRIPTION
Fixes #3288 

Attempted to find any instances of the incorrect CSS class name `personalBarContainer` in the core and there aren't in any file other file.  

To keep with the current naming convention and make it easier for any third-party developers to correct, a new class name of `personaBarContainer` has been added for now to allow for developers to have a period of time to resolve any potential compatibility updates in their own extensions.  