### PR TITLE
Use ReplyTo Address in MailProvider implementations

### DIFF
--- a/DNN Platform/Library/Services/Mail/CoreMailProvider.cs
+++ b/DNN Platform/Library/Services/Mail/CoreMailProvider.cs
@@ -67,6 +67,12 @@ namespace DotNetNuke.Services.Mail
                 mailMessage.Bcc.Add(mailInfo.BCC);
             }
 
+            if (!string.IsNullOrEmpty(mailInfo.ReplyTo))
+            {
+                mailInfo.ReplyTo = mailInfo.ReplyTo.Replace(";", ",");
+                mailMessage.ReplyToList.Add(mailInfo.ReplyTo);
+            }
+
             mailMessage.Priority = (System.Net.Mail.MailPriority)mailInfo.Priority;
             mailMessage.IsBodyHtml = mailInfo.BodyFormat == MailFormat.Html;
 
@@ -119,7 +125,9 @@ namespace DotNetNuke.Services.Mail
             }
 
             // message
+            mailMessage.SubjectEncoding = mailInfo.BodyEncoding;
             mailMessage.Subject = HtmlUtils.StripWhiteSpace(mailInfo.Subject, true);
+            mailMessage.BodyEncoding = mailInfo.BodyEncoding;
             mailMessage.Body = mailInfo.Body;
             smtpInfo.Server = smtpInfo.Server.Trim();
             if (!SmtpServerRegex.IsMatch(smtpInfo.Server))

--- a/DNN Platform/Library/Services/Mail/MailKitMailProvider.cs
+++ b/DNN Platform/Library/Services/Mail/MailKitMailProvider.cs
@@ -71,6 +71,12 @@ namespace DotNetNuke.Services.Mail
                 mailMessage.Bcc.AddRange(InternetAddressList.Parse(mailInfo.BCC));
             }
 
+            if (!string.IsNullOrEmpty(mailInfo.ReplyTo))
+            {
+                mailInfo.ReplyTo = mailInfo.ReplyTo.Replace(";", ",");
+                mailMessage.ReplyTo.AddRange(InternetAddressList.Parse(mailInfo.ReplyTo));
+            }
+
             mailMessage.Priority = (MessagePriority)mailInfo.Priority;
 
             // Only modify senderAddress if smtpAuthentication is enabled


### PR DESCRIPTION
Fixes #4502 

Related to Issue #4472 and PR #4473 which add usage of CC and BCC fields to the MailProvider implementations.

## Summary
This PR adds the use of ReplyTo to both the CoreMailProvider and MailKitMailProvider.
Also, the BodyEncoding property of the MailInfo object passed into the provider is now used by CoreMailProvider, the same way as it was before the implementation of the provider model.

The change was tested by using OpenForm to send a message with a custom ReplyTo address.