### PR TITLE
Adds Dependency Injection to WebAPI Action Filters using Property Injection

### DIFF
--- a/DNN Platform/DotNetNuke.DependencyInjection/DependencyAttribute.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/DependencyAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.DependencyInjection
+{
+    using System;
+
+    /// <summary>
+    /// Dependency used for property injection in Action Filters.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class DependencyAttribute : Attribute
+    {
+    }
+}

--- a/DNN Platform/DotNetNuke.Web/Api/Internal/DnnActionFilterProvider.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Internal/DnnActionFilterProvider.cs
@@ -4,6 +4,7 @@
 
 namespace DotNetNuke.Web.Api.Internal
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Web.Http;
@@ -11,13 +12,20 @@ namespace DotNetNuke.Web.Api.Internal
     using System.Web.Http.Filters;
 
     using DotNetNuke.Common;
+    using DotNetNuke.DependencyInjection.Extensions;
 
     internal class DnnActionFilterProvider : IFilterProvider
     {
+        private IServiceProvider container;
+
+        public DnnActionFilterProvider(IServiceProvider container)
+        {
+            this.container = container;
+        }
+
         /// <inheritdoc/>
         public IEnumerable<FilterInfo> GetFilters(HttpConfiguration configuration, HttpActionDescriptor actionDescriptor)
         {
-            // Requires.NotNull("configuration", configuration);
             Requires.NotNull("actionDescriptor", actionDescriptor);
 
             var controllerFilters = actionDescriptor.ControllerDescriptor.GetFilters().Select(instance => new FilterInfo(instance, FilterScope.Controller));
@@ -30,6 +38,11 @@ namespace DotNetNuke.Web.Api.Internal
             if (!overrideFilterPresent)
             {
                 allFilters.Add(new FilterInfo(new RequireHostAttribute(), FilterScope.Action));
+            }
+
+            foreach (var filterInfo in allFilters)
+            {
+                this.container.BuildUp(filterInfo.Instance);
             }
 
             return allFilters;

--- a/DNN Platform/DotNetNuke.Web/Api/Internal/ServicesRoutingManager.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Internal/ServicesRoutingManager.cs
@@ -134,7 +134,7 @@ namespace DotNetNuke.Web.Api.Internal
                 GlobalConfiguration.Configuration.Services.Replace(typeof(ITraceWriter), new TraceWriter(IsTracingEnabled()));
 
                 // replace the default action filter provider with our own
-                GlobalConfiguration.Configuration.Services.Add(typeof(IFilterProvider), new DnnActionFilterProvider());
+                GlobalConfiguration.Configuration.Services.Add(typeof(IFilterProvider), Globals.DependencyProvider.GetRequiredService<IFilterProvider>());
                 var defaultprovider = GlobalConfiguration.Configuration.Services.GetFilterProviders().Where(x => x is ActionDescriptorFilterProvider);
                 GlobalConfiguration.Configuration.Services.Remove(typeof(IFilterProvider), defaultprovider);
 

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -32,10 +32,10 @@ namespace DotNetNuke.DependencyInjection.Extensions
             var properties = GetDependencyProperties(filter.GetType());
             foreach (var property in properties)
             {
-                var service = container.GetService(property.GetType());
+                var service = container.GetService(property.PropertyType);
                 if (service != null)
                 {
-                    property.SetValue(service, filter);
+                    property.SetValue(filter, service);
                 }
             }
 

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.DependencyInjection.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Web.Http.Filters;
+
+    using DotNetNuke.Common.Utilities;
+
+    /// <summary>
+    /// Adds property injection extension methods.
+    /// </summary>
+    public static class BuildUpExtensions
+    {
+        /// <summary>
+        /// Injects property dependency for public or proetected
+        /// properties that are decorated with <see cref="DependencyAttribute"/>.
+        /// </summary>
+        /// <param name="container">The service provider.</param>
+        /// <param name="filter">The <see cref="IFilter"/> to inject properties.</param>
+        public static void BuildUp(this IServiceProvider container, IFilter filter)
+        {
+            if (container == null || filter == null)
+            {
+                return;
+            }
+
+            var properties = GetDependencyProperties(filter.GetType());
+            foreach (var property in properties)
+            {
+                var service = container.GetService(property.GetType());
+                if (service != null)
+                {
+                    property.SetValue(service, filter);
+                }
+            }
+
+            IEnumerable<PropertyInfo> GetDependencyProperties(Type type)
+            {
+                return CBO.Instance.GetCachedObject<IEnumerable<PropertyInfo>>(
+                    new CacheItemArgs($"WebApiDependencyProperties_{type.FullName}"),
+                    (args) => type
+                        .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                        .Where(propertyInfo => propertyInfo.GetCustomAttribute<DependencyAttribute>() != null)
+                        .ToList(),
+                    false);
+            }
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -10,12 +10,15 @@ namespace DotNetNuke.DependencyInjection.Extensions
     using System.Web.Http.Filters;
 
     using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Instrumentation;
 
     /// <summary>
     /// Adds property injection extension methods.
     /// </summary>
     public static class BuildUpExtensions
     {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(BuildUpExtensions));
+
         /// <summary>
         /// Injects property dependency for public or proetected
         /// properties that are decorated with <see cref="DependencyAttribute"/>.
@@ -35,7 +38,14 @@ namespace DotNetNuke.DependencyInjection.Extensions
                 var service = container.GetService(property.PropertyType);
                 if (service != null)
                 {
-                    property.SetValue(filter, service);
+                    try
+                    {
+                        property.SetValue(filter, service);
+                    }
+                    catch (Exception exception)
+                    {
+                        Logger.Error(exception);
+                    }
                 }
             }
 

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -20,8 +20,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(BuildUpExtensions));
 
         /// <summary>
-        /// Injects property dependency for public or proetected
-        /// properties that are decorated with <see cref="DependencyAttribute"/>.
+        /// Injects property dependency for properties that are decorated with <see cref="DependencyAttribute"/>.
         /// </summary>
         /// <param name="container">The service provider.</param>
         /// <param name="filter">The <see cref="IFilter"/> to inject properties.</param>

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -45,7 +45,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
                     new CacheItemArgs($"WebApiDependencyProperties_{type.FullName}"),
                     (args) => type
                         .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                        .Where(propertyInfo => propertyInfo.GetCustomAttribute<DependencyAttribute>() != null)
+                        .Where(propertyInfo => propertyInfo.GetSetMethod(true) != null && propertyInfo.GetCustomAttribute<DependencyAttribute>() != null)
                         .ToList(),
                     false);
             }

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -56,7 +56,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
                         .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                         .Where(propertyInfo => propertyInfo.GetSetMethod(true) != null && propertyInfo.GetCustomAttribute<DependencyAttribute>() != null)
                         .ToList(),
-                    false);
+                    saveInDictionary: false);
             }
         }
     }

--- a/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjection/BuildUpExtensions.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
     /// <summary>
     /// Adds property injection extension methods.
     /// </summary>
-    public static class BuildUpExtensions
+    internal static class BuildUpExtensions
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(BuildUpExtensions));
 
@@ -25,7 +25,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
         /// </summary>
         /// <param name="container">The service provider.</param>
         /// <param name="filter">The <see cref="IFilter"/> to inject properties.</param>
-        public static void BuildUp(this IServiceProvider container, IFilter filter)
+        internal static void BuildUp(this IServiceProvider container, IFilter filter)
         {
             if (container == null || filter == null)
             {

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -212,6 +212,7 @@
     <Compile Include="ConfigSection\AuthServicesConfiguration.cs" />
     <Compile Include="ConfigSection\MessageHandlerEntry.cs" />
     <Compile Include="ConfigSection\MessageHandlersCollection.cs" />
+    <Compile Include="DependencyInjection\BuildUpExtensions.cs" />
     <Compile Include="Prompt\ListServices.cs" />
     <Compile Include="Models\ModuleDetail.cs" />
     <Compile Include="Models\ModuleInstance.cs" />

--- a/DNN Platform/DotNetNuke.Web/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web/Startup.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Web
 {
+    using System.Web.Http.Filters;
+
     using DotNetNuke.DependencyInjection;
+    using DotNetNuke.Web.Api.Internal;
     using DotNetNuke.Web.Extensions;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +17,7 @@ namespace DotNetNuke.Web
         /// <inheritdoc />
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddTransient<IFilterProvider, DnnActionFilterProvider>();
             services.AddWebApi();
         }
     }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
@@ -75,6 +75,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Management.Automation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Management.Automation.6.1.7601.17515\lib\net45\System.Management.Automation.dll</HintPath>
       <Private>True</Private>
@@ -101,6 +102,7 @@
     <Compile Include="HttpSimulator\ReflectionHelper.cs" />
     <Compile Include="HttpSimulator\SimulatedHttpRequest.cs" />
     <Compile Include="MailAssert.cs" />
+    <Compile Include="Mocks\MockCBO.cs" />
     <Compile Include="Mocks\MockComponentProvider.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Mocks/MockCBO.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Mocks/MockCBO.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Utilities.Mocks
+{
+    using System;
+    using System.Data;
+    using DotNetNuke.Common.Utilities;
+
+    /// <summary>A mock <see cref="ICBO"/> implementation that implements <see cref="GetCachedObject{T}"/> by always calling the callback function (i.e. never caching).</summary>
+    public class MockCBO : ICBO
+    {
+        public System.Collections.Generic.List<TObject> FillCollection<TObject>(IDataReader dr)
+            where TObject : new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public TObject FillObject<TObject>(IDataReader dr)
+            where TObject : new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public TObject GetCachedObject<TObject>(CacheItemArgs cacheItemArgs, CacheItemExpiredCallback cacheItemExpired, bool saveInDictionary)
+        {
+            return (TObject)cacheItemExpired(cacheItemArgs);
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/DnnActionFilterProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/DnnActionFilterProviderTests.cs
@@ -4,12 +4,16 @@
 
 namespace DotNetNuke.Tests.Web.Api
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Reflection;
     using System.Web.Http;
     using System.Web.Http.Controllers;
     using System.Web.Http.Filters;
-
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Web.Api;
     using DotNetNuke.Web.Api.Internal;
     using Moq;
@@ -18,6 +22,23 @@ namespace DotNetNuke.Tests.Web.Api
     [TestFixture]
     public class DnnActionFilterProviderTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            var mockCache = new Mock<ICBO>();
+            mockCache
+                .Setup(x => x.GetCachedObject<IEnumerable<PropertyInfo>>(It.IsAny<CacheItemArgs>(), It.IsAny<CacheItemExpiredCallback>(), It.IsAny<bool>()))
+                .Returns(new PropertyInfo[0]);
+
+            CBO.SetTestableInstance(mockCache.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            CBO.ClearInstance();
+        }
+
         [Test]
         public void RequiresHostAttributeAddedWhenNoOtherActionFiltersPresent()
         {
@@ -34,7 +55,7 @@ namespace DotNetNuke.Tests.Web.Api
             var configuration = new HttpConfiguration();
 
             // Act
-            var filterProvider = new DnnActionFilterProvider();
+            var filterProvider = new DnnActionFilterProvider(Mock.Of<IServiceProvider>());
             var filters = filterProvider.GetFilters(configuration, actionDescriptor).ToList();
 
             // Assert
@@ -58,7 +79,7 @@ namespace DotNetNuke.Tests.Web.Api
             var configuration = new HttpConfiguration();
 
             // Act
-            var filterProvider = new DnnActionFilterProvider();
+            var filterProvider = new DnnActionFilterProvider(Mock.Of<IServiceProvider>());
             var filters = filterProvider.GetFilters(configuration, actionDescriptor).ToList();
 
             // Assert
@@ -82,7 +103,7 @@ namespace DotNetNuke.Tests.Web.Api
             var configuration = new HttpConfiguration();
 
             // Act
-            var filterProvider = new DnnActionFilterProvider();
+            var filterProvider = new DnnActionFilterProvider(Mock.Of<IServiceProvider>());
             var filters = filterProvider.GetFilters(configuration, actionDescriptor).ToList();
 
             // Assert

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/DnnActionFilterProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/DnnActionFilterProviderTests.cs
@@ -1,22 +1,22 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api
 {
     using System;
-    using System.Collections;
-    using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
-    using System.Reflection;
     using System.Web.Http;
     using System.Web.Http.Controllers;
     using System.Web.Http.Filters;
+
     using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Tests.Utilities.Mocks;
     using DotNetNuke.Web.Api;
     using DotNetNuke.Web.Api.Internal;
+
     using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
@@ -25,12 +25,7 @@ namespace DotNetNuke.Tests.Web.Api
         [SetUp]
         public void SetUp()
         {
-            var mockCache = new Mock<ICBO>();
-            mockCache
-                .Setup(x => x.GetCachedObject<IEnumerable<PropertyInfo>>(It.IsAny<CacheItemArgs>(), It.IsAny<CacheItemExpiredCallback>(), It.IsAny<bool>()))
-                .Returns(new PropertyInfo[0]);
-
-            CBO.SetTestableInstance(mockCache.Object);
+            CBO.SetTestableInstance(new MockCBO());
         }
 
         [TearDown]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/ServiceRoutingManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/ServiceRoutingManagerTests.cs
@@ -8,12 +8,15 @@ namespace DotNetNuke.Tests.Web.Api
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
+    using System.Web.Http.Filters;
     using System.Web.Routing;
 
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework.Internal.Reflection;
     using DotNetNuke.Framework.Reflections;
@@ -57,6 +60,7 @@ namespace DotNetNuke.Tests.Web.Api
             services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
             services.AddScoped(typeof(INavigationManager), (x) => navigationManagerMock.Object);
             services.AddScoped<IPortalAliasService>(_ => this.mockPortalAliasService.Object);
+            services.AddScoped(_ => Mock.Of<IFilterProvider>());
 
             Globals.DependencyProvider = services.BuildServiceProvider();
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DependencyInjection/BuildUpExtensionsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DependencyInjection/BuildUpExtensionsTests.cs
@@ -4,13 +4,12 @@
 namespace DotNetNuke.Tests.Web.DependencyInjection
 {
     using System;
-    using System.Collections.Generic;
-    using System.Reflection;
     using System.Web.Http.Filters;
 
     using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.DependencyInjection.Extensions;
+    using DotNetNuke.Tests.Utilities.Mocks;
 
     using Moq;
 
@@ -26,12 +25,7 @@ namespace DotNetNuke.Tests.Web.DependencyInjection
         [SetUp]
         public void Setup()
         {
-            var mockCbo = new Mock<ICBO>();
-            mockCbo
-                .Setup(x => x.GetCachedObject<IEnumerable<PropertyInfo>>(It.IsAny<CacheItemArgs>(), It.IsAny<CacheItemExpiredCallback>(), It.IsAny<bool>()))
-                .Returns<CacheItemArgs, CacheItemExpiredCallback, bool>((args, callback, _) => (IEnumerable<PropertyInfo>)callback(args));
-
-            CBO.SetTestableInstance(mockCbo.Object);
+            CBO.SetTestableInstance(new MockCBO());
 
             this.eventLogger = Mock.Of<IEventLogger>();
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DependencyInjection/BuildUpExtensionsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DependencyInjection/BuildUpExtensionsTests.cs
@@ -1,0 +1,161 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Web.DependencyInjection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Web.Http.Filters;
+
+    using DotNetNuke.Abstractions.Logging;
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.DependencyInjection;
+    using DotNetNuke.DependencyInjection.Extensions;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public partial class BuildUpExtensionsTests
+    {
+        // The event logger is used in the test Filters
+        private IEventLogger eventLogger;
+        private IServiceProvider container;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.eventLogger = Mock.Of<IEventLogger>();
+
+            var mockContainer = new Mock<IServiceProvider>();
+            mockContainer.Setup(provider => provider.GetService(typeof(IEventLogger))).Returns(this.eventLogger);
+
+            this.container = mockContainer.Object;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.eventLogger = null;
+            this.container = null;
+            CBO.ClearInstance();
+        }
+
+        [Test]
+        public void CheckParameter_ContainerIsNullTest()
+        {
+            var container = default(IServiceProvider);
+
+            // This should invoke without exceptions
+            container.BuildUp(Mock.Of<IFilter>());
+        }
+
+        [Test]
+        public void CheckParameter_Filter_IsNullTest()
+        {
+            var container = Mock.Of<IServiceProvider>();
+
+            // This should invoke without exceptions
+            container.BuildUp(null);
+        }
+
+        [Test]
+        public void BuildUp_PrivateProperty_Test()
+        {
+            this.MockCBO<PrivateFilterAttribute>();
+            var filter = new PrivateFilterAttribute();
+
+            this.container.BuildUp(filter);
+            filter.OnActionExecuted(null);
+
+            this.VerifyEventLoggerInvoked();
+        }
+
+        [Test]
+        public void BuildUp_ProtectedProperty_Test()
+        {
+            this.MockCBO<ProtectedFilterAttribute>();
+            var filter = new ProtectedFilterAttribute();
+
+            this.container.BuildUp(filter);
+            filter.OnActionExecuted(null);
+
+            this.VerifyEventLoggerInvoked();
+
+        }
+
+        [Test]
+        public void BuildUp_ProtectedInternalProperty_Test()
+        {
+            this.MockCBO<ProtectedInternalFilterAttribute>();
+            var filter = new ProtectedInternalFilterAttribute();
+
+            this.container.BuildUp(filter);
+            filter.OnActionExecuted(null);
+
+            this.VerifyEventLoggerInvoked();
+        }
+
+        [Test]
+        public void BuildUp_InternalProperty_Test()
+        {
+            this.MockCBO<InternalFilterAttribute>();
+            var filter = new InternalFilterAttribute();
+
+            this.container.BuildUp(filter);
+            filter.OnActionExecuted(null);
+
+            this.VerifyEventLoggerInvoked();
+        }
+
+        [Test]
+        public void BuildUp_NoDependencyAttribute_Test()
+        {
+            this.MockCBO<PublicNoDependencyAttributeFilterAttribute>();
+            var filter = new PublicNoDependencyAttributeFilterAttribute();
+
+            this.container.BuildUp(filter);
+            Assert.Throws<NullReferenceException>(() => filter.OnActionExecuted(null));
+
+            this.VerifyEventLoggerInvoked(Times.Never());
+        }
+
+        [Test]
+        public void BuildUp_NoSetter_Test()
+        {
+            this.MockCBO<NoSetFilterAttribute>();
+            var filter = new NoSetFilterAttribute();
+
+            this.container.BuildUp(filter);
+            Assert.Throws<NullReferenceException>(() => filter.OnActionExecuted(null));
+
+            this.VerifyEventLoggerInvoked(Times.Never());
+        }
+
+        void MockCBO<T>()
+            where T : IFilter
+        {
+            var properties = typeof(T)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(propertyInfo => propertyInfo.GetSetMethod(true) != null && propertyInfo.GetCustomAttribute<DependencyAttribute>() != null)
+                .ToList();
+
+            var mockCbo = new Mock<ICBO>();
+            mockCbo
+                .Setup(x => x.GetCachedObject<IEnumerable<PropertyInfo>>(It.IsAny<CacheItemArgs>(), It.IsAny<CacheItemExpiredCallback>(), It.IsAny<bool>()))
+                .Returns(properties);
+
+            CBO.SetTestableInstance(mockCbo.Object);
+        }
+
+        private void VerifyEventLoggerInvoked() => this.VerifyEventLoggerInvoked(Times.Once());
+
+        private void VerifyEventLoggerInvoked(Times times) =>
+            Mock.Get(this.eventLogger)
+                .Verify(logger => logger.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()), times);
+
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DependencyInjection/BuildUpExtensions_SampleFilters.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DependencyInjection/BuildUpExtensions_SampleFilters.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Web.DependencyInjection
+{
+    using System.Web.Http.Filters;
+
+    using DotNetNuke.Abstractions.Logging;
+    using DotNetNuke.DependencyInjection;
+
+    public partial class BuildUpExtensionsTests
+    {
+        private class PrivateFilterAttribute : ActionFilterAttribute
+        {
+            [Dependency]
+            private IEventLogger EventLogger { get; set; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+
+        private class ProtectedFilterAttribute : ActionFilterAttribute
+        {
+            [Dependency]
+            protected IEventLogger EventLogger { get; set; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+
+        private class ProtectedInternalFilterAttribute : ActionFilterAttribute
+        {
+            [Dependency]
+            protected internal IEventLogger EventLogger { get; set; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+
+        private class InternalFilterAttribute : ActionFilterAttribute
+        {
+            [Dependency]
+            internal IEventLogger EventLogger { get; set; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+
+        private class PublicFilterAttribute : ActionFilterAttribute
+        {
+            [Dependency]
+            public IEventLogger EventLogger { get; set; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+
+        private class PublicNoDependencyAttributeFilterAttribute : ActionFilterAttribute
+        {
+            public IEventLogger EventLogger { get; set; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                // This should throw an exception as EventLogger will be null
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+
+        private class NoSetFilterAttribute : ActionFilterAttribute
+        {
+            [Dependency]
+            public IEventLogger EventLogger { get; }
+
+            public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+            {
+                this.EventLogger.AddLog("Test", "Message", EventLogType.ADMIN_ALERT);
+                base.OnActionExecuted(actionExecutedContext);
+            }
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Api\HttpRequestMessageExtensionsTests.cs" />
     <Compile Include="Api\StandardTabAndModuleInfoProviderTests.cs" />
     <Compile Include="Api\ValidateAntiForgeryTokenAttributeTests.cs" />
+    <Compile Include="DependencyInjection\BuildUpExtensionsTests.cs" />
+    <Compile Include="DependencyInjection\BuildUpExtensions_SampleFilters.cs" />
     <Compile Include="InternalServices\FakeModuleCrawlerController.cs" />
     <Compile Include="InternalServices\SearchServiceControllerTests.cs">
       <SubType>Code</SubType>


### PR DESCRIPTION
## Summary
This adds property injection for WebAPI filters using the current Dependency Injection model. It mimics similar techniques that are common in the Unity Dependency Injection library by creating a new `BuildUp()` extension method to manage the Property Injection.

## Why
Suppose you have an `ActionFilter` that decorates one of your WebAPI methods and you need to leverage dependency injection to access a specific service. In ASP.NET WebAPI you can't use constructor injection due to how the filters are generated in the pipeline. It is considered a best practice to use Property Injection instead of the standard constructor injection.

This can be dangerous for us to adopt into the platform as I can see property injection and the `BuildUp()` method being abused. I would like to take a closer look at the `AttributeUsage` and see if we can tightly-couple the `[Dependency]` attribute just to `ActionFilter`. **I do not want and do not think we should support property injection in DNN, this is a discussion I have had with @mitchelsellers and I am not trying to bring it back up with this PR.** I am using property injection here as it appears to be required to get Dependency Injection support in ActionFilters

## Example
```c#
public class MyCustomFilter : ActionFilterAttribute
{
    [Dependency]
    public IMyCustomService MyCustomService { get; set; }

    public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
    {
        // When this method executes MyCustomService will be injected and ready for use
    }
}
```

## Steps to Merge
| Task | Status |
|------|-------|
| Unit Tests | ✔ Success |
| Test Installer | ✔ Success |
| XML Documentation | ✔ Success |