### PR TITLE
Ensure new Localization HTTP module is running soon enough

### DIFF
--- a/DNN Platform/Website/Install/Config/09.08.00.config
+++ b/DNN Platform/Website/Install/Config/09.08.00.config
@@ -1,6 +1,6 @@
 <configuration>
   <nodes configfile="web.config">
-    <node path="/configuration/system.webServer/modules" action="update" key="name" collision="overwrite">
+    <node path="/configuration/system.webServer/modules/add[@name='UrlRewrite']" action="insertafter">
       <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
     </node>
     <node path="/configuration/configSections/sectionGroup[@name='dotnetnuke']" action="update" key="name" collision="ignore">


### PR DESCRIPTION
## Summary

This PR places the new Localization HTTP module right after URL Rewrite (which determines the culture from the URL), and then all modules after it can make use of that culture info.  The current behavior puts it at the end for upgrades, which potentially causes issues.