### PR TITLE
Fixe Caching Issue in TermsController

### DIFF
--- a/DNN Platform/Library/Entities/Content/Taxonomy/TermController.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/TermController.cs
@@ -215,6 +215,9 @@ namespace DotNetNuke.Entities.Content.Taxonomy
             Requires.NotNull("contentItem", contentItem);
 
             this._DataService.RemoveTermsFromContent(contentItem);
+
+            // We have adjusted a content item, remove it from cache
+            DataCache.RemoveCache(string.Format(DataCache.ContentItemsCacheKey, contentItem.ContentTypeId));
         }
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Content/Taxonomy/TermController.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/TermController.cs
@@ -96,6 +96,9 @@ namespace DotNetNuke.Entities.Content.Taxonomy
             Requires.NotNull("contentItem", contentItem);
 
             this._DataService.AddTermToContent(term, contentItem);
+
+            // We have adjusted a content item, remove it from cache
+            DataCache.RemoveCache(string.Format(DataCache.ContentItemsCacheKey, contentItem.ContentTypeId));
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #4410 by clearing the cache of the content item if a new term was associated.  Additionally fixed a situation where a term was removed.