### PR TITLE
Fixed an issue where CK-Editor provider did not include image files in install package

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.csproj
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-	<Deterministic>true</Deterministic>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -237,6 +237,87 @@
     <Content Include="css\CkEditorContents.css" />
     <Content Include="css\CkEditorToolBars.css" />
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
+    <Content Include="icons\About.png" />
+    <Content Include="icons\Anchor.png" />
+    <Content Include="icons\BGColor.png" />
+    <Content Include="icons\BidiLtr.png" />
+    <Content Include="icons\BidiRtl.png" />
+    <Content Include="icons\Blockquote.png" />
+    <Content Include="icons\Bold.png" />
+    <Content Include="icons\BulletedList.png" />
+    <Content Include="icons\Copy.png" />
+    <Content Include="icons\CreateDiv.png" />
+    <Content Include="icons\Cut.png" />
+    <Content Include="icons\Find.png" />
+    <Content Include="icons\Flash.png" />
+    <Content Include="icons\Font.png" />
+    <Content Include="icons\FontSize.png" />
+    <Content Include="icons\Format.png" />
+    <Content Include="icons\HorizontalRule.png" />
+    <Content Include="icons\Iframe.png" />
+    <Content Include="icons\Image.png" />
+    <Content Include="icons\Indent.png" />
+    <Content Include="icons\Italic.png" />
+    <Content Include="icons\JustifyBlock.png" />
+    <Content Include="icons\JustifyCenter.png" />
+    <Content Include="icons\JustifyLeft.png" />
+    <Content Include="icons\JustifyRight.png" />
+    <Content Include="icons\Link.png" />
+    <Content Include="icons\mathjax.png" />
+    <Content Include="icons\Maximize.png" />
+    <Content Include="icons\NewPage.png" />
+    <Content Include="icons\newsarticleslinks.gif" />
+    <Content Include="icons\NumberedList.png" />
+    <Content Include="icons\oEmbed.png" />
+    <Content Include="icons\Outdent.png" />
+    <Content Include="icons\PageBreak.png" />
+    <Content Include="icons\Paste.png" />
+    <Content Include="icons\PasteFromWord.png" />
+    <Content Include="icons\PasteText.png" />
+    <Content Include="icons\Preview.png" />
+    <Content Include="icons\Print.png" />
+    <Content Include="icons\qrcodes.jpg" />
+    <Content Include="icons\Redo.png" />
+    <Content Include="icons\RemoveFormat.png" />
+    <Content Include="icons\Replace.png" />
+    <Content Include="icons\Save.png" />
+    <Content Include="icons\SelectAll.png" />
+    <Content Include="icons\separator.png" />
+    <Content Include="icons\ShowBlocks.png" />
+    <Content Include="icons\Smiley.png" />
+    <Content Include="icons\Source.png" />
+    <Content Include="icons\SpecialChar.png" />
+    <Content Include="icons\SpellChecker.png" />
+    <Content Include="icons\Strike.png" />
+    <Content Include="icons\Styles.png" />
+    <Content Include="icons\Subscript.png" />
+    <Content Include="icons\Superscript.png" />
+    <Content Include="icons\syntaxhighlight.gif" />
+    <Content Include="icons\Table.png" />
+    <Content Include="icons\Templates.png" />
+    <Content Include="icons\TextColor.png" />
+    <Content Include="icons\Underline.png" />
+    <Content Include="icons\Undo.png" />
+    <Content Include="icons\Unlink.png" />
+    <Content Include="images\bg-input-focus.png" />
+    <Content Include="images\bg-input.png" />
+    <Content Include="images\editor_config_large.png" />
+    <Content Include="images\editor_config_small.png" />
+    <Content Include="images\error.png" />
+    <Content Include="images\HostHasSetting.png" />
+    <Content Include="images\HostNoSetting.png" />
+    <Content Include="images\information.png" />
+    <Content Include="images\loading.gif" />
+    <Content Include="images\ModuleHasSetting.png" />
+    <Content Include="images\ModuleNoSetting.png" />
+    <Content Include="images\PageHasSetting.png" />
+    <Content Include="images\PageNoSetting.png" />
+    <Content Include="images\PortalHasSetting.png" />
+    <Content Include="images\PortalNoSetting.png" />
+    <Content Include="images\progressbar.gif" />
+    <Content Include="images\spacer.gif" />
+    <Content Include="images\tick.png" />
+    <Content Include="images\warning.png" />
     <Content Include="Install\Dnn.CKEditorDefaultSettings.xml" />
     <Content Include="CKEditorOptions.ascx">
       <SubType>ASPXCodeBehind</SubType>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Provider.build
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Provider.build
@@ -18,7 +18,7 @@
       <Views Include="**\*.ashx;**\*.aspx;**\*.ascx" />
       <CssFiles Include="css\*.css;Browser\*.css" />
       <JsFiles Include="js\*.js;Browser\js\*.js;js\**\*.*" />
-      <ImagesFiles Include="Browser\images\**\*.*" />
+      <ImagesFiles Include="images\**\*.*;icons\**\*.*;Browser\images\**\*.*" />
       <ResourceFiles Include="App_LocalResources\*.resx" />
       <CKEditor Include="CKEditor\**\*.*" />
       <Resources Include="@(ResourceFiles);@(TextFiles);@(CKEditor);@(Views);@(CssFiles);@(JsFiles);@(ImagesFiles);" />


### PR DESCRIPTION
Fixes #4537 

## Summary
In a previous PR I moved images and icons out of the ckeditor folder, since they really where not related to the editor, but the provider itself. In issue #4537 it was pointed out that the moved images are currently not included in the install package.
This PR fixes that by changing the build file.

Tested with a new install from the develop branch.