### PR TITLE
Updated .NET & SQL requirements in InstallWizard localization files

### DIFF
--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.de-DE.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.de-DE.resx
@@ -269,8 +269,6 @@
 &lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;Ihre Website hat die Berechtigungsprüfung nicht bestanden.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;
 Gehen Sie im Windows Explorer zum Basisverzeichnis Ihrer Website ({0}). Klicken Sie das Verzeichnis mit der rechten Maustaste an und wählen Sie Sicherheit und Berechtigungen im Kontextmenü und dann den Reiter Berechtigungen. Fügen Sie hier das entsprechenden Benutzerkonto hinzu und gewähren Sie die Berechtigungen.
 &lt;br/&gt;&lt;br/&gt;
-&lt;h3&gt;Falls Sie Windows Server 2003, Windows Vista oder Windows Server 2008 mit IIS6 oder IIS7 verwenden&lt;/h3&gt;
-&lt;p&gt;Das Konto NT AUTHORITY\Netzwerkdienst muss die Berechtigungen Lesen, Schreiben und Ändern für das Basisverzeichnis der Website erhalten.&lt;/p&gt;
 &lt;h3&gt;Falls Sie Windows 7, Windows 8 oder Windows Server 2008 R2 bzw. 2012 verwenden mit IIS7.5&lt;/h3&gt;
 &lt;p&gt;Das Benutzerkonto IIS AppPool\DefaultAppPool muss die Berechtigungen Lesen, Schreiben und Ändern für das Basisverzeichnis der Website erhalten.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Recheck&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
@@ -352,14 +350,11 @@ Gehen Sie im Windows Explorer zum Basisverzeichnis Ihrer Website ({0}). Klicken 
   <data name="IsSqlServerDbo.Text" xml:space="preserve">
     <value>Ihr Datenbank-Benutzer verfügt nicht über die DBO-Berechtigungen.</value>
   </data>
-  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
-    <value>DotNetNuke erfordert mindestens Version 4.0 des .Net-Frameworks.</value>
-  </data>
   <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
-    <value>DotNetNuke erfordert mindestens Version 2008 des Microsoft SQL Servers (Express oder höher).</value>
+    <value>DotNetNuke erfordert mindestens Version 2008 R2 des Microsoft SQL Servers (Express oder höher).</value>
   </data>
   <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
-    <value>Prüfe, ob mindestens SQL-Server 2008 (Express oder höher) installiert ist.</value>
+    <value>Prüfe, ob mindestens SQL-Server 2008 R2 (Express oder höher) installiert ist.</value>
   </data>
   <data name="Language.Help" xml:space="preserve">
     <value>Wählen Sie hier die Standardsprache, die Sie für Ihre Website verwenden wollen.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.es-ES.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.es-ES.resx
@@ -290,11 +290,7 @@
 &lt;p&gt;&lt;strong&gt;&lt;font color='red'&gt;Su sitio ha fallado las verificaciones de permisos.&lt;/font&gt;&lt;/strong&gt;&lt;/p&gt;
 Utilice el Explorador de Windows para ver las carpetas de su sitio web ( {0} ). Vaya a las propiedades de la carpeta, y seleccione la pestaña Seguridad. Añada las cuentas y permisos necesarios.
 &lt;br/&gt;&lt;br/&gt;
-&lt;h3&gt;Si utiliza Windows 2000 - IIS5&lt;/h3&gt;
-&lt;p&gt;La cuenta ASPNET tiene que tener permisos de Lectura, Escritura y Modificación en la carpeta raíz de la web.&lt;/p&gt;
-&lt;h3&gt;Si utiliza Windows 2003, Windows Vista o Windows Server 2008 y  IIS6 o IIS7&lt;/h3&gt;
-&lt;p&gt;La cuenta NT AUTHORITY\SERVICIO DE RED tiene que tener permisos de Lectura, Escritura y Modificación en la carpeta raíz de la web.&lt;/p&gt;
-&lt;h3&gt;Si utiliza Windows 7 o Windows Server 2008 R2 y  IIS7.5&lt;/h3&gt;
+&lt;h3&gt;Si utiliza Windows 8 o Windows Server 2008 R2 y  IIS7.5&lt;/h3&gt;
 &lt;p&gt;La cuenta IIS AppPool\DefaultAppPool tiene que tener permisos de Lectura, Escritura y Modificación en la carpeta raíz de la web.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Verificar de nuevo&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
   <data name="FileAndFolderPermissionCheckTitle.Text" xml:space="preserve">
