### PR TITLE
Fixed redirection after login

### DIFF
--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -60,8 +60,6 @@
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
 	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
-    <add key="PreserveLoginUrl" value="true" />
-	  <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -60,8 +60,6 @@
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
 	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
-    <add key="PreserveLoginUrl" value="true" />
-	  <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />


### PR DESCRIPTION
Fixes #4261

## Summary
In the redirection after login logic, there is this `IsRedirectingFromLoginUrl()` method checking whether current URL ends with `/login` or not (hard coded), and DNN would redirect after login based on this condition.

Redirection after login should occur no matter which referrer URL, provided there is no `returnurl` parameter in the query string.

I executed 184 test cases to make sure this is now working as expected. These cases are the permutations of:

Portal: [ None | subsite ]
Login Page: [ None | My Login ]
Redirect After Login: [ None | Welcome ]

across following login URL formats:

/?ctl=login
/?ctl=login&returnurl=/Test-Page
/?ctl=login&returnurl=/Test-Page&popup=true
/login
/login?returnurl=/
/login?returnurl=/&popUp=true
/login?returnurl=/Test-Page
/login?returnurl=/Test-Page&popUp=true
/login.aspx
/login.aspx?returnurl=/
/login.aspx?returnurl=/&popUp=true
/login.aspx?returnurl=/Test-Page
/login.aspx?returnurl=/Test-Page&popUp=true
/my-login
/my-login?returnurl=/
/my-login?returnurl=/&popUp=true
/my-login?returnurl=/Test-Page
/my-login?returnurl=/Test-Page&popUp=true
/my-login.aspx
/my-login.aspx?returnurl=/
/my-login.aspx?returnurl=/&popUp=true
/my-login.aspx?returnurl=/Test-Page
/my-login.aspx?returnurl=/Test-Page&popUp=true

See attached spreadsheet for details.