### PR TITLE
Run unit tests in parallel

### DIFF
--- a/Build/Cake/unit-tests.cs
+++ b/Build/Cake/unit-tests.cs
@@ -19,18 +19,17 @@ public sealed class UnitTests : FrostingTask<Context>
         testAssemblies -= context.GetFiles(@"**\DotNetNuke.Tests.Utilities.dll");
         testAssemblies -= context.GetFiles(@"**\DotNetNuke.Tests.Urls.dll");
 
-        foreach (var file in testAssemblies)
-        {
-            context.VSTest(file.FullPath,
-                FixToolPath(context, new VSTestSettings()
+        context.VSTest(
+            testAssemblies,
+            FixToolPath(
+                context, 
+                new VSTestSettings
                 {
-                    Logger = $"trx;LogFileName={file.GetFilename()}.xml",
+                    Logger = "trx",
                     Parallel = true,
                     EnableCodeCoverage = true,
-                    FrameworkVersion = VSTestFrameworkVersion.NET45,
                     TestAdapterPath = @"tools\NUnitTestAdapter.2.3.0\build"
                 }));
-        }
     }
 
 // https://github.com/cake-build/cake/issues/1522

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ steps:
   displayName: 'Publish Test Results **/TestResults/*.xml'
   inputs:
     testResultsFormat: VSTest
-    testResultsFiles: '**/TestResults/*.xml'
+    testResultsFiles: '**/TestResults/*.trx'
     mergeTestResults: true
     failTaskOnFailedTests: true
   condition: eq(variables['RunTests'], 'True')


### PR DESCRIPTION
Cake currently runs each test assembly in its own test process and these processes are not run in parallel.  This PR adjusts the build to pass all test assemblies to the test runner at once.