### PR TITLE
Fix DnnImageHandler bug when filepath mixedcase #4420

### DIFF
--- a/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
@@ -465,7 +465,7 @@ namespace DotNetNuke.Services.GeneratedImage
             }
 
             // File outside the white list cannot be served
-            return WhiteListFolderPaths.Any(normalizeFilePath.StartsWith);
+            return WhiteListFolderPaths.Any(s => normalizeFilePath.StartsWith(s, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private static string NormalizeFilePath(string filePath)


### PR DESCRIPTION
return WhiteListFolderPaths.Any(normalizeFilePath.StartsWith); => 
return WhiteListFolderPaths.Any(s => normalizeFilePath.StartsWith(s, StringComparison.InvariantCultureIgnoreCase));

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
