### PR TITLE
Web.config Cleanup

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -85,32 +85,6 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
                     }
                 }
 
-                // HttpModules Config
-                var systemWebServerHttpModulesConfig = xmlDoc.DocumentElement.SelectSingleNode("system.web/httpModules");
-                if (systemWebServerHttpModulesConfig != null)
-                {
-                    var httpModuleConfig = systemWebServerHttpModulesConfig.SelectSingleNode("add[@name=\"ClientDependencyModule\"]");
-                    if (httpModuleConfig == null)
-                    {
-                        xmlFrag = xmlDoc.CreateDocumentFragment();
-                        xmlFrag.InnerXml = "<add name=\"ClientDependencyModule\" type=\"ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core\" />";
-                        xmlDoc.DocumentElement.SelectSingleNode("system.web/httpModules").AppendChild(xmlFrag);
-                    }
-                }
-
-                // HttpHandler Config
-                var systemWebServerHttpHandlersConfig = xmlDoc.DocumentElement.SelectSingleNode("system.web/httpHandlers");
-                if (systemWebServerHttpHandlersConfig != null)
-                {
-                    var httpHandlerConfig = systemWebServerHttpHandlersConfig.SelectSingleNode("add[@type=\"ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core\"]");
-                    if (httpHandlerConfig == null)
-                    {
-                        xmlFrag = xmlDoc.CreateDocumentFragment();
-                        xmlFrag.InnerXml = "<add verb=\"*\" path=\"DependencyHandler.axd\" type=\"ClientDependency.Core.CompositeFiles.CompositeDependencyHandler, ClientDependency.Core\" />";
-                        xmlDoc.DocumentElement.SelectSingleNode("system.web/httpHandlers").AppendChild(xmlFrag);
-                    }
-                }
-
                 // ClientDependency Config
                 var clientDependencyConfig = xmlDoc.DocumentElement.SelectSingleNode("clientDependency");
                 if (clientDependencyConfig == null)

--- a/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/SimpleWebFarmCachingProvider.dnn
+++ b/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/SimpleWebFarmCachingProvider.dnn
@@ -40,11 +40,6 @@
                          type="DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.SimpleWebFarmSynchronizationHandler, DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider"
                          preCondition="integratedMode" />
                   </node>
-                  <node path="/configuration/system.web/httpHandlers" action="update" key="path" collision="overwrite">
-                    <add verb="*"
-                         path="SimpleWebFarmSync.aspx"
-                         type="DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.SimpleWebFarmSynchronizationHandler, DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider" />
-                  </node>
                 </nodes>
               </configuration>
             </install>
@@ -53,7 +48,6 @@
                 <nodes>
                   <node path="/configuration/dotnetnuke/caching/providers/add[@name='SimpleWebFarmCachingProvider']" action="remove" />
 				          <node path="/configuration/system.webServer/handlers/add[@name='SimpleWebFarmSynchronizationHandler']" action="remove" />
-				          <node path="/configuration/system.web/httpHandlers/add[@path='SimpleWebFarmSync.aspx']" action="remove" />
                   <!-- Clear any default to prevent issues loading the site -->
                   <node path="/configuration/dotnetnuke/caching" action="updateattribute"  name="defaultProvider" value="" />
                 </nodes>

--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -87,31 +87,7 @@
   </system.webServer>
   <system.web>
     <machineKey validationKey="3CF26670752F33E0AEB07F6FA77AD4F24073F577" decryptionKey="988C4A46C83C5D03E20B63AC0C39B9CB3B0DA5FB35893825" decryption="3DES" validation="SHA1" />
-    <!-- HttpModules for Common Functionality -->
-    <httpModules>
-      <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" />
-      <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" />
-      <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" />
-      <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" />
-      <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" />
-      <add name="Personalization" type="DotNetNuke.HttpModules.Personalization.PersonalizationModule, DotNetNuke.HttpModules" />
-      <add name="Analytics" type="DotNetNuke.HttpModules.Analytics.AnalyticsModule, DotNetNuke.HttpModules" />
-      <add name="Services" type="DotNetNuke.HttpModules.Services.ServicesModule, DotNetNuke.HttpModules" />
-    </httpModules>
-    <httpHandlers>
-      <!-- This is for CAPTCHA support -->
-      <add verb="*" path="*.captcha.aspx" type="DotNetNuke.UI.WebControls.CaptchaHandler, DotNetNuke" />
-      <!-- This is for Serving files, secure, insecure, from database -->
-      <add verb="*" path="LinkClick.aspx" type="DotNetNuke.Services.FileSystem.FileServerHandler, DotNetNuke" />
-      <!-- This adds syndication support -->
-      <add verb="*" path="RSS.aspx" type="DotNetNuke.Services.Syndication.RssHandler, DotNetNuke" />
-      <!-- This adds legacy support for the Logoff page -->
-      <add verb="*" path="Logoff.aspx" type="DotNetNuke.Services.Authentication.LogOffHandler, DotNetNuke" />
-      <!-- ASP.NET AJAX support -->
-      <add path="User.aspx" verb="*" type="DotNetNuke.Services.UserProfile.UserProfilePageHandler, DotNetNuke" />
-      <add path="ProfilePic.ashx" verb="*" type="DotNetNuke.Services.UserProfile.UserProfilePicHandler, DotNetNuke" />
-    </httpHandlers>
-    <!-- set code access security trust level - this is generally set in the machine.config
+        <!-- set code access security trust level - this is generally set in the machine.config
     <trust level="Medium" originUrl=".*" />
     -->
     <!-- set debugmode to false for running application -->

--- a/DNN Platform/Website/Install/Config/09.09.00.config
+++ b/DNN Platform/Website/Install/Config/09.09.00.config
@@ -3,5 +3,7 @@
     <node path="/configuration/dotnetnuke/mail/providers" action="update" key="name" collision="ignore">
       <add name="MailKitMailProvider" type="DotNetNuke.Services.Mail.MailKitMailProvider, DotNetNuke" hideCoreSettings="False" />
     </node>
+    <node path="/configuration/system.web/httpModules" action="remove" />
+    <node path="/configuration/system.web/httpHandlers" action="remove" />
   </nodes>
 </configuration>

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -76,7 +76,6 @@
     </pages>
   </system.web.webPages.razor>
 
-  <!-- The system.webServer section is required for IIS7 compatability It is ignored by IIS6-->
   <system.webServer>
     <staticContent>
       <clientCache cacheControlCustom="public" cacheControlMode="UseMaxAge" cacheControlMaxAge="365.00:00:00" />

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -76,7 +76,6 @@
     </pages>
   </system.web.webPages.razor>
 
-  <!-- The system.webServer section is required for IIS7 compatability It is ignored by IIS6-->
   <system.webServer>
     <staticContent>
       <clientCache cacheControlCustom="public" cacheControlMode="UseMaxAge" cacheControlMaxAge="365.00:00:00" />


### PR DESCRIPTION
Resolves #4447 by removing the old system.web/httpHandlers and system.web/httpModules sections from the web.config.  Additionally removed one instance where DNN would have manually added one back in.