### PR TITLE
Migrate moment to dayjs for Pages.Web

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
@@ -66,7 +66,7 @@
     "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
-    "moment": "^2.22.2",
+    "dayjs": "^1.10.4",
     "promise": "^8.0.2",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
@@ -1,4 +1,4 @@
-import Moment from "moment";
+import * as dayjs from "dayjs";
 import UrlParse from "url-parse";
 let utilities = null;
 let config = null;
@@ -190,7 +190,9 @@ function formatDate(dateValue, longformat) {
         return "-";
     }
 
-    return Moment(dateValue).locale(utilities.getCulture()).format(longformat === true ? "LLL" : "L");
+    const localizedFormat = require('dayjs/plugin/localizedFormat');
+    dayjs.extend(localizedFormat);
+    return dayjs(dateValue).locale(utilities.getCulture()).format(longformat === true ? "LLL" : "L");
 }
 function getUserMode() {
     return config.userMode;

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
@@ -1,5 +1,6 @@
-import * as dayjs from "dayjs";
 import UrlParse from "url-parse";
+import * as dayjs from "dayjs";
+const localizedFormat = require('dayjs/plugin/localizedFormat');
 let utilities = null;
 let config = null;
 let moduleName = null;
@@ -190,7 +191,6 @@ function formatDate(dateValue, longformat) {
         return "-";
     }
 
-    const localizedFormat = require('dayjs/plugin/localizedFormat');
     dayjs.extend(localizedFormat);
     return dayjs(dateValue).locale(utilities.getCulture()).format(longformat === true ? "LLL" : "L");
 }


### PR DESCRIPTION
## Summary
Migrate `moment` to `dayjs` for `Pages.Web` project.  This relates to #3875. 