### PR TITLE
Azure page css

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -297,7 +297,8 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
 
             // Some "legacy URLs" could be using their own query string versioning scheme (and we've forced them to use the new API through re-routing PageBase.RegisterStyleSheet
             // Ensure that physical CSS files with query strings have their query strings removed
-            if (filePath.Contains(".css?"))
+            // Ignore absolute urls, they will not exist locally
+            if (!Uri.TryCreate(filePath, UriKind.Absolute, out _) && filePath.Contains(".css?"))
             {
                 var filePathSansQueryString = RemoveQueryString(filePath);
                 if (File.Exists(page.Server.MapPath(filePathSansQueryString)))

--- a/DNN Platform/Library/Services/FileSystem/FileContentTypeManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileContentTypeManager.cs
@@ -101,6 +101,7 @@ namespace DotNetNuke.Services.FileSystem
             contentTypes.Add("pps", "application/vnd.ms-powerpoint");
             contentTypes.Add("pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation");
             contentTypes.Add("ppsx", "application/vnd.openxmlformats-officedocument.presentationml.slideshow");
+            contentTypes.Add("css", "text/css");
 
             return contentTypes;
         }

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
@@ -9,4 +9,7 @@
 /************************************************************/
 
 -- Add CSS contnet type, this will help when a Page Style Sheet is uploaded to a folder provider such as AzureFolderProvider.
-INSERT INTO {databaseOwner}[{objectQualifier}Lists] ( [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (N'ContentTypes', N'css', N'text/css', 0, 0, 0, -1, N'', -1, 1, -1, '2020-02-17 09:13:51.647', -1, '2020-02-17 09:13:51.647')
+IF NOT EXISTS (SELECT * FROM {databaseOwner}{objectQualifier}Lists WHERE ListName='ContentTypes' AND Value = 'css')
+BEGIN
+    INSERT INTO {databaseOwner}[{objectQualifier}Lists] ( [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (N'ContentTypes', N'css', N'text/css', 0, 0, 0, -1, N'', -1, 1, -1, '2020-02-17 09:13:51.647', -1, '2020-02-17 09:13:51.647')
+END

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
@@ -11,5 +11,5 @@
 -- Add CSS content type, this will help when a Page Style Sheet is uploaded to a folder provider such as AzureFolderProvider.
 IF NOT EXISTS (SELECT * FROM {databaseOwner}{objectQualifier}Lists WHERE ListName='ContentTypes' AND Value = 'css')
 BEGIN
-    INSERT INTO {databaseOwner}[{objectQualifier}Lists] ( [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (N'ContentTypes', N'css', N'text/css', 0, 0, 0, -1, N'', -1, 1, -1, '2020-02-17 09:13:51.647', -1, '2020-02-17 09:13:51.647')
+    INSERT INTO {databaseOwner}[{objectQualifier}Lists] ( [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (N'ContentTypes', N'css', N'text/css', 0, 0, 0, -1, N'', -1, 1, -1, GETDATE(), -1, GETDATE())
 END

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
@@ -1,0 +1,12 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/
+
+-- Add CSS contnet type, this will help when a Page Style Sheet is uploaded to a folder provider such as AzureFolderProvider.
+INSERT INTO {databaseOwner}[{objectQualifier}Lists] ( [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (N'ContentTypes', N'css', N'text/css', 0, 0, 0, -1, N'', -1, 1, -1, '2020-02-17 09:13:51.647', -1, '2020-02-17 09:13:51.647')

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.01.SqlDataProvider
@@ -8,7 +8,7 @@
 /*****                                                  *****/
 /************************************************************/
 
--- Add CSS contnet type, this will help when a Page Style Sheet is uploaded to a folder provider such as AzureFolderProvider.
+-- Add CSS content type, this will help when a Page Style Sheet is uploaded to a folder provider such as AzureFolderProvider.
 IF NOT EXISTS (SELECT * FROM {databaseOwner}{objectQualifier}Lists WHERE ListName='ContentTypes' AND Value = 'css')
 BEGIN
     INSERT INTO {databaseOwner}[{objectQualifier}Lists] ( [ListName], [Value], [Text], [ParentID], [Level], [SortOrder], [DefinitionID], [Description], [PortalID], [SystemList], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES (N'ContentTypes', N'css', N'text/css', 0, 0, 0, -1, N'', -1, 1, -1, '2020-02-17 09:13:51.647', -1, '2020-02-17 09:13:51.647')


### PR DESCRIPTION
Fixes #4499

## Summary
1. To support Page Stylesheets stored in AzureFolderProvider (and others).  Attempt to get the Page Stylesheet from the FolderProvider first.  If it exists with an external url, then include the css in a page header `link`.  If not, include through ClientResourceMananger (current way)
2. Add CSS contenttype to FileContentTypeManager.cs and Database Lists of type 'ContentTypes'.  If this doesn't exist .css will be uploaded as 'application/octet-stream' and browsers won't use it as a css file.