### PR TITLE
fixed redirect to primary alias when PortalAliasMapping is set to redirect

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -255,7 +255,12 @@ namespace DotNetNuke.Entities.Urls
             {
                 var portalAliases = PortalAliasController.Instance.GetPortalAliasesByPortalId(result.PortalId).ToList();
 
-                if (queryStringCol != null && queryStringCol["forceAlias"] != null && queryStringCol["forceAlias"] != "true")
+                // if we're not on the primary alias, and portalaliasmapping is set to redirect, we might need to be redirected
+                var redirectToPrimary = !result.PortalAlias.IsPrimary && result.PortalAliasMapping == PortalSettings.PortalAliasMapping.Redirect;
+
+                // forceAlias used in querystring?
+                var forceAliasInQueryString = queryStringCol != null && queryStringCol["forceAlias"] != null && queryStringCol["forceAlias"] != "true";
+                if (redirectToPrimary || forceAliasInQueryString)
                 {
                     if (portalAliases.Count > 0)
                     {


### PR DESCRIPTION
Fixes #4306 

If PortalAliasMapping is set to redirect, and the request is not for the primary alias, user will be redirected

## Summary
In advancedUrlRewriter.IsPortalAliasIncorrect there was a check to allow redirection to an alias when forceAlias was used in the querystring.
I added to that check that if the request is not for a primary alias, and PortalAliasMapping is set to redirect, the user will also be redirected to the primary alias