### PR TITLE
Revert "Simplify cookie setting to avoid duplicate language cookies being set"

### DIFF
--- a/DNN Platform/Library/Services/Localization/Localization.cs
+++ b/DNN Platform/Library/Services/Localization/Localization.cs
@@ -1569,11 +1569,26 @@ namespace DotNetNuke.Services.Localization
                 }
 
                 // save the page culture as a cookie
-                response.Cookies.Remove("language");
-                if (!string.IsNullOrEmpty(value))
+                HttpCookie cookie = response.Cookies.Get("language");
+                if (cookie == null)
                 {
-                    var cookie = new HttpCookie("language", value) { Path = !string.IsNullOrEmpty(Globals.ApplicationPath) ? Globals.ApplicationPath : "/" };
-                    response.Cookies.Add(cookie);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        cookie = new HttpCookie("language", value) { Path = !string.IsNullOrEmpty(Globals.ApplicationPath) ? Globals.ApplicationPath : "/" };
+                        response.Cookies.Add(cookie);
+                    }
+                }
+                else
+                {
+                    cookie.Value = value;
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        response.Cookies.Set(cookie);
+                    }
+                    else
+                    {
+                        response.Cookies.Remove("language");
+                    }
                 }
             }
             catch


### PR DESCRIPTION
Fixes #4304 

As I mentioned in the issue, this does cause the duplication of some `Set-Cookie` headers.  So we'll have to decide which is more important, unless someone else wants to spend more time trying to figure out how to get ASP.NET cookies to behave.

This reverts commit 2435e149b1fd8cf484916dbdedc7d765789e8b02.