### PR TITLE
Fix the web.config errors for the new Localization module

### DIFF
--- a/DNN Platform/Website/Install/Config/09.08.00.config
+++ b/DNN Platform/Website/Install/Config/09.08.00.config
@@ -1,6 +1,6 @@
 <configuration>
   <nodes configfile="web.config">
-    <node path="/configuration/system.webServer/modules/add[@name='UrlRewrite']" action="insertafter">
+    <node path="/configuration/system.webServer/modules" action="update" key="name" collision="overwrite">
       <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
     </node>
     <node path="/configuration/configSections/sectionGroup[@name='dotnetnuke']" action="update" key="name" collision="ignore">


### PR DESCRIPTION
Unfortunately the XmlMerge in DNN does not allow a collision check when doing any other action than "update". This prompted two Localization modules to be present in the web.config for new installs which makes the site unuseable. This PR changes the action to be "update". Note that it means we don't control where in the modules pipeline the module sits. But this has become a moot point since we changed the event order for this module.

In the future we should adjust the XmlMerge class to cater for collision control for the other actions, IMHO.