### PR TITLE
removed languages not provided in dnnpages plugin

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/lang/fr.js
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/lang/fr.js
@@ -1,0 +1,7 @@
+CKEDITOR.plugins.setLang('dnnpages', 'en', {
+    dnnpages: 'Page du site',
+    fileToBig: 'Le fichier est trop grand pour être télévresé.',
+	localPageLabel : 'Page qui provient de votre site.',
+	localPageTitle: 'Choisissez la page de votre site pour laquelle vous désirez créer un lien',
+	portalUrl: 'Fichier du site ou autre URL'
+});

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/lang/nl.js
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/lang/nl.js
@@ -1,0 +1,7 @@
+CKEDITOR.plugins.setLang('dnnpages', 'nl', {
+    dnnpages: 'Website pagina',
+    fileToBig: 'Bestand is te groot.',
+	localPageLabel : 'Een pagina van uw website',
+	localPageTitle: 'Kies de pagina van uw website waar u naar wilt verwijzen met een link',
+	portalUrl: 'Bestand van uw website, of een andere URL'
+});

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/plugin.js
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/plugin.js
@@ -9,7 +9,7 @@
 	CKEDITOR.plugins.add( 'dnnpages', {
 		requires: 'dialog,fakeobjects',
 		// jscs:disable maximumLineLength
-		lang: 'af,ar,az,bg,bn,bs,ca,cs,cy,da,de,de-ch,el,en,en-au,en-ca,en-gb,eo,es,es-mx,et,eu,fa,fi,fo,fr,fr-ca,gl,gu,he,hi,hr,hu,id,is,it,ja,ka,km,ko,ku,lt,lv,mk,mn,ms,nb,nl,no,oc,pl,pt,pt-br,ro,ru,si,sk,sl,sq,sr,sr-latn,sv,th,tr,tt,ug,uk,vi,zh,zh-cn', // %REMOVE_LINE_CORE%
+		lang: 'de,en,pl', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
 		icons: 'anchor,anchor-rtl,link,unlink', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/plugin.js
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/plugin.js
@@ -9,7 +9,7 @@
 	CKEDITOR.plugins.add( 'dnnpages', {
 		requires: 'dialog,fakeobjects',
 		// jscs:disable maximumLineLength
-		lang: 'de,en,pl', // %REMOVE_LINE_CORE%
+		lang: 'de,en,fr,pl', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
 		icons: 'anchor,anchor-rtl,link,unlink', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/plugin.js
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/plugins/dnnpages/plugin.js
@@ -9,7 +9,7 @@
 	CKEDITOR.plugins.add( 'dnnpages', {
 		requires: 'dialog,fakeobjects',
 		// jscs:disable maximumLineLength
-		lang: 'de,en,fr,pl', // %REMOVE_LINE_CORE%
+		lang: 'de,en,fr,nl,pl', // %REMOVE_LINE_CORE%
 		// jscs:enable maximumLineLength
 		icons: 'anchor,anchor-rtl,link,unlink', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%


### PR DESCRIPTION
In the upgraded dnnpages-plugin for CKEditor, I left the full list of langues. Since only 3 (en,de,pl) language files are actually supported currently, the others result in an error.

This simple removal provides the same solution we had before.

I skipped creating an issue this time, since it's not in a RC yet, anyway. If needed, I'm happy to create one, of course.
