### PR TITLE
Issue-4386 - Cannot Create Pages of Type "File"

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageDetails/PageUrl/PageFile/PageFile.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageDetails/PageUrl/PageFile/PageFile.jsx
@@ -35,6 +35,7 @@ class PageFile extends Component {
                             utils={utilities}
                             selectedFile={selectedFile}
                             onSelectFile={this.onFileSelect.bind(this)}
+                            validationCode={this.props.page.validationCode}
                             browseButtonText={Localization.get("BrowseButton")}
                             uploadButtonText={Localization.get("UploadButton")}
                             linkButtonText={Localization.get("LinkButton")}


### PR DESCRIPTION
Fixes #4386 

## Summary
Validation code was not getting passed to PageFile.jsx which is fixed now. The code gets sent to the file upload control along the chain.

Demo: https://drive.google.com/file/d/1rcSV2QK1p9Yp54Zde-Cbcim44j6wPbQ5/view