### PR TITLE
Remove moment package from SiteImportExport.Web

### DIFF
--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
@@ -34,7 +34,6 @@
     "less": "3.9.0",
     "less-loader": "5.0.0",
     "localization": "^1.0.2",
-    "moment": "^2.15.0",
     "prop-types": "^15.6.2",
     "raw-loader": "^2.0.0",
     "rc-progress": "^2.0.6",


### PR DESCRIPTION
## Summary
`moment` is not used in this project, so to avoid confusion, the package has been removed.  This resolves the need identified in #3875  for migrating to `dayjs` as well.