### PR TITLE
Deprecates dependencies in common bundle

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/WebpackExternals/index.js
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/WebpackExternals/index.js
@@ -1,24 +1,34 @@
 module.exports = {
     "react": "window.dnn.nodeModules.React",
+    /** @deprecated for v.10 - will no longer be delivered. */
     "react/lib/ReactMount": "window.dnn.nodeModules.ReactMount",
+    /** @deprecated for v.10 - will no longer be delivered. */
     "react/lib/ReactComponentWithPureRenderMixin": "window.dnn.nodeModules.ReactComponentWithPureRenderMixin",
     "redux": "window.dnn.nodeModules.Redux",
     "react-redux": "window.dnn.nodeModules.ReactRedux",
     "react-dom": "window.dnn.nodeModules.ReactDOM",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "react-tabs": "window.dnn.nodeModules.ReactTabs",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "redux-devtools": "window.dnn.nodeModules.ReduxDevTools",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "redux-devtools-dock-monitor": "window.dnn.nodeModules.ReduxDevToolsDockMonitor",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "redux-devtools-log-monitor": "window.dnn.nodeModules.ReduxDevToolsLogMonitor",
     "redux-immutable-state-invariant": "window.dnn.nodeModules.ReduxImmutableStateInvariant",
     "redux-thunk": "window.dnn.nodeModules.ReduxThunk",
     "react-collapse": "window.dnn.nodeModules.ReactCollapse",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "react-modal": "window.dnn.nodeModules.ReactModal",
     "react-custom-scrollbars": "window.dnn.nodeModules.ReactCustomScrollBars",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "react-tooltip": "window.dnn.nodeModules.ReactTooltip",
     "react-widgets": "window.dnn.nodeModules.ReactWidgets",
+    /** @deprecated for v.10 - will no longer be lelivered. */
     "throttle-debounce": "window.dnn.nodeModules.ThrottleDebounce",
     /** @deprecated for v.10 - moment JS will no longer be delivered - recommended to manage own packages moving forward */
     "moment": "window.dnn.nodeModules.Moment",
+    /** @deprecated for v.11 - will no longer be lelivered. */
     "es6-promise": "window.dnn.nodeModules.Es6Promise",
     "@dnnsoftware/dnn-react-common": "window.dnn.nodeModules.CommonComponents"
 };


### PR DESCRIPTION
The common bundle goal was to put on the page stuff that most of our React modules use in order to reduce each of the bundles for individual modules at the cost of a larger common bundle. This is nice but several of the exported (Webpack Externals) packages are simply not used by any module or a single module.

This PR marks all of those deprecated for removal in v.10 except es6-promise which is a polyfill needed to support IE11 and it's used by some of the modules.

It also removes all development time only dependencies, which should not even be distributed. I was hoping for a big file reduction, but well, it will remove about 300Kb to the bundle when we do remove it, so it's better than nothing 🤷 