### PR TITLE
Fix typo in image-actions

### DIFF
--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - development # merging PRs from other forks (will open a new PR)
-  worflow_dispatch: # on demand
+  workflow_dispatch: # on demand
   schedule:
     - cron: "0 0 * * 0" # every Sunday at midnight
 jobs:


### PR DESCRIPTION
## Summary
There's a typo in the `image-actions.yml` GitHub Actions workflow since my PR #4478 was merged