@@ -375,14 +371,11 @@ Utilice el Explorador de Windows para ver las carpetas de su sitio web ( {0} ). 
   <data name="IsSqlServerDbo.Text" xml:space="preserve">
     <value>El usuario de base de datos no tiene permisos de dbo</value>
   </data>
-  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
-    <value>DotNetNuke necesita la versión .NET 4.0 o superior</value>
-  </data>
   <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
-    <value>DotNetNuke necesita la versión SQL Server 2008 (Express o normal)</value>
+    <value>DotNetNuke necesita la versión SQL Server 2008 R2 (Express o normal)</value>
   </data>
   <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
-    <value>Verificando si la base de datos es SQL Server 2008</value>
+    <value>Verificando si la base de datos es SQL Server 2008 R2</value>
   </data>
   <data name="Language.Help" xml:space="preserve">
     <value>Seleccione el idioma que quiere utilizar para su sitio web.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.fr-FR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.fr-FR.resx
@@ -59,8 +59,8 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -265,7 +265,7 @@
     <value>Vérification des permissions au niveau des fichiers et des dossiers</value>
   </data>
   <data name="FileAndFolderPermissionCheckFailed.Text" xml:space="preserve">
-    <value>&lt;div class="permission"&gt;&lt;img alt="Image montrant que les paramètres de sécurité du répertoire racine du site web doivent être définis sur Lecture, Ecriture, Modification pour les comptes ASPNET ou NT AUTHORITY/NETWORK SERVICE." src="..\403-3.gif" align="right" hspace="10"/&gt; &lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;La vérification des permissions a échoué pour votre site web.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;   &lt;p&gt;Naviguez jusqu'au dossier de votre site web  ( {0} ) en utilisateur l'explorateur Windows. Faites un clic droit sur le dossier, cliquez sur &amp;quot;Propriétés&amp;quot; puis  sur l'onglet &amp;quot;Sécurité&amp;quot;. Ajoutez l'utilisateur approprié et définissez les permissions associées.  &lt;/p&gt;  &lt;h3&gt;Si vous utilisez Windows 2000 - IIS5&lt;/h3&gt;   &lt;p&gt;Le compte utilisateur &lt;em&gt;ASPNET&lt;/em&gt; doit avoir les droits de lecture, écriture et modification sur le dossier virtuel de votre site web.&lt;/p&gt;   &lt;h3&gt;Si vous utilisez  Windows 2003, Windows Vista ou Windows Server 2008 avec IIS6 ou IIS7&lt;/h3&gt;   &lt;p&gt;Le compte utilisateur &lt;em&gt;NT AUTHORITY\NETWORK SERVICE&lt;/em&gt; doit avoir les droits de lecture, écriture et modification sur le dossier virtuel de votre site web.&lt;/p&gt;   &lt;h3&gt;Si vous utilisez Windows 7 ou Windows Server 2008 R2 avec IIS7.5&lt;/h3&gt;   &lt;p&gt;Le compte utilisateur &lt;em&gt;IIS AppPool\DefaultAppPool&lt;/em&gt; doit avoir les droits de lecture, écriture et modification sur le dossier virtuel de votre site web.&lt;/p&gt;  &lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Relancer la vérification&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
+    <value>&lt;div class="permission"&gt;&lt;img alt="Image montrant que les paramètres de sécurité du répertoire racine du site web doivent être définis sur Lecture, Ecriture, Modification pour les comptes ASPNET ou NT AUTHORITY/NETWORK SERVICE." src="..\403-3.gif" align="right" hspace="10"/&gt; &lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;La vérification des permissions a échoué pour votre site web.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;   &lt;p&gt;Naviguez jusqu'au dossier de votre site web  ( {0} ) en utilisateur l'explorateur Windows. Faites un clic droit sur le dossier, cliquez sur &amp;quot;Propriétés&amp;quot; puis  sur l'onglet &amp;quot;Sécurité&amp;quot;. Ajoutez l'utilisateur approprié et définissez les permissions associées.  &lt;/p&gt;   &lt;h3&gt;Si vous utilisez Windows 8 ou Windows Server 2008 R2 avec IIS7.5&lt;/h3&gt;   &lt;p&gt;Le compte utilisateur &lt;em&gt;IIS AppPool\DefaultAppPool&lt;/em&gt; doit avoir les droits de lecture, écriture et modification sur le dossier virtuel de votre site web.&lt;/p&gt;  &lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Relancer la vérification&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
   <data name="FileAndFolderPermissionCheckTitle.Text" xml:space="preserve">
     <value>Vérification des permissions de fichier et dossier</value>
