### PR TITLE
Fixes #4481 AzureFolderProvider uploading same file with different case

### DIFF
--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
@@ -270,11 +270,18 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
             this.ClearCache(folderMapping.FolderMappingID);
         }
 
+        /// <summary>
+        /// Updates a file in Azure folder provider.
+        /// </summary>
+        /// <remarks>
+        /// Azure is case sensitive.  If you update dnninternals.pdf with DNNINTERNALS.pdf, to DNN it's the same
+        /// so it just re-uploads it, causing both files to exist in Azure. This azure specific method deletes the
+        /// old existing duplicate that only differs in case as part of the update.
+        /// </remarks>
         public override void UpdateFile(IFolderInfo folder, string fileName, Stream content)
         {
-            // Azure is case sensitive.  If you update dnninternals.pdf with DNNINTERNALS.pdf, to DNN it's the same
-            // so it just re-uploads it, causing both files to exist in Azure.
             IFileInfo originalFile = FileManager.Instance.GetFile(folder, fileName);
+
 
             base.UpdateFile(folder, fileName, content);
 

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
@@ -270,7 +270,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
             this.ClearCache(folderMapping.FolderMappingID);
         }
 
-    /*    public override void UpdateFile(IFolderInfo folder, string fileName, Stream content)
+        public override void UpdateFile(IFolderInfo folder, string fileName, Stream content)
         {
             // Azure is case sensitive.  If you update dnninternals.pdf with DNNINTERNALS.pdf, to DNN it's the same
             // so it just re-uploads it, causing both files to exist in Azure.
@@ -284,7 +284,7 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
                 this.DeleteFileInternal(folderMapping, folder.MappedPath + originalFile.FileName);
             }
         }
-    */
+
         protected override void UpdateFileInternal(Stream stream, FolderMappingInfo folderMapping, string uri)
         {
             var container = this.GetContainer(folderMapping);

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
@@ -282,7 +282,6 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
         {
             IFileInfo originalFile = FileManager.Instance.GetFile(folder, fileName);
 
-
             base.UpdateFile(folder, fileName, content);
 
             if (originalFile != null && originalFile.FileName != fileName)

--- a/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
+++ b/DNN Platform/Providers/FolderProviders/AzureFolderProvider/AzureFolderProvider.cs
@@ -270,6 +270,21 @@ namespace DotNetNuke.Providers.FolderProviders.AzureFolderProvider
             this.ClearCache(folderMapping.FolderMappingID);
         }
 
+    /*    public override void UpdateFile(IFolderInfo folder, string fileName, Stream content)
+        {
+            // Azure is case sensitive.  If you update dnninternals.pdf with DNNINTERNALS.pdf, to DNN it's the same
+            // so it just re-uploads it, causing both files to exist in Azure.
+            IFileInfo originalFile = FileManager.Instance.GetFile(folder, fileName);
+
+            base.UpdateFile(folder, fileName, content);
+
+            if (originalFile != null && originalFile.FileName != fileName)
+            {
+                FolderMappingInfo folderMapping = FolderMappingController.Instance.GetFolderMapping(folder.FolderMappingID);
+                this.DeleteFileInternal(folderMapping, folder.MappedPath + originalFile.FileName);
+            }
+        }
+    */
         protected override void UpdateFileInternal(Stream stream, FolderMappingInfo folderMapping, string uri)
         {
             var container = this.GetContainer(folderMapping);


### PR DESCRIPTION
Fixes #4481

## Summary
Override UpdateFile in the AzureFolderProvider, look to see if the original filename is different from the new one.  If it is, then delete it.
