### PR TITLE
Remove moment package from Roles.Web

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
@@ -33,7 +33,6 @@
     "jwt-decode": "2.2.0",
     "less": "3.9.0",
     "less-loader": "5.0.0",
-    "moment": "^2.15.0",
     "prop-types": "^15.6.2",
     "raw-loader": "2.0.0",
     "react": "^16.6.3",


### PR DESCRIPTION
`moment` is not used in this project, so to avoid confusion, the package has been removed. This resolves the need identified in #3875 for migrating to `dayjs` as well.