### PR TITLE
Deprecates IEventLogController in favor of DI

### DIFF
--- a/DNN Platform/Library/Entities/Users/Social/RelationshipControllerImpl.cs
+++ b/DNN Platform/Library/Entities/Users/Social/RelationshipControllerImpl.cs
@@ -5,13 +5,14 @@ namespace DotNetNuke.Entities.Users.Social
 {
     using System.Collections.Generic;
     using System.Linq;
-
+    using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users.Social.Data;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Log.EventLog;
+    using Microsoft.Extensions.DependencyInjection;
 
     internal class RelationshipControllerImpl : IRelationshipController
     {
@@ -19,29 +20,29 @@ namespace DotNetNuke.Entities.Users.Social
         internal const string FollowerRequest = "FollowerRequest";
         internal const string FollowBackRequest = "FollowBackRequest";
         private readonly IDataService _dataService;
-        private readonly IEventLogController _eventLogController;
+        private readonly IEventLogger eventLogger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RelationshipControllerImpl"/> class.
         /// </summary>
         public RelationshipControllerImpl()
-            : this(DataService.Instance, EventLogController.Instance)
+            : this(DataService.Instance, Globals.DependencyProvider.GetRequiredService<IEventLogger>())
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RelationshipControllerImpl"/> class.
         /// </summary>
-        /// <param name="dataService"></param>
-        /// <param name="eventLogController"></param>
-        public RelationshipControllerImpl(IDataService dataService, IEventLogController eventLogController)
+        /// <param name="dataService">An instance of the data service.</param>
+        /// <param name="eventLogger">An instance of the event logger.</param>
+        public RelationshipControllerImpl(IDataService dataService, IEventLogger eventLogger)
         {
             // Argument Contract
             Requires.NotNull("dataService", dataService);
-            Requires.NotNull("eventLogController", eventLogController);
+            Requires.NotNull("eventLogger", eventLogger);
 
             this._dataService = dataService;
-            this._eventLogController = eventLogController;
+            this.eventLogger = eventLogger;
         }
 
         /// <inheritdoc/>
@@ -591,7 +592,7 @@ namespace DotNetNuke.Entities.Users.Social
 
         private void AddLog(string logContent)
         {
-            this._eventLogController.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT);
+            this.eventLogger.AddLog("Message", logContent, EventLogType.ADMIN_ALERT);
         }
 
         private void ClearRelationshipCache(Relationship relationship)

--- a/DNN Platform/Library/Obsolete/EventLogController.cs
+++ b/DNN Platform/Library/Obsolete/EventLogController.cs
@@ -16,9 +16,16 @@ namespace DotNetNuke.Services.Log.EventLog
 
     using Microsoft.Extensions.DependencyInjection;
 
+    [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
+#pragma warning disable SA1601 // Partial elements should be documented, not documenting, the whole class is deprecated.
+#pragma warning disable SA1600 // Elements should be documented, not documenting, the whole class is deprecated.
     public partial class EventLogController : ServiceLocator<IEventLogController, EventLogController>, IEventLogController
     {
         [Obsolete("Deprecated in 9.8.0. Use 'DotNetNuke.Abstractions.Logging.EventLogType' instead. Scheduled for removal in v11.0.0.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "StyleCop.CSharp.DocumentationRules",
+            "SA1602:Enumeration items should be documented",
+            Justification = "Not documenting since the whole class is deprecated.")]
         public enum EventLogType
         {
             USER_CREATED = 0,
@@ -330,7 +337,11 @@ namespace DotNetNuke.Services.Log.EventLog
 
         /// <inheritdoc/>
         [Obsolete("Deprecated in 9.8.0. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.Logging.IEventLogger' instead. Scheduled for removal in v11.0.0.")]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         protected override Func<IEventLogController> GetFactory() =>
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
             () => new EventLogController();
     }
+#pragma warning restore SA1601 // Partial elements should be documented
+#pragma warning restore SA1600 // Elements should be documented
 }

--- a/DNN Platform/Library/Services/Log/EventLog/IEventLogController.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/IEventLogController.cs
@@ -12,8 +12,11 @@ namespace DotNetNuke.Services.Log.EventLog
     /// Do not implement.  This interface is only implemented by the DotNetNuke core framework. Outside the framework it should used as a type and for unit test purposes only.
     /// There is no guarantee that this interface will not change.
     /// </summary>
+    [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
     public interface IEventLogController : ILogController
     {
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
+#pragma warning disable SA1600 // Elements should be documented, not documenting since the whole class is deprecated.
         void AddLog(string propertyName, string propertyValue, EventLogController.EventLogType logType);
 
         [Obsolete("Deprecated in DNN 9.7.  It has been replaced by the overload taking IPortalSettings. Scheduled removal in v11.0.0.")]
@@ -22,10 +25,13 @@ namespace DotNetNuke.Services.Log.EventLog
         [Obsolete("Deprecated in DNN 9.7.  It has been replaced by the overload taking IPortalSettings. Scheduled removal in v11.0.0.")]
         void AddLog(string propertyName, string propertyValue, PortalSettings portalSettings, int userID, string logType);
 
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
         void AddLog(string propertyName, string propertyValue, IPortalSettings portalSettings, int userID, EventLogController.EventLogType logType);
 
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
         void AddLog(string propertyName, string propertyValue, IPortalSettings portalSettings, int userID, string logType);
 
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
         void AddLog(PortalSettings portalSettings, int userID, EventLogController.EventLogType logType);
 
         [Obsolete("Deprecated in DNN 9.7.  It has been replaced by the overload taking IPortalSettings. Scheduled removal in v11.0.0.")]
@@ -37,10 +43,14 @@ namespace DotNetNuke.Services.Log.EventLog
         [Obsolete("Deprecated in DNN 9.7.  It has been replaced by the overload taking IPortalSettings. Scheduled removal in v11.0.0.")]
         void AddLog(object businessObject, PortalSettings portalSettings, int userID, string userName, string logType);
 
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
         void AddLog(LogProperties properties, IPortalSettings portalSettings, int userID, string logTypeKey, bool bypassBuffering);
 
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
         void AddLog(object businessObject, IPortalSettings portalSettings, int userID, string userName, EventLogController.EventLogType logType);
 
+        [Obsolete("Deprecated in v9.8.1, use dependency injection to resolve IEventLogger, IEventLogService or IEventLogConfigService instead, scheduled removal in v11.")]
         void AddLog(object businessObject, IPortalSettings portalSettings, int userID, string userName, string logType);
+#pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
@@ -94,10 +95,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_Constructor_Throws_On_Null_DataService()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
+            var mockEventLogger = new Mock<IEventLogger>();
 
             // Act, Assert
-            Assert.Throws<ArgumentNullException>(() => new RelationshipControllerImpl(null, mockEventLogController.Object));
+            Assert.Throws<ArgumentNullException>(() => new RelationshipControllerImpl(null, mockEventLogger.Object));
         }
 
         [Test]
@@ -143,10 +144,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_DeleteRelationshipType_Calls_EventLogController_AddLog()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
-            var relationshipController = this.CreateRelationshipController(mockEventLogController);
+            var relationshipController = this.CreateRelationshipController(mockEventLogger);
             var relationshipType = new RelationshipType()
             {
                 RelationshipTypeId = Constants.SOCIAL_FollowerRelationshipTypeID,
@@ -158,7 +159,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_RelationshipType_Deleted, Constants.SOCIAL_RelationshipTypeName, Constants.SOCIAL_FollowerRelationshipTypeID);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -270,11 +271,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_SaveRelationshipType_Calls_EventLogController_AddLog()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = this.CreateRelationshipController(mockEventLogController);
+            var relationshipController = this.CreateRelationshipController(mockEventLogger);
             var relationshipType = new RelationshipType()
             {
                 RelationshipTypeId = Constants.SOCIAL_FollowerRelationshipTypeID,
@@ -286,7 +287,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_RelationshipType_Updated, Constants.SOCIAL_RelationshipTypeName);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -340,11 +341,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_DeleteRelationship_Calls_EventLogController_AddLog()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = this.CreateRelationshipController(mockEventLogController);
+            var relationshipController = this.CreateRelationshipController(mockEventLogger);
             var relationship = new Relationship()
             {
                 RelationshipId = Constants.SOCIAL_FollowerRelationshipID,
@@ -356,7 +357,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_Relationship_Deleted, Constants.SOCIAL_RelationshipName, Constants.SOCIAL_FollowerRelationshipID);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -572,11 +573,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_SaveRelationship_Calls_EventLogController_AddLog()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = this.CreateRelationshipController(mockEventLogController);
+            var relationshipController = this.CreateRelationshipController(mockEventLogger);
             var relationship = new Relationship
             {
                 RelationshipId = Constants.SOCIAL_FollowerRelationshipID,
@@ -588,7 +589,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_Relationship_Updated, Constants.SOCIAL_RelationshipName);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -642,11 +643,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_DeleteUserRelationship_Calls_EventLogController_AddLog()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = this.CreateRelationshipController(mockEventLogController);
+            var relationshipController = this.CreateRelationshipController(mockEventLogger);
             var userRelationship = new UserRelationship
             {
                 UserRelationshipId = Constants.SOCIAL_UserRelationshipIDUser10User11,
@@ -659,7 +660,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_UserRelationship_Deleted, Constants.SOCIAL_UserRelationshipIDUser10User11, Constants.USER_ElevenId, Constants.USER_TenId);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -776,11 +777,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             var mockDataService = new Mock<IDataService>();
             mockDataService.Setup(ds => ds.SaveUserRelationship(It.IsAny<UserRelationship>(), It.IsAny<int>()))
                                 .Returns(Constants.SOCIAL_UserRelationshipIDUser10User11);
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = new RelationshipControllerImpl(mockDataService.Object, mockEventLogController.Object);
+            var relationshipController = new RelationshipControllerImpl(mockDataService.Object, mockEventLogger.Object);
             var userRelationship = new UserRelationship
             {
                 UserRelationshipId = Constants.SOCIAL_UserRelationshipIDUser10User11,
@@ -793,7 +794,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_UserRelationship_Updated, Constants.SOCIAL_UserRelationshipIDUser10User11, Constants.USER_ElevenId, Constants.USER_TenId);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -829,11 +830,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
         public void RelationshipController_DeleteUserRelationshipPreference_Calls_EventLogController_AddLog()
         {
             // Arrange
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = this.CreateRelationshipController(mockEventLogController);
+            var relationshipController = this.CreateRelationshipController(mockEventLogger);
             var preference = new UserRelationshipPreference()
             {
                 PreferenceId = Constants.SOCIAL_PrefereceIDForUser11,
@@ -846,7 +847,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_UserRelationshipPreference_Deleted, Constants.SOCIAL_PrefereceIDForUser11, Constants.USER_ElevenId, Constants.SOCIAL_FriendRelationshipID);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -919,11 +920,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             var mockDataService = new Mock<IDataService>();
             mockDataService.Setup(ds => ds.SaveUserRelationshipPreference(It.IsAny<UserRelationshipPreference>(), It.IsAny<int>()))
                                 .Returns(Constants.SOCIAL_PrefereceIDForUser11);
-            var mockEventLogController = new Mock<IEventLogController>();
-            mockEventLogController.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogController.EventLogType>()));
+            var mockEventLogger = new Mock<IEventLogger>();
+            mockEventLogger.Setup(c => c.AddLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventLogType>()));
             this.CreateLocalizationProvider();
 
-            var relationshipController = new RelationshipControllerImpl(mockDataService.Object, mockEventLogController.Object);
+            var relationshipController = new RelationshipControllerImpl(mockDataService.Object, mockEventLogger.Object);
             var preference = new UserRelationshipPreference()
             {
                 PreferenceId = Constants.SOCIAL_PrefereceIDForUser11,
@@ -936,7 +937,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
             // Assert
             var logContent = string.Format(Constants.LOCALIZATION_UserRelationshipPreference_Updated, Constants.SOCIAL_PrefereceIDForUser11, Constants.USER_ElevenId, Constants.SOCIAL_FriendRelationshipID);
-            mockEventLogController.Verify(e => e.AddLog("Message", logContent, EventLogController.EventLogType.ADMIN_ALERT));
+            mockEventLogger.Verify(e => e.AddLog("Message", logContent, EventLogType.ADMIN_ALERT));
         }
 
         [Test]
@@ -1205,14 +1206,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
 
         private RelationshipControllerImpl CreateRelationshipController(Mock<IDataService> mockDataService)
         {
-            var mockEventLogController = new Mock<IEventLogController>();
-            return new RelationshipControllerImpl(mockDataService.Object, mockEventLogController.Object);
+            var mockEventLogger = new Mock<IEventLogger>();
+            return new RelationshipControllerImpl(mockDataService.Object, mockEventLogger.Object);
         }
 
-        private RelationshipControllerImpl CreateRelationshipController(Mock<IEventLogController> mockEventLogController)
+        private RelationshipControllerImpl CreateRelationshipController(Mock<IEventLogger> mockEventLogger)
         {
             var mockDataService = new Mock<IDataService>();
-            return new RelationshipControllerImpl(mockDataService.Object, mockEventLogController.Object);
+            return new RelationshipControllerImpl(mockDataService.Object, mockEventLogger.Object);
         }
 
         private void SetupDataTables()


### PR DESCRIPTION
Resolves #4242

The PR:
- Deprecates the interface
- Deprecates the implementation
- The implementation beeing internal and the interface having a warning to not implement by 3rd parties, we can replace it's usage in other downstream classes without too much worry
- I did only one usage replacement in RelationshipController as a proof of concept and adjusted the related test on it.
- There are many many usages of this in Platform, so if thise PR is ok, we have a plan forward for the other usages, any feedback welcome.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
