### PR TITLE
Ensure properties in DTO objects use backing fields

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/Dto/UserBasicDto.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/Dto/UserBasicDto.cs
@@ -33,10 +33,11 @@ namespace Dnn.PersonaBar.Users.Components.Dto
             this.RequestsRemoval = user.RequestsRemoval;
             this.IsSuperUser = user.IsSuperUser;
             this.IsAdmin = user.Roles.Contains(this.PortalSettings.AdministratorRoleName);
+            this.AvatarUrl = Utilities.GetProfileAvatar(this.UserId);
         }
 
         [DataMember(Name = "avatar")]
-        public string AvatarUrl => Utilities.GetProfileAvatar(this.UserId);
+        public string AvatarUrl { get; set; }
 
         [DataMember(Name = "userId")]
         public int UserId { get; set; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/Dto/UserDetailDto.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/Dto/UserDetailDto.cs
@@ -49,13 +49,15 @@ namespace Dnn.PersonaBar.Users.Components.Dto
             }
 
             this.HasAgreedToTermsOn = user.HasAgreedToTermsOn;
+            this.ProfileUrl = this.UserId > 0 ? Globals.UserProfileURL(this.UserId) : null;
+            this.EditProfileUrl = this.UserId > 0 ? GetSettingUrl(this.PortalId, this.UserId) : null;
         }
 
         [DataMember(Name = "profileUrl")]
-        public string ProfileUrl => this.UserId > 0 ? Globals.UserProfileURL(this.UserId) : null;
+        public string ProfileUrl { get; set; }
 
         [DataMember(Name = "editProfileUrl")]
-        public string EditProfileUrl => this.UserId > 0 ? GetSettingUrl(this.PortalId, this.UserId) : null;
+        public string EditProfileUrl { get; set; }
 
         [DataMember(Name = "lastLogin")]
         public DateTime LastLogin { get; set; }


### PR DESCRIPTION
DTO objects should not have expression-bodied properties as .net serialization does not keep the thread locale and reverts to en-US. This caused the user profile editing to not respect the current locale.