### PR TITLE
Generic module event

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Data\PetaPoco\FluentMapperExtensions.cs" />
     <Compile Include="Data\SqlDatabaseConnectionProvider.cs" />
     <Compile Include="Entities\Content\Taxonomy\TermHelper.cs" />
+    <Compile Include="Entities\Modules\Actions\ModuleGenericEventArgs.cs" />
     <Compile Include="Entities\Modules\Prompt\AddModule.cs" />
     <Compile Include="Entities\Modules\ICustomTokenProvider.cs" />
     <Compile Include="Entities\Modules\InstalledModuleInfo.cs" />

--- a/DNN Platform/Library/Entities/EventManager.cs
+++ b/DNN Platform/Library/Entities/EventManager.cs
@@ -74,6 +74,7 @@ namespace DotNetNuke.Entities
                 this.ModuleUpdated += handlers.Value.ModuleUpdated;
                 this.ModuleRemoved += handlers.Value.ModuleRemoved;
                 this.ModuleDeleted += handlers.Value.ModuleDeleted;
+                this.ModuleGenericEvent += handlers.Value.ModuleGenericEvent;
             }
 
             foreach (var handler in EventHandlersContainer<IPortalEventHandlers>.Instance.EventHandlers)
@@ -172,6 +173,8 @@ namespace DotNetNuke.Entities
         private event EventHandler<ModuleEventArgs> ModuleRemoved; // soft delete
 
         private event EventHandler<ModuleEventArgs> ModuleDeleted; // hard delete
+
+        private event EventHandler<ModuleGenericEventArgs> ModuleGenericEvent;
 
         private event EventHandler<PortalCreatedEventArgs> PortalCreated;
 
@@ -392,6 +395,15 @@ namespace DotNetNuke.Entities
             if (this.ModuleDeleted != null)
             {
                 this.ModuleDeleted(this, args);
+            }
+        }
+
+        /// <inheritdoc/>
+        public virtual void OnModuleGenericEvent(ModuleGenericEventArgs args)
+        {
+            if (this.ModuleGenericEvent != null)
+            {
+                this.ModuleGenericEvent(this, args);
             }
         }
 

--- a/DNN Platform/Library/Entities/IEventManager.cs
+++ b/DNN Platform/Library/Entities/IEventManager.cs
@@ -126,6 +126,12 @@ namespace DotNetNuke.Entities
         void OnModuleDeleted(ModuleEventArgs args);
 
         /// <summary>
+        /// Generic event that module vendors can use within their modules.
+        /// </summary>
+        /// <param name="args">The event arguments.</param>
+        void OnModuleGenericEvent(ModuleGenericEventArgs args);
+
+        /// <summary>
         /// Fires up when a module was removed.
         /// </summary>
         /// <param name="args">The event arguments.</param>

--- a/DNN Platform/Library/Entities/Modules/Actions/IModuleEventHandler.cs
+++ b/DNN Platform/Library/Entities/Modules/Actions/IModuleEventHandler.cs
@@ -13,5 +13,7 @@ namespace DotNetNuke.Entities.Modules.Actions
         void ModuleRemoved(object sender, ModuleEventArgs args);
 
         void ModuleDeleted(object sender, ModuleEventArgs args);
+
+        void ModuleGenericEvent(object sender, ModuleGenericEventArgs args);
     }
 }

--- a/DNN Platform/Library/Entities/Modules/Actions/ModuleGenericEventArgs.cs
+++ b/DNN Platform/Library/Entities/Modules/Actions/ModuleGenericEventArgs.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Entities.Modules.Actions
+{
+    /// <summary>
+    /// Event arguments for a generic module event.
+    /// </summary>
+    public class ModuleGenericEventArgs : ModuleEventArgs
+    {
+        /// <summary>
+        /// Gets or sets the name of the event.
+        /// </summary>
+        public string EventName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the payload for the event.
+        /// </summary>
+        public object Payload { get; set; }
+    }
+}

--- a/DNN Platform/Modules/HTML/EditHtml.ascx.cs
+++ b/DNN Platform/Modules/HTML/EditHtml.ascx.cs
@@ -270,6 +270,7 @@ namespace DotNetNuke.Modules.Html
                         }
 
                         this._htmlTextController.UpdateHtmlText(htmlContent, this._htmlTextController.GetMaximumVersionHistory(this.PortalId));
+                        Entities.EventManager.Instance.OnModuleUpdated(new Entities.Modules.Actions.ModuleGenericEventArgs { Module = this.ModuleConfiguration, EventName = "Update", Payload = htmlContent });
                         break;
                 }
             }

--- a/DNN Platform/Modules/HTML/EditHtml.ascx.cs
+++ b/DNN Platform/Modules/HTML/EditHtml.ascx.cs
@@ -270,7 +270,7 @@ namespace DotNetNuke.Modules.Html
                         }
 
                         this._htmlTextController.UpdateHtmlText(htmlContent, this._htmlTextController.GetMaximumVersionHistory(this.PortalId));
-                        Entities.EventManager.Instance.OnModuleUpdated(new Entities.Modules.Actions.ModuleGenericEventArgs { Module = this.ModuleConfiguration, EventName = "Update", Payload = htmlContent });
+                        Entities.EventManager.Instance.OnModuleGenericEvent(new Entities.Modules.Actions.ModuleGenericEventArgs { Module = this.ModuleConfiguration, EventName = "Update", Payload = htmlContent });
                         break;
                 }
             }


### PR DESCRIPTION
## Summary
This PR adds a generic event for modules. It includes an example in the HTML module.

## Background
In a scenario where we'd want to allow a more loose coupling between DNN extensions, having a generic handler allows us to send events between modules. It would also allow simple messagebus-type applications. The sample shows how the HTML module would implement this. As the UpdateModule event only fires when the **Settings** of a module are updated, it doesn't tell us when the actual content of a module is updated. Now, with this simple change, the HTML module can signal that it's content has changed and any other component can leverage this if it needs to.