### PR TITLE
Fixes Event Log from Failing Silently during Application Startup

### DIFF
--- a/DNN Platform/Library/Services/Log/EventLog/LogController.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/LogController.cs
@@ -13,6 +13,7 @@ namespace DotNetNuke.Services.Log.EventLog
     using System.Threading;
     using System.Web;
     using System.Xml;
+
     using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -46,12 +47,19 @@ namespace DotNetNuke.Services.Log.EventLog
 
                     if (string.IsNullOrEmpty(logInfo.LogUserName))
                     {
-                        if (HttpContext.Current != null)
+                        try
                         {
-                            if (HttpContext.Current.Request.IsAuthenticated)
+                            if (HttpContext.Current != null)
                             {
-                                logInfo.LogUserName = UserController.Instance.GetCurrentUserInfo().Username;
+                                if (HttpContext.Current.Request.IsAuthenticated)
+                                {
+                                    logInfo.LogUserName = UserController.Instance.GetCurrentUserInfo().Username;
+                                }
                             }
+                        }
+                        catch (Exception exception)
+                        {
+                            Logger.Error("Unable to retrieve HttpContext, ignoring LogUserName", exception);
                         }
                     }
 

--- a/DNN Platform/Library/Services/Log/EventLog/LogController.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/LogController.cs
@@ -47,19 +47,19 @@ namespace DotNetNuke.Services.Log.EventLog
 
                     if (string.IsNullOrEmpty(logInfo.LogUserName))
                     {
-                        try
+                        if (HttpContext.Current != null)
                         {
-                            if (HttpContext.Current != null)
+                            try
                             {
                                 if (HttpContext.Current.Request.IsAuthenticated)
                                 {
                                     logInfo.LogUserName = UserController.Instance.GetCurrentUserInfo().Username;
                                 }
                             }
-                        }
-                        catch (Exception exception)
-                        {
-                            Logger.Error("Unable to retrieve HttpContext, ignoring LogUserName", exception);
+                            catch (HttpException exception)
+                            {
+                                Logger.Error("Unable to retrieve HttpContext.Request, ignoring LogUserName", exception);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fixes: #4175

## Summary
Fixes a bug where the event log will silently fail if the username is not provided and the `HttpContext` is not set. This will happen if the event log is being used during the Application Startup which executes prior to the initialization of the `HttpContext`.