### PR TITLE
MailKit missing BouncyCastle.Crypto

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-	<Deterministic>true</Deterministic>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -76,8 +76,8 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.9.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Portable.BouncyCastle.1.8.9\lib\net40\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.8.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Portable.BouncyCastle.1.8.8\lib\net40\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
     <Reference Include="ClientDependency.Core, Version=1.9.2.7, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Dnn.ClientDependency.1.9.2.7\lib\net45\ClientDependency.Core.dll</HintPath>

--- a/DNN Platform/Library/Library.build
+++ b/DNN Platform/Library/Library.build
@@ -7,5 +7,6 @@
   </Target>
   <Target Name="DebugProject">
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Microsoft.Extensions.FileSystemGlobbing.dll" DestinationFolder="$(WebsitePath)/bin" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\BouncyCastle.Crypto.dll" DestinationFolder="$(WebsitePath)/bin" />
   </Target>
 </Project>

--- a/DNN Platform/Library/packages.config
+++ b/DNN Platform/Library/packages.config
@@ -11,7 +11,7 @@
   <package id="MimeKit" version="2.10.1" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="PetaPoco.Compiled" version="6.0.415" targetFramework="net472" />
-  <package id="Portable.BouncyCastle" version="1.8.9" targetFramework="net472" />
+  <package id="Portable.BouncyCastle" version="1.8.8" targetFramework="net472" />
   <package id="QuickIO.NET" version="2.6.2.0" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />


### PR DESCRIPTION
When I was doing my PR for DependencyInjection logging the MailKit provider was logging an error saying it was missing the 1.8.8 version of BouncyCastle.Crypto. The NuGet package was referenced, however, the DLL was never being added to the bin folder on install. This PR fixes that issue.