### PR TITLE
Migrate moment to dayjs for Dnn.React.Common

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/.storybook/utils.js
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/.storybook/utils.js
@@ -184,7 +184,9 @@ function formatDate(dateValue, longformat) {
         return "-";
     }
 
-    return Moment(dateValue).locale(utilities.getCulture()).format(longformat === true ? "LLL" : "L");
+    const localizedFormat = require('dayjs/plugin/localizedFormat');
+    dayjs.extend(localizedFormat);
+    return dayjs(dateValue).locale(utilities.getCulture()).format(longformat === true ? "LLL" : "L");
 }
 function getUserMode(){
     return config.userMode;

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/WebpackExternals/index.js
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/WebpackExternals/index.js
@@ -17,6 +17,7 @@ module.exports = {
     "react-tooltip": "window.dnn.nodeModules.ReactTooltip",
     "react-widgets": "window.dnn.nodeModules.ReactWidgets",
     "throttle-debounce": "window.dnn.nodeModules.ThrottleDebounce",
+    /** @deprecated for v.10 - moment JS will no longer be delivered - recommended to manage own packages moving forward */
     "moment": "window.dnn.nodeModules.Moment",
     "es6-promise": "window.dnn.nodeModules.Es6Promise",
     "@dnnsoftware/dnn-react-common": "window.dnn.nodeModules.CommonComponents"

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -24,8 +24,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "dependencies": {
+    "dayjs": "^1.10.4",
     "interact.js": "^1.2.8",
-    "moment": "^2.22.2",
     "raw-loader": "2.0.0",
     "react-accessible-tooltip": "^2.0.3",
     "react-collapse": "^4.0.3",

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/DatePicker/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/DatePicker/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import DayPicker, { WeekdayPropTypes, DateUtils } from "react-day-picker";
-import moment from "moment";
+import * as dayjs from "dayjs";
 import TimePicker from "./TimePicker";
 import TimezonePicker from "./TimezonePicker";
 import timeZones from "./timeZones";
@@ -250,7 +250,7 @@ class DatePicker extends Component {
 
     formatDate(date, format = "dddd, MMMM, Do, YYYY") {
         if (date) {
-            return moment(date).format(format);
+            return dayjs(date).format(format);
         }
         return date;
     }


### PR DESCRIPTION
## Summary
Migrate `moment` to `dayjs` for `Dnn.React.Common` - relates to #3375 