### PR TITLE
Migrate from moment to dayjs for Sites.Web

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-object-assign": "7.0.0",
     "@babel/preset-env": "7.1.6",
     "@babel/preset-react": "7.0.0",
-    "@dnnsoftware/dnn-react-common": "9.7.2",
+    "@dnnsoftware/dnn-react-common": "9.8.1",
     "babel-loader": "8.0.6",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-polyfill": "6.26.0",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sites",
-  "version": "9.7.2",
+  "version": "9.8.1",
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "boilerplate",
-  "version": "9.8.1",
+  "name": "sites",
+  "version": "9.7.2",
   "private": true,
   "scripts": {
     "build": "set NODE_ENV=production&&webpack -p",
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-object-assign": "7.0.0",
     "@babel/preset-env": "7.1.6",
     "@babel/preset-react": "7.0.0",
-    "@dnnsoftware/dnn-react-common": "9.8.1",
+    "@dnnsoftware/dnn-react-common": "9.7.2",
     "babel-loader": "8.0.6",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-polyfill": "6.26.0",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-object-assign": "7.0.0",
     "@babel/preset-env": "7.1.6",
     "@babel/preset-react": "7.0.0",
-    "@dnnsoftware/dnn-react-common": "9.7.2",
+    "@dnnsoftware/dnn-react-common": "9.8.1",
     "babel-loader": "8.0.4",
     "babel-plugin-transform-react-remove-prop-types": "0.4.20",
     "babel-polyfill": "6.26.0",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnn-sites-list-view",
-  "version": "9.7.2",
+  "version": "9.8.1",
   "description": "DNN Sites List View",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnn-sites-list-view",
-  "version": "9.8.1",
+  "version": "9.7.2",
   "description": "DNN Sites List View",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -15,12 +15,13 @@
     "@babel/plugin-transform-object-assign": "7.0.0",
     "@babel/preset-env": "7.1.6",
     "@babel/preset-react": "7.0.0",
-    "@dnnsoftware/dnn-react-common": "9.8.1",
+    "@dnnsoftware/dnn-react-common": "9.7.2",
     "babel-loader": "8.0.4",
     "babel-plugin-transform-react-remove-prop-types": "0.4.20",
     "babel-polyfill": "6.26.0",
     "create-react-class": "^15.6.3",
     "css-loader": "1.0.1",
+    "dayjs": "^1.8.36",
     "eslint": "5.9.0",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-loader": "2.1.1",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ListView/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/src/Components/ListView/index.jsx
@@ -6,7 +6,7 @@ import Localization from "localization";
 import { CommonVisiblePanelActions, CommonPortalListActions } from "actions";
 import { GridCell, SvgIcons } from "@dnnsoftware/dnn-react-common";
 import utilities from "utils";
-import Moment from "moment";
+import * as dayjs from "dayjs";
 import styles from "./style.less";
 
 class ListView extends Component {
@@ -138,6 +138,9 @@ class ListView extends Component {
         });
     }
     getPortalMapping(portal) {
+        const localizedFormat = require('dayjs/plugin/localizedFormat');
+        dayjs.extend(localizedFormat);
+
         return [
             {
                 label: Localization.get("SiteDetails_SiteID"),
@@ -149,7 +152,7 @@ class ListView extends Component {
             },
             {
                 label: Localization.get("SiteDetails_Updated"),
-                value: Moment(portal.LastModifiedOnDate).locale(this.props.culture).fromNow()
+                value: dayjs(portal.LastModifiedOnDate).locale(this.props.culture).fromNow()
             },
             {
                 label: Localization.get("SiteDetails_Pages"),

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/containers/Root.prod.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/containers/Root.prod.js
@@ -7,7 +7,7 @@ class Root extends Component {
     }
     render() {
         return (
-            <div className="boilerplate-app personaBar-mainContainer">
+            <div className="sites-app personaBar-mainContainer">
                 <App />
             </div>
         );


### PR DESCRIPTION
## Summary
This is related to #3875 and is for the `Sites.Web` project.  
* `moment` replaced with `dayjs`
* ClientSide project name changed from `boilerplate` (wtf) to `sites`