@@ -345,14 +345,11 @@
   <data name="IsSqlServerDbo.Text" xml:space="preserve">
     <value>Votre utilisateur de base de données n'a pas les permissions dbo</value>
   </data>
-  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
-    <value>DotNetNuke requiert .net 4.0 ou supérieur pour fonctionner</value>
-  </data>
   <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
-    <value>DotNetNuke requiert SQL 2008 (express ou complet) pour fonctionner</value>
+    <value>DotNetNuke requiert SQL 2008 R2 (express ou complet) pour fonctionner</value>
   </data>
   <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
-    <value>Vérification de la version de base de données. SQL 2008 (express ou complet) ou supérieur est nécessaire pour le fonctionnement de DotNetNuke.</value>
+    <value>Vérification de la version de base de données. SQL 2008 R2 (express ou complet) ou supérieur est nécessaire pour le fonctionnement de DotNetNuke.</value>
   </data>
   <data name="Language.Help" xml:space="preserve">
     <value>La langue que vous souhaitez utiliser pour votre site Web.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.it-IT.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.it-IT.resx
@@ -265,7 +265,7 @@
     <value>Controllo Permessi sui File e Cartelle</value>
   </data>
   <data name="FileAndFolderPermissionCheckFailed.Text" xml:space="preserve">
-    <value>&lt;div class="permission"&gt;&lt;img alt="Immagine che mostra le impostazioni di protezione della cartella principale del sito web, la quale deve essere impostata su Read, Write, e Change Control per gli account ASPNET o NT AUTHORITY / NETWORK SERVICES." src="..\403-3.gif" align="right" hspace="10"/&gt;&lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;Il tuo sito non ha superato il controllo delle autorizzazioni.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;Utilizzando Esplora risorse, individuare le cartelle del Sito web ({0}). Fai clic destro sulla cartella e seleziona Condivisione e Protezione dal menu a comparsa. Selezionare la scheda Protezione. Aggiungere l'account utente appropriato e impostare le autorizzazioni.&lt;br/&gt;&lt;br/&gt;&lt;h3&gt;Se si sta usando Windows 2000 - IIS5&lt;/h3&gt;&lt;p&gt;L'utente ASPNET deve avere Read, Write, e Change Control della cartella virtuale del sito.&lt;/p&gt;&lt;h3&gt;Se stai usando Windows 2003, Windows Vista oppure Windows Server 2008 con  IIS6 or IIS7&lt;/h3&gt;&lt;p&gt;L'utente NT AUTHORITY\NETWORK SERVICE deve avere Read, Write, e Change Control della root virtulae del sito Web.&lt;/p&gt;&lt;h3&gt;Se si sta usando Windows 7 o Windows Server 2008 R2 con  IIS7.5&lt;/h3&gt;&lt;p&gt;L'utente  IIS AppPool\DefaultAppPool deve avere Read, Write, e Change Control della cartella virtuale del sito.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Ricontrolla&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
+    <value>&lt;div class="permission"&gt;&lt;img alt="Immagine che mostra le impostazioni di protezione della cartella principale del sito web, la quale deve essere impostata su Read, Write, e Change Control per gli account ASPNET o NT AUTHORITY / NETWORK SERVICES." src="..\403-3.gif" align="right" hspace="10"/&gt;&lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;Il tuo sito non ha superato il controllo delle autorizzazioni.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;Utilizzando Esplora risorse, individuare le cartelle del Sito web ({0}). Fai clic destro sulla cartella e seleziona Condivisione e Protezione dal menu a comparsa. Selezionare la scheda Protezione. Aggiungere l'account utente appropriato e impostare le autorizzazioni.&lt;br/&gt;&lt;br/&gt;&lt;h3&gt;Se si sta usando Windows 8 o Windows Server 2008 R2 con  IIS7.5&lt;/h3&gt;&lt;p&gt;L'utente  IIS AppPool\DefaultAppPool deve avere Read, Write, e Change Control della cartella virtuale del sito.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Ricontrolla&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
   <data name="FileAndFolderPermissionCheckTitle.Text" xml:space="preserve">
     <value>Controllo File e Autorizzazioni Cartella</value>
