### PR TITLE
Fixes an issue where folder search would not work in resrouce manager

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderPicker.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderPicker.jsx
@@ -58,14 +58,15 @@ export default class FolderPicker extends React.Component {
         if (this.unmounted) {
             return;
         }
-        
+
         const { props } = this;
         let homeFolderId = props.homeFolderId;
 
         let source = result.Tree;
         let filtered = this.findNode(source, (n) => {return n !== null && n.data.key === homeFolderId.toString();});
-        source.children.splice(0, source.children.length, filtered);
-
+        if (filtered !== null){
+            source.children.splice(0, source.children.length, filtered);
+        }
         this.setState({ folders: result.Tree });
     }
 

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderSelector.jsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/app/components/FolderSelector/FolderSelector.jsx
@@ -51,7 +51,9 @@ export default class FolderSelector extends Component {
         const searchFolderText = e.target.value ? e.target.value : "";
         this.setState({ searchFolderText });
         clearTimeout(this.timeOut);
-        this.timeOut = setTimeout(() => {this.props.searchFolder(searchFolderText.toLowerCase());}, 500);
+        this.timeOut = setTimeout(() => 
+            this.props.searchFolder(searchFolderText.toLowerCase()),
+        500);
     }
 
     clearSearch(e) {
@@ -87,7 +89,7 @@ export default class FolderSelector extends Component {
                             <input 
                                 type="text" 
                                 value={this.state.searchFolderText} 
-                                onChange={this.onChangeSearchFolderText.bind(this) } 
+                                onChange={e => this.onChangeSearchFolderText(e) } 
                                 placeholder={searchFolderPlaceHolder}
                                 aria-label="Search" />
                             {this.state.searchFolderText && 


### PR DESCRIPTION
Closes #4200

The filtering logic was applied with a null result and removing all the results, I added a check for null which makes the fileting work when the search is used.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
