### PR TITLE
Fixed an issue where new users would have no preferred locale.

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/RegisterController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/RegisterController.cs
@@ -116,8 +116,8 @@ namespace Dnn.PersonaBar.Users.Components
             newUser.Membership.PasswordConfirm = newUser.Membership.Password;
 
             //set other profile properties
-            newUser.Profile.PreferredLocale = new Localization().CurrentUICulture;
             newUser.Profile.InitialiseProfile(portalSettings.PortalId);
+            newUser.Profile.PreferredLocale = new Localization().CurrentUICulture;
             newUser.Profile.PreferredTimeZone = portalSettings.TimeZone;
 
             //derive display name from supplied firstname, lastname or from email


### PR DESCRIPTION
The user preferred locale is a required field in user profiles. Some change made it that in 9.8.0 this property is null. This PR reverts the behavior so the preferred locale is set on new users.

Basically the locale was already set but before initializing the profile and initializing the profile would reset it, this PR just moves one line