### PR TITLE
Introduce MailAttachment class

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -823,6 +823,7 @@
     <Compile Include="Services\Log\EventLog\ILogController.cs" />
     <Compile Include="Services\Mail\CoreMailProvider.cs" />
     <Compile Include="Services\Mail\MailInfo.cs" />
+    <Compile Include="Services\Mail\MailAttachment.cs" />
     <Compile Include="Services\Mail\MailProvider.cs" />
     <Compile Include="Services\Mail\SmtpInfo.cs" />
     <Compile Include="Services\OutputCache\Providers\DatabaseProvider.cs" />

--- a/DNN Platform/Library/Services/Mail/Mail.cs
+++ b/DNN Platform/Library/Services/Mail/Mail.cs
@@ -24,7 +24,6 @@ namespace DotNetNuke.Services.Mail
 
     public class Mail
     {
-
         public static bool IsValidEmailAddress(string Email, int portalid)
         {
             string pattern = Null.NullString;
@@ -51,57 +50,55 @@ namespace DotNetNuke.Services.Mail
                 return;
             }
 
-            MailInfo mailInfo = new MailInfo()
-            {
-                From = fromAddress,
-                Sender = senderAddress,
-                To = toAddress,
-                Subject = subject,
-                Body = body,
-                Priority = MailPriority.Normal,
-                BodyFormat = HtmlUtils.IsHtml(body) ? MailFormat.Html : MailFormat.Text,
-                BodyEncoding = Encoding.UTF8,
-            };
+            var mailInfo = new MailInfo
+                           {
+                               From = fromAddress,
+                               Sender = senderAddress,
+                               To = toAddress,
+                               Subject = subject,
+                               Body = body,
+                               Priority = MailPriority.Normal,
+                               BodyFormat = HtmlUtils.IsHtml(body) ? MailFormat.Html : MailFormat.Text,
+                               BodyEncoding = Encoding.UTF8,
+                           };
 
             MailProvider.Instance().SendMail(mailInfo);
         }
 
-        [Obsolete("This method has been deprecated. Please use SendEmail() with List<MailAttachment> Scheduled removal in v11.0.0.")]
+        [Obsolete("This method has been deprecated. Please use SendEmail() with ICollection<MailAttachment> Scheduled removal in v11.0.0.")]
         public static string SendEmail(string fromAddress, string senderAddress, string toAddress, string subject, string body, List<Attachment> attachments)
         {
-            MailInfo mailInfo = new MailInfo()
-            {
-                From = fromAddress,
-                Sender = senderAddress,
-                To = toAddress,
-                Subject = subject,
-                Body = body,
-                Priority = MailPriority.Normal,
-                BodyFormat = HtmlUtils.IsHtml(body) ? MailFormat.Html : MailFormat.Text,
-                BodyEncoding = Encoding.UTF8,
-                Attachments = ConvertAttachments(attachments),
-            };
-
+            var mailInfo = new MailInfo
+                           {
+                               From = fromAddress,
+                               Sender = senderAddress,
+                               To = toAddress,
+                               Subject = subject,
+                               Body = body,
+                               Priority = MailPriority.Normal,
+                               BodyFormat = HtmlUtils.IsHtml(body) ? MailFormat.Html : MailFormat.Text,
+                               BodyEncoding = Encoding.UTF8,
+                               Attachments = ConvertAttachments(attachments),
+                           };
 
             return MailProvider.Instance().SendMail(mailInfo);
         }
 
