### PR TITLE
Remove NuGet dependency from Instrumentation

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Instrumentation.nuspec
@@ -14,9 +14,6 @@
       Provides references to enhanced logging and instrumentation available within DNN Platform for extension developers. Including access to Log4Net
     </description>
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>
-    <dependencies>
-      <dependency id="DotNetNuke.Core" version="$version$" />
-    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\Website\bin\DotNetNuke.Instrumentation.dll" target="lib\net45\" />


### PR DESCRIPTION
The current state includes a circular dependency from DotNetNuke.Core
to DotNetNuke.DependencyInjection to DotNetNuke.Instrumentation to
DotNetNuke.Core.