### PR TITLE
Removed "Running Default" check from Default.aspx

### DIFF
--- a/DNN Platform/Library/Entities/Urls/FriendlyUrlSettings.cs
+++ b/DNN Platform/Library/Entities/Urls/FriendlyUrlSettings.cs
@@ -341,6 +341,7 @@ namespace DotNetNuke.Entities.Urls
             {
                 // 661 : do not include in path
                 // 742 : was not reading and saving value when 'doNotIncludeInPathRegex' used
+                // FUTURE: DNN 11.x Update to remove the runningDefault value
                 return this._doNotIncludeInPathRegex ??
                        (this._doNotIncludeInPathRegex =
                            this.GetStringSetting(

--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -353,6 +353,7 @@ namespace DotNetNuke.Entities.Users
         /// <see cref="UserLoginStatus.LOGIN_INSECUREADMINPASSWORD"/> or
         /// <see cref="UserLoginStatus.LOGIN_INSECUREHOSTPASSWORD"/>.
         /// </param>
+        [Obsolete("Deprecated in 9.8.1.  Scheduled removal in v11.0.0.  No alternative method implemented.")]
         public static void CheckInsecurePassword(string username, string password, ref UserLoginStatus loginStatus)
         {
             if (username == "admin" && (password == "admin" || password == "dnnadmin"))

--- a/DNN Platform/Library/Security/Membership/UserLoginStatus.cs
+++ b/DNN Platform/Library/Security/Membership/UserLoginStatus.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
+using System;
+
 namespace DotNetNuke.Security.Membership
 {
     public enum UserLoginStatus
@@ -11,7 +13,9 @@ namespace DotNetNuke.Security.Membership
         LOGIN_SUPERUSER = 2,
         LOGIN_USERLOCKEDOUT = 3,
         LOGIN_USERNOTAPPROVED = 4,
+        [Obsolete("Deprecated in 9.8.1.  Scheduled removal in v11.0.0.  No alternative method implemented.")]
         LOGIN_INSECUREADMINPASSWORD = 5,
+        [Obsolete("Deprecated in 9.8.1.  Scheduled removal in v11.0.0.  No alternative method implemented.")]
         LOGIN_INSECUREHOSTPASSWORD = 6,
     }
 }

--- a/DNN Platform/Website/App_GlobalResources/SharedResources.resx
+++ b/DNN Platform/Website/App_GlobalResources/SharedResources.resx
@@ -1026,18 +1026,6 @@
   <data name="PasswordResetFailed_WrongAnswer.Text" xml:space="preserve">
     <value>Your new password was not accepted for security reasons. Please ensure the correct user name and answer were entered.</value>
   </data>
-  <data name="InsecureAdmin.Text" xml:space="preserve">
-    <value>Your admin account is still using a known default password. Please go to the Manage-&gt;Users menu and update the password. In addition, please ensure a valid email address is entered.</value>
-  </data>
-  <data name="InsecureHost.Text" xml:space="preserve">
-    <value>Your host (Super User) account is still using a known default password. Please go to the Manage-&gt;Users menu and update the password.</value>
-  </data>
-  <data name="InsecureDefaults.Text" xml:space="preserve">
-    <value>Both the default accounts (host and admin) are using known default passwords. Please go to the Manage-&gt;Users menu and update the passwords. In addition, please ensure valid email addresses are entered.</value>
-  </data>
-  <data name="InsecureDefaults.Title" xml:space="preserve">
-    <value>Insecure account details</value>
-  </data>
   <data name="PrivateMembership.Text" xml:space="preserve">
     <value>&lt;strong&gt;*Note:&lt;/strong&gt; Membership to this site is private. Once your account information has been submitted, the Site Administrator will be notified and your application will be subjected to a screening procedure. If your application is authorized, you will receive notification that you can access the site.</value>
   </data>

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -270,21 +270,6 @@ namespace DotNetNuke.Framework
                 }
             }
 
-            // check if running with known account defaults
-            if (this.Request.IsAuthenticated && string.IsNullOrEmpty(this.Request.QueryString["runningDefault"]) == false)
-            {
-                var userInfo = HttpContext.Current.Items["UserInfo"] as UserInfo;
-                var usernameLower = userInfo?.Username?.ToLowerInvariant();
-
-                // only show message to default users
-                if ("admin".Equals(usernameLower) || "host".Equals(usernameLower))
-                {
-                    var messageText = this.RenderDefaultsWarning();
-                    var messageTitle = Localization.GetString("InsecureDefaults.Title", Localization.GlobalResourceFile);
-                    UI.Skins.Skin.AddPageMessage(ctlSkin, messageTitle, messageText, ModuleMessage.ModuleMessageType.RedError);
-                }
-            }
-
             // add CSS links
             ClientResourceManager.RegisterDefaultStylesheet(this, string.Concat(Globals.ApplicationPath, "/Resources/Shared/stylesheets/dnndefault/7.0.0/default.css"));
             ClientResourceManager.RegisterIEStylesheet(this, string.Concat(Globals.HostPath, "ie.css"));
@@ -736,31 +721,6 @@ namespace DotNetNuke.Framework
             }
 
             return objDict;
-        }
-
-        /// <summary>
-        /// check if a warning about account defaults needs to be rendered.
-        /// </summary>
-        /// <returns>localised error message.</returns>
-        /// <remarks></remarks>
-        private string RenderDefaultsWarning()
-        {
-            var warningLevel = this.Request.QueryString["runningDefault"];
-            var warningMessage = string.Empty;
-            switch (warningLevel)
-            {
-                case "1":
-                    warningMessage = Localization.GetString("InsecureAdmin.Text", Localization.SharedResourceFile);
-                    break;
-                case "2":
-                    warningMessage = Localization.GetString("InsecureHost.Text", Localization.SharedResourceFile);
-                    break;
-                case "3":
-                    warningMessage = Localization.GetString("InsecureDefaults.Text", Localization.SharedResourceFile);
-                    break;
-            }
-
-            return warningMessage;
         }
 
         private IFileInfo GetBackgroundFileInfo()

--- a/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Authentication/Login.ascx.cs
@@ -153,22 +153,6 @@ namespace DotNetNuke.Modules.Admin.Authentication
                     }
                 }
 
-                // check for insecure account defaults
-                var qsDelimiter = "?";
-                if (redirectURL.Contains("?"))
-                {
-                    qsDelimiter = "&";
-                }
-
-                if (this.LoginStatus == UserLoginStatus.LOGIN_INSECUREADMINPASSWORD)
-                {
-                    redirectURL = redirectURL + qsDelimiter + "runningDefault=1";
-                }
-                else if (this.LoginStatus == UserLoginStatus.LOGIN_INSECUREHOSTPASSWORD)
-                {
-                    redirectURL = redirectURL + qsDelimiter + "runningDefault=2";
-                }
-
                 return redirectURL;
             }
         }


### PR DESCRIPTION
Fixes #4346 by removing the Running Default check from default.aspx and marked enum members and validation methods as obsolete. 