@@ -345,14 +345,11 @@
   <data name="IsSqlServerDbo.Text" xml:space="preserve">
     <value>Il tuo utente del database non possiede le autorizzazioni dbo</value>
   </data>
-  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
-    <value>DotNetNuke richiede. Net 4.0 o superiore per funzionare</value>
-  </data>
   <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
-    <value>DotNetNuke richiede SQL 2008 (express o prodotto completo) per lavorare</value>
+    <value>DotNetNuke richiede SQL 2008 R2 (express o prodotto completo) per lavorare</value>
   </data>
   <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
-    <value>Controllo se la versione del database è SQL 2008 (express o prodotto completo) o superiore per funzionare</value>
+    <value>Controllo se la versione del database è SQL 2008 R2 (express o prodotto completo) o superiore per funzionare</value>
   </data>
   <data name="Language.Help" xml:space="preserve">
     <value>La lingua che si desidera utilizzare sul sito.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.nl-NL.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.nl-NL.resx
@@ -188,11 +188,7 @@
 &amp;lt;p&amp;gt;&amp;lt;b&amp;gt;&amp;lt;font color='red'&amp;gt;De website voldoet niet aan de beveiligingscheck&amp;lt;/font&amp;gt;&amp;lt;/b&amp;gt;&amp;lt;/p&amp;gt;
 Bij gebruik van Windows Explorer, browse naar de folders van uw website ( {0} ). Rechtermuisklik op de  folder en selecteer Delen en Beveiliging in het popupmenu. Selecteer de beveiligingstab. Voeg de vereiste gebruikers toe en stel de juiste rechten in.
 &amp;lt;br/&amp;gt;&amp;lt;br/&amp;gt;
-&amp;lt;h3&amp;gt;Bij gebruik van Windows 2000 - IIS5&amp;lt;/h3&amp;gt;
-&amp;lt;p&amp;gt;De ASPNET User Account moet Lees, Schrijf, en Wijzigrechten hebben op de hoofdfolder van uw website&amp;lt;/p&amp;gt;
-&amp;lt;h3&amp;gt;Bij gebruik van Windows 2003, Windows Vista of Windows Server 2008 en  IIS6 of IIS7&amp;lt;/h3&amp;gt;
-&amp;lt;p&amp;gt;De NT AUTHORITY\NETWORK SERVICE User Account moet Lees, Schrijf en Wijzigrechten hebben op de hoofdfolder van uw website.&amp;lt;/p&amp;gt;
-&amp;lt;h3&amp;gt;Bij gebruik van Windows 7 of Windows Server 2008 R2 en  IIS7.5&amp;lt;/h3&amp;gt;
+&amp;lt;h3&amp;gt;Bij gebruik van Windows 8 of Windows Server 2008 R2 en  IIS7.5&amp;lt;/h3&amp;gt;
 &amp;lt;p&amp;gt;Moet de IIS AppPool\DefaultAppPool User Account Lees, Schrijf en Wijzigrechten hebben op de hoofdfolder van uw website.&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;a class="dnnPrimaryAction" href=""&amp;gt;Recheck&amp;lt;/a&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;/div&amp;gt;</value>
   </data>
   <data name="FileAndFolderPermissionCheckTitle.Text" xml:space="preserve">
