### PR TITLE
Reset redirect url for redirecting to 'Redirect After Login' page

### DIFF
--- a/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -80,9 +80,8 @@ namespace DotNetNuke.Modules.Admin.Authentication
             get
             {
                 var redirectURL = string.Empty;
-                var redirectAfterLoginUrl = Convert.ToInt32(GetSetting(this.PortalId, "Redirect_AfterLogin"));
-                var isValidRedirectAfterLoginUrl = this.NeedRedirectAfterLogin
-                    && redirectAfterLoginUrl != Null.NullInteger;
+
+                var setting = GetSetting(this.PortalId, "Redirect_AfterLogin");
 
                 // first we need to check if there is a returnurl
                 if (this.Request.QueryString["returnurl"] != null)
@@ -112,12 +111,6 @@ namespace DotNetNuke.Modules.Admin.Authentication
                     redirectURL = UrlUtils.ValidReturnUrl(redirectURL);
                 }
 
-                // Reset redirect url for redirecting to 'Redirect After Login' page
-                if (isValidRedirectAfterLoginUrl)
-                {
-                    redirectURL = string.Empty;
-                }
-
                 var alias = this.PortalAlias.HTTPAlias;
                 var comparison = StringComparison.InvariantCultureIgnoreCase;
 
@@ -127,9 +120,12 @@ namespace DotNetNuke.Modules.Admin.Authentication
 
                 if (string.IsNullOrEmpty(redirectURL) || isDefaultPage)
                 {
-                    if (isValidRedirectAfterLoginUrl && (isDefaultPage || this.IsRedirectingFromLoginUrl()))
+                    if (
+                        this.NeedRedirectAfterLogin
+                        && (isDefaultPage || this.IsRedirectingFromLoginUrl())
+                        && Convert.ToInt32(setting) != Null.NullInteger)
                     {
-                        redirectURL = this._navigationManager.NavigateURL(redirectAfterLoginUrl);
+                        redirectURL = this._navigationManager.NavigateURL(Convert.ToInt32(setting));
                     }
                     else
                     {

--- a/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -806,13 +806,13 @@ namespace DotNetNuke.Modules.Admin.Authentication
             }
 
             var tab = TabController.Instance.GetTab(this.PortalSettings.LoginTabId, this.PortalId);
-            return tab != null ? $"/{this._navigationManager.NavigateURL(tab.TabName)}" : LOGIN_PATH;
+            return tab != null ? new Uri(this._navigationManager.NavigateURL(tab.TabName)).LocalPath : LOGIN_PATH;
         }
 
         private bool IsRedirectingFromLoginUrl()
         {
             return this.Request.UrlReferrer != null &&
-                this.Request.UrlReferrer.LocalPath.EndsWith(GetLoginPath(), StringComparison.InvariantCultureIgnoreCase);
+                this.GetLoginPath().StartsWith(this.Request.UrlReferrer.LocalPath, StringComparison.InvariantCultureIgnoreCase);
         }
 
         private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)

--- a/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -806,7 +806,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
             }
 
             var tab = TabController.Instance.GetTab(this.PortalSettings.LoginTabId, this.PortalId);
-            return tab != null ? $"/{tab.TabName}" : LOGIN_PATH;
+            return tab != null ? $"/{this._navigationManager.NavigateURL(tab.TabName)}" : LOGIN_PATH;
         }
 
         private bool IsRedirectingFromLoginUrl()

--- a/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -806,13 +806,13 @@ namespace DotNetNuke.Modules.Admin.Authentication
             }
 
             var tab = TabController.Instance.GetTab(this.PortalSettings.LoginTabId, this.PortalId);
-            return tab != null ? new Uri(this._navigationManager.NavigateURL(tab.TabName)).LocalPath : LOGIN_PATH;
+            return tab != null ? new Uri(this._navigationManager.NavigateURL(this.PortalSettings.LoginTabId), UriKind.RelativeOrAbsolute).LocalPath : LOGIN_PATH;
         }
 
         private bool IsRedirectingFromLoginUrl()
         {
             return this.Request.UrlReferrer != null &&
-                this.GetLoginPath().StartsWith(this.Request.UrlReferrer.LocalPath, StringComparison.InvariantCultureIgnoreCase);
+                this.Request.UrlReferrer.LocalPath.EndsWith(GetLoginPath(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)

--- a/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
+
 namespace DotNetNuke.Modules.Admin.Authentication
 {
     using System;
@@ -23,6 +24,7 @@ namespace DotNetNuke.Modules.Admin.Authentication
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Profile;
+    using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Framework;
     using DotNetNuke.Instrumentation;
@@ -796,10 +798,21 @@ namespace DotNetNuke.Modules.Admin.Authentication
             return returnValue;
         }
 
+        private string GetLoginPath()
+        {
+            if (this.PortalSettings.LoginTabId == Null.NullInteger)
+            {
+                return LOGIN_PATH;
+            }
+
+            var tab = TabController.Instance.GetTab(this.PortalSettings.LoginTabId, this.PortalId);
+            return tab != null ? $"/{tab.TabName}" : LOGIN_PATH;
+        }
+
         private bool IsRedirectingFromLoginUrl()
         {
             return this.Request.UrlReferrer != null &&
-                this.Request.UrlReferrer.LocalPath.ToLowerInvariant().EndsWith(LOGIN_PATH);
+                this.Request.UrlReferrer.LocalPath.EndsWith(GetLoginPath(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         private void AddLoginControlAttributes(AuthenticationLoginBase loginControl)


### PR DESCRIPTION
Fixes #3661

## Summary
Reset redirectURL value so that it will be empty for populating redirectURL with 'Redirect After Login' value
