### PR TITLE
SCAYT language code configuration fixed

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Web/EditorControl.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Web/EditorControl.cs
@@ -291,7 +291,9 @@ namespace DNNConnect.CKEditorProvider.Web
 
                     if (string.IsNullOrEmpty(currentSettings.Config.Scayt_sLang))
                     {
-                        _settings["scayt_sLang"] = currentCulture.Name.ToLowerInvariant();
+                        // 'en-us' is not a language code that is supported, the correct is 'en_US'
+                        // https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_sLang
+                        _settings["scayt_sLang"] = currentCulture.Name.Replace("-", "_");
                     }
                 }
                 catch (Exception)


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #4247 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
The language code for SCAYT plugin is fixed to match specification. The supported code is en_US instead of en-us, for example.