### PR TITLE
Add Logging to the Dependency Injection SafeGetTypes function

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.DependencyInjection.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.DependencyInjection.nuspec
@@ -16,6 +16,7 @@
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.Extensions.DependencyInjection" version="2.1.1" />
+      <dependency id="DotNetNuke.Instrumentation" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
+++ b/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
@@ -30,6 +30,10 @@
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj" />
+  </ItemGroup>
+
   <Import Project="..\..\DNN_Platform.build" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.DependencyInjection*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
         /// </summary>
         /// <param name="assembly">The assembly to retrieve all types from.</param>
         /// <returns>An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.</returns>
-        /// <remarks>This is obsolete because logging is not added. Please use the SafeGetTypes with the ILog parameter</remarks>
+        /// <remarks>This is obsolete because logging is not added. Please use the SafeGetTypes with the ILog parameter.</remarks>
         [Obsolete("Please use the SafeGetTypes with the ILog parameter.")]
         public static Type[] SafeGetTypes(this Assembly assembly)
         {

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
         /// <param name="assembly">The assembly to retrieve all types from.</param>
         /// <returns>An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.</returns>
         /// <remarks>This is obsolete because logging is not added. Please use the SafeGetTypes with the ILog parameter.</remarks>
-        [Obsolete("Please use the SafeGetTypes with the ILog parameter.")]
+        [Obsolete("Deprecated in DotNetNuke 9.9.0. Please use the SafeGetTypes overload with the ILog parameter. Scheduled removal in v11.0.0.")]
         public static Type[] SafeGetTypes(this Assembly assembly)
         {
             return assembly.SafeGetTypes(null);

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -29,9 +29,7 @@ namespace DotNetNuke.DependencyInjection.Extensions
         /// <returns>
         /// An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.
         /// </returns>
-#pragma warning disable CS3001 // Argument type is not CLS-compliant
         public static Type[] SafeGetTypes(this Assembly assembly, ILog logger = null)
-#pragma warning restore CS3001 // Argument type is not CLS-compliant
         {
             Type[] types = null;
             try

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -15,11 +15,6 @@ namespace DotNetNuke.DependencyInjection.Extensions
     /// </summary>
     public static class TypeExtensions
     {
-        // There is no logging in this file by design as
-        // it would create a dependency on the Logging library
-        // and this library can't have any dependencies on other
-        // DNN Libraries.
-
         /// <summary>
         /// Safely Get all Types from the assembly. If there
         /// is an error while retrieving the types it will

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -7,6 +7,8 @@ namespace DotNetNuke.DependencyInjection.Extensions
     using System.Linq;
     using System.Reflection;
 
+    using DotNetNuke.Instrumentation;
+
     /// <summary>
     /// <see cref="Type"/> specific extensions to be used
     /// in Dependency Injection invocations.
@@ -26,10 +28,15 @@ namespace DotNetNuke.DependencyInjection.Extensions
         /// <param name="assembly">
         /// The assembly to retrieve all types from.
         /// </param>
+        /// <param name="logger">
+        /// A optional <see cref="ILog"/> object. This will log any messages from the exception catching to the logs as an Error.
+        /// </param>
         /// <returns>
         /// An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.
         /// </returns>
-        public static Type[] SafeGetTypes(this Assembly assembly)
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
+        public static Type[] SafeGetTypes(this Assembly assembly, ILog logger = null)
+#pragma warning restore CS3001 // Argument type is not CLS-compliant
         {
             Type[] types = null;
             try
@@ -38,13 +45,26 @@ namespace DotNetNuke.DependencyInjection.Extensions
             }
             catch (ReflectionTypeLoadException ex)
             {
-                // TODO: We should log the reason of the exception after the API cleanup
+                if (logger != null)
+                {
+                    logger.Error($"Unable to configure services for {assembly.FullName}, see exception for details", ex);
+
+                    foreach (var loaderEx in ex.LoaderExceptions)
+                    {
+                        logger.Error($"LoaderException for {assembly.FullName}, details", loaderEx);
+                    }
+                }
+
                 // Ensure that Dnn obtains all types that were loaded, ignoring the failure(s)
                 types = ex.Types.Where(x => x != null).ToArray<Type>();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: We should log the reason of the exception after the API cleanup
+                if (logger != null)
+                {
+                    logger.Error($"Unable to configure services for {assembly.FullName}, see exception for details", ex);
+                }
+
                 types = new Type[0];
             }
 

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -20,6 +20,20 @@ namespace DotNetNuke.DependencyInjection.Extensions
         /// is an error while retrieving the types it will
         /// return an empty array of <see cref="Type"/>.
         /// </summary>
+        /// <param name="assembly">The assembly to retrieve all types from.</param>
+        /// <returns>An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.</returns>
+        /// <remarks>This is obsolete because logging is not added. Please use the SafeGetTypes with the ILog parameter</remarks>
+        [Obsolete("Please use the SafeGetTypes with the ILog parameter.")]
+        public static Type[] SafeGetTypes(this Assembly assembly)
+        {
+            return assembly.SafeGetTypes(null);
+        }
+
+        /// <summary>
+        /// Safely Get all Types from the assembly. If there
+        /// is an error while retrieving the types it will
+        /// return an empty array of <see cref="Type"/>.
+        /// </summary>
         /// <param name="assembly">
         /// The assembly to retrieve all types from.
         /// </param>

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -47,12 +47,12 @@ namespace DotNetNuke.DependencyInjection.Extensions
             {
                 if (logger != null)
                 {
-                    logger.Error($"Unable to configure services for {assembly.FullName}, see exception for details", ex);
+                    // The loaderexceptions will repeat. Need to get distinct messages here.
+                    string distinctLoaderExceptions = string.Join(
+                        Environment.NewLine,
+                        ex.LoaderExceptions.Select(i => i.Message).Distinct().Select(i => $"- LoaderException: {i}"));
 
-                    foreach (var loaderEx in ex.LoaderExceptions)
-                    {
-                        logger.Error($"LoaderException for {assembly.FullName}, details", loaderEx);
-                    }
+                    logger.Error($"Unable to configure services for {assembly.FullName}, see exception for details {Environment.NewLine}{distinctLoaderExceptions}", ex);
                 }
 
                 // Ensure that Dnn obtains all types that were loaded, ignoring the failure(s)

--- a/DNN Platform/DotNetNuke.Instrumentation/Properties/AssemblyInfo.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -15,6 +16,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("cb8f5692-4ea1-4397-85ec-094334605289")]

--- a/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
@@ -11,16 +11,30 @@ namespace DotNetNuke.Web.Mvc.Extensions
     using System.Threading.Tasks;
 
     using DotNetNuke.DependencyInjection.Extensions;
+    using DotNetNuke.Instrumentation;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
 
+    /// <summary>
+    /// Adds DNN MVC Contoller Specific startup extensions to simplify the
+    /// <see cref="Startup"/> Class.
+    /// </summary>
     public static class StartupExtensions
     {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(StartupExtensions));
+
+        /// <summary>
+        /// Configures all of the <see cref="DnnController"/>'s to be used
+        /// with the Service Collection for Dependency Injection.
+        /// </summary>
+        /// <param name="services">
+        /// Service Collection used to registering services in the container.
+        /// </param>       
         public static void AddMvcControllers(this IServiceCollection services)
         {
             var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(TypeExtensions.SafeGetTypes)
+                .SelectMany(x => x.SafeGetTypes(Logger))
                 .Where(x => typeof(IDnnController).IsAssignableFrom(x)
                     && x.IsClass
                     && !x.IsAbstract);

--- a/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Web.Extensions
     using System.Linq;
 
     using DotNetNuke.DependencyInjection.Extensions;
+    using DotNetNuke.Instrumentation;
     using DotNetNuke.Web.Api;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -18,6 +19,8 @@ namespace DotNetNuke.Web.Extensions
     /// </summary>
     internal static class StartupExtensions
     {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(StartupExtensions));
+
         /// <summary>
         /// Configures all of the <see cref="DnnApiController"/>'s to be used
         /// with the Service Collection for Dependency Injection.
@@ -28,7 +31,7 @@ namespace DotNetNuke.Web.Extensions
         public static void AddWebApi(this IServiceCollection services)
         {
             var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.SafeGetTypes())
+                .SelectMany(x => x.SafeGetTypes(Logger))
                 .Where(x => typeof(DnnApiController).IsAssignableFrom(x) &&
                             x.IsClass &&
                             !x.IsAbstract);

--- a/DNN Platform/DotNetNuke.Web/DependencyInjectionInitialize.cs
+++ b/DNN Platform/DotNetNuke.Web/DependencyInjectionInitialize.cs
@@ -39,7 +39,7 @@ namespace DotNetNuke.Web
                     assembly => assembly.FullName.StartsWith("DotNetNuke", StringComparison.OrdinalIgnoreCase) ? 0 :
                          assembly.FullName.StartsWith("DNN", StringComparison.OrdinalIgnoreCase) ? 1 : 2)
                 .ThenBy(assembly => assembly.FullName)
-                .SelectMany(assembly => assembly.SafeGetTypes().OrderBy(type => type.FullName ?? type.Name))
+                .SelectMany(assembly => assembly.SafeGetTypes(Logger).OrderBy(type => type.FullName ?? type.Name))
                 .Where(type => typeof(IDnnStartup).IsAssignableFrom(type) && type.IsClass && !type.IsAbstract);
 
             var startupInstances = startupTypes.Select(CreateInstance).Where(x => x != null);


### PR DESCRIPTION
Fixes #4454

## Summary
Added logging to the SafeGetTypes function. The function would successfully load the types safely, without crashing, but would eat any exceptions that were thrown about missing references. I have added an `ILog` parameter to the function to print out the missing types.