### PR TITLE
Remove moment package from Prompt.Web

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
@@ -46,7 +46,6 @@
     "less": "3.9.0",
     "less-loader": "5.0.0",
     "localization": "^1.0.2",
-    "moment": "^2.15.0",
     "object-assign": "*",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
## Summary
Remove `moment` package from `Prompt.Web` since it is not used.  This PR relates to #3875 