### PR TITLE
Issues/fix pr 4165

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
@@ -52,7 +52,7 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
             }
             else
             {
-                var doc = File.ReadAllText(string.Concat(Globals.ApplicationMapPath, "\\", configFile));
+                var doc = File.ReadAllText(Path.Combine(Globals.ApplicationMapPath, configFile));
                 return doc;
             }
         }
@@ -110,7 +110,7 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
             var retMsg = string.Empty;
             try
             {
-                var strFilePath = string.Concat(Globals.ApplicationMapPath, "\\", filename);
+                var strFilePath = Path.Combine(Globals.ApplicationMapPath, filename);
                 var existingFileAttributes = FileAttributes.Normal;
                 if (File.Exists(strFilePath))
                 {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
@@ -110,7 +110,7 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
             var retMsg = string.Empty;
             try
             {
-                var strFilePath = Path.Combine(Globals.ApplicationMapPath, "\\", filename);
+                var strFilePath = string.Concat(Globals.ApplicationMapPath, "\\", filename);
                 var existingFileAttributes = FileAttributes.Normal;
                 if (File.Exists(strFilePath))
                 {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/ConfigConsole/ConfigConsoleController.cs
@@ -52,7 +52,7 @@ namespace Dnn.PersonaBar.ConfigConsole.Components
             }
             else
             {
-                var doc = File.ReadAllText(Path.Combine(Globals.ApplicationMapPath, "\\", configFile));
+                var doc = File.ReadAllText(string.Concat(Globals.ApplicationMapPath, "\\", configFile));
                 return doc;
             }
         }


### PR DESCRIPTION
## Summary
Fixes a testing issue discovered in PR #4165 

For some reason, this line returns the path as `\\Robots.txt` (for both load and save):

```cs
var doc = File.ReadAllText(Path.Combine(Globals.ApplicationMapPath, "\\", configFile));
```

When I put it back to what it was before the code review, it works. (Also, this is the way it's done in Config.cs in at least one spot.)  

```cs
var doc = File.ReadAllText(string.Concat(Globals.ApplicationMapPath, "\\", configFile));
```

Video Showing it Working:  https://www.screencast.com/t/Z1u6MwY567