### PR TITLE
Fix wrong Language Culture in WebAPI

### DIFF
--- a/DNN Platform/HttpModules/Membership/MembershipModule.cs
+++ b/DNN Platform/HttpModules/Membership/MembershipModule.cs
@@ -157,10 +157,7 @@ namespace DotNetNuke.HttpModules.Membership
                 }
 
                 // Localization.SetLanguage also updates the user profile, so this needs to go after the profile is loaded
-                if (request.RawUrl != null && !ServicesModule.ServiceApi.IsMatch(request.RawUrl))
-                {
-                    Localization.SetLanguage(user.Profile.PreferredLocale);
-                }
+                
             }
 
             if (context.Items["UserInfo"] == null)


### PR DESCRIPTION
`Localization.SetLanguage(user.Profile.PreferredLocale) `=> Wrong ThreadCulture in WebAPI
This error affects the multilingual web, and allows the user to select the display language, and the user has specified the language-specific PreferedLocale in the profile.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fix: Response wrong language cookie #4307, Fix: Thread locale doesn't pervade to data backend using WebAPI #3545 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Fix wrong Language Culture in WebAPI