### PR TITLE
Installs JWT provider by default

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Auth/JwtAuthMessageHandler.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Auth/JwtAuthMessageHandler.cs
@@ -24,8 +24,13 @@ namespace Dnn.AuthServices.Jwt.Auth
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(JwtAuthMessageHandler));
 
-        private readonly IJwtController _jwtController = JwtController.Instance;
+        private readonly IJwtController jwtController = JwtController.Instance;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JwtAuthMessageHandler"/> class.
+        /// </summary>
+        /// <param name="includeByDefault">A value indicating whether this handler should be inlcuded by default on all API endpoints.</param>
+        /// <param name="forceSsl">A value indicating whether this handler should enforce SSL usage.</param>
         public JwtAuthMessageHandler(bool includeByDefault, bool forceSsl)
             : base(includeByDefault, forceSsl)
         {
@@ -35,12 +40,18 @@ namespace Dnn.AuthServices.Jwt.Auth
             IsEnabled = true;
         }
 
-        public override string AuthScheme => this._jwtController.SchemeType;
+        /// <inheritdoc/>
+        public override string AuthScheme => this.jwtController.SchemeType;
 
+        /// <inheritdoc/>
         public override bool BypassAntiForgeryToken => true;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this handler is enabled.
+        /// </summary>
         internal static bool IsEnabled { get; set; }
 
