### PR TITLE
Resolved issue with Keyword and Description Defaults

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/Converters.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/Converters.cs
@@ -79,9 +79,6 @@ namespace Dnn.PersonaBar.Pages.Components
             }
 
             var pageManagementController = PageManagementController.Instance;
-
-            var description = !string.IsNullOrEmpty(tab.Description) ? tab.Description : PortalSettings.Current.Description;
-            var keywords = !string.IsNullOrEmpty(tab.KeyWords) ? tab.KeyWords : PortalSettings.Current.KeyWords;
             var pageType = GetPageType(tab.Url);
 
             var file = GetFileRedirection(tab.Url);
@@ -97,8 +94,8 @@ namespace Dnn.PersonaBar.Pages.Components
                 AbsoluteUrl = tab.FullUrl,
                 LocalizedName = tab.LocalizedTabName,
                 Title = tab.Title,
-                Description = description,
-                Keywords = keywords,
+                Description = tab.Description,
+                Keywords = tab.KeyWords,
                 Tags = string.Join(",", from t in tab.Terms select t.Name),
                 Alias = PortalSettings.Current.PortalAlias.HTTPAlias,
                 Url = pageManagementController.GetTabUrl(tab),


### PR DESCRIPTION
Closes #3541 

The existing behavior when editing a tab would add the Portal level description and keyword fields.  If the user then clicked saved it would be saved to the page as content.

The defaulting of descriptions when rendered is correct, but this behavior resulted in improper values being set without the user knowing.