### PR TITLE
Resolved issue with lowercase URL's and account verifications

### DIFF
--- a/DNN Platform/Library/Entities/Urls/FriendlyUrlSettings.cs
+++ b/DNN Platform/Library/Entities/Urls/FriendlyUrlSettings.cs
@@ -405,7 +405,7 @@ namespace DotNetNuke.Entities.Urls
 
         public string ForceLowerCaseRegex
         {
-            get { return this._forceLowerCaseRegex ?? (this._forceLowerCaseRegex = this.GetStringSetting(PreventLowerCaseUrlRegexSetting, string.Empty)); }
+            get { return this._forceLowerCaseRegex ?? (this._forceLowerCaseRegex = this.GetStringSetting(PreventLowerCaseUrlRegexSetting, @"\bverificationcode\b")); }
             internal set { this._forceLowerCaseRegex = value; }
         }
 


### PR DESCRIPTION
## Summary
Resolved #2862 by introducing a new default exclusion for lowercase URL's to prevent lowercasing the URL's that contain the verification code.

This DOES not change anything for users on upgrade that has custom values for the "prevent lowercase" setting due to risk of manipulating the value they may have.