### PR TITLE
Adding Page ID to the Page Management

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageTypeSelector/PageTypeSelector.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageTypeSelector/PageTypeSelector.jsx
@@ -100,6 +100,14 @@ class PageTypeSelector extends Component {
                                 {this._defineVisibleOrHidden(page.includeInMenu)}
                             </span>
                         </div>
+                        <div className="page-info-item">
+                            <span className="page-info-item-label">
+                            {Localization.get("PageId") + ": "}
+                            </span>
+                            <span className="page-info-item-value">
+                                {page.tabId}
+                            </span>
+                        </div>
                     </div>
                     <div className="page-info-row">
                         <div className="page-info-item page-type">

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -432,6 +432,9 @@
   <data name="PageType.Text" xml:space="preserve">
     <value>Page Type</value>
   </data>
+  <data name="PageId.Text" xml:space="preserve">
+    <value>Page ID</value>
+  </data>
   <data name="Standard.Text" xml:space="preserve">
     <value>Standard</value>
   </data>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

This PR is in relation to #4239 

## Summary

I have made a simple addition to the Persona Bar so that you can see the Page ID without having to go the the SEO -> URL Test service to get it.

Unless there is somewhere else where people would see it fit I can re-do the change elsewhere however this is the most logical place I could think of...
