### PR TITLE
Use parameters instead of variables in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,11 +4,31 @@ pool:
 variables:
   - name: "Build.ArtifactStagingDirectory"
     value: "Artifacts/"
-  # The following variables are defined as settable at queue time, so they cannot be included here
-  # CakeTarget: BuildAll
-  # CakeVerbosity: Normal # valid values include Quiet, Minimal, Normal, Verbose, Diagnostic
-  # ReleaseMode: Beta
-  # RunTests: True
+
+parameters:
+  - name: "CakeTarget"
+    type: string
+    default: "BuildAll"
+  - name: "CakeVerbosity"
+    type: string
+    default: "Normal"
+    values:
+    - "Quiet"
+    - "Minimal"
+    - "Normal"
+    - "Verbose"
+    - "Diagnostic"
+  - name: "ReleaseMode"
+    type: string
+    default: "Beta"
+    values:
+    - "Alpha"
+    - "Beta"
+    - "RC"
+    - "Stable"
+  - name: "RunTests"
+    type: boolean
+    default: true
 
 trigger:
   batch: true
@@ -29,11 +49,11 @@ steps:
   inputs:
     targetType: filePath
     filePath: ./build.ps1
-    arguments: '--target=BuildServerSetVersion --verbosity=$(CakeVerbosity)'
+    arguments: '--target=BuildServerSetVersion --verbosity=${{ parameters.CakeVerbosity }}'
 
 - script: 'sqllocaldb start mssqllocaldb'
   displayName: 'Start Sql LocalDb Service'
-  condition: and(succeeded(), eq(variables['RunTests'], 'True'))
+  condition: and(succeeded(), eq(parameters.RunTests, true))
 
 - powershell: 'npm config set registry https://www.myget.org/F/dnn-software-public/npm/'
   displayName: 'npm config set registry'
@@ -45,7 +65,7 @@ steps:
    (Get-Content $path) | ForEach-Object{
       if($_ -match $pattern3){
        # We have found the matching line
-       '[assembly: AssemblyStatus(ReleaseMode.{0})]' -f '$(ReleaseMode)'
+       '[assembly: AssemblyStatus(ReleaseMode.{0})]' -f '${{ parameters.ReleaseMode }}'
       } else {
        $_
       }
@@ -58,16 +78,16 @@ steps:
   inputs:
     targetType: filePath
     filePath: ./build.ps1
-    arguments: '--target=$(CakeTarget) --verbosity=$(CakeVerbosity)'
+    arguments: '--target=${{ parameters.CakeTarget }} --verbosity=${{ parameters.CakeVerbosity }}'
 
 - task: PowerShell@2
   displayName: 'Run Unit Tests via Cake'
   inputs:
     targetType: filePath
     filePath: ./build.ps1
-    arguments: '--target=UnitTests --verbosity=$(CakeVerbosity)'
+    arguments: '--target=UnitTests --verbosity=${{ parameters.CakeVerbosity }}'
   continueOnError: true
-  condition: and(succeeded(), eq(variables['RunTests'], 'True'))
+  condition: and(succeeded(), eq(parameters.RunTests, true))
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results **/TestResults/*.xml'
@@ -76,7 +96,7 @@ steps:
     testResultsFiles: '**/TestResults/*.trx'
     mergeTestResults: true
     failTaskOnFailedTests: true
-  condition: eq(variables['RunTests'], 'True')
+  condition: eq(parameters.RunTests, true)
 
 - publish: 'Artifacts'
   continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,6 @@ variables:
   - name: "Build.ArtifactStagingDirectory"
     value: "Artifacts/"
   # The following variables are defined as settable at queue time, so they cannot be included here
-  # Branch.CdfProvider: dnn
-  # Branch.CkEditor: development
   # CakeTarget: BuildAll
   # CakeVerbosity: Normal # valid values include Quiet, Minimal, Normal, Verbose, Diagnostic
   # ReleaseMode: Beta
@@ -60,7 +58,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: ./build.ps1
-    arguments: '--target=$(CakeTarget) --verbosity=$(CakeVerbosity) --CkBranch="$(Branch.CkEditor)" --CdfBranch="$(Branch.CdfProvider)"'
+    arguments: '--target=$(CakeTarget) --verbosity=$(CakeVerbosity)'
 
 - task: PowerShell@2
   displayName: 'Run Unit Tests via Cake'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,9 +51,9 @@ steps:
     filePath: ./build.ps1
     arguments: '--target=BuildServerSetVersion --verbosity=${{ parameters.CakeVerbosity }}'
 
-- script: 'sqllocaldb start mssqllocaldb'
-  displayName: 'Start Sql LocalDb Service'
-  condition: and(succeeded(), eq(parameters.RunTests, true))
+- ${{ if eq(parameters.RunTests, true) }}:
+  - script: 'sqllocaldb start mssqllocaldb'
+    displayName: 'Start Sql LocalDb Service'
 
 - powershell: 'npm config set registry https://www.myget.org/F/dnn-software-public/npm/'
   displayName: 'npm config set registry'
@@ -80,23 +80,24 @@ steps:
     filePath: ./build.ps1
     arguments: '--target=${{ parameters.CakeTarget }} --verbosity=${{ parameters.CakeVerbosity }}'
 
-- task: PowerShell@2
-  displayName: 'Run Unit Tests via Cake'
-  inputs:
-    targetType: filePath
-    filePath: ./build.ps1
-    arguments: '--target=UnitTests --verbosity=${{ parameters.CakeVerbosity }}'
-  continueOnError: true
-  condition: and(succeeded(), eq(parameters.RunTests, true))
+- ${{ if eq(parameters.RunTests, true) }}:
+  - task: PowerShell@2
+    displayName: 'Run Unit Tests via Cake'
+    inputs:
+      targetType: filePath
+      filePath: ./build.ps1
+      arguments: '--target=UnitTests --verbosity=${{ parameters.CakeVerbosity }}'
+    continueOnError: true
 
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results **/TestResults/*.xml'
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '**/TestResults/*.trx'
-    mergeTestResults: true
-    failTaskOnFailedTests: true
-  condition: eq(parameters.RunTests, true)
+- ${{ if eq(parameters.RunTests, true) }}:
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results **/TestResults/*.xml'
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '**/TestResults/*.trx'
+      mergeTestResults: true
+      failTaskOnFailedTests: true
+    condition: always()
 
 - publish: 'Artifacts'
   continueOnError: true


### PR DESCRIPTION
Currently the YAML pipeline for Azure DevOps documents the required variables in comments, but they're actually configured separately with the pipeline.  Using [parameters](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops&tabs=script) instead allows us to restrict the available options and declare defaults in the YAML document, instead of having them defined separately.