### PR TITLE
Changed WebConfigurationManager for ConfigurationManager

### DIFF
--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -228,7 +228,7 @@ namespace DotNetNuke.Common.Utilities
             {
                 // ASP.NET 2 version connection string (in <connectionstrings>)
                 // This will be for new v4.x installs or upgrades from v4.x
-                connectionString = WebConfigurationManager.ConnectionStrings[name].ConnectionString;
+                connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[name].ConnectionString;
             }
 
             if (string.IsNullOrEmpty(connectionString))
@@ -527,7 +527,7 @@ namespace DotNetNuke.Common.Utilities
         /// <returns>A string representing the application setting.</returns>
         public static string GetSetting(string setting)
         {
-            return WebConfigurationManager.AppSettings[setting];
+            return System.Configuration.ConfigurationManager.AppSettings[setting];
         }
 
         /// <summary>


### PR DESCRIPTION
Changed WebConfigurationManager for System.Configuration.ConfigurationManager when reading connection strings and app settings

Fixes #4227 

## Summary

Changed only the WebConfigurationManager instances being used for reading app settings and connection strings. Tested on a 9.7.2 website.
