### PR TITLE
Fix some integration tests

### DIFF
--- a/DNN Platform/Library/Properties/AssemblyInfo.cs
+++ b/DNN Platform/Library/Properties/AssemblyInfo.cs
@@ -31,6 +31,7 @@ using DotNetNuke.Application;
 [assembly: InternalsVisibleTo("DotNetNuke.Modules.MemberDirectory")]
 [assembly: InternalsVisibleTo("DotNetNuke.Provider.AspNetProvider")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Content")]
+[assembly: InternalsVisibleTo("DotNetNuke.Tests.Data")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Web")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Web.Mvc")]
 [assembly: InternalsVisibleTo("DotNetNuke.Tests.Urls")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/DotNetNuke.Tests.Data.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/DotNetNuke.Tests.Data.csproj
@@ -66,6 +66,14 @@
     <Reference Include="Microsoft.ApplicationBlocks.Data">
       <HintPath>..\..\Components\DataAccessBlock\bin\Microsoft.ApplicationBlocks.Data.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
@@ -116,6 +124,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
       <Project>{ddf18e36-41a0-4ca7-a098-78ca6e6f41c1}</Project>
       <Name>DotNetNuke.Instrumentation</Name>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/RepositoryBaseTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/RepositoryBaseTests.cs
@@ -1,14 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Data
 {
     using System;
     using System.Collections.Generic;
     using System.Web.Caching;
 
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Collections;
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Controllers;
@@ -17,6 +19,7 @@ namespace DotNetNuke.Tests.Data
     using DotNetNuke.Tests.Data.Models;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
+    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using Moq.Protected;
     using NUnit.Framework;
@@ -503,6 +506,12 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_Get_Calls_GetAllInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
+            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
+            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();
             mockHostController.Setup(h => h.GetString("PerformanceSetting")).Returns("3");
 
@@ -640,6 +649,12 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_Get_Overload_Calls_GetAllByScopeInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
+            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
+            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             var cacheKey = CachingProvider.GetCacheKey(string.Format(Constants.CACHE_CatsKey + "_" + Constants.CACHE_ScopeModule + "_{0}", Constants.MODULE_ValidId));
 
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();
@@ -991,6 +1006,12 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_GetPage_Overload_Calls_GetAllByScopeInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
+            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
+            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+
             var cacheKey = CachingProvider.GetCacheKey(string.Format(Constants.CACHE_CatsKey + "_" + Constants.CACHE_ScopeModule + "_{0}", Constants.MODULE_ValidId));
 
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/DotNetNuke.Tests.Urls.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/DotNetNuke.Tests.Urls.csproj
@@ -34,6 +34,9 @@
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetNuke.Abstractions, Version=9.7.2.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\Modules\CoreMessaging\bin\DotNetNuke.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="DotNetNuke.HttpModules">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\HttpModules\bin\DotNetNuke.HttpModules.dll</HintPath>
@@ -45,6 +48,14 @@
     <Reference Include="DotNetNuke.log4net">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\DotNetNuke.Log4net\bin\dotnetnuke.log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+      <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
@@ -179,6 +190,10 @@
     <None Include="TestFiles\UrlRewrite\TestList.csv" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Library\DotNetNuke.Library.csproj">
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
       <Name>DotNetNuke.Library</Name>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/ExtensionUrlProviderControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/ExtensionUrlProviderControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Urls
 {
     using System;
@@ -10,6 +9,8 @@ namespace DotNetNuke.Tests.Urls
     using System.Data;
     using System.Linq;
 
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
@@ -17,11 +18,25 @@ namespace DotNetNuke.Tests.Urls
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Tests.Utilities.Mocks;
 
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class ExtensionUrlProviderControllerTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
+            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
+            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        }
+
         [Test]
         public void GetModuleProviders_ExcludeSingleProviderWithTypeThatDoesNotExist()
         {

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
@@ -53,6 +53,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\DNN Platform\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
+      <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>
+      <Name>DotNetNuke.Instrumentation</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\DNN Platform\DotNetNuke.Web\DotNetNuke.Web.csproj">
       <Project>{ee1329fe-fd88-4e1a-968c-345e394ef080}</Project>
       <Name>DotNetNuke.Web</Name>


### PR DESCRIPTION
## Summary
We don't automatically run the integration tests, so we weren't notified that some of them are failing because they aren't setting up the services container.  This commit fixes that for a couple projects.