+        /// <inheritdoc/>
         public override HttpResponseMessage OnInboundRequest(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (this.NeedsAuthentication(request))
@@ -55,7 +66,7 @@ namespace Dnn.AuthServices.Jwt.Auth
         {
             try
             {
-                var username = this._jwtController.ValidateToken(request);
+                var username = this.jwtController.ValidateToken(request);
                 if (!string.IsNullOrEmpty(username))
                 {
                     if (Logger.IsTraceEnabled)

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/IJwtController.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/IJwtController.cs
@@ -8,16 +8,44 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
 
     using Dnn.AuthServices.Jwt.Components.Entity;
 
+    /// <summary>
+    /// Controls JWT features.
+    /// </summary>
     public interface IJwtController
     {
+        /// <summary>
+        /// Gets the name of the authentication Scheme Type.
+        /// </summary>
         string SchemeType { get; }
 
+        /// <summary>
+        /// Validates the JWT token for the request.
+        /// </summary>
+        /// <param name="request">The current HTTP request.</param>
+        /// <returns>Returns the UserName if the token is valid or null if not.</returns>
         string ValidateToken(HttpRequestMessage request);
 
+        /// <summary>
+        /// Logs the user out.
+        /// </summary>
+        /// <param name="request">The current HTTP request.</param>
+        /// <returns>A value indicating whether the logout attempt succeeded.</returns>
         bool LogoutUser(HttpRequestMessage request);
 
+        /// <summary>
+        /// Logs the user in.
+        /// </summary>
+        /// <param name="request">The current HTTP request.</param>
+        /// <param name="loginData">The login information, <see cref="LoginData"/>.</param>
+        /// <returns><see cref="LoginResultData"/>.</returns>
         LoginResultData LoginUser(HttpRequestMessage request, LoginData loginData);
 
+        /// <summary>
+        /// Attempts to renew a JWT token.
+        /// </summary>
+        /// <param name="request">The current HTTP request.</param>
+        /// <param name="renewalToken">The JWT renewal token.</param>
+        /// <returns><see cref="LoginResultData"/>.</returns>
         LoginResultData RenewToken(HttpRequestMessage request, string renewalToken);
     }
 }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
@@ -547,9 +547,33 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
                 status == UserValidStatus.UPDATEPROFILE ||
                 status == UserValidStatus.UPDATEPASSWORD;
 
-            if (!valid && Logger.IsTraceEnabled)
+            if (!valid)
             {
-                Logger.Trace("Inactive user status: " + status);
+                if (Logger.IsTraceEnabled)
+                {
+                    Logger.Trace("Inactive user status: " + status);
+                }
+
+                return null;
+            }
+
+            if (!userInfo.Membership.Approved)
+            {
+                if (Logger.IsTraceEnabled)
+                {
+                    Logger.Trace("Non Approved user id: " + userInfo.UserID + " UserName: " + userInfo.Username);
+                }
+
+                return null;
+            }
+
+            if (userInfo.IsDeleted)
+            {
+                if (Logger.IsTraceEnabled)
+                {
+                    Logger.Trace("Deleted user id: " + userInfo.UserID + " UserName: " + userInfo.Username);
+                }
+
                 return null;
             }
 

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Common/Controllers/JwtController.cs
@@ -17,6 +17,8 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
     using Dnn.AuthServices.Jwt.Auth;
     using Dnn.AuthServices.Jwt.Components.Entity;
     using Dnn.AuthServices.Jwt.Data;
+    using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Common;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Framework;
@@ -25,9 +27,19 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
     using DotNetNuke.Web.Api;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Controls JWT features.
+    /// </summary>
     internal class JwtController : ServiceLocator<IJwtController, JwtController>, IJwtController
     {
+        /// <summary>
+        /// The name of the authentication scheme header.
+        /// </summary>
         public const string AuthScheme = "Bearer";
+
+        /// <summary>
+        /// A reference to the Dnn data provider.
+        /// </summary>
         public readonly IDataService DataProvider = DataService.Instance;
 
         private const int ClockSkew = 5; // in minutes; default for clock skew
@@ -40,14 +52,12 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
         private static readonly HashAlgorithm Hasher = SHA384.Create();
         private static readonly Encoding TextEncoder = Encoding.UTF8;
 
+        /// <inheritdoc/>
         public string SchemeType => "JWT";
 
         private static string NewSessionId => DateTime.UtcNow.Ticks.ToString("x16") + Guid.NewGuid().ToString("N").Substring(16);
 
-        /// <summary>
-        /// Validates the received JWT against the databas eand returns username when successful.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public string ValidateToken(HttpRequestMessage request)
         {
             if (!JwtAuthMessageHandler.IsEnabled)
@@ -60,6 +70,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             return string.IsNullOrEmpty(authorization) ? null : this.ValidateAuthorizationValue(authorization);
         }
 
+        /// <inheritdoc/>
         public bool LogoutUser(HttpRequestMessage request)
         {
             if (!JwtAuthMessageHandler.IsEnabled)
@@ -90,10 +101,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             return true;
         }
 
-        /// <summary>
-        /// Validates user login credentials and returns result when successful.
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public LoginResultData LoginUser(HttpRequestMessage request, LoginData loginData)
         {
             if (!JwtAuthMessageHandler.IsEnabled)
@@ -113,7 +121,13 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             var ipAddress = request.GetIPAddress() ?? string.Empty;
             var userInfo = UserController.ValidateUser(
                 portalSettings.PortalId,
-                loginData.Username, loginData.Password, "DNN", string.Empty, AuthScheme, ipAddress, ref status);
+                loginData.Username,
+                loginData.Password,
+                "DNN",
+                string.Empty,
+                AuthScheme,
+                ipAddress,
+                ref status);
 
             if (userInfo == null)
             {
@@ -147,7 +161,11 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             };
 
             var secret = ObtainSecret(sessionId, portalSettings.GUID, userInfo.Membership.LastPasswordChangeDate);
-            var jwt = CreateJwtToken(secret, portalSettings.PortalAlias.HTTPAlias, ptoken, userInfo.Roles);
+            var jwt = CreateJwtToken(
+                secret,
+                portalSettings.PortalAlias.HTTPAlias,
+                ptoken,
+                userInfo.Roles);
             var accessToken = jwt.RawData;
 
             ptoken.TokenHash = GetHashedStr(accessToken);
@@ -162,6 +180,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             };
         }
 
+        /// <inheritdoc/>
         public LoginResultData RenewToken(HttpRequestMessage request, string renewalToken)
         {
             if (!JwtAuthMessageHandler.IsEnabled)
@@ -258,6 +277,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
             return this.UpdateToken(renewalToken, ptoken, userInfo);
         }
 
+        /// <inheritdoc/>
         protected override Func<IJwtController> GetFactory()
         {
             return () => new JwtController();
@@ -523,7 +543,7 @@ namespace Dnn.AuthServices.Jwt.Components.Common.Controllers
                 return null;
             }
 
-            var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
+            var portalSettings = PortalController.Instance.GetCurrentSettings();
             if (portalSettings == null)
             {
                 Logger.Trace("Unable to retrieve portal settings");

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/LoginData.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/LoginData.cs
@@ -12,9 +12,15 @@ namespace Dnn.AuthServices.Jwt.Components.Entity
     [JsonObject]
     public struct LoginData
     {
+        /// <summary>
+        /// The authentication username.
+        /// </summary>
         [JsonProperty("u")]
         public string Username;
 
+        /// <summary>
+        /// The authentication password.
+        /// </summary>
         [JsonProperty("p")]
         public string Password;
     }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/LoginResultData.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/LoginResultData.cs
@@ -6,21 +6,39 @@ namespace Dnn.AuthServices.Jwt.Components.Entity
 {
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Represents information about a login result.
+    /// </summary>
     [JsonObject]
     public class LoginResultData
     {
+        /// <summary>
+        /// Gets or sets the id of the user.
+        /// </summary>
         [JsonProperty("userId")]
         public int UserId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the user display name.
+        /// </summary>
         [JsonProperty("displayName")]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the access token.
+        /// </summary>
         [JsonProperty("accessToken")]
         public string AccessToken { get; set; }
 
+        /// <summary>
+        /// Gets or sets the renewal token.
+        /// </summary>
         [JsonProperty("renewalToken")]
         public string RenewalToken { get; set; }
 
+        /// <summary>
+        /// Gets or sets any error message.
+        /// </summary>
         [JsonIgnore]
         public string Error { get; set; }
     }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/PersistedToken.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/PersistedToken.cs
@@ -6,21 +6,45 @@ namespace Dnn.AuthServices.Jwt.Components.Entity
 {
     using System;
 
+    /// <summary>
+    /// Represents a persisted token.
+    /// </summary>
     [Serializable]
     public class PersistedToken
     {
+        /// <summary>
+        /// Gets or sets the ID for the token.
+        /// </summary>
         public string TokenId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the id of the user.
+        /// </summary>
         public int UserId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the renewal count.
+        /// </summary>
         public int RenewCount { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating when the token expires.
+        /// </summary>
         public DateTime TokenExpiry { get; set; }
 
+        /// <summary>
+        /// Gets or sets when the renewal token expires.
+        /// </summary>
         public DateTime RenewalExpiry { get; set; }
 
+        /// <summary>
+        /// Gets or sets the token hash value.
+        /// </summary>
         public string TokenHash { get; set; }
 
+        /// <summary>
+        /// Gets or sets the renewal token hash value.
+        /// </summary>
         public string RenewalHash { get; set; }
     }
 }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/RenewalDto.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/RenewalDto.cs
@@ -6,9 +6,15 @@ namespace Dnn.AuthServices.Jwt.Components.Entity
 {
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Renewal token data transfer object.
+    /// </summary>
     [JsonObject]
     public class RenewalDto
     {
+        /// <summary>
+        /// A string representing the renewal token.
+        /// </summary>
         [JsonProperty("rtoken")]
         public string RenewalToken;
     }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Schedule/PurgeExpiredTokensTask.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Schedule/PurgeExpiredTokensTask.cs
@@ -12,7 +12,7 @@ namespace Dnn.AuthServices.Jwt.Components.Schedule
     using DotNetNuke.Services.Scheduling;
 
     /// <summary>
-    /// Scheduled task to delete tokens that linger in the database after having expired
+    /// Scheduled task to delete tokens that linger in the database after having expired.
     /// </summary>
     public class PurgeExpiredTokensTask : SchedulerClient
     {
@@ -21,7 +21,7 @@ namespace Dnn.AuthServices.Jwt.Components.Schedule
         /// <summary>
         /// Initializes a new instance of the <see cref="PurgeExpiredTokensTask"/> class.
         /// </summary>
-        /// <param name="objScheduleHistoryItem">The object used to record the results from this task</param>
+        /// <param name="objScheduleHistoryItem">The object used to record the results from this task.</param>
         public PurgeExpiredTokensTask(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem;

--- a/DNN Platform/Dnn.AuthServices.Jwt/Data/IDataService.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Data/IDataService.cs
@@ -8,20 +8,52 @@ namespace Dnn.AuthServices.Jwt.Data
 
     using Dnn.AuthServices.Jwt.Components.Entity;
 
+    /// <summary>
+    /// Provides data access services.
+    /// </summary>
     public interface IDataService
     {
+        /// <summary>
+        /// Gets a token by a given token id.
+        /// </summary>
+        /// <param name="tokenId">The token id.</param>
+        /// <returns><see cref="PersistedToken"/>.</returns>
         PersistedToken GetTokenById(string tokenId);
 
+        /// <summary>
+        /// Gets a user token by the user id.
+        /// </summary>
+        /// <param name="userId">The id of the user.</param>
+        /// <returns>A list of tokens.</returns>
         IList<PersistedToken> GetUserTokens(int userId);
 
+        /// <summary>
+        /// Adds (persists) a token.
+        /// </summary>
+        /// <param name="token">The token to persist.</param>
         void AddToken(PersistedToken token);
 
+        /// <summary>
+        /// Updates an existing token.
+        /// </summary>
+        /// <param name="token">The token to persist.</param>
         void UpdateToken(PersistedToken token);
 
+        /// <summary>
+        /// Deletes an existing token.
+        /// </summary>
+        /// <param name="tokenId">The id of the token to delete.</param>
         void DeleteToken(string tokenId);
 
+        /// <summary>
+        /// Deletes all tokens for a user.
+        /// </summary>
+        /// <param name="userId">The id of user for which to delete the tokens.</param>
         void DeleteUserTokens(int userId);
 
+        /// <summary>
+        /// Deletes the expired tokens.
+        /// </summary>
         void DeleteExpiredTokens();
     }
 }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Dnn.AuthServices.Jwt.csproj
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Dnn.AuthServices.Jwt.csproj
@@ -99,6 +99,10 @@
     <Content Include="releaseNotes.txt" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928A9B1-F88A-4581-A132-D3EB38669BB0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
     <ProjectReference Include="..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
       <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>
       <Name>DotNetNuke.Instrumentation</Name>

--- a/DNN Platform/Dnn.AuthServices.Jwt/Library.build
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Library.build
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <Import Project="..\..\DNN_Platform.build" />
   <PropertyGroup>
-    <Extension>resources</Extension>
+    <Extension>zip</Extension>
     <DNNFileName>Dnn.Jwt</DNNFileName>
     <PackageName>DnnJwtAuth</PackageName>
     <ModuleFolderName>$(WebsitePath)\DesktopModules\AuthenticationServices\JWTAuth</ModuleFolderName>

--- a/DNN Platform/Dnn.AuthServices.Jwt/Services/MobileController.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Services/MobileController.cs
@@ -12,13 +12,16 @@ namespace Dnn.AuthServices.Jwt.Services
     using DotNetNuke.Web.Api;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// API controller for JWT services (usually mobile).
+    /// </summary>
     [DnnAuthorize(AuthTypes = "JWT")]
     public class MobileController : DnnApiController
     {
         /// <summary>
         /// Clients that used JWT login should use this API call to logout and invalidate the tokens.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>An asynchronous HTTP response.</returns>
         [HttpGet]
         public IHttpActionResult Logout()
         {
@@ -32,7 +35,8 @@ namespace Dnn.AuthServices.Jwt.Services
         /// </summary>
         /// <remarks>AllowAnonymous attribute must stay in this call even though the
         /// DnnAuthorize attribute is present at a class level.</remarks>
-        /// <returns></returns>
+        /// <param name="loginData">The information usd for login, <see cref="LoginData"/>.</param>
+        /// <returns>An asynchronous HTTP response.</returns>
         [HttpPost]
         [AllowAnonymous]
         public IHttpActionResult Login(LoginData loginData)
@@ -50,7 +54,8 @@ namespace Dnn.AuthServices.Jwt.Services
         /// AllowAnonymous attribute must stay in this call even though the
         /// DnnAuthorize attribute is present at a class level.
         /// </remarks>
-        /// <returns></returns>
+        /// <param name="rtoken">The renewal token information, <see cref="RenewalDto"/>.</param>
+        /// <returns>An asynchronous HTTP response.</returns>
         [HttpPost]
         [AllowAnonymous]
         public IHttpActionResult ExtendToken(RenewalDto rtoken)
@@ -59,7 +64,10 @@ namespace Dnn.AuthServices.Jwt.Services
             return this.ReplyWith(result);
         }
 
-        // Test API Method 1
+        /// <summary>
+        /// Tests a get HTTP request.
+        /// </summary>
+        /// <returns>Basic information about the identity.</returns>
         [HttpGet]
         public IHttpActionResult TestGet()
         {
@@ -68,7 +76,11 @@ namespace Dnn.AuthServices.Jwt.Services
             return this.Ok(new { reply });
         }
 
-        // Test API Method 2
+        /// <summary>
+        /// Tests a POST api method.
+        /// </summary>
+        /// <param name="something"><see cref="TestPostData"/>.</param>
+        /// <returns>Basic information about the identity and the text provided in the POST.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public IHttpActionResult TestPost(TestPostData something)
@@ -95,9 +107,15 @@ namespace Dnn.AuthServices.Jwt.Services
             return this.Ok(result);
         }
 
+        /// <summary>
+        /// Represents the request data for a test POST.
+        /// </summary>
         [JsonObject]
         public class TestPostData
         {
+            /// <summary>
+            /// The text used in the test.
+            /// </summary>
             [JsonProperty("text")]
             public string Text;
         }

--- a/DNN Platform/Dnn.AuthServices.Jwt/Services/ServiceRouteMapper.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Services/ServiceRouteMapper.cs
@@ -6,12 +6,15 @@ namespace Dnn.AuthServices.Jwt.Services
 {
     using DotNetNuke.Web.Api;
 
+    /// <summary>
+    /// Registers the API routes for this extension.
+    /// </summary>
     public class ServiceRouteMapper : IServiceRouteMapper
     {
+        /// <inheritdoc/>
         public void RegisterRoutes(IMapRoute mapRouteManager)
         {
-            mapRouteManager.MapHttpRoute(
-                "JwtAuth", "default", "{controller}/{action}", new[] { this.GetType().Namespace });
+            mapRouteManager.MapHttpRoute("JwtAuth", "default", "{controller}/{action}", new[] { this.GetType().Namespace });
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web/Api/Auth/AuthMessageHandlerBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Auth/AuthMessageHandlerBase.cs
@@ -14,29 +14,49 @@ namespace DotNetNuke.Web.Api.Auth
 
     using DotNetNuke.Instrumentation;
 
+    /// <summary>
+    /// Base class for authentication providers message handlers.
+    /// </summary>
     public abstract class AuthMessageHandlerBase : DelegatingHandler
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(AuthMessageHandlerBase));
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthMessageHandlerBase"/> class.
+        /// </summary>
+        /// <param name="includeByDefault">A value indicating whether this handler should be included by default in all API endpoints.</param>
+        /// <param name="forceSsl">A value indicating whether this handler should enforce SSL usage.</param>
         protected AuthMessageHandlerBase(bool includeByDefault, bool forceSsl)
         {
             this.DefaultInclude = includeByDefault;
             this.ForceSsl = forceSsl;
         }
 
+        /// <summary>
+        /// Gets the name of the authentication scheme.
+        /// </summary>
         public abstract string AuthScheme { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this handler should bypass the anti-forgery token check.
+        /// </summary>
         public virtual bool BypassAntiForgeryToken => false;
 
+        /// <summary>
+        /// Gets a value indicating whether this handler should be included by default on all API endpoints.
+        /// </summary>
         public bool DefaultInclude { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this handler should enforce SSL usage on it's endpoints.
+        /// </summary>
         public bool ForceSsl { get; }
 
         /// <summary>
         /// A chance to process inbound requests.
         /// </summary>
-        /// <param name="request">the request message.</param>
-        /// <param name="cancellationToken">a cancellationtoken.</param>
+        /// <param name="request">The request message.</param>
+        /// <param name="cancellationToken">A cancellationtoken.</param>
         /// <returns>null normally, if a response is returned all inbound processing is terminated and the resposne is returned.</returns>
         public virtual HttpResponseMessage OnInboundRequest(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -47,13 +67,18 @@ namespace DotNetNuke.Web.Api.Auth
         /// A change to process outbound responses.
         /// </summary>
         /// <param name="response">The response message.</param>
-        /// <param name="cancellationToken">a cancellationtoken.</param>
-        /// <returns>the responsemessage.</returns>
+        /// <param name="cancellationToken">A cancellationtoken.</param>
+        /// <returns>The responsemessage.</returns>
         public virtual HttpResponseMessage OnOutboundResponse(HttpResponseMessage response, CancellationToken cancellationToken)
         {
             return response;
         }
 
+        /// <summary>
+        /// Checks if the current request is an XmlHttpRequest.
+        /// </summary>
+        /// <param name="request">The HTTP Request.</param>
+        /// <returns>A value indicating whether the request is an XmlHttpRequest.</returns>
         protected static bool IsXmlHttpRequest(HttpRequestMessage request)
         {
             string value = null;
@@ -67,12 +92,23 @@ namespace DotNetNuke.Web.Api.Auth
                    value.Equals("XmlHttpRequest", StringComparison.InvariantCultureIgnoreCase);
         }
 
+        /// <summary>
+        /// Sets the current principal for the request.
+        /// </summary>
+        /// <param name="principal">The principal to set.</param>
+        /// <param name="request">The current request.</param>
         protected static void SetCurrentPrincipal(IPrincipal principal, HttpRequestMessage request)
         {
             Thread.CurrentPrincipal = principal;
             request.GetHttpContext().User = principal;
         }
 
+        /// <summary>
+        /// Asynchronously sends a response.
+        /// </summary>
+        /// <param name="request">The current request.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>An HttpResponseMessage Task.</returns>
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var response = this.OnInboundRequest(request, cancellationToken);
@@ -85,6 +121,11 @@ namespace DotNetNuke.Web.Api.Auth
             return base.SendAsync(request, cancellationToken).ContinueWith(x => this.OnOutboundResponse(x.Result, cancellationToken), cancellationToken);
         }
 
+        /// <summary>
+        /// Checks if the current request requires authentication.
+        /// </summary>
+        /// <param name="request">The current request.</param>
+        /// <returns>A value indication whether the current request needs authentication.</returns>
         protected bool NeedsAuthentication(HttpRequestMessage request)
         {
             if (this.MustEnforceSslInRequest(request))


### PR DESCRIPTION
Currently JWT provider is not installed by default, this is an issue because we can't update it's code upon Dnn upgrades and are currently planning on doing some improvements in this area soonish. For the next improvements to actually run and have some sort of expected behavior on it in the next releases, it should be installed by default.

This PR makes it install be default as well as resolves almost all it's styleocop warnings.