### PR TITLE
Adjust Yarn configuration for CI

### DIFF
--- a/Build/BuildScripts/AEModule.build
+++ b/Build/BuildScripts/AEModule.build
@@ -45,7 +45,7 @@
   <Target Name="RunYarnWorkspace">
     <Message Importance="high" Text="Running Yarn for $(WorkingDirectory)" />
 
-    <Yarn Command="install" WorkingDirectory="$(WorkingDirectory)" IgnoreExitCode="false" Condition="$(WorkingDirectory.Length) > 0" />
+    <Yarn Command="install --frozen-lockfile" WorkingDirectory="$(WorkingDirectory)" IgnoreExitCode="false" Condition="$(WorkingDirectory.Length) > 0" />
     <Yarn Command="build" WorkingDirectory="$(WorkingDirectory)" IgnoreExitCode="false" Condition="$(WorkingDirectory.Length) > 0" />
   </Target>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,8 @@ pool:
 variables:
   - name: "Build.ArtifactStagingDirectory"
     value: "Artifacts/"
+  - name: "YARN_CACHE_FOLDER"
+    value: "$(Pipeline.Workspace)/.yarn"
 
 parameters:
   - name: "CakeTarget"
@@ -43,6 +45,13 @@ pr:
       - '*'
 
 steps:
+
+- task: Cache@2
+  displayName: Cache Yarn packages
+  inputs:
+    key: 'yarn | "$(Agent.OS)" | yarn.lock'
+    restoreKeys: 'yarn | "$(Agent.OS)"'
+    path: $(YARN_CACHE_FOLDER)
 
 - task: PowerShell@2
   displayName: 'Run DNN Update Versions'


### PR DESCRIPTION
* Add caching of Yarn files to speed up builds
* Pass `--frozen-lockfile` to `yarn install` to avoid extra work and inconsistent build state