-        public static string SendEmail(string fromAddress, string senderAddress, string toAddress, string subject, string body, List<MailAttachment> attachments)
+        public static string SendEmail(string fromAddress, string senderAddress, string toAddress, string subject, string body, ICollection<MailAttachment> attachments)
         {
-            MailInfo mailInfo = new MailInfo()
-            {
-                From = fromAddress,
-                Sender = senderAddress,
-                To = toAddress,
-                Subject = subject,
-                Body = body,
-                Priority = MailPriority.Normal,
-                BodyFormat = HtmlUtils.IsHtml(body) ? MailFormat.Html : MailFormat.Text,
-                BodyEncoding = Encoding.UTF8,
-                Attachments = attachments,
-            };
+            var mailInfo = new MailInfo
+                           {
+                               From = fromAddress,
+                               Sender = senderAddress,
+                               To = toAddress,
+                               Subject = subject,
+                               Body = body,
+                               Priority = MailPriority.Normal,
+                               BodyFormat = HtmlUtils.IsHtml(body) ? MailFormat.Html : MailFormat.Text,
+                               BodyEncoding = Encoding.UTF8,
+                               Attachments = attachments,
+                           };
 
-            
             return MailProvider.Instance().SendMail(mailInfo);
         }
 
@@ -168,11 +165,18 @@ namespace DotNetNuke.Services.Mail
                     if (HttpContext.Current != null)
                     {
                         custom = new ArrayList
-                        {
-                            HttpContext.Current.Server.HtmlEncode(HttpContext.Current.Server.UrlEncode(user.Username)),
-                            HttpContext.Current.Server.UrlEncode(user.GetProperty("verificationcode", string.Empty, null,
-                                user, Scope.SystemMessages, ref propertyNotFound)),
-                        };
+                                 {
+                                     HttpContext.Current.Server.HtmlEncode(
+                                         HttpContext.Current.Server.UrlEncode(user.Username)),
+                                     HttpContext.Current.Server.UrlEncode(
+                                         user.GetProperty(
+                                             "verificationcode",
+                                             string.Empty,
+                                             null,
+                                             user,
+                                             Scope.SystemMessages,
+                                             ref propertyNotFound)),
+                                 };
                     }
 
                     break;
@@ -387,7 +391,7 @@ namespace DotNetNuke.Services.Mail
                 smtpEnableSSL);
         }
 
-        [Obsolete("This method has been deprecated. Please use SendEmail() with List<MailAttachment> Scheduled removal in v11.0.0.")]
+        [Obsolete("This method has been deprecated. Please use SendEmail() with ICollection<MailAttachment> Scheduled removal in v11.0.0.")]
         public static string SendMail(string mailFrom, string mailTo, string cc, string bcc, string replyTo, MailPriority priority, string subject, MailFormat bodyFormat, Encoding bodyEncoding,
                               string body, List<Attachment> attachments, string smtpServer, string smtpAuthentication, string smtpUsername, string smtpPassword, bool smtpEnableSSL)
         {
@@ -410,8 +414,9 @@ namespace DotNetNuke.Services.Mail
                 smtpPassword,
                 smtpEnableSSL);
         }
+
         public static string SendMail(string mailFrom, string mailTo, string cc, string bcc, string replyTo, MailPriority priority, string subject, MailFormat bodyFormat, Encoding bodyEncoding,
-                              string body, List<MailAttachment> attachments, string smtpServer, string smtpAuthentication, string smtpUsername, string smtpPassword, bool smtpEnableSSL)
+                              string body, ICollection<MailAttachment> attachments, string smtpServer, string smtpAuthentication, string smtpUsername, string smtpPassword, bool smtpEnableSSL)
         {
             return SendMail(
                 mailFrom,
@@ -433,34 +438,34 @@ namespace DotNetNuke.Services.Mail
                 smtpEnableSSL);
         }
 
