### PR TITLE
Use YAML for build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://dotnet.visualstudio.com/DNN/_apis/build/status/DNN%20%5BCI%5D?branchName=develop)](https://dotnet.visualstudio.com/DNN/_build/latest?definitionId=27&branchName=develop)
+[![Build status](https://dotnet.visualstudio.com/DNN/_apis/build/status/dnnsoftware.Dnn.Platform?branchName=develop)](https://dotnet.visualstudio.com/DNN/_build/latest?definitionId=145&branchName=develop)
 
 ![DNN Platform At A Glance](dnnplatform.png)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,84 @@
+pool:
+  name: Hosted VS2017
+
+variables:
+  - name: "Build.ArtifactStagingDirectory"
+    value: "Artifacts/"
+  # The following variables are defined as settable at queue time, so they cannot be included here
+  # Branch.CdfProvider: dnn
+  # Branch.CkEditor: development
+  # CakeTarget: BuildAll
+  # ReleaseMode: Beta
+  # RunTests: True
+
+steps:
+- task: PowerShell@2
+  displayName: 'Run DNN Update Versions'
+  inputs:
+    targetType: filePath
+    filePath: ./build.ps1
+    arguments: '-Target BuildServerSetVersion'
+
+- script: 'sqllocaldb start mssqllocaldb'
+  displayName: 'Start Sql LocalDb Service'
+  condition: and(succeeded(), eq(variables['RunTests'], 'True'))
+
+- powershell: 'npm config set registry https://www.myget.org/F/dnn-software-public/npm/'
+  displayName: 'npm config set registry'
+  enabled: false
+
+- powershell: |
+   $path = '.\DNN Platform\Library\Properties\AssemblyInfo.cs'
+   $pattern3 = '\[assembly: AssemblyStatus'
+   (Get-Content $path) | ForEach-Object{
+      if($_ -match $pattern3){
+       # We have found the matching line
+       '[assembly: AssemblyStatus(ReleaseMode.{0})]' -f '$(ReleaseMode)'
+      } else {
+       $_
+      }
+     } | Set-Content $path
+   
+  displayName: 'Update Alpha/Beta/Stable flag'
+
+- task: PowerShell@2
+  displayName: 'Run DNN Build via Cake'
+  inputs:
+    targetType: filePath
+    filePath: ./build.ps1
+    arguments: '-Target $(CakeTarget) -ScriptArgs ''--CkBranch="$(Branch.CkEditor)"'',''--CdfBranch="$(Branch.CdfProvider)"'''
+
+- task: PowerShell@2
+  displayName: 'Run Unit Tests via Cake'
+  inputs:
+    targetType: filePath
+    filePath: ./build.ps1
+    arguments: '-Target UnitTests'
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['RunTests'], 'True'))
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results **/TestResults/*.xml'
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '**/TestResults/*.xml'
+    mergeTestResults: true
+    failTaskOnFailedTests: true
+  condition: eq(variables['RunTests'], 'True')
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifacts'
+  inputs:
+    PathtoPublish: Artifacts
+    ArtifactName: Artifacts
+  continueOnError: true
+
+- task: NuGetCommand@2
+  displayName: 'Publish to MyGet'
+  inputs:
+    command: push
+    packagesToPush: 'Artifacts/**/*.nupkg;!Artifacts/**/*.symbols.nupkg'
+    nuGetFeedType: external
+    publishFeedCredentials: 'DNN-NuGet-MyGet'
+  enabled: false
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,16 @@ variables:
   # ReleaseMode: Beta
   # RunTests: True
 
+trigger:
+  batch: true
+  branches:
+    include: '*'
+
+pr:
+  autoCancel: true
+  branches:
+    include: '*'
+
 steps:
 - task: PowerShell@2
   displayName: 'Run DNN Update Versions'


### PR DESCRIPTION
This adds a YAML definition for the build, so that pull requests can make incremental changes to the build process, and to publicly document the build process.

This is just a copy of the existing build process, using the View YAML feature in pipelines.