### PR TITLE
Remove moment package from AdminLogs.Web

### DIFF
--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
@@ -33,7 +33,6 @@
     "jwt-decode": "2.2.0",
     "less": "3.9.0",
     "less-loader": "5.0.0",
-    "moment": "^2.15.0",
     "prop-types": "15.6.2",
     "raw-loader": "2.0.0",
     "react": "^16.6.3",


### PR DESCRIPTION
## Summary
Remove `moment` package from `AdminLogs.Web` because it is not used.  This PR relates to #3875.