-        [Obsolete("This method has been deprecated. Please use SendEmail() with List<MailAttachment> Scheduled removal in v11.0.0.")]
+        [Obsolete("This method has been deprecated. Please use SendEmail() with ICollection<MailAttachment> Scheduled removal in v11.0.0.")]
         public static string SendMail(string mailFrom, string mailSender, string mailTo, string cc, string bcc, string replyTo, MailPriority priority, string subject, MailFormat bodyFormat, Encoding bodyEncoding,
                                       string body, List<Attachment> attachments, string smtpServer, string smtpAuthentication, string smtpUsername, string smtpPassword, bool smtpEnableSSL)
         {
-            SmtpInfo smtpInfo = new SmtpInfo()
-            {
-                Server = smtpServer,
-                Authentication = smtpAuthentication,
-                Username = smtpUsername,
-                Password = smtpPassword,
-                EnableSSL = smtpEnableSSL,
-            };
+            var smtpInfo = new SmtpInfo
+                           {
+                               Server = smtpServer,
+                               Authentication = smtpAuthentication,
+                               Username = smtpUsername,
+                               Password = smtpPassword,
+                               EnableSSL = smtpEnableSSL,
+                           };
 
-            MailInfo mailInfo = new MailInfo()
-            {
-                From = mailFrom,
-                Sender = mailSender,
-                To = mailTo,
-                CC = cc,
-                BCC = bcc,
-                ReplyTo = replyTo,
-                Priority = priority,
-                BodyEncoding = bodyEncoding,
-                BodyFormat = bodyFormat,
-                Body = body,
-                Subject = subject,
-                Attachments = ConvertAttachments(attachments),
-            };
+            var mailInfo = new MailInfo
+                           {
+                               From = mailFrom,
+                               Sender = mailSender,
+                               To = mailTo,
+                               CC = cc,
+                               BCC = bcc,
+                               ReplyTo = replyTo,
+                               Priority = priority,
+                               BodyEncoding = bodyEncoding,
+                               BodyFormat = bodyFormat,
+                               Body = body,
+                               Subject = subject,
+                               Attachments = ConvertAttachments(attachments),
+                           };
 
             if (PortalSettings.Current != null && UserController.GetUserByEmail(PortalSettings.Current.PortalId, mailFrom) != null)
             {
@@ -469,33 +474,34 @@ namespace DotNetNuke.Services.Mail
 
             return MailProvider.Instance().SendMail(mailInfo, smtpInfo);
         }
+
         public static string SendMail(string mailFrom, string mailSender, string mailTo, string cc, string bcc, string replyTo, MailPriority priority, string subject, MailFormat bodyFormat, Encoding bodyEncoding,
-                                      string body, List<MailAttachment> attachments, string smtpServer, string smtpAuthentication, string smtpUsername, string smtpPassword, bool smtpEnableSSL)
+                                      string body, ICollection<MailAttachment> attachments, string smtpServer, string smtpAuthentication, string smtpUsername, string smtpPassword, bool smtpEnableSSL)
         {
-            SmtpInfo smtpInfo = new SmtpInfo()
-            {
-                Server = smtpServer,
-                Authentication = smtpAuthentication,
-                Username = smtpUsername,
-                Password = smtpPassword,
-                EnableSSL = smtpEnableSSL,
-            };
+            var smtpInfo = new SmtpInfo
+                           {
+                               Server = smtpServer,
+                               Authentication = smtpAuthentication,
+                               Username = smtpUsername,
+                               Password = smtpPassword,
+                               EnableSSL = smtpEnableSSL,
+                           };
 
-            MailInfo mailInfo = new MailInfo()
-            {
-                From = mailFrom,
-                Sender = mailSender,
-                To = mailTo,
-                CC = cc,
-                BCC = bcc,
-                ReplyTo = replyTo,
-                Priority = priority,
-                BodyEncoding = bodyEncoding,
-                BodyFormat = bodyFormat,
-                Body = body,
-                Subject = subject,
-                Attachments = attachments,
-            };
+            var mailInfo = new MailInfo
+                           {
+                               From = mailFrom,
+                               Sender = mailSender,
+                               To = mailTo,
+                               CC = cc,
+                               BCC = bcc,
+                               ReplyTo = replyTo,
+                               Priority = priority,
+                               BodyEncoding = bodyEncoding,
+                               BodyFormat = bodyFormat,
+                               Body = body,
+                               Subject = subject,
+                               Attachments = attachments,
+                           };
 
             if (PortalSettings.Current != null && UserController.GetUserByEmail(PortalSettings.Current.PortalId, mailFrom) != null)
             {
@@ -505,21 +511,18 @@ namespace DotNetNuke.Services.Mail
             return MailProvider.Instance().SendMail(mailInfo, smtpInfo);
         }
 
-        private static List<MailAttachment> ConvertAttachments(List<Attachment> attachments)
+        private static ICollection<MailAttachment> ConvertAttachments(List<Attachment> attachments)
         {
-            var list = new List<MailAttachment>();
-
-            foreach (var attachment in attachments)
-            {
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    attachment.ContentStream.CopyTo(ms);
-                    MailAttachment attach = new MailAttachment(attachment.Name, ms.ToArray());
-                    list.Add(attach);
-                }
-            }
-
-            return list;
+            return attachments.Select(
+                    attachment =>
+                    {
+                        using (var ms = new MemoryStream())
+                        {
+                            attachment.ContentStream.CopyTo(ms);
+                            return new MailAttachment(attachment.Name, ms.ToArray());
+                        }
+                    })
+                .ToList();
         }
     }
 }

