### PR TITLE
Fixed an issue that prevented Google Tag Manager to create scripts and delete connection

### DIFF
--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -246,7 +246,7 @@ namespace DNN.Connectors.GoogleAnalytics
         /// <returns>The string representing a boolean after the correction.</returns>
         private string HandleCustomBoolean(string value)
         {
-            if (value.Trim().Equals("true", StringComparison.OrdinalIgnoreCase))
+            if ((value ?? string.Empty).Trim().Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 return "true";
             }

--- a/DNN Platform/Connectors/GoogleTagManager/GoogleTagManagerConnector.cs
+++ b/DNN Platform/Connectors/GoogleTagManager/GoogleTagManagerConnector.cs
@@ -198,7 +198,7 @@ namespace DNN.Connectors.GoogleTagManager
         /// <returns>The string representing a boolean after the correction.</returns>
         private string HandleCustomBoolean(string value)
         {
-            if (value.Trim().Equals("true", StringComparison.OrdinalIgnoreCase))
+            if ((value ?? string.Empty).Trim().Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 return "true";
             }

--- a/DNN Platform/Connectors/GoogleTagManager/Scripts/connector.js
+++ b/DNN Platform/Connectors/GoogleTagManager/Scripts/connector.js
@@ -69,7 +69,7 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
 
                     // Set the isDeactivating flag to true to override the default save behaviour
                     // Temporary workaround until delete functionality on connectors is improved
-                    conn.configurations[6].value("true");
+                    conn.configurations[2].value("true");
                     wasDeactivated = true;
                     conn.save(conn, e, onSaveComplete.bind(this, conn, conn.id));
                 }
@@ -100,7 +100,7 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
 
                         // Set the isDeactivating flag to true to override the default save behaviour
                         // Temporary workaround until delete functionality on connectors is improved
-                        conn.configurations[6].value("true");
+                        conn.configurations[2].value("true");
                         wasDeactivated = true;
                         conn.save(conn, e, onSaveComplete.bind(this, conn, conn.id));
                     }

--- a/DNN Platform/Library/Services/Analytics/Config/AnalyticsConfiguration.cs
+++ b/DNN Platform/Library/Services/Analytics/Config/AnalyticsConfiguration.cs
@@ -84,7 +84,7 @@ namespace DotNetNuke.Services.Analytics.Config
                     {
                         var setting = new AnalyticsSetting();
                         setting.SettingName = nav.SelectSingleNode("SettingName").Value;
-                        setting.SettingValue = nav.SelectSingleNode("SettingValue").Value;
+                        setting.SettingValue = nav.SelectSingleNode("SettingValue")?.Value;
                         Config.Settings.Add(setting);
                     }
 


### PR DESCRIPTION
Fixes #4452 
Fixes #4453 

## Summary
Both issues were found in the GTM Connector I previously contributed, but I found #4453 (Null Reference exception thrown on deletion of connection) to also occur with the GA Connector (which makes sense since the GTm Connector was initially a copy of that one).
To fix that I added null-checks in a few places.

The other issue is not a bug, but it's a valid point that  it's not very friendly to make the user manually edit SiteAnalytics.config before being able to use the GTM connector.
So I added code to check siteanalytics.config for the presence of a script for it. If there is none, the default script is added. If there is any (which could be edited in the installation) it's not changed.

However, I have one issue in the code. To find SiteAnalytics.config, I wanted to use Globals.ApplicationMapPath, but that's now oboslete. The message tells me to `Use Dependency Injection to resolve 'DotNetNuke.Abstractions.IApplicationStatusInfo' instead.`
but to be honest, I have no clue how. So could anyone be of assistence here? @ahoefling maybe?