### PR TITLE
Enable warnings as errors for 3rd party auth providers

### DIFF
--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Components/FacebookClient.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Components/FacebookClient.cs
@@ -10,8 +10,12 @@ namespace DotNetNuke.Authentication.Facebook.Components
     using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     public class FacebookClient : OAuthClientBase
     {
+        /// <summary>Initializes a new instance of the <see cref="FacebookClient"/> class.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="mode">The auth mode.</param>
         public FacebookClient(int portalId, AuthMode mode)
             : base(portalId, mode, "Facebook")
         {
@@ -29,6 +33,7 @@ namespace DotNetNuke.Authentication.Facebook.Components
             this.LoadTokenCookie(string.Empty);
         }
 
+        /// <inheritdoc/>
         protected override TimeSpan GetExpiry(string responseText)
         {
             TimeSpan expiry = TimeSpan.MinValue;
@@ -41,6 +46,7 @@ namespace DotNetNuke.Authentication.Facebook.Components
             return expiry;
         }
 
+        /// <inheritdoc/>
         protected override string GetToken(string responseText)
         {
             string authToken = string.Empty;

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Components/FacebookUserData.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Components/FacebookUserData.cs
@@ -8,30 +8,37 @@ namespace DotNetNuke.Authentication.Facebook.Components
 
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     [DataContract]
     public class FacebookUserData : UserData
     {
+        /// <inheritdoc/>
         public override string FirstName
         {
             get { return this.FacebookFirstName; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string LastName
         {
             get { return this.FacebookLastName; }
             set { }
         }
 
+        /// <summary>Gets or sets the birthday.</summary>
         [DataMember(Name = "birthday")]
         public string Birthday { get; set; }
 
+        /// <summary>Gets or sets the link URL.</summary>
         [DataMember(Name = "link")]
         public Uri Link { get; set; }
 
+        /// <summary>Gets or sets the first name.</summary>
         [DataMember(Name = "first_name")]
         public string FacebookFirstName { get; set; }
 
+        /// <summary>Gets or sets the last name.</summary>
         [DataMember(Name = "last_name")]
         public string FacebookLastName { get; set; }
     }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/DotNetNuke.Authentication.Facebook.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/DotNetNuke.Authentication.Facebook.csproj
@@ -26,6 +26,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <Use64BitIISExpress />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Login.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Login.ascx.cs
@@ -12,29 +12,34 @@ namespace DotNetNuke.Authentication.Facebook
     using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Skins.Controls;
 
+    /// <inheritdoc/>
     public partial class Login : OAuthLoginBase
     {
+        /// <inheritdoc/>
         public override bool SupportsRegistration
         {
             get { return true; }
         }
 
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Facebook"; }
         }
 
+        /// <inheritdoc/>
         protected override UserData GetCurrentUser()
         {
             return this.OAuthClient.GetCurrentUser<FacebookUserData>();
         }
 
+        /// <inheritdoc/>
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
 
-            this.loginButton.Click += this.loginButton_Click;
-            this.registerButton.Click += this.loginButton_Click;
+            this.loginButton.Click += this.LoginButton_Click;
+            this.registerButton.Click += this.LoginButton_Click;
 
             this.OAuthClient = new FacebookClient(this.PortalId, this.Mode);
 
@@ -42,6 +47,7 @@ namespace DotNetNuke.Authentication.Facebook
             this.registerItem.Visible = this.Mode == AuthMode.Register;
         }
 
+        /// <inheritdoc/>
         protected override void AddCustomProperties(NameValueCollection properties)
         {
             base.AddCustomProperties(properties);
@@ -53,7 +59,7 @@ namespace DotNetNuke.Authentication.Facebook
             }
         }
 
-        private void loginButton_Click(object sender, EventArgs e)
+        private void LoginButton_Click(object sender, EventArgs e)
         {
             AuthorisationResult result = this.OAuthClient.Authorize();
             if (result == AuthorisationResult.Denied)

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Settings.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Facebook/Settings.ascx.cs
@@ -7,8 +7,10 @@ namespace DotNetNuke.Authentication.Facebook
 
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     public partial class Settings : OAuthSettingsBase
     {
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Facebook"; }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Components/GoogleClient.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Components/GoogleClient.cs
@@ -11,8 +11,12 @@ namespace DotNetNuke.Authentication.Google.Components
     using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     public class GoogleClient : OAuthClientBase
     {
+        /// <summary>Initializes a new instance of the <see cref="GoogleClient"/> class.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="mode">The auth mode.</param>
         public GoogleClient(int portalId, AuthMode mode)
             : base(portalId, mode, "Google")
         {
@@ -30,6 +34,7 @@ namespace DotNetNuke.Authentication.Google.Components
             this.LoadTokenCookie(string.Empty);
         }
 
+        /// <inheritdoc/>
         protected override TimeSpan GetExpiry(string responseText)
         {
             var jsonSerializer = new JavaScriptSerializer();
@@ -38,6 +43,7 @@ namespace DotNetNuke.Authentication.Google.Components
             return new TimeSpan(0, 0, Convert.ToInt32(tokenDictionary["expires_in"]));
         }
 
+        /// <inheritdoc/>
         protected override string GetToken(string responseText)
         {
             var jsonSerializer = new JavaScriptSerializer();

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Components/GoogleUserData.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Components/GoogleUserData.cs
@@ -7,33 +7,40 @@ namespace DotNetNuke.Authentication.Google.Components
 
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     [DataContract]
     public class GoogleUserData : UserData
     {
+        /// <inheritdoc/>
         public override string FirstName
         {
             get { return this.GivenName; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string LastName
         {
             get { return this.FamilyName; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string ProfileImage
         {
             get { return this.Picture; }
             set { }
         }
 
+        /// <summary>Gets or sets the given name.</summary>
         [DataMember(Name = "given_name")]
         public string GivenName { get; set; }
 
+        /// <summary>Gets or sets the family name.</summary>
         [DataMember(Name = "family_name")]
         public string FamilyName { get; set; }
 
+        /// <summary>Gets or sets the picture URL.</summary>
         [DataMember(Name = "picture")]
         public string Picture { get; set; }
     }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/DotNetNuke.Authentication.Google.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/DotNetNuke.Authentication.Google.csproj
@@ -26,6 +26,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <Use64BitIISExpress />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Login.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Login.ascx.cs
@@ -11,29 +11,34 @@ namespace DotNetNuke.Authentication.Google
     using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Skins.Controls;
 
+    /// <inheritdoc/>
     public partial class Login : OAuthLoginBase
     {
+        /// <inheritdoc/>
         public override bool SupportsRegistration
         {
             get { return true; }
         }
 
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Google"; }
         }
 
+        /// <inheritdoc/>
         protected override UserData GetCurrentUser()
         {
             return this.OAuthClient.GetCurrentUser<GoogleUserData>();
         }
 
+        /// <inheritdoc/>
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
 
-            this.loginButton.Click += this.loginButton_Click;
-            this.registerButton.Click += this.loginButton_Click;
+            this.loginButton.Click += this.LoginButton_Click;
+            this.registerButton.Click += this.LoginButton_Click;
 
             this.OAuthClient = new GoogleClient(this.PortalId, this.Mode);
 
@@ -41,7 +46,7 @@ namespace DotNetNuke.Authentication.Google
             this.registerItem.Visible = this.Mode == AuthMode.Register;
         }
 
-        private void loginButton_Click(object sender, EventArgs e)
+        private void LoginButton_Click(object sender, EventArgs e)
         {
             AuthorisationResult result = this.OAuthClient.Authorize();
             if (result == AuthorisationResult.Denied)

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Settings.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Google/Settings.ascx.cs
@@ -5,13 +5,12 @@ namespace DotNetNuke.Authentication.Google
 {
     using System;
 
-    using DotNetNuke.Authentication.Google.Components;
-    using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Authentication.OAuth;
-    using DotNetNuke.Services.Exceptions;
 
+    /// <inheritdoc/>
     public partial class Settings : OAuthSettingsBase
     {
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Google"; }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Components/LiveClient.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Components/LiveClient.cs
@@ -11,8 +11,12 @@ namespace DotNetNuke.Authentication.LiveConnect.Components
     using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     public class LiveClient : OAuthClientBase
     {
+        /// <summary>Initializes a new instance of the <see cref="LiveClient"/> class.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="mode">The auth mode.</param>
         public LiveClient(int portalId, AuthMode mode)
             : base(portalId, mode, "Live")
         {
@@ -32,6 +36,7 @@ namespace DotNetNuke.Authentication.LiveConnect.Components
             this.LoadTokenCookie(string.Empty);
         }
 
+        /// <inheritdoc/>
         protected override TimeSpan GetExpiry(string responseText)
         {
             var jsonSerializer = new JavaScriptSerializer();
@@ -40,6 +45,7 @@ namespace DotNetNuke.Authentication.LiveConnect.Components
             return new TimeSpan(0, 0, Convert.ToInt32(tokenDictionary["expires_in"]));
         }
 
+        /// <inheritdoc/>
         protected override string GetToken(string responseText)
         {
             var jsonSerializer = new JavaScriptSerializer();

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Components/LiveUserData.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Components/LiveUserData.cs
@@ -4,32 +4,37 @@
 namespace DotNetNuke.Authentication.LiveConnect.Components
 {
     using System;
-    using System.Collections.Generic;
     using System.Runtime.Serialization;
 
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     [DataContract]
     public class LiveUserData : UserData
     {
+        /// <inheritdoc/>
         public override string FirstName
         {
             get { return this.LiveFirstName; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string LastName
         {
             get { return this.LiveLastName; }
             set { }
         }
 
+        /// <summary>Gets or sets the link URL.</summary>
         [DataMember(Name = "link")]
         public Uri Link { get; set; }
 
+        /// <summary>Gets or sets the first name.</summary>
         [DataMember(Name = "first_name")]
         public string LiveFirstName { get; set; }
 
+        /// <summary>Gets or sets the last name.</summary>
         [DataMember(Name = "last_name")]
         public string LiveLastName { get; set; }
     }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/DotNetNuke.Authentication.LiveConnect.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/DotNetNuke.Authentication.LiveConnect.csproj
@@ -26,6 +26,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <Use64BitIISExpress />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Login.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Login.ascx.cs
@@ -11,29 +11,34 @@ namespace DotNetNuke.Authentication.LiveConnect
     using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Skins.Controls;
 
+    /// <inheritdoc/>
     public partial class Login : OAuthLoginBase
     {
+        /// <inheritdoc/>
         public override bool SupportsRegistration
         {
             get { return true; }
         }
 
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Live"; }
         }
 
+        /// <inheritdoc/>
         protected override UserData GetCurrentUser()
         {
             return this.OAuthClient.GetCurrentUser<LiveUserData>();
         }
 
+        /// <inheritdoc/>
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
 
-            this.loginButton.Click += this.loginButton_Click;
-            this.registerButton.Click += this.loginButton_Click;
+            this.loginButton.Click += this.LoginButton_Click;
+            this.registerButton.Click += this.LoginButton_Click;
 
             this.OAuthClient = new LiveClient(this.PortalId, this.Mode);
 
@@ -41,7 +46,7 @@ namespace DotNetNuke.Authentication.LiveConnect
             this.registerItem.Visible = this.Mode == AuthMode.Register;
         }
 
-        private void loginButton_Click(object sender, EventArgs e)
+        private void LoginButton_Click(object sender, EventArgs e)
         {
             AuthorisationResult result = this.OAuthClient.Authorize();
             if (result == AuthorisationResult.Denied)

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Settings.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.LiveConnect/Settings.ascx.cs
@@ -9,8 +9,10 @@ namespace DotNetNuke.Authentication.LiveConnect
     using DotNetNuke.Services.Authentication.OAuth;
     using DotNetNuke.Services.Exceptions;
 
+    /// <inheritdoc/>
     public partial class Settings : OAuthSettingsBase
     {
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Live"; }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Components/TwitterClient.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Components/TwitterClient.cs
@@ -8,8 +8,12 @@ namespace DotNetNuke.Authentication.Twitter.Components
     using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     public class TwitterClient : OAuthClientBase
     {
+        /// <summary>Initializes a new instance of the <see cref="TwitterClient"/> class.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="mode">The auth mode.</param>
         public TwitterClient(int portalId, AuthMode mode)
             : base(portalId, mode, "Twitter")
         {

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Components/TwitterUserData.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Components/TwitterUserData.cs
@@ -7,42 +7,51 @@ namespace DotNetNuke.Authentication.Twitter.Components
 
     using DotNetNuke.Services.Authentication.OAuth;
 
+    /// <inheritdoc/>
     [DataContract]
     public class TwitterUserData : UserData
     {
+        /// <inheritdoc/>
         public override string DisplayName
         {
             get { return this.ScreenName; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string Locale
         {
             get { return this.LanguageCode; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string ProfileImage
         {
             get { return this.ProfileImageUrl; }
             set { }
         }
 
+        /// <inheritdoc/>
         public override string Website
         {
             get { return this.Url; }
             set { }
         }
 
+        /// <summary>Gets or sets the screen name.</summary>
         [DataMember(Name = "screen_name")]
         public string ScreenName { get; set; }
 
+        /// <summary>Gets or sets the language code.</summary>
         [DataMember(Name = "lang")]
         public string LanguageCode { get; set; }
 
+        /// <summary>Gets or sets the URL of the profile image.</summary>
         [DataMember(Name = "profile_image_url")]
         public string ProfileImageUrl { get; set; }
 
+        /// <summary>Gets or sets the URL.</summary>
         [DataMember(Name = "url")]
         public string Url { get; set; }
     }

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/DotNetNuke.Authentication.Twitter.csproj
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/DotNetNuke.Authentication.Twitter.csproj
@@ -26,6 +26,7 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <Use64BitIISExpress />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Login.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Login.ascx.cs
@@ -11,23 +11,28 @@ namespace DotNetNuke.Authentication.Twitter
     using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Skins.Controls;
 
+    /// <inheritdoc/>
     public partial class Login : OAuthLoginBase
     {
+        /// <inheritdoc/>
         public override bool SupportsRegistration
         {
             get { return true; }
         }
 
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Twitter"; }
         }
 
+        /// <inheritdoc/>
         protected override UserData GetCurrentUser()
         {
             return this.OAuthClient.GetCurrentUser<TwitterUserData>();
         }
 
+        /// <inheritdoc/>
         protected override void AddCustomProperties(System.Collections.Specialized.NameValueCollection properties)
         {
             base.AddCustomProperties(properties);
@@ -35,12 +40,13 @@ namespace DotNetNuke.Authentication.Twitter
             properties.Add("Twitter", string.Format("http://twitter.com/{0}", this.OAuthClient.GetCurrentUser<TwitterUserData>().ScreenName));
         }
 
+        /// <inheritdoc/>
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
 
-            this.loginButton.Click += this.loginButton_Click;
-            this.registerButton.Click += this.loginButton_Click;
+            this.loginButton.Click += this.LoginButton_Click;
+            this.registerButton.Click += this.LoginButton_Click;
 
             this.OAuthClient = new TwitterClient(this.PortalId, this.Mode);
 
@@ -48,7 +54,7 @@ namespace DotNetNuke.Authentication.Twitter
             this.registerItem.Visible = this.Mode == AuthMode.Register;
         }
 
-        private void loginButton_Click(object sender, EventArgs e)
+        private void LoginButton_Click(object sender, EventArgs e)
         {
             this.OAuthClient.CallbackUri = new Uri(this.OAuthClient.CallbackUri + "?state=Twitter");
             AuthorisationResult result = this.OAuthClient.Authorize();

--- a/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Settings.ascx.cs
+++ b/DNN Platform/Providers/AuthenticationProviders/DotNetNuke.Authentication.Twitter/Settings.ascx.cs
@@ -5,12 +5,12 @@ namespace DotNetNuke.Authentication.Twitter
 {
     using System;
 
-    using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Authentication.OAuth;
-    using DotNetNuke.Services.Exceptions;
 
+    /// <inheritdoc/>
     public partial class Settings : OAuthSettingsBase
     {
+        /// <inheritdoc/>
         protected override string AuthSystemApplicationName
         {
             get { return "Twitter"; }


### PR DESCRIPTION
This enabled warnings as errors for all four external auth providers (Twitter, Facebook, Google, and Live)