### PR TITLE
Remove duplicate references to Yarn.MsBuild

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.props" Condition="Exists('..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -766,12 +765,4 @@
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="Module.build" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.targets" Condition="Exists('..\..\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.targets')" />
 </Project>


### PR DESCRIPTION
This addresses the build warnings:
```
  D:\a\1\s\Build\BuildScripts\AEModule.build(3,3): warning MSB4011: "D:\a\1\s\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.props" cannot be imported again. It was already imported at "D:\a\1\s\Dnn.AdminExperience\Dnn.PersonaBar.Extensions\Dnn.PersonaBar.Extensions.csproj (3,3)". This is most likely a build authoring error. This subsequent import will be ignored.
  D:\a\1\s\Dnn.AdminExperience\Dnn.PersonaBar.Extensions\Dnn.PersonaBar.Extensions.csproj(776,3): warning MSB4011: "D:\a\1\s\packages\Yarn.MSBuild.1.16.0\build\Yarn.MSBuild.targets" cannot be imported again. It was already imported at "D:\a\1\s\Build\BuildScripts\AEModule.build (4,3)". This is most likely a build authoring error. This subsequent import will be ignored.
```