--- a/DNN Platform/Library/Services/Mail/MailAttachment.cs
+++ b/DNN Platform/Library/Services/Mail/MailAttachment.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Web;
+
+namespace DotNetNuke.Services.Mail
+{
+    public class MailAttachment
+    {
+        private const string DefaultContentType = "application/octet-stream";
+
+        public MailAttachment(string FilePath)
+        {
+            var Content = File.ReadAllBytes(FilePath);
+            var Filename = Path.GetFileName(FilePath);
+            var ContentType = MimeMapping.GetMimeMapping(Filename);
+
+            this.MailAttachmentInternal(Filename, Content, ContentType);
+        }
+
+        public MailAttachment(string Filename, Byte[] Content)
+        {
+            this.MailAttachmentInternal(Filename, Content, MimeMapping.GetMimeMapping(Filename));
+        }
+
+        public MailAttachment(string Filename, Byte[] Content, string ContentType)
+        {
+            this.MailAttachmentInternal(Filename, Content, ContentType);
+        }
+
+        private void MailAttachmentInternal(string Filename, Byte[] Content, string ContentType)
+        {
+            this.Filename = Filename;
+            this.Content = Content;
+            this.ContentType = ContentType;
+        }
+
+        public byte[] Content { get; set; }
+        public string Filename { get; set; }
+        public string ContentType { get; set; }
+    }
+}

--- a/DNN Platform/Library/Services/Mail/MailInfo.cs
+++ b/DNN Platform/Library/Services/Mail/MailInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 using System.Collections.Generic;
-using System.Net.Mail;
 using System.Text;
 
 namespace DotNetNuke.Services.Mail
@@ -72,6 +71,6 @@ namespace DotNetNuke.Services.Mail
         /// <summary>
         /// Gets or sets mail attachments.
         /// </summary>
-        public List<Attachment> Attachments { get; set; }
+        public List<MailAttachment> Attachments { get; set; }
     }
 }

--- a/DNN Platform/Library/Services/Mail/MailInfo.cs
+++ b/DNN Platform/Library/Services/Mail/MailInfo.cs
@@ -1,11 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-using System.Collections.Generic;
-using System.Text;
-
 namespace DotNetNuke.Services.Mail
 {
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>Information about an email to be sent.</summary>
     public class MailInfo
     {
         /// <summary>
@@ -71,6 +72,6 @@ namespace DotNetNuke.Services.Mail
         /// <summary>
         /// Gets or sets mail attachments.
         /// </summary>
-        public List<MailAttachment> Attachments { get; set; }
+        public ICollection<MailAttachment> Attachments { get; set; }
     }
 }


### PR DESCRIPTION
This PR takes the work done by @meetmandeep in #4156 and extracts the `MailAttachment` class, so that we can process the switch to MailKit separately (i.e. for a later release).