### PR TITLE
child page without a parent should not be validated

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/BulkPagesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/BulkPagesController.cs
@@ -80,7 +80,11 @@ namespace Dnn.PersonaBar.Pages.Components
                 {
                     string errorMessage = null;
 
-                    if (DuplicateExists(currentIndex, pages))
+                    if (currentIndex == 0 && oTab.Level > 0)
+                    {
+                        errorMessage = Localization.GetString("NoParentTabName");
+                    }
+                    else if (DuplicateExists(currentIndex, pages))
                     {
                         errorMessage = Localization.GetString("TabExists");
                     }
@@ -90,7 +94,14 @@ namespace Dnn.PersonaBar.Pages.Components
                     }
                     else if (validateOnly)
                     {
-                        errorMessage = string.Empty;
+                        if (string.IsNullOrWhiteSpace(oTab.TabName))
+                        {
+                            errorMessage = string.Format(Localization.GetString("EmptyTabName"), oTab.TabName);
+                        }
+                        else
+                        {
+                            errorMessage = string.Empty;
+                        }
                     }
                     else
                     {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -1759,4 +1759,7 @@
   <data name="LocalizedSharedModule_tooltip.Text" xml:space="preserve">
     <value>This is a localized shared module</value>
   </data>
+  <data name="NoParentTabName.Text" xml:space="preserve">
+    <value>No parent page supplied</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #4196 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
A child page given as first option in the "Add Multiple Pages" is an invalid option now. In addition to that a parent with just ">" in next line is also marked as invalid (Empty child tab name).