### PR TITLE
Fixed an issue where all emails where missing the body

### DIFF
--- a/DNN Platform/Library/Services/Mail/CoreMailProvider.cs
+++ b/DNN Platform/Library/Services/Mail/CoreMailProvider.cs
@@ -120,6 +120,7 @@ namespace DotNetNuke.Services.Mail
 
             // message
             mailMessage.Subject = HtmlUtils.StripWhiteSpace(mailInfo.Subject, true);
+            mailMessage.Body = mailInfo.Body;
             smtpInfo.Server = smtpInfo.Server.Trim();
             if (SmtpServerRegex.IsMatch(smtpInfo.Server))
             {


### PR DESCRIPTION
While working on the Feedback module the messages where missing their body, then I tried creating new users and those emails where also missing the body. Looks like the CoreMailProvider was missing setting the body to the emails.

This PR solves that.