### PR TITLE
Fixed an issue where checksums where not generated in CI builds

### DIFF
--- a/Build/Cake/build.cs
+++ b/Build/Cake/build.cs
@@ -222,7 +222,6 @@ public sealed class CleanArtifacts : FrostingTask<Context>
 [Dependency(typeof(CreateUpgrade))]
 [Dependency(typeof(CreateDeploy))]
 [Dependency(typeof(CreateSymbols))]
-[Dependency(typeof(GeneratePackagesChecksums))]
 public sealed class Default : FrostingTask<Context>
 {
 }

--- a/Build/Cake/ci.cs
+++ b/Build/Cake/ci.cs
@@ -11,6 +11,7 @@ using Cake.Frosting;
 [Dependency(typeof(CreateDeploy))]
 [Dependency(typeof(CreateSymbols))]
 [Dependency(typeof(CreateNugetPackages))]
+[Dependency(typeof(GeneratePackagesChecksums))]
 public sealed class BuildAll : FrostingTask<Context>
 {
     public override void Run(Context context)


### PR DESCRIPTION
This is a follow up on my previous PR to automatically calculate the packages checksums during CI builds, by mistake I put the target dependencies on the wrong target, this PR should fix that and actually make the correct target run.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
