### PR TITLE
Admin Logs - Fixed Log Settings errors

### DIFF
--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/src/components/LogSettings/LogSettingEditor/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/src/components/LogSettings/LogSettingEditor/index.jsx
@@ -152,7 +152,7 @@ class LogSettingEditor extends Component {
                     util.utilities.notify(Localization.get("ConfigUpdated"));
                     props.Collapse(event);
                 }, () => {
-                    util.utilities.notify(Localization.get("ConfigUpdateError"));
+                    util.utilities.notifyError(Localization.get("ConfigUpdateError"));
                 }));
             } else {
                 props.dispatch(LogSettingActions.addLogSetting(logSettingDetail, () => {
@@ -175,7 +175,7 @@ class LogSettingEditor extends Component {
                     util.utilities.notify(Localization.get("ConfigDeleted"));
                     props.Collapse(event);
                 }, () => {
-                    util.utilities.notify(Localization.get("DeleteError"));
+                    util.utilities.notifyError(Localization.get("DeleteError"));
                 })
                 );
             }, () => {
@@ -183,7 +183,7 @@ class LogSettingEditor extends Component {
             });
         }
         else {
-            util.utilities.notify(Localization.get("ConfigDeleteInconsistency"));
+            util.utilities.notifyError(Localization.get("ConfigDeleteInconsistency"));
         }
     }
 

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
@@ -386,11 +386,6 @@ namespace Dnn.PersonaBar.AdminLogs.Services
         {
             try
             {
-                var isAdmin = this.UserInfo.Roles.Contains(this.PortalSettings.AdministratorRoleName);
-                if (isAdmin)
-                {
-                    return this.Request.CreateResponse(HttpStatusCode.Unauthorized);
-                }
                 request.LogTypePortalID = this.UserInfo.IsSuperUser ? request.LogTypePortalID : this.PortalId.ToString();
 
                 var logTypeConfigInfo = JObject.FromObject(request).ToObject<LogTypeConfigInfo>();

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
@@ -386,6 +386,11 @@ namespace Dnn.PersonaBar.AdminLogs.Services
         {
             try
             {
+                var isAdmin = this.UserInfo.Roles.Contains(this.PortalSettings.AdministratorRoleName);
+                if (isAdmin)
+                {
+                    return this.Request.CreateResponse(HttpStatusCode.Unauthorized);
+                }
                 request.LogTypePortalID = this.UserInfo.IsSuperUser ? request.LogTypePortalID : this.PortalId.ToString();
 
                 var logTypeConfigInfo = JObject.FromObject(request).ToObject<LogTypeConfigInfo>();

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
@@ -388,13 +388,7 @@ namespace Dnn.PersonaBar.AdminLogs.Services
             {
                 if (!this.UserInfo.IsSuperUser)
                 {
-                    var isAdmin = this.UserInfo.Roles.Contains(this.PortalSettings.AdministratorRoleName);
-                    if (isAdmin)
-                    {
-                        return this.Request.CreateResponse(HttpStatusCode.Unauthorized);
-                    }
-
-                    request.LogTypePortalID = this.PortalId.ToString();
+                    return this.Request.CreateResponse(HttpStatusCode.Unauthorized);
                 }
 
                 var logTypeConfigInfo = JObject.FromObject(request).ToObject<LogTypeConfigInfo>();

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/AdminLogsController.cs
@@ -386,12 +386,16 @@ namespace Dnn.PersonaBar.AdminLogs.Services
         {
             try
             {
-                var isAdmin = this.UserInfo.Roles.Contains(this.PortalSettings.AdministratorRoleName);
-                if (isAdmin)
+                if (!this.UserInfo.IsSuperUser)
                 {
-                    return this.Request.CreateResponse(HttpStatusCode.Unauthorized);
+                    var isAdmin = this.UserInfo.Roles.Contains(this.PortalSettings.AdministratorRoleName);
+                    if (isAdmin)
+                    {
+                        return this.Request.CreateResponse(HttpStatusCode.Unauthorized);
+                    }
+
+                    request.LogTypePortalID = this.PortalId.ToString();
                 }
-                request.LogTypePortalID = this.UserInfo.IsSuperUser ? request.LogTypePortalID : this.PortalId.ToString();
 
                 var logTypeConfigInfo = JObject.FromObject(request).ToObject<LogTypeConfigInfo>();
                 this._controller.AddLogTypeConfig(logTypeConfigInfo);


### PR DESCRIPTION
Fixes #4398

## Summary
This pull request reverts 4d1f352e8ca076ab9092362d9bc2da367dadc4e6 and changes the Admin Logs panel to show error notifications when Log Settings operations fail (instead of success notifications)