### PR TITLE
remove dragover state from element when dragged BETWEEN pages

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -62,11 +62,17 @@ export class PersonaBarPageTreeview extends Component {
             e.preventDefault();
             const elm = document.getElementById(`dropzone-${item.name}-${item.id}-${direction}`);
             (direction === "before") ? elm.classList.add("list-item-border-bottom") : elm.classList.add("list-item-border-top");
+            const containerElm = document.getElementById(`list-item-container-${item.name}-${item.id}`);
+            item.onDragOverState = false;
+            containerElm.className = this.getClassName(item);
         };
 
         const onDragLeave = (item, direction) => {
             const elm = document.getElementById(`dropzone-${item.name}-${item.id}-${direction}`);
             (direction === "before") ? elm.classList.remove("list-item-border-bottom") : elm.classList.remove("list-item-border-top");
+            const containerElm = document.getElementById(`list-item-container-${item.name}-${item.id}`);
+            item.onDragOverState = true;
+            containerElm.className = this.getClassName(item);
         };
         if (!utils.getIsSuperUser() && (parentItem === undefined || parentItem && !parentItem.canManagePage)) {
             return;
@@ -161,7 +167,7 @@ export class PersonaBarPageTreeview extends Component {
                         >
                         </div>
 
-                        <div style={style} className={this.getClassName(item)}>
+                        <div id={`list-item-container-${item.name}-${item.id}`} style={style} className={this.getClassName(item)}>
                             <PersonaBarPageIcon iconType={item.pageType} selected={item.selected || false} />
                             <span
                                 className={`item-name ${itemNameHidden}`}


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #4324 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Removed the dragover state from destination element when dragged and hold between pages.