### PR TITLE
Adds Application Startup Events with Dependency Injection

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IApplicationInfo.cs
@@ -5,10 +5,12 @@ namespace DotNetNuke.Abstractions.Application
 {
     using System;
 
+    using Microsoft.Extensions.Hosting;
+
     /// <summary>
     /// The Application class contains properties that describe the DotNetNuke Application.
     /// </summary>
-    public interface IApplicationInfo
+    public interface IApplicationInfo : IHostingEnvironment
     {
         /// <summary>
         /// Gets the company to which the DotNetNuke application is related.

--- a/DNN Platform/DotNetNuke.Abstractions/Application/IDnnStartupConfigure.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/IDnnStartupConfigure.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Abstractions.Application
+{
+    using Microsoft.AspNetCore.Builder;
+
+    /// <summary>
+    /// test.
+    /// </summary>
+    public interface IDnnStartupConfigure
+    {
+        /// <summary>
+        /// Configure.
+        /// </summary>
+        /// <param name="app">app.</param>
+        /// <param name="env">env.</param>
+        void Configure(IApplicationBuilder app, IApplicationInfo env);
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
+++ b/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
+++ b/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
+++ b/DNN Platform/DotNetNuke.Web/Common/DotNetNukeHttpApplication.cs
@@ -174,6 +174,8 @@ namespace DotNetNuke.Web.Common.Internal
             DotNetNuke.Services.Zip.SharpZipLibRedirect.RegisterSharpZipLibRedirect();
 
             // DotNetNukeSecurity.Initialize();
+
+            StartupConfigureInitialize.ConfigureApplication(Globals.DependencyProvider);
         }
 
         private static bool IsInstallOrUpgradeRequest(HttpRequest request)

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -95,11 +95,35 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DotNetNuke.WebUtility\bin\DotNetNuke.WebUtility.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.WebUtilities.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.ObjectPool.2.1.1\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.Headers.2.1.1\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -110,17 +134,33 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Extensions" />
@@ -262,6 +302,7 @@
     <Compile Include="Services\ServiceRouteMapper.cs" />
     <Compile Include="DependencyInjectionInitialize.cs" />
     <Compile Include="Startup.cs" />
+    <Compile Include="StartupConfigureInitialize.cs" />
     <Compile Include="UI\WebControls\DnnDropDownListState.cs" />
     <Compile Include="UI\WebControls\DnnFileDropDownList.cs" />
     <Compile Include="UI\WebControls\DnnFileUploadOptions.cs" />

--- a/DNN Platform/DotNetNuke.Web/StartupConfigureInitialize.cs
+++ b/DNN Platform/DotNetNuke.Web/StartupConfigureInitialize.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Web
+{
+    using System;
+    using System.Linq;
+
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.DependencyInjection.Extensions;
+    using DotNetNuke.Instrumentation;
+
+    using Microsoft.AspNetCore.Builder.Internal;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Initializes the Startup Configure API.
+    /// </summary>
+    internal static class StartupConfigureInitialize
+    {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(DependencyInjectionInitialize));
+
+        /// <summary>
+        /// Instantiates all implementations of <see cref="IDnnStartupConfigure"/>
+        /// and invokes the Configure method.
+        /// </summary>
+        /// <param name="container">The Dependency Injection container.</param>
+        public static void ConfigureApplication(IServiceProvider container)
+        {
+            var applicationBuilder = new ApplicationBuilder(container);
+            var applicationInfo = container.GetRequiredService<IApplicationInfo>();
+
+            var startupInstances = AppDomain.CurrentDomain.GetAssemblies()
+                .OrderBy(assembly =>
+                    assembly.FullName.StartsWith("DotNetNuke", StringComparison.OrdinalIgnoreCase) ?
+                    0 :
+                    assembly.FullName.StartsWith("DNN", StringComparison.OrdinalIgnoreCase) ? 1 : 2)
+                .ThenBy(assembly => assembly.FullName)
+                .SelectMany(assembly => assembly
+                    .SafeGetTypes()
+                    .OrderBy(type => type.FullName ?? type.Name))
+                .Where(type => typeof(IDnnStartupConfigure).IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
+                .Select(CreateInstance)
+                .Where(instance => instance != null);
+
+            foreach (var startup in startupInstances)
+            {
+                try
+                {
+                    startup.Configure(applicationBuilder, applicationInfo);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Unable to configure services for {startup.GetType().FullName}, see exception for details", ex);
+                }
+            }
+
+            IDnnStartupConfigure CreateInstance(Type startupType)
+            {
+                try
+                {
+                    return (IDnnStartupConfigure)Activator.CreateInstance(startupType);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Unable to instantiate startup code for {startupType.FullName}", ex);
+                    return null;
+                }
+            }
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web/packages.config
+++ b/DNN Platform/DotNetNuke.Web/packages.config
@@ -7,10 +7,23 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Net.Http.Headers" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.1" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net472" />
   <package id="WebFormsMVP" version="1.4.1.0" targetFramework="net45" />
 </packages>

--- a/DNN Platform/Library/Application/Application.cs
+++ b/DNN Platform/Library/Application/Application.cs
@@ -11,6 +11,8 @@ namespace DotNetNuke.Application
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
 
+    using Microsoft.Extensions.FileProviders;
+
     using NewReleaseMode = DotNetNuke.Abstractions.Application.ReleaseMode;
 
     /// <inheritdoc />
@@ -23,6 +25,16 @@ namespace DotNetNuke.Application
         /// </summary>
         public Application()
         {
+            this.ApplicationName = this.Title;
+            this.ContentRootPath = this.GetCurrentDomainDirectory();
+            this.ContentRootFileProvider = new PhysicalFileProvider(this.ContentRootPath);
+
+#if DEBUG
+            var environment = "Development";
+#else
+            var environment = "Production";
+#endif
+            this.EnvironmentName = environment;
         }
 
         /// <inheritdoc />
@@ -185,9 +197,36 @@ namespace DotNetNuke.Application
         }
 
         /// <inheritdoc />
+        public string EnvironmentName { get; set; }
+
+        /// <inheritdoc />
+        public string ApplicationName { get; set; }
+
+        /// <inheritdoc />
+        public string ContentRootPath { get; set; }
+
+        /// <inheritdoc />
+        public IFileProvider ContentRootFileProvider { get; set; }
+
+        /// <inheritdoc />
         public virtual bool ApplyToProduct(string productNames)
         {
             return productNames.Contains(this.Name);
+        }
+
+        /// <summary>
+        /// Get the current domain directory.
+        /// </summary>
+        /// <returns>returns the domain directory.</returns>
+        private string GetCurrentDomainDirectory()
+        {
+            var dir = AppDomain.CurrentDomain.BaseDirectory.Replace("/", "\\");
+            if (dir.Length > 3 && dir.EndsWith("\\"))
+            {
+                dir = dir.Substring(0, dir.Length - 1);
+            }
+
+            return dir;
         }
     }
 }

--- a/DNN Platform/Library/Application/ApplicationStatusInfo.cs
+++ b/DNN Platform/Library/Application/ApplicationStatusInfo.cs
@@ -128,7 +128,7 @@ namespace DotNetNuke.Application
         public Version DatabaseVersion { get; private set; }
 
         /// <inheritdoc />
-        public string ApplicationMapPath { get => this.applicationMapPath ?? (this.applicationMapPath = this.GetCurrentDomainDirectory()); }
+        public string ApplicationMapPath => this.applicationInfo.ContentRootPath;
 
         /// <inheritdoc />
         public bool IsInstalled()
@@ -298,21 +298,6 @@ namespace DotNetNuke.Application
         private bool HasInstallVersion()
         {
             return Config.GetSetting("InstallVersion") != null;
-        }
-
-        /// <summary>
-        /// Get the current domain directory.
-        /// </summary>
-        /// <returns>returns the domain directory.</returns>
-        private string GetCurrentDomainDirectory()
-        {
-            var dir = AppDomain.CurrentDomain.BaseDirectory.Replace("/", "\\");
-            if (dir.Length > 3 && dir.EndsWith("\\"))
-            {
-                dir = dir.Substring(0, dir.Length - 1);
-            }
-
-            return dir;
         }
     }
 }

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -80,10 +80,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Controls\CountryListBox\bin\CountryListBox.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Instrumentation">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\DotNetNuke.Instrumentation\bin\DotNetNuke.Instrumentation.dll</HintPath>
-    </Reference>
     <Reference Include="dotnetnuke.log4net">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DotNetNuke.Log4net\bin\dotnetnuke.log4net.dll</HintPath>
@@ -119,15 +115,42 @@
       <HintPath>..\Components\DataAccessBlock\bin\Microsoft.ApplicationBlocks.Data.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=3.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.FileSystemGlobbing.3.1.1\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Physical.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileSystemGlobbing.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Hosting.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Web.Infrastructure">
@@ -147,6 +170,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.configuration" />
@@ -154,8 +180,24 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.2\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -1779,6 +1821,7 @@
     <AdditionalFiles Include="..\..\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>
+    <None Include="app.config" />
     <None Include="Library.build">
       <SubType>Designer</SubType>
     </None>
@@ -1892,6 +1935,10 @@
     </ProjectReference>
     <ProjectReference Include="..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
       <Project>{ddf18e36-41a0-4ca7-a098-78ca6e6f41c1}</Project>
+      <Name>DotNetNuke.Instrumentation</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
+      <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>
       <Name>DotNetNuke.Instrumentation</Name>
     </ProjectReference>
     <ProjectReference Include="..\DotNetNuke.Log4net\DotNetNuke.Log4Net.csproj">

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1821,7 +1821,6 @@
     <AdditionalFiles Include="..\..\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>
-    <None Include="app.config" />
     <None Include="Library.build">
       <SubType>Designer</SubType>
     </None>

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -16,7 +16,6 @@ namespace DotNetNuke
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.UI.Modules.Html5;
-
     using Microsoft.Extensions.DependencyInjection;
 
     /// <inheritdoc />

--- a/DNN Platform/Library/packages.config
+++ b/DNN Platform/Library/packages.config
@@ -3,13 +3,26 @@
   <package id="Dnn.ClientDependency" version="1.9.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.1.2" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.2" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileSystemGlobbing" version="3.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="PetaPoco.Compiled" version="6.0.415" targetFramework="net472" />
   <package id="QuickIO.NET" version="2.6.2.0" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.2" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -83,11 +83,26 @@
       <HintPath>..\..\Components\Lucene.Net.Contrib\bin\Lucene.Net.Contrib.FastVectorHighlighter.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Hosting.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
@@ -100,10 +115,23 @@
       <HintPath>..\..\Components\PetaPoco\bin\PetaPoco.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
@@ -1,9 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net472" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.1" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Fixes: #4167 

## Summary
Adds new `IDnnStartupConfigure` interface to `DotNetNuke.Abstractions` project which allows developers to add startup code to their extension with Dependency Injection. 

In modern AspNetCore applications there is a `Startup.cs` file that has a `Configure` method. This method provides advanced startup initialization such as
- Registering middleware
- Configuring special loggers based on environments
- Configured connection strings for Entity Framework
- Setting up swashbuckle Web API docs
- Much More

This adds the most basic implementation via a new interface `IDnnStartupConfigure` which adds a carbon copy of the what is being used in AspNetCore 2.1

## Notable Changes
This PR adds several AspNetCore 2.1 assemblies which is the LTS build but has since been out of date. 

## Draft PR
This PR has been created as a draft as it demonstrates how we can accomplish this with AspNetCore assemblies. I want to share this with the maintainers so they can see how this would be implemented. 

### Alternative
If we decide this adds too much of a footprint in DNN, I recommend we update the interface to use custom dnn objects
```c#
public interface IDnnApplicationBuilder {}
public interface IDnnApplicationInfo {}
```


