### PR TITLE
Remove member with case-sensitive naming conflict

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Entities.Portals
 {
     using System;
@@ -19,7 +18,7 @@ namespace DotNetNuke.Entities.Portals
 
     /// <summary>
     /// PortalInfo provides a base class for Portal information
-    /// This class inherites from the <c>BaseEntityInfo</c> and is <c>Hydratable</c>.
+    /// This class inherits from the <c>BaseEntityInfo</c> and is <c>Hydratable</c>.
     /// </summary>
     /// <remarks><seealso cref="IHydratable"/>
     /// <example>This example shows how the <c>PortalInfo</c> class is used to get physical file names
@@ -61,7 +60,6 @@ namespace DotNetNuke.Entities.Portals
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PortalInfo"/> class.
-        /// Create new Portalinfo instance.
         /// </summary>
         /// <remarks>
         /// <example>This example illustrates the creation of a new <c>PortalInfo</c> object
@@ -150,7 +148,7 @@ namespace DotNetNuke.Entities.Portals
         public string CultureCode { get; set; }
 
         /// <summary>
-        /// Gets or sets curreny format that is used in the portal.
+        /// Gets or sets currency format that is used in the portal.
         /// </summary>
         /// <value>Currency of the portal.</value>
         [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0.")]
@@ -219,23 +217,23 @@ namespace DotNetNuke.Entities.Portals
 
         /// <inheritdoc />
         [XmlElement("portalid")]
-        public int PortalId { get; set; }
+        int IPortalInfo.PortalId { get; set; }
 
         [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalInfo.PortalId instead.")]
         public int PortalID
         {
-            get => this.PortalId;
-            set => this.PortalId = value;
+            get => this.ThisAsInterface.PortalId;
+            set => this.ThisAsInterface.PortalId = value;
         }
 
         /// <inheritdoc />
-        public int PortalGroupId { get; set; }
+        int IPortalInfo.PortalGroupId { get; set; }
 
-        [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalAliasInfo.HttpAlias instead.")]
+        [Obsolete("Deprecated in 9.7.2. Scheduled for removal in v11.0.0, use DotNetNuke.Abstractions.Portals.IPortalInfo.PortalGroupId instead.")]
         public int PortalGroupID
         {
-            get => this.PortalGroupId;
-            set => this.PortalGroupId = value;
+            get => this.ThisAsInterface.PortalGroupId;
+            set => this.ThisAsInterface.PortalGroupId = value;
         }
 
         /// <inheritdoc />
@@ -324,7 +322,7 @@ namespace DotNetNuke.Entities.Portals
             {
                 if (this._users < 0)
                 {
-                    this._users = UserController.GetUserCountByPortal(this.PortalID);
+                    this._users = UserController.GetUserCountByPortal(this.ThisAsInterface.PortalId);
                 }
 
                 return this._users;
@@ -350,7 +348,7 @@ namespace DotNetNuke.Entities.Portals
                 if (this._administratorRoleName == Null.NullString && this.AdministratorRoleId > Null.NullInteger)
                 {
                     // Get Role Name
-                    RoleInfo adminRole = RoleController.Instance.GetRole(this.PortalID, r => r.RoleID == this.AdministratorRoleId);
+                    RoleInfo adminRole = RoleController.Instance.GetRole(this.ThisAsInterface.PortalId, r => r.RoleID == this.AdministratorRoleId);
                     if (adminRole != null)
                     {
                         this._administratorRoleName = adminRole.RoleName;
@@ -378,7 +376,7 @@ namespace DotNetNuke.Entities.Portals
             {
                 if (this._pages < 0)
                 {
-                    this._pages = TabController.Instance.GetUserTabsByPortal(this.PortalID).Count;
+                    this._pages = TabController.Instance.GetUserTabsByPortal(this.ThisAsInterface.PortalId).Count;
                 }
 
                 return this._pages;
@@ -399,7 +397,7 @@ namespace DotNetNuke.Entities.Portals
                 if (this._registeredRoleName == Null.NullString && this.RegisteredRoleId > Null.NullInteger)
                 {
                     // Get Role Name
-                    RoleInfo regUsersRole = RoleController.Instance.GetRole(this.PortalID, r => r.RoleID == this.RegisteredRoleId);
+                    RoleInfo regUsersRole = RoleController.Instance.GetRole(this.ThisAsInterface.PortalId, r => r.RoleID == this.RegisteredRoleId);
                     if (regUsersRole != null)
                     {
                         this._registeredRoleName = regUsersRole.RoleName;
@@ -424,14 +422,16 @@ namespace DotNetNuke.Entities.Portals
         {
             get
             {
-                return this.PortalID;
+                return this.ThisAsInterface.PortalId;
             }
 
             set
             {
-                this.PortalID = value;
+                this.ThisAsInterface.PortalId = value;
             }
         }
+
+        private IPortalInfo ThisAsInterface => this;
 
         /// <summary>
         /// Fills a PortalInfo from a Data Reader.
@@ -441,11 +441,11 @@ namespace DotNetNuke.Entities.Portals
         /// <seealso cref="KeyID"></seealso></remarks>
         public void Fill(IDataReader dr)
         {
-            this.PortalId = Null.SetNullInteger(dr["PortalID"]);
+            this.ThisAsInterface.PortalId = Null.SetNullInteger(dr["PortalID"]);
 
             try
             {
-                this.PortalGroupId = Null.SetNullInteger(dr["PortalGroupID"]);
+                this.ThisAsInterface.PortalGroupId = Null.SetNullInteger(dr["PortalGroupID"]);
             }
             catch (IndexOutOfRangeException)
             {


### PR DESCRIPTION
`PortalInfo.PortalId` was introduced in DNN 9.7.2, but should have been made private (i.e. should have been an explicit interface implementation), in order to avoid breaking case insensitive languages (e.g. VB.NET)

I'm not sure this is the right solution, since it will be breaking to anyone using the new member for the last three releases (whereas with #4139 we resolved an issue introduced in 9.7.2 in 9.7.3).