### PR TITLE
Add back method which was removed in #3969

### DIFF
--- a/DNN Platform/Library/Services/Mail/Mail.cs
+++ b/DNN Platform/Library/Services/Mail/Mail.cs
@@ -24,6 +24,13 @@ namespace DotNetNuke.Services.Mail
 
     public class Mail
     {
+        public static string ConvertToText(string sHTML)
+        {
+            var formattedHtml = HtmlUtils.FormatText(sHTML, true);
+            var styleLessHtml = HtmlUtils.RemoveInlineStyle(formattedHtml);
+            return HtmlUtils.StripTags(styleLessHtml, true);
+        }
+
         public static bool IsValidEmailAddress(string Email, int portalid)
         {
             string pattern = Null.NullString;


### PR DESCRIPTION
## Summary
The public method `Mail.ConvertToText` was accidentally removed in #3969, this PR adds it back.