### PR TITLE
DNN-42147 Denying the `ADD` permission for a role on an asset makes it invisible to users on CKE Editor.

### DIFF
--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.08.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.08.01.SqlDataProvider
@@ -1,0 +1,90 @@
+﻿
+/****************************************************************
+ * SPROC: GetFoldersByPermission DNN-42147
+ ****************************************************************/
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}GetFoldersByPermissions]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}GetFoldersByPermissions]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetFoldersByPermissions] 
+	@PortalID int,
+	@Permissions nvarchar(300),
+	@UserID int,
+	@FolderID int,
+	@FolderPath nvarchar(300)
+
+AS
+	DECLARE @IsSuperUser BIT
+	DECLARE @Admin BIT
+	DECLARE @Read INT
+	DECLARE @Write INT
+	DECLARE @Browse INT
+	DECLARE @Add INT
+
+	--Determine Admin or SuperUser
+	IF @UserId IN (
+		SELECT UserId 
+		FROM {databaseOwner}[{objectQualifier}UserRoles] 
+		WHERE RoleId IN (
+			SELECT RoleId 
+			FROM {databaseOwner}[{objectQualifier}Roles] 
+			WHERE PortalId = @PortalId 
+			AND RoleName = 'Administrators')) 
+	BEGIN 
+		SET @Admin = 1 
+	END;
+	
+	SELECT @IsSuperUser = IsSuperUser 
+	FROM {databaseOwner}[{objectQualifier}Users] 
+	WHERE UserId = @UserId;
+
+	--Retrieve Permission Ids
+	IF @Permissions LIKE '%READ%' BEGIN SELECT TOP 1 @Read = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'READ' END;
+	IF @Permissions LIKE '%WRITE%' BEGIN SELECT TOP 1 @Write = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'WRITE' END;
+	IF @Permissions LIKE '%BROWSE%' BEGIN SELECT TOP 1 @Browse = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'BROWSE' END;
+	IF @Permissions LIKE '%ADD%' BEGIN SELECT TOP 1 @Add = PermissionID FROM {databaseOwner}[{objectQualifier}Permission] WHERE PermissionCode = 'SYSTEM_FOLDER' AND PermissionKey = 'ADD' END;
+
+	IF @PortalID IS NULL
+		BEGIN
+			SELECT DISTINCT F.*
+			FROM {databaseOwner}[{objectQualifier}Folders] F
+			WHERE F.PortalID IS NULL
+				AND (F.FolderID = @FolderID OR @FolderID = -1)
+				AND (F.FolderPath = @FolderPath OR @FolderPath = '')
+		  
+			 ORDER BY F.FolderPath
+		END
+	ELSE
+		BEGIN
+			CREATE TABLE #Skip_Folders(folderid INT PRIMARY KEY(folderid))
+			INSERT INTO #Skip_Folders
+				 SELECT DISTINCT folderid FROM {databaseOwner}[{objectQualifier}FolderPermission] FP
+									JOIN {databaseOwner}[{objectQualifier}Permission] P ON FP.PermissionID = P.PermissionID
+									WHERE
+										((P.PermissionKey = 'WRITE' OR @IsSuperUser=1 OR @Admin=1) OR
+										FP.PermissionID = CASE WHEN @Read > 0 THEN @Read END OR
+										FP.PermissionID = CASE WHEN @Write > 0 THEN @Write END OR
+										FP.PermissionID = CASE WHEN @Browse > 0 THEN @Browse END OR
+										FP.PermissionID = CASE WHEN @Add > 0 THEN @Add END)
+										AND FP.PermissionID NOT IN (SELECT DISTINCT PermissionID FROM {databaseOwner}[{objectQualifier}FolderPermission] WHERE allowaccess=0 AND (userid=@UserId OR roleid=-1 OR roleid IN (SELECT roleid FROM {databaseOwner}[{objectQualifier}UserRoles] WHERE UserID=@UserId)))		
+
+			SELECT DISTINCT F.*
+			FROM {databaseOwner}[{objectQualifier}Folders] F
+				JOIN {databaseOwner}[{objectQualifier}FolderPermission] FP ON F.FolderId = FP.FolderID
+				JOIN {databaseOwner}[{objectQualifier}Permission] P ON FP.PermissionID = P.PermissionID
+				JOIN #Skip_Folders sf ON sf.folderid=f.folderid 
+			WHERE ((F.PortalID = @PortalID) OR (F.PortalID IS NULL AND @PortalID IS NULL))
+				AND (F.FolderID = @FolderID OR @FolderID = -1)
+				AND (F.FolderPath = @FolderPath OR @FolderPath = '')
+				AND 
+					((P.PermissionKey = 'WRITE' OR @IsSuperUser=1 OR @Admin=1) OR
+						FP.PermissionID = CASE WHEN @Read > 0 THEN @Read END OR
+						FP.PermissionID = CASE WHEN @Write > 0 THEN @Write END OR
+						FP.PermissionID = CASE WHEN @Browse > 0 THEN @Browse END OR
+						FP.PermissionID = CASE WHEN @Add > 0 THEN @Add END)
+				AND FP.AllowAccess = 1
+			 ORDER BY F.FolderPath
+
+			 DROP TABLE #Skip_Folders
+		END
+GO


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/4362

The rootcause of this problem is in the following line of a `GetFoldersByPermissions` stored procedure:

![image](https://user-images.githubusercontent.com/22524011/102238261-38c54600-3efe-11eb-898e-87247e67029e.png)

The subquery above is trying to get all the folders for the specific user/role for which access is denied (`allowAccess=0`). The subquery returns list of folder ID's.

Problem is that `allowAccess` flag relates to a concrete folder permission (READ, WRITE, ADD...) and not to an entire folder. This means, if at least one permission is denied so we return entire folder and consider it as denied. This is the issue. Due to that it is not getting appeared on UI.
Instead, we must return concrete denied **folder permission** for the specific user/role. 

See the changes I did highlighted in yellow below. FolderID is replaced by PermissionID.

![image](https://user-images.githubusercontent.com/22524011/102240902-0f59e980-3f01-11eb-9d59-31dd6479c20a.png)
