### PR TITLE
Fix Issue #3466 - Incorrect Redirect Response Codes

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -1023,22 +1023,18 @@ namespace DotNetNuke.Entities.Urls
                                     if (redirectUrl != null)
                                     {
                                         doRedirect = true;
-                                        if (settings.ForwardExternalUrlsType == DNNPageForwardType.Redirect301)
+                                        if (tab.PermanentRedirect)
                                         {
                                             result.Action = ActionType.Redirect301;
-                                            result.Reason = RedirectReason.Tab_External_Url;
                                         }
-                                        else if (settings.ForwardExternalUrlsType == DNNPageForwardType.Redirect302)
+                                        else
                                         {
                                             result.Action = ActionType.Redirect302;
-                                            result.Reason = RedirectReason.Tab_External_Url;
                                         }
                                     }
 
                                     break;
                                 case TabType.Tab:
-                                    // if a tabType.tab is specified, it's either an external url or a permanent redirect
-
                                     // get the redirect path of the specific tab, as long as we have a valid request to work from
                                     if (request != null)
                                     {
@@ -1078,24 +1074,16 @@ namespace DotNetNuke.Entities.Urls
                                         {
                                             result.Action = ActionType.Redirect301;
                                             result.Reason = RedirectReason.Tab_Permanent_Redirect;
-
-                                            // should be already set, anyway
-                                            result.RewritePath = cleanPath;
                                         }
                                         else
                                         {
                                             // not a permanent redirect, check if the page forwarding is set
-                                            if (settings.ForwardExternalUrlsType == DNNPageForwardType.Redirect301)
-                                            {
-                                                result.Action = ActionType.Redirect301;
-                                                result.Reason = RedirectReason.Tab_External_Url;
-                                            }
-                                            else if (settings.ForwardExternalUrlsType == DNNPageForwardType.Redirect302)
-                                            {
-                                                result.Action = ActionType.Redirect302;
-                                                result.Reason = RedirectReason.Tab_External_Url;
-                                            }
+                                            result.Action = ActionType.Redirect302;
+                                            result.Reason = RedirectReason.Tab_Temporary_Redirect;
                                         }
+
+                                        // should be already set, anyway
+                                        result.RewritePath = cleanPath;
                                     }
 
                                     break;

--- a/DNN Platform/Library/Entities/Urls/RedirectReason.cs
+++ b/DNN Platform/Library/Entities/Urls/RedirectReason.cs
@@ -43,5 +43,6 @@ namespace DotNetNuke.Entities.Urls
         Module_Provider_Rewrite_Redirect,
         Module_Provider_Redirect,
         Requested_SplashPage,
+        Tab_Temporary_Redirect,
     }
 }


### PR DESCRIPTION
Fixes #3466

While using the default Advanced URL format setting on the DNNFriendlyUrl config, redirects would always return 301 Permanent response codes even when the user had it set as a Temporary redirect from the Persona Bar.

This PR removes: 

1. the evaluation of a static setting (ForwardExternalUrlsType) that always forces both Internal Page and External URL redirects to be permanent without evaluating the user defined setting. This setting is hardcoded and not read from the DB.

This PR adds: 

1. logic to check if the user has defined the page as permanent/redirect for both Internal DNN Page redirects and External URL redirects
2. A new redirect reason so that the response reason matches the response code.