### PR TITLE
Upgrade optional packages when they've already been installed

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Library.build
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Library.build
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <Import Project="..\..\DNN_Platform.build" />
   <PropertyGroup>
-    <Extension>zip</Extension>
+    <Extension>resources</Extension>
     <DNNFileName>Dnn.Jwt</DNNFileName>
     <PackageName>DnnJwtAuth</PackageName>
     <ModuleFolderName>$(WebsitePath)\DesktopModules\AuthenticationServices\JWTAuth</ModuleFolderName>

--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -2777,6 +2777,7 @@ namespace DotNetNuke.Services.Upgrade
                         continue;
                     }
 
+                    var isInstalled = false;
                     PackageController.ParsePackage(file, installPackagePath, packages, invalidPackages);
                     if (packages.ContainsKey(file))
                     {
@@ -2787,6 +2788,7 @@ namespace DotNetNuke.Services.Upgrade
                             Null.NullInteger,
                             p => p.Name.Equals(package.Name, StringComparison.OrdinalIgnoreCase)
                                     && p.PackageType.Equals(package.PackageType, StringComparison.OrdinalIgnoreCase));
+                        isInstalled = installedPackage != null;
 
                         if (packages.Values.Count(p => p.FriendlyName.Equals(package.FriendlyName, StringComparison.OrdinalIgnoreCase)) > 1
                                 || installedPackage != null)
@@ -2818,7 +2820,7 @@ namespace DotNetNuke.Services.Upgrade
                         }
                     }
 
-                    if (extension != ".zip")
+                    if (extension != ".zip" && !isInstalled)
                     {
                         optionalPackages.Add(file);
                     }


### PR DESCRIPTION
DNN is distributed with a number of optional packages like Jwt Auth. If we make a fix to these packages they should be upgraded together with DNN.

This PR will install optional packages (i.e. .resources files) if they have been installed previously. It also reverts an earlier change where we made Jwt install by default to work around this issue.