### PR TITLE
sitemappriority for new page set to 0.5

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/services/pageService.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/services/pageService.js
@@ -92,6 +92,7 @@ const PageService = function () {
                 page.parentId = parentPage && typeof parentPage !== "function" && parentPage.id || page.parentId;
                 page.iconFile = null;
                 page.iconFileLarge = null;
+                page.sitemapPriority = 0.5;
                 return page;
             });
     };


### PR DESCRIPTION
Fixes #3081 

## Summary
I added the default value for sitemapPriority on the client, since several other "controls" get their ddefault values there too, and since I didn't really find a better place for it.
I concidered PagesController.GetDefaultSettings but that didn't seem right either.

This change adds the default value to the property that is being used for the value of the dropdown. When the page is saved, this value is posted to the server too and correctly saved.