### PR TITLE
Issue-4353 - Connectors use black and white icons when they're in disconnected state which is against branding rules

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Connectors/css/Connectors.css
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Connectors/css/Connectors.css
@@ -36,9 +36,8 @@ table#connectionstbl span.socialnetwork-favicon {
     width: 38px;
     height: 37px;
     background-repeat: no-repeat;
-    background-position: 0 0;
-    position: relative;
     background-position: 0 -37px;
+    position: relative;
 }
 
 table#connectionstbl span.socialnetwork-favicon div {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Connectors/css/Connectors.css
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Connectors/css/Connectors.css
@@ -38,6 +38,7 @@ table#connectionstbl span.socialnetwork-favicon {
     background-repeat: no-repeat;
     background-position: 0 0;
     position: relative;
+    background-position: 0 -37px;
 }
 
 table#connectionstbl span.socialnetwork-favicon div {
@@ -49,10 +50,6 @@ table#connectionstbl span.socialnetwork-favicon div {
     border-radius: 4px;
     top: -4px;
     right: -4px;
-}
-
-table#connectionstbl span.socialnetwork-favicon.connected {
-    background-position: 0 -37px;
 }
 
 table#connectionstbl span.socialnetwork-name {


### PR DESCRIPTION
Fixes #4353
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
This simple CSS change will ensure that the colorful icons will be used both when the Connectors are connected and disconnected.

Demo: https://drive.google.com/file/d/1N_O47unL7H5UV0X4zZKEN8yvs9YnOmi6/view?usp=sharing