### PR TITLE
Fix build error

### DIFF
--- a/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
+++ b/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DotNetNuke.DependencyInjection\DotNetNuke.DependencyInjection.csproj" />
     <ProjectReference Include="..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj" />
     <ProjectReference Include="..\DotNetNuke.Web.Mvc\DotNetNuke.Web.Mvc.csproj" />
     <ProjectReference Include="..\DotNetNuke.Web.Razor\DotNetNuke.Web.Razor.csproj" />


### PR DESCRIPTION
I think this missing reference is causing the build error we started seeing on Friday, though I'm not sure why it wasn't required before.