### PR TITLE
Fixes AddContentItem Audit Trail for CreatedByUserId & LastModifiedByUserId

### DIFF
--- a/DNN Platform/Library/Entities/Content/ContentController.cs
+++ b/DNN Platform/Library/Entities/Content/ContentController.cs
@@ -46,7 +46,7 @@ namespace DotNetNuke.Entities.Content
             Requires.NotNull("contentItem", contentItem);
             var currentUser = UserController.Instance.GetCurrentUserInfo();
             var createdByUserId = currentUser.UserID;
-            if (contentItem.CreatedByUserID != currentUser.UserID)
+            if (contentItem.CreatedByUserID >= 0 && contentItem.CreatedByUserID != currentUser.UserID)
             {
                 createdByUserId = contentItem.CreatedByUserID;
             }

--- a/DNN Platform/Library/Entities/Content/ContentController.cs
+++ b/DNN Platform/Library/Entities/Content/ContentController.cs
@@ -272,10 +272,11 @@ namespace DotNetNuke.Entities.Content
             DataCache.RemoveCache(GetContentItemCacheKey(contentItem.ContentItemId)); // remove first to synch web-farm servers
             if (readdItem)
             {
-                CBO.GetCachedObject<ContentItem>(
+                CBO.Instance.GetCachedObject<ContentItem>(
                     new CacheItemArgs(
                     GetContentItemCacheKey(contentItem.ContentItemId),
-                    DataCache.ContentItemsCacheTimeOut, DataCache.ContentItemsCachePriority), c => contentItem);
+                    DataCache.ContentItemsCacheTimeOut, DataCache.ContentItemsCachePriority), c => contentItem,
+                    false);
             }
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Tests.Content
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Linq;
-
+    using System.Web;
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
@@ -18,6 +18,7 @@ namespace DotNetNuke.Tests.Content
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Entities.Controllers;
+    using DotNetNuke.Entities.Users;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Tests.Content.Mocks;
@@ -141,6 +142,64 @@ namespace DotNetNuke.Tests.Content
 
             // Assert
             Assert.AreEqual(Constants.CONTENT_AddContentItemId, content.ContentItemId);
+        }
+
+        [Test]
+        public void ContentController_AddContentItem_Sets_CreatedByUserId_And_LastModifiedUserId()
+        {
+            // Arrange
+            Mock<IDataService> mockDataService = new Mock<IDataService>();
+            mockDataService.Setup(ds => ds.AddContentItem(It.IsAny<ContentItem>(), It.IsAny<int>())).Returns(Constants.CONTENT_AddContentItemId);
+            ContentController controller = new ContentController(mockDataService.Object);
+
+            ComponentFactory.RegisterComponentInstance<IContentController>(controller);
+
+            ContentItem content = ContentTestHelper.CreateValidContentItem();
+            content.ContentItemId = Constants.CONTENT_ValidContentItemId;
+            content.CreatedByUserID = 1;
+
+            // Act
+            int contentId = controller.AddContentItem(content);
+
+            // Assert
+            mockDataService.Verify(
+                service =>
+                    service.AddContentItem(It.IsAny<ContentItem>(), content.CreatedByUserID), Times.Once);
+        }
+
+        [Test]
+        public void ContentController_AddContentItem_Sets_Override_CreatedByUserId_And_LastModifiedUserId()
+        {
+            // TODO - This unit test is failing because the UserController can't be mocked. We should
+            // be able to mock out the Cache object that will allow us to specify the UserID. The only
+            // challenge with that, is it will make this unit test very brittle
+
+            // Arrange
+            int expectedUserId = 5;
+            Mock<IUserController> mockUserController = new Mock<IUserController>();
+            mockUserController.Setup(user => user.GetCurrentUserInfo()).Returns(new UserInfo { UserID = expectedUserId });
+            UserController.SetTestableInstance(mockUserController.Object);
+
+            Mock<IDataService> mockDataService = new Mock<IDataService>();
+            mockDataService.Setup(ds => ds.AddContentItem(It.IsAny<ContentItem>(), It.IsAny<int>())).Returns(Constants.CONTENT_AddContentItemId);
+
+            ContentController controller = new ContentController(mockDataService.Object);
+
+            ComponentFactory.RegisterComponentInstance<IContentController>(controller);
+
+            ContentItem content = ContentTestHelper.CreateValidContentItem();
+            content.ContentItemId = Constants.CONTENT_ValidContentItemId;
+
+            // Act
+            int contentId = controller.AddContentItem(content);
+
+            // Assert
+            mockDataService.Verify(
+                service =>
+                    service.AddContentItem(It.IsAny<ContentItem>(), expectedUserId), Times.Once);
+
+            // Cleanup
+            UserController.ClearInstance();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentControllerTests.cs
@@ -170,15 +170,14 @@ namespace DotNetNuke.Tests.Content
         [Test]
         public void ContentController_AddContentItem_Sets_Override_CreatedByUserId_And_LastModifiedUserId()
         {
-            // TODO - This unit test is failing because the UserController can't be mocked. We should
-            // be able to mock out the Cache object that will allow us to specify the UserID. The only
-            // challenge with that, is it will make this unit test very brittle
-
             // Arrange
             int expectedUserId = 5;
             Mock<IUserController> mockUserController = new Mock<IUserController>();
             mockUserController.Setup(user => user.GetCurrentUserInfo()).Returns(new UserInfo { UserID = expectedUserId });
             UserController.SetTestableInstance(mockUserController.Object);
+
+            Mock<ICBO> mockCBO = new Mock<ICBO>();
+            CBO.SetTestableInstance(mockCBO.Object);
 
             Mock<IDataService> mockDataService = new Mock<IDataService>();
             mockDataService.Setup(ds => ds.AddContentItem(It.IsAny<ContentItem>(), It.IsAny<int>())).Returns(Constants.CONTENT_AddContentItemId);
@@ -200,6 +199,7 @@ namespace DotNetNuke.Tests.Content
 
             // Cleanup
             UserController.ClearInstance();
+            CBO.ClearInstance();
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4002 

## High Level Summary
Fixes audit trail for adding new content to the DNN database. This now properly assigns the CreatedByUserID & LastModifiedByUserID if it is not explicitly set on the `ContentItem`.

## Technical Summary
When adding Content to the DNN database using the `ContentController.AddContentItem(ContentItem item)` API it would not set the `CreatedByUserId` or `LastModifiedByUserId` correctly. In this API DNN invokes a Stored Procedure and uses the same value for both fields, it then sets `LastModifiedByUserId` after the stored procedure is invoked. This is why we would get some odd behavior where `CreatedByUserId` was -1 and `LastModifiedByUserId` would be 1. 

I have outlined the new rules in this table below
| New/existing rules | ContentItem.CreatedByUserID | CurrentUser().UserID | Resulting CreatedByUserID & LastModifiedByUser ID |
|------------------|----------------------------------|-------------------------|-----------------------------------------------------------|
| new | -1 (not set)                               | 5                                  | 5                                                                                   |
| existing | 5                                               | 5                                  | 5                                                                                   |
| existing | 2                                               | 5                                   | 5                                                                                   |

## Additional Changes
I needed to update usage of the `CBO` object in the `UpdateContentItemsCache()` method. This code change uses the instance object instead of the static API which allows us to properly test the changes to this API. I looked up what the static API was doing and made sure to use the correct instance API
