### PR TITLE
Feature/2334 setting for minimum username length

### DIFF
--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -197,6 +197,12 @@ namespace DotNetNuke.Common
         public const string glbUserNameRegEx = @"";
 
         /// <summary>
+        /// User Name default minimum length.
+        /// </summary>
+        /// <value></value>
+        public const int glbUserNameMinLength = 5;
+
+        /// <summary>
         /// Format of a script tag.
         /// </summary>
         /// <value><![CDATA[<script type=\"text/javascript\" src=\"{0}\" ></script>]]></value>

--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -1813,7 +1813,15 @@ namespace DotNetNuke.Entities.Users
         public bool IsValidUserName(string userName)
         {
             char[] unallowedAscii = HostController.Instance.GetString("UsernameUnallowedCharacters", Globals.USERNAME_UNALLOWED_ASCII).ToCharArray();
-            return userName.Length >= 5 &&
+
+            // if the httpcontext is null, then use the default minimum length
+            var usernameMinLength = Globals.glbUserNameMinLength;
+            if (HttpContext.Current != null)
+            {
+                usernameMinLength = PortalController.GetPortalSettingAsInteger("Security_UserNameMinLength", this.PortalId, usernameMinLength);
+            }
+
+            return userName.Length >= usernameMinLength &&
                         userName == userName.Trim() &&
                         userName.All(ch => ch >= ' ') &&
                         userName.IndexOfAny(unallowedAscii) < 0;

--- a/DNN Platform/Website/DesktopModules/Admin/Security/App_LocalResources/SharedResources.resx
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/App_LocalResources/SharedResources.resx
@@ -121,7 +121,7 @@
     <value>User Name:</value>
   </data>
   <data name="Username.Help" xml:space="preserve">
-    <value>Enter a user name.  It must be at least five characters long, must be an alphanumeric value,
+    <value>Enter a user name.  It must be of at least the minimum configured length, must be an alphanumeric value,
     must not start/end with a space, and must not contain any of these characters !"#$%&amp;'()*+,/:;&lt;=&gt;?@[\]^`{|}</value>
   </data>
   <data name="FirstName.Text" xml:space="preserve">

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/registrationSettings/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/registrationSettings/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { security as SecurityActions } from "../../actions";
-import { 
+import {
     InputGroup,
     SingleLineInputWithError,
     SearchableTags,
@@ -18,6 +18,7 @@ import resx from "../../resources";
 import styles from "./style.less";
 
 let canEdit = false;
+const reUserNameMinLength = /^[1-9][0-9]?[0-9]?$|^0$/;
 /*eslint-disable eqeqeq*/
 class RegistrationSettingsPanelBody extends Component {
     constructor() {
@@ -27,14 +28,15 @@ class RegistrationSettingsPanelBody extends Component {
             triedToSubmit: false,
             error: {
                 registrationFields: "",
-                validationFields:""
+                userNameMinLength: false,
+                validationFields: ""
             }
         };
         canEdit = util.settings.isHost || util.settings.isAdmin || util.settings.permissions.REGISTRATION_SETTINGS_EDIT;
     }
 
     UNSAFE_componentWillMount() {
-        const {props} = this;
+        const { props } = this;
         if (props.registrationSettings) {
             this.setState({
                 registrationSettings: props.registrationSettings
@@ -57,7 +59,7 @@ class RegistrationSettingsPanelBody extends Component {
     }
 
     onSettingChange(key, event) {
-        let {state, props} = this;
+        let { state, props } = this;
 
         let registrationSettings = Object.assign({}, state.registrationSettings);
 
@@ -75,9 +77,14 @@ class RegistrationSettingsPanelBody extends Component {
         else {
             registrationSettings[key] = typeof (event) === "object" ? event.target.value : event;
         }
+        if (key === "UserNameMinLength") {
+            state.error.userNameMinLength = !reUserNameMinLength.test(registrationSettings[key]);
+        }
+
         this.setState({
             registrationSettings: registrationSettings,
-            triedToSubmit: false
+            triedToSubmit: false,
+            error: state.error
         });
 
         props.dispatch(SecurityActions.registrationSettingsClientModified(registrationSettings));
@@ -85,8 +92,14 @@ class RegistrationSettingsPanelBody extends Component {
 
     onUpdate(event) {
         event.preventDefault();
-        const {props, state} = this;
+        const { props, state } = this;
         state.error["validationFields"] = "";
+
+        if (state.error.userNameMinLength) {
+            // there is an error, so no saving
+            return;
+        }
+
         this.setState({
             triedToSubmit: true
         });
@@ -105,7 +118,7 @@ class RegistrationSettingsPanelBody extends Component {
     }
 
     onCancel() {
-        const {props} = this;
+        const { props } = this;
         util.utilities.confirm(resx.get("RegistrationSettingsRestoreWarning"), resx.get("Yes"), resx.get("No"), () => {
             props.dispatch(SecurityActions.getRegistrationSettings((data) => {
                 let registrationSettings = Object.assign({}, data.Results.Settings);
@@ -127,7 +140,7 @@ class RegistrationSettingsPanelBody extends Component {
     }
 
     isCustomFormType() {
-        const {state} = this;
+        const { state } = this;
         if (state.registrationSettings != undefined && state.registrationSettings.RegistrationFormType === 1) {
             return true;
         }
@@ -145,7 +158,7 @@ class RegistrationSettingsPanelBody extends Component {
     }
 
     onUpdateTags(event) {
-        let {state, props} = this;
+        let { state, props } = this;
         let registrationSettings = Object.assign({}, state.registrationSettings);
         let fields = event.map((field) => { return field.name; }).join(",");
         registrationSettings["RegistrationFields"] = fields;
@@ -158,7 +171,7 @@ class RegistrationSettingsPanelBody extends Component {
 
     /* eslint-disable react/no-danger */
     render() {
-        const {props, state} = this;
+        const { props, state } = this;
         const noneSpecifiedText = "<" + resx.get("NoneSpecified") + ">";
         const RedirectAfterRegistrationParameters = {
             portalId: -2,
@@ -180,11 +193,11 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-options">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("plUserRegistration.Help") }
-                                label={resx.get("plUserRegistration") } />
+                                tooltipMessage={resx.get("plUserRegistration.Help")}
+                                label={resx.get("plUserRegistration")} />
                             <RadioButtons
-                                onChange={this.onSettingChange.bind(this, "UserRegistration") }
-                                options={this.keyValuePairsToOptions(props.userRegistrationOptions) }
+                                onChange={this.onSettingChange.bind(this, "UserRegistration")}
+                                options={this.keyValuePairsToOptions(props.userRegistrationOptions)}
                                 buttonGroup="registrationType"
                                 value={state.registrationSettings.UserRegistration}
                                 disabled={!canEdit} />
@@ -194,11 +207,11 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-options">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("registrationFormTypeLabel.Help") }
-                                label={resx.get("registrationFormTypeLabel") } />
+                                tooltipMessage={resx.get("registrationFormTypeLabel.Help")}
+                                label={resx.get("registrationFormTypeLabel")} />
                             <RadioButtons
-                                onChange={this.onSettingChange.bind(this, "RegistrationFormType") }
-                                options={this.keyValuePairsToOptions(props.registrationFormTypeOptions) }
+                                onChange={this.onSettingChange.bind(this, "RegistrationFormType")}
+                                options={this.keyValuePairsToOptions(props.registrationFormTypeOptions)}
                                 buttonGroup="formType"
                                 value={state.registrationSettings.RegistrationFormType}
                                 disabled={!canEdit} />
@@ -209,12 +222,12 @@ class RegistrationSettingsPanelBody extends Component {
                         <InputGroup style={{ marginBottom: "30px" }}>
                             <div className="registrationSettings-row-input">
                                 <Label
-                                    tooltipMessage={resx.get("registrationFieldsLabel.Help") }
-                                    label={resx.get("registrationFieldsLabel") } />
+                                    tooltipMessage={resx.get("registrationFieldsLabel.Help")}
+                                    label={resx.get("registrationFieldsLabel")} />
                                 <SearchableTags
                                     utils={util}
-                                    tags={this.getRegistrationFields(state.registrationSettings.RegistrationFields) }
-                                    onUpdateTags={this.onUpdateTags.bind(this) }
+                                    tags={this.getRegistrationFields(state.registrationSettings.RegistrationFields)}
+                                    onUpdateTags={this.onUpdateTags.bind(this)}
                                     error={this.state.error.registrationFields !== ""}
                                     errorMessage={this.state.error.registrationFields}
                                     enabled={canEdit} />
@@ -224,65 +237,78 @@ class RegistrationSettingsPanelBody extends Component {
                     <InputGroup>
                         <div className="registrationSettings-row-input">
                             <Label
-                                tooltipMessage={resx.get("Security_DisplayNameFormat.Help") }
-                                label={resx.get("Security_DisplayNameFormat") } />
+                                tooltipMessage={resx.get("Security_DisplayNameFormat.Help")}
+                                label={resx.get("Security_DisplayNameFormat")} />
                             <SingleLineInputWithError
                                 error={false}
                                 value={state.registrationSettings.DisplayNameFormat}
-                                onChange={this.onSettingChange.bind(this, "DisplayNameFormat") }
+                                onChange={this.onSettingChange.bind(this, "DisplayNameFormat")}
                                 enabled={canEdit} />
                         </div>
                     </InputGroup>
                     <InputGroup>
                         <div className="registrationSettings-row-input">
                             <Label
-                                tooltipMessage={resx.get("Security_UserNameValidation.Help") }
-                                label={resx.get("Security_UserNameValidation") } />
+                                tooltipMessage={resx.get("Security_UserNameValidation.Help")}
+                                label={resx.get("Security_UserNameValidation")} />
                             <SingleLineInputWithError
                                 error={false}
                                 value={state.registrationSettings.UserNameValidation}
-                                onChange={this.onSettingChange.bind(this, "UserNameValidation") }
+                                onChange={this.onSettingChange.bind(this, "UserNameValidation")}
                                 enabled={canEdit} />
                         </div>
                     </InputGroup>
+
+                    <InputGroup>
+                        <Label
+                            tooltipMessage={resx.get("Security_UserNameMinLength.Help")}
+                            label={resx.get("Security_UserNameMinLength")} />
+                        <SingleLineInputWithError
+                            withLabel={false}
+                            error={this.state.error.userNameMinLength}
+                            errorMessage={resx.get("Security_UserNameMinLength.ErrorMessage")}
+                            value={state.registrationSettings.UserNameMinLength}
+                            onChange={this.onSettingChange.bind(this, "UserNameMinLength")} />
+                    </InputGroup>
+
                     <InputGroup>
                         <div className="registrationSettings-row-input">
                             <Label
-                                tooltipMessage={resx.get("Security_EmailValidation.Help") }
-                                label={resx.get("Security_EmailValidation") } />
+                                tooltipMessage={resx.get("Security_EmailValidation.Help")}
+                                label={resx.get("Security_EmailValidation")} />
                             <SingleLineInputWithError
                                 error={false}
                                 withLabel={false}
                                 value={state.registrationSettings.EmailAddressValidation}
-                                onChange={this.onSettingChange.bind(this, "EmailAddressValidation") }
+                                onChange={this.onSettingChange.bind(this, "EmailAddressValidation")}
                                 enabled={canEdit} />
                         </div>
                     </InputGroup>
                     <InputGroup>
                         <div className="registrationSettings-row-input">
                             <Label
-                                tooltipMessage={resx.get("Registration_ExcludeTerms.Help") }
-                                label={resx.get("Registration_ExcludeTerms") } />
+                                tooltipMessage={resx.get("Registration_ExcludeTerms.Help")}
+                                label={resx.get("Registration_ExcludeTerms")} />
                             <SingleLineInputWithError
                                 error={false}
                                 withLabel={false}
                                 value={state.registrationSettings.ExcludedTerms}
-                                onChange={this.onSettingChange.bind(this, "ExcludedTerms") }
+                                onChange={this.onSettingChange.bind(this, "ExcludedTerms")}
                                 enabled={canEdit} />
                         </div>
                     </InputGroup>
-                    <div style={{paddingBottom: "15px", fontStyle: "italic"}}>{resx.get("RedirectionMovedToSiteSettings")}</div>
+                    <div style={{ paddingBottom: "15px", fontStyle: "italic" }}>{resx.get("RedirectionMovedToSiteSettings")}</div>
                     <InputGroup>
                         <div className="registrationSettings-row_switch">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("plEnableRegisterNotification.Help") }
-                                label={resx.get("plEnableRegisterNotification") } />
+                                tooltipMessage={resx.get("plEnableRegisterNotification.Help")}
+                                label={resx.get("plEnableRegisterNotification")} />
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.registrationSettings.EnableRegisterNotification}
-                                onChange={this.onSettingChange.bind(this, "EnableRegisterNotification") }
+                                onChange={this.onSettingChange.bind(this, "EnableRegisterNotification")}
                                 readOnly={!canEdit} />
                         </div>
                     </InputGroup>
@@ -290,13 +316,13 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row_switch">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("Registration_UseAuthProviders.Help") }
-                                label={resx.get("Registration_UseAuthProviders") } />
+                                tooltipMessage={resx.get("Registration_UseAuthProviders.Help")}
+                                label={resx.get("Registration_UseAuthProviders")} />
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.registrationSettings.UseAuthenticationProviders}
-                                onChange={this.onSettingChange.bind(this, "UseAuthenticationProviders") }
+                                onChange={this.onSettingChange.bind(this, "UseAuthenticationProviders")}
                                 readOnly={!canEdit} />
                         </div>
                     </InputGroup>
@@ -304,13 +330,13 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row_switch">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("Registration_UseProfanityFilter.Help") }
-                                label={resx.get("Registration_UseProfanityFilter") } />
+                                tooltipMessage={resx.get("Registration_UseProfanityFilter.Help")}
+                                label={resx.get("Registration_UseProfanityFilter")} />
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.registrationSettings.UseProfanityFilter}
-                                onChange={this.onSettingChange.bind(this, "UseProfanityFilter") }
+                                onChange={this.onSettingChange.bind(this, "UseProfanityFilter")}
                                 readOnly={!canEdit} />
                         </div>
                     </InputGroup>
@@ -319,21 +345,21 @@ class RegistrationSettingsPanelBody extends Component {
                             <div className="registrationSettings-row_switch">
                                 <Label
                                     labelType="inline"
-                                    tooltipMessage={resx.get("Registration_UseEmailAsUserName.Help") }
-                                    label={resx.get("Registration_UseEmailAsUserName") } />
+                                    tooltipMessage={resx.get("Registration_UseEmailAsUserName.Help")}
+                                    label={resx.get("Registration_UseEmailAsUserName")} />
                                 <Switch
                                     onText={resx.get("SwitchOn")}
                                     offText={resx.get("SwitchOff")}
                                     value={state.registrationSettings.UseEmailAsUsername}
-                                    onChange={this.onSettingChange.bind(this, "UseEmailAsUsername") }
+                                    onChange={this.onSettingChange.bind(this, "UseEmailAsUsername")}
                                     readOnly={!canEdit} />
                                 {this.state.error.validationFields["request.UseEmailAsUsername"] !== ""
-                                && <Tooltip
-                                    messages={[this.state.error.validationFields["request.UseEmailAsUsername"]]}
-                                    type="error"
-                                    tooltipPlace={"top"}
-                                    style = {ToolTipStyle}
-                                    rendered={this.state.error.validationFields["request.UseEmailAsUsername"] !== ""}/>}
+                                    && <Tooltip
+                                        messages={[this.state.error.validationFields["request.UseEmailAsUsername"]]}
+                                        type="error"
+                                        tooltipPlace={"top"}
+                                        style={ToolTipStyle}
+                                        rendered={this.state.error.validationFields["request.UseEmailAsUsername"] !== ""} />}
                             </div>
                         </InputGroup>
                     }
@@ -341,13 +367,13 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row_switch">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("Registration_RequireUniqueDisplayName.Help") }
-                                label={resx.get("Registration_RequireUniqueDisplayName") } />
+                                tooltipMessage={resx.get("Registration_RequireUniqueDisplayName.Help")}
+                                label={resx.get("Registration_RequireUniqueDisplayName")} />
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.registrationSettings.RequireUniqueDisplayName}
-                                onChange={this.onSettingChange.bind(this, "RequireUniqueDisplayName") }
+                                onChange={this.onSettingChange.bind(this, "RequireUniqueDisplayName")}
                                 readOnly={!canEdit} />
                         </div>
                     </InputGroup>
@@ -356,13 +382,13 @@ class RegistrationSettingsPanelBody extends Component {
                             <div className="registrationSettings-row_switch">
                                 <Label
                                     labelType="inline"
-                                    tooltipMessage={resx.get("Registration_RandomPassword.Help") }
-                                    label={resx.get("Registration_RandomPassword") } />
+                                    tooltipMessage={resx.get("Registration_RandomPassword.Help")}
+                                    label={resx.get("Registration_RandomPassword")} />
                                 <Switch
                                     onText={resx.get("SwitchOn")}
                                     offText={resx.get("SwitchOff")}
                                     value={state.registrationSettings.UseRandomPassword}
-                                    onChange={this.onSettingChange.bind(this, "UseRandomPassword") }
+                                    onChange={this.onSettingChange.bind(this, "UseRandomPassword")}
                                     readOnly={!canEdit} />
                             </div>
                         </InputGroup>
@@ -372,13 +398,13 @@ class RegistrationSettingsPanelBody extends Component {
                             <div className="registrationSettings-row_switch">
                                 <Label
                                     labelType="inline"
-                                    tooltipMessage={resx.get("Registration_RequireConfirmPassword.Help") }
-                                    label={resx.get("Registration_RequireConfirmPassword") } />
+                                    tooltipMessage={resx.get("Registration_RequireConfirmPassword.Help")}
+                                    label={resx.get("Registration_RequireConfirmPassword")} />
                                 <Switch
                                     onText={resx.get("SwitchOn")}
                                     offText={resx.get("SwitchOff")}
                                     value={state.registrationSettings.RequirePasswordConfirmation}
-                                    onChange={this.onSettingChange.bind(this, "RequirePasswordConfirmation") }
+                                    onChange={this.onSettingChange.bind(this, "RequirePasswordConfirmation")}
                                     readOnly={!canEdit} />
                             </div>
                         </InputGroup>
@@ -387,13 +413,13 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row_switch">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("Security_RequireValidProfile.Help") }
-                                label={resx.get("Security_RequireValidProfile") } />
+                                tooltipMessage={resx.get("Security_RequireValidProfile.Help")}
+                                label={resx.get("Security_RequireValidProfile")} />
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.registrationSettings.RequireValidProfile}
-                                onChange={this.onSettingChange.bind(this, "RequireValidProfile") }
+                                onChange={this.onSettingChange.bind(this, "RequireValidProfile")}
                                 readOnly={!canEdit} />
                         </div>
                     </InputGroup>
@@ -401,13 +427,13 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row_switch">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("Security_CaptchaRegister.Help") }
-                                label={resx.get("Security_CaptchaRegister") } />
+                                tooltipMessage={resx.get("Security_CaptchaRegister.Help")}
+                                label={resx.get("Security_CaptchaRegister")} />
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.registrationSettings.UseCaptchaRegister}
-                                onChange={this.onSettingChange.bind(this, "UseCaptchaRegister") }
+                                onChange={this.onSettingChange.bind(this, "UseCaptchaRegister")}
                                 readOnly={!canEdit} />
                         </div>
                     </InputGroup>
@@ -415,8 +441,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("RequiresUniqueEmail.Help") }
-                                label={resx.get("RequiresUniqueEmail") } />
+                                tooltipMessage={resx.get("RequiresUniqueEmail.Help")}
+                                label={resx.get("RequiresUniqueEmail")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.RequiresUniqueEmail}
                             </div>
@@ -426,8 +452,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("PasswordFormat.Help") }
-                                label={resx.get("PasswordFormat") } />
+                                tooltipMessage={resx.get("PasswordFormat.Help")}
+                                label={resx.get("PasswordFormat")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.PasswordFormat}
                             </div>
@@ -437,8 +463,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("PasswordRetrievalEnabled.Help") }
-                                label={resx.get("PasswordRetrievalEnabled") } />
+                                tooltipMessage={resx.get("PasswordRetrievalEnabled.Help")}
+                                label={resx.get("PasswordRetrievalEnabled")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.PasswordRetrievalEnabled}
                             </div>
@@ -448,8 +474,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("PasswordResetEnabledTitle.Help") }
-                                label={resx.get("PasswordResetEnabledTitle") } />
+                                tooltipMessage={resx.get("PasswordResetEnabledTitle.Help")}
+                                label={resx.get("PasswordResetEnabledTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.PasswordResetEnabled}
                             </div>
@@ -459,8 +485,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("MinPasswordLengthTitle.Help") }
-                                label={resx.get("MinPasswordLengthTitle") } />
+                                tooltipMessage={resx.get("MinPasswordLengthTitle.Help")}
+                                label={resx.get("MinPasswordLengthTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.MinPasswordLength}
                             </div>
@@ -470,8 +496,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("MinNonAlphanumericCharactersTitle.Help") }
-                                label={resx.get("MinNonAlphanumericCharactersTitle") } />
+                                tooltipMessage={resx.get("MinNonAlphanumericCharactersTitle.Help")}
+                                label={resx.get("MinNonAlphanumericCharactersTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.MinNonAlphanumericCharacters}
                             </div>
@@ -481,8 +507,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("RequiresQuestionAndAnswerTitle.Help") }
-                                label={resx.get("RequiresQuestionAndAnswerTitle") } />
+                                tooltipMessage={resx.get("RequiresQuestionAndAnswerTitle.Help")}
+                                label={resx.get("RequiresQuestionAndAnswerTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.RequiresQuestionAndAnswer}
                             </div>
@@ -492,8 +518,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("PasswordStrengthRegularExpressionTitle.Help") }
-                                label={resx.get("PasswordStrengthRegularExpressionTitle") } />
+                                tooltipMessage={resx.get("PasswordStrengthRegularExpressionTitle.Help")}
+                                label={resx.get("PasswordStrengthRegularExpressionTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.PasswordStrengthRegularExpression}
                             </div>
@@ -503,8 +529,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("MaxInvalidPasswordAttemptsTitle.Help") }
-                                label={resx.get("MaxInvalidPasswordAttemptsTitle") } />
+                                tooltipMessage={resx.get("MaxInvalidPasswordAttemptsTitle.Help")}
+                                label={resx.get("MaxInvalidPasswordAttemptsTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.MaxInvalidPasswordAttempts}
                             </div>
@@ -514,8 +540,8 @@ class RegistrationSettingsPanelBody extends Component {
                         <div className="registrationSettings-row-static">
                             <Label
                                 labelType="inline"
-                                tooltipMessage={resx.get("PasswordAttemptWindowTitle.Help") }
-                                label={resx.get("PasswordAttemptWindowTitle") } />
+                                tooltipMessage={resx.get("PasswordAttemptWindowTitle.Help")}
+                                label={resx.get("PasswordAttemptWindowTitle")} />
                             <div className="registrationSettings-row-static-text">
                                 {state.registrationSettings.PasswordAttemptWindow}
                             </div>
@@ -526,14 +552,14 @@ class RegistrationSettingsPanelBody extends Component {
                             <Button
                                 disabled={!this.props.registrationSettingsClientModified}
                                 type="secondary"
-                                onClick={this.onCancel.bind(this) }>
-                                {resx.get("Cancel") }
+                                onClick={this.onCancel.bind(this)}>
+                                {resx.get("Cancel")}
                             </Button>
                             <Button
                                 disabled={!this.props.registrationSettingsClientModified}
                                 type="primary"
-                                onClick={this.onUpdate.bind(this) }>
-                                {resx.get("Save") }
+                                onClick={this.onUpdate.bind(this)}>
+                                {resx.get("Save")}
                             </Button>
                         </div>
                     }

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/CreateUserBox/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/CreateUserBox/index.jsx
@@ -112,6 +112,7 @@ class CreateUserBox extends Component {
 
         let valid = true;
         let requiresQuestionAndAnswer = props.appSettings.applicationSettings.settings.requiresQuestionAndAnswer;
+        let userNameMinLength = this.props.appSettings.applicationSettings.settings.userNameMinLength;
         if (this.submitted) {
             let {UserDetails} = this.state;
             let {errors} = this.state;
@@ -132,7 +133,7 @@ class CreateUserBox extends Component {
                 errors.lastName = true;
                 valid = false;
             }
-            if (UserDetails.userName === "") {
+            if (UserDetails.userName === "" || UserDetails.userName.length < userNameMinLength) {
                 errors.userName = true;
                 valid = false;
             }

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/UserTable/UserSettings/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/UserTable/UserSettings/index.jsx
@@ -30,6 +30,9 @@ class UserSettings extends Component {
                 loading: false,
                 email: false
             },
+            startingValues: {
+                userName: undefined,
+            },
             ChangePasswordVisible: false
         };
     }
@@ -70,14 +73,16 @@ class UserSettings extends Component {
     }
     updateUserDetailsState(details) {
         let userDetails = Object.assign({}, details);
-        let {accountSettings} = this.state;
+        let {accountSettings, startingValues} = this.state;
         accountSettings.displayName = userDetails.displayName;
         accountSettings.userName = userDetails.userName;
         accountSettings.email = userDetails.email;
         accountSettings.userId = userDetails.userId;
+        startingValues.userName = userDetails.userName;
         this.setState({
             accountSettings,
             userDetails,
+            startingValues,
             loading: false
         });
     }
@@ -109,12 +114,16 @@ class UserSettings extends Component {
         errors.displayName = false;
         errors.userName = false;
         errors.email = false;
-        let {accountSettings} = this.state;
+        let {accountSettings, startingValues} = this.state;
         if (accountSettings.displayName === "") {
             errors.displayName = true;
             valid = false;
         }
         if (accountSettings.userName === "") {
+            errors.userName = true;
+            valid = false;
+        }
+        if (startingValues.userName !== accountSettings.userName && accountSettings.userName.length < this.props.appSettings.applicationSettings.settings.userNameMinLength) {
             errors.userName = true;
             valid = false;
         }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/UsersController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/UsersController.cs
@@ -196,9 +196,10 @@ namespace Dnn.PersonaBar.Users.Components
             {
                 user.UpdateDisplayName(requestPortalSettings.Registration.DisplayNameFormat);
             }
-            // either update the username or update the user details
 
-            if (this.CanUpdateUsername(user) && !requestPortalSettings.Registration.UseEmailAsUserName)
+            // either update the username or update the user details
+            // only call ChangeUsername when the username has actually changed
+            if (userBasicDto.Username != user.Username && this.CanUpdateUsername(user) && !requestPortalSettings.Registration.UseEmailAsUserName)
             {
                 UserController.ChangeUsername(user.UserID, userBasicDto.Username);
                 user.Username = userBasicDto.Username;

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/UsersMenuController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/UsersMenuController.cs
@@ -9,6 +9,7 @@ namespace Dnn.PersonaBar.Users.Components
 
     using Dnn.PersonaBar.Library.Controllers;
     using Dnn.PersonaBar.Library.Model;
+    using DotNetNuke.Common;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Security.Membership;
@@ -30,6 +31,7 @@ namespace Dnn.PersonaBar.Users.Components
             settings.Add("userId", UserController.Instance.GetCurrentUserInfo().UserID);
             settings.Add("requiresQuestionAndAnswer", MembershipProviderConfig.RequiresQuestionAndAnswer);
             settings.Add("dataConsentActive", PortalSettings.Current.DataConsentActive);
+            settings.Add("userNameMinLength", PortalController.GetPortalSettingAsInteger("Security_UserNameMinLength", PortalSettings.Current.PortalId, Globals.glbUserNameMinLength));
             return settings;
         }
     }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/DTO/UpdateRegistrationSettingsRequest.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/DTO/UpdateRegistrationSettingsRequest.cs
@@ -30,6 +30,8 @@ namespace Dnn.PersonaBar.Security.Services.Dto
 
         public string DisplayNameFormat { get; set; }
 
+        public string UserNameMinLength { get; set; }
+
         public string UserNameValidation { get; set; }
 
         public string EmailAddressValidation { get; set; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
@@ -441,6 +441,7 @@ namespace Dnn.PersonaBar.Security.Services
                             UseEmailAsUsername = PortalController.GetPortalSettingAsBoolean("Registration_UseEmailAsUserName", this.PortalId, false),
                             RequireUniqueDisplayName = PortalController.GetPortalSettingAsBoolean("Registration_RequireUniqueDisplayName", this.PortalId, false),
                             DisplayNameFormat = PortalController.GetPortalSetting("Security_DisplayNameFormat", this.PortalId, string.Empty),
+                            UserNameMinLength = PortalController.GetPortalSettingAsInteger("Security_UserNameMinLength", this.PortalId, Globals.glbUserNameMinLength),
                             UserNameValidation = PortalController.GetPortalSetting("Security_UserNameValidation", this.PortalId, Globals.glbUserNameRegEx),
                             EmailAddressValidation = PortalController.GetPortalSetting("Security_EmailValidation", this.PortalId, Globals.glbEmailRegEx),
                             UseRandomPassword = PortalController.GetPortalSettingAsBoolean("Registration_RandomPassword", this.PortalId, false),
@@ -549,6 +550,7 @@ namespace Dnn.PersonaBar.Security.Services
                 PortalController.UpdatePortalSetting(this.PortalId, "Registration_UseProfanityFilter", request.UseProfanityFilter.ToString(), false);
                 PortalController.UpdatePortalSetting(this.PortalId, "Registration_RequireUniqueDisplayName", request.RequireUniqueDisplayName.ToString(), false);
                 PortalController.UpdatePortalSetting(this.PortalId, "Security_DisplayNameFormat", request.DisplayNameFormat, false);
+                PortalController.UpdatePortalSetting(this.PortalId, "Security_UserNameMinLength", request.UserNameMinLength, false);
                 PortalController.UpdatePortalSetting(this.PortalId, "Security_UserNameValidation", request.UserNameValidation, false);
                 PortalController.UpdatePortalSetting(this.PortalId, "Security_EmailValidation", request.EmailAddressValidation, false);
                 PortalController.UpdatePortalSetting(this.PortalId, "Registration_RandomPassword", request.UseRandomPassword.ToString(), false);

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -1150,4 +1150,13 @@
   <data name="IncorrectDisplayNameConfiguration.Text" xml:space="preserve">
     <value>The Display Name configuration is not correct. Either provide Display Name Format or include Display Name in the list of fields.</value>
   </data>
+  <data name="Security_UserNameMinLength.Text" xml:space="preserve">
+    <value>Minimum Username length</value>
+  </data>
+  <data name="Security_UserNameMinLength.Help" xml:space="preserve">
+    <value>Specify the minimum length of a username for new users or changed usernames.</value>
+  </data>
+  <data name="Security_UserNameMinLength.ErrorMessage" xml:space="preserve">
+    <value>Minimum Username length must be an integer greater than 0 and less than or equal to 100.</value>
+  </data>
 </root>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
@@ -397,7 +397,7 @@
     <value>User Folder:</value>
   </data>
   <data name="Username.Help" xml:space="preserve">
-    <value>Enter a user name. It must be of at least the minimum configured length and is must be an alphanumeric value.</value>
+    <value>Enter a user name. It must be of at least the minimum configured length and it must be an alphanumeric value.</value>
   </data>
   <data name="Username.Text" xml:space="preserve">
     <value>User Name:</value>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
@@ -397,7 +397,7 @@
     <value>User Folder:</value>
   </data>
   <data name="Username.Help" xml:space="preserve">
-    <value>Enter a user name.  It must be at least five characters long and is must be an alphanumeric value.</value>
+    <value>Enter a user name. It must be of at least the minimum configured length and is must be an alphanumeric value.</value>
   </data>
   <data name="Username.Text" xml:space="preserve">
     <value>User Name:</value>


### PR DESCRIPTION
Fixes #2334 

## Summary
This PR changes the built in minimum length of a username, to a setting under Security --> Member Accounts --> Registration Settings.
The default minimum length is now a constant in Globals.
Also, I changed the behavior of updating UserBasicDetails to only check (and change) a usrename when it has actually changed. This way, when the minimum username length is changed to a higher value, existing users with a shorter username can still be editted.
The username can of course only be changed to a valid length according to the new setting.