### PR TITLE
Prevents JWT upgrade to change existing config

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Dnn.Jwt.dnn
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Dnn.Jwt.dnn
@@ -55,7 +55,7 @@
             <install>
               <configuration>
                 <nodes>
-                  <node path="/configuration/dotnetnuke/authServices/messageHandlers" action="update" key="name" collision="overwrite">
+                  <node path="/configuration/dotnetnuke/authServices/messageHandlers" action="update" key="name" collision="ignore">
                     <add name="JWTAuth" type="Dnn.AuthServices.Jwt.Auth.JwtAuthMessageHandler, Dnn.AuthServices.Jwt"
                          enabled="true" defaultInclude="false" forceSSL="true" />
                   </node>


### PR DESCRIPTION
With the recent change to make optional packages (.resources) upgrade if the package was previously installed, while upgrading the JWT authentication provider, it cause the existing web.config configuration to be reset to the default and that would happen on each upgrade.

This PR makes it ignore the node if it is already present from a previous installation.