### PR TITLE
Adds support for editing the robots.txt on a website

### DIFF
--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -528,14 +528,6 @@ namespace DotNetNuke.Common.Utilities
             return xmlDoc;
         }
 
-        public static string LoadNonConfig(string filename)
-        {
-            // open the config file
-            var doc = File.ReadAllText(Globals.ApplicationMapPath + "\\" + filename);
-
-            return doc;
-        }
-
         public static void RemoveCodeSubDirectory(string name)
         {
             XmlDocument xmlConfig = Load();
@@ -611,61 +603,6 @@ namespace DotNetNuke.Common.Utilities
                             writer.Flush();
                             writer.Close();
                         }
-
-                        break;
-                    }
-                    catch (IOException exc)
-                    {
-                        if (retry == 0)
-                        {
-                            Logger.Error(exc);
-                            retMsg = exc.Message;
-                        }
-
-                        // try incremental delay; maybe the file lock is released by then
-                        Thread.Sleep((int)(miltiplier * (maxRetires - retry + 1)) * 1000);
-                    }
-                }
-
-                // reset file attributes
-                File.SetAttributes(strFilePath, objFileAttributes);
-            }
-            catch (Exception exc)
-            {
-                // the file permissions may not be set properly
-                Logger.Error(exc);
-                retMsg = exc.Message;
-            }
-
-            return retMsg;
-        }
-
-        public static string SaveNonConfig(string document, string filename)
-        {
-            var retMsg = string.Empty;
-            try
-            {
-                var strFilePath = Globals.ApplicationMapPath + "\\" + filename;
-                var objFileAttributes = FileAttributes.Normal;
-                if (File.Exists(strFilePath))
-                {
-                    // save current file attributes
-                    objFileAttributes = File.GetAttributes(strFilePath);
-
-                    // change to normal ( in case it is flagged as read-only )
-                    File.SetAttributes(strFilePath, FileAttributes.Normal);
-                }
-
-                // Attempt a few times in case the file was locked; occurs during modules' installation due
-                // to application restarts where IIS can overlap old application shutdown and new one start.
-                const int maxRetires = 4;
-                const double miltiplier = 2.5;
-                for (var retry = maxRetires; retry >= 0; retry--)
-                {
-                    try
-                    {
-                        // save the config file
-                        File.WriteAllText(strFilePath, document);
 
                         break;
                     }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
@@ -52,7 +52,7 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
             }
             else
             {
-                var doc = LoadNonConfig(configFile);
+                var doc = File.ReadAllText(Path.Combine(Globals.ApplicationMapPath, "\\", configFile));
                 return doc;
             }
         }
@@ -105,25 +105,17 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
             }
         }
 
-        private static string LoadNonConfig(string filename)
-        {
-            // open the config file
-            var doc = File.ReadAllText(string.Concat(Globals.ApplicationMapPath, "\\", filename));
-
-            return doc;
-        }
-
         private static string SaveNonConfig(string document, string filename)
         {
             var retMsg = string.Empty;
             try
             {
-                var strFilePath = string.Concat(Globals.ApplicationMapPath, "\\", filename);
-                var objFileAttributes = FileAttributes.Normal;
+                var strFilePath = Path.Combine(Globals.ApplicationMapPath, "\\", filename);
+                var existingFileAttributes = FileAttributes.Normal;
                 if (File.Exists(strFilePath))
                 {
                     // save current file attributes
-                    objFileAttributes = File.GetAttributes(strFilePath);
+                    existingFileAttributes = File.GetAttributes(strFilePath);
 
                     // change to normal ( in case it is flagged as read-only )
                     File.SetAttributes(strFilePath, FileAttributes.Normal);
@@ -156,7 +148,7 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
                 }
 
                 // reset file attributes
-                File.SetAttributes(strFilePath, objFileAttributes);
+                File.SetAttributes(strFilePath, existingFileAttributes);
             }
             catch (Exception exc)
             {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.ConfigConsole/scripts/ConfigConsole.js
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.ConfigConsole/scripts/ConfigConsole.js
@@ -46,6 +46,12 @@ define(['jquery',
                 configEditor.setValue('');
             } else {
                 requestService('get', 'GetConfigFile', { 'fileName': curConfigName }, function (data) {
+                    if (curConfigName.endsWith("config")) {
+                        configEditor.setOption("mode", "xml");
+                    }
+                    else if (curConfigName.endsWith("txt")) {
+                        configEditor.setOption("mode", "text");
+                    }
                     configEditor.setValue(data.FileContent);
                 }, function () {
                     // failed


### PR DESCRIPTION
Closes #3103

## Summary
Adds support to edit Robots.txt in the Persona Bar's Configuration Manager feature.  

This supports instances where there may be multiple robots.txt files for multi-portal instances.  An included update detects the correct mode to render in CodeMirror based on the file extension of the "configuration" file in question.  