### PR TITLE
Use pipeline artifacts instead of build artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,11 +80,7 @@ steps:
     failTaskOnFailedTests: true
   condition: eq(variables['RunTests'], 'True')
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifacts'
-  inputs:
-    PathtoPublish: Artifacts
-    ArtifactName: Artifacts
+- publish: 'Artifacts'
   continueOnError: true
 
 - task: NuGetCommand@2


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml states:
>We recommend upgrading from build artifacts (`PublishBuildArtifacts@1` and `DownloadBuildArtifacts@0`) to pipeline artifacts (`PublishPipelineArtifact@1` and `DownloadPipelineArtifact@2`) for faster output storage speeds.