@@ -273,14 +269,11 @@ Bij gebruik van Windows Explorer, browse naar de folders van uw website ( {0} ).
   <data name="IsSqlServerDbo.Text" xml:space="preserve">
     <value>De door jou opgegeven databasegebruiker heeft geen dbo rechten</value>
   </data>
-  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
-    <value>DNNPlatform heeft .net 4.0 of hoger nodig om te kunnen werken</value>
-  </data>
   <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
-    <value>DNNPlatform heeft SQL 2008 (Express of volledig produkt) nodig om te kunnen werken.</value>
+    <value>DNNPlatform heeft SQL 2008 R2 (Express of volledig produkt) nodig om te kunnen werken.</value>
   </data>
   <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
-    <value>Controleren of database versie SQL 2008 (express of volledig product) of hoger is</value>
+    <value>Controleren of database versie SQL 2008 R2 (express of volledig product) of hoger is</value>
   </data>
   <data name="Language.Help" xml:space="preserve">
     <value>De taal die je wilt gebruiken voor je website.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
@@ -210,14 +210,11 @@
   <data name="IsSqlServerDbo.Text" xml:space="preserve">
     <value>Your database user does not have dbo permissions</value>
   </data>
-  <data name="IsValidDotNetVersion.Text" xml:space="preserve">
-    <value>DNN requires .net 4.0 or higher to work</value>
-  </data>
   <data name="IsValidSqlServerVersionCheck.Text" xml:space="preserve">
-    <value>Checking database version is SQL 2008 (express or full product) or higher to work</value>
+    <value>Checking database version is SQL 2008 R2 (express or full product) or higher to work</value>
   </data>
   <data name="IsValidSqlServerVersion.Text" xml:space="preserve">
-    <value>DNN requires SQL 2008 (express or full product) to work</value>
+    <value>DNN requires SQL 2008 R2 (express or full product) to work</value>
   </data>
   <data name="Language.Text" xml:space="preserve">
     <value>Language</value>
@@ -504,11 +501,7 @@ Standard Database setup option is unavailable</value>
 &lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;Your site failed the permissions check.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;
 Using Windows Explorer, browse to the folders of your website ( {0} ). Right-click the folder and select Sharing and Security from the popup menu. Select the Security tab. Add the appropriate User Account and set the Permissions.
 &lt;br/&gt;&lt;br/&gt;
-&lt;h3&gt;If using Windows 2000 - IIS5&lt;/h3&gt;
-&lt;p&gt;The ASPNET User Account must have Read, Write, and Change Control of the virtual root of your website.&lt;/p&gt;
-&lt;h3&gt;If using Windows 2003, Windows Vista or Windows Server 2008 and  IIS6 or IIS7&lt;/h3&gt;
-&lt;p&gt;The NT AUTHORITY\NETWORK SERVICE User Account must have Read, Write, and Change Control of the virtual root of your Website.&lt;/p&gt;
-&lt;h3&gt;If using Windows 7 or Windows Server 2008 R2 and  IIS7.5&lt;/h3&gt;
+&lt;h3&gt;If using Windows 8 or greater, Windows Server 2008 R2 or greater, and  IIS7.5 or greater&lt;/h3&gt;
 &lt;p&gt;The IIS AppPool\DefaultAppPool User Account must have Read, Write, and Change Control of the virtual root of your Website.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Recheck&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
   <data name="InstallVersion.Text" xml:space="preserve">


### PR DESCRIPTION
Fixes #3791 
## Summary
Some of the localization files made reference to some unsupported operating systems. With this change, those unsupported systems have been removed from the messaging for the **FileAndFolderPermissionCheckFailed**. Other keys in the localization file referenced an unsupported version of SQL in the **IsValidSqlServerVersionCheck** and **IsValidSqlServerVersion** keys. The following changes have been made. 

- Updated the InstallWizard.aspx.resx files to update the .NET Framework requirements from 4.0 to 4.7.2
- Updated the minimum SQL version from 2008 to 2008 R2 to match the Docs
- Removed mentions of unsupported operating systems for the **FileAndFolderPermissionCheckFailed** message. 
- Removed **IsValidDotNetVersion.Text** as it was no longer referenced in the solution
