### PR TITLE
Upgrade Cake to 1.1.0

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -7,11 +7,11 @@
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.BuildSystems.Module" Version="1.0.0" />
-    <PackageReference Include="Cake.FileHelpers" Version="3.3.0" />
-    <PackageReference Include="Cake.Frosting" Version="1.0.0" />
-    <PackageReference Include="Cake.Git" Version="0.22.0" />
-    <PackageReference Include="Cake.XdtTransform" Version="0.18.1" />
+    <PackageReference Include="Cake.BuildSystems.Module" Version="3.0.1" />
+    <PackageReference Include="Cake.FileHelpers" Version="4.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="1.1.0" />
+    <PackageReference Include="Cake.Git" Version="1.0.0" />
+    <PackageReference Include="Cake.XdtTransform" Version="1.0.0" />
     <PackageReference Include="Dnn.CakeUtils" Version="1.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/Build/Cake/build.cs
+++ b/Build/Cake/build.cs
@@ -5,6 +5,7 @@ using Cake.Common.IO;
 using Cake.Common.IO.Paths;
 using Cake.Common.Tools.GitVersion;
 using Cake.Core;
+using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.FileHelpers;
 using Cake.Frosting;
@@ -52,8 +53,8 @@ public class Context : FrostingContext
             this.sqlDataProviderExists = false;
 
             var settingsFile = "./settings.local.json";
-            this.Settings = this.LoadSettings(settingsFile);
-            WriteSettings(settingsFile);
+            this.Settings = this.LoadSettings(context, settingsFile);
+            this.WriteSettings(context, settingsFile);
 
             this.buildId = context.EnvironmentVariable("BUILD_BUILDID") ?? "0";
             context.Information($"BuildId: {buildId}");
@@ -124,18 +125,23 @@ public class Context : FrostingContext
         return productVersion;
     }
 
-    private void WriteSettings(string settingsFile)
+    private void WriteSettings(ICakeContext context, string settingsFile)
     {
         using (var sw = new System.IO.StreamWriter(settingsFile))
         {
-            sw.WriteLine(JsonConvert.SerializeObject(Settings, Formatting.Indented));
+            sw.WriteLine(JsonConvert.SerializeObject(this.Settings, Formatting.Indented));
         }
+
+        context.Information(log => log($"Saved settings to {System.IO.Path.GetFullPath(settingsFile)}"));
+        context.Debug(log => log($"Settings: {JsonConvert.SerializeObject(this.Settings, Formatting.Indented).Replace("{", "{{")}"));
     }
 
-    private LocalSettings LoadSettings(string settingsFile) {
+    private LocalSettings LoadSettings(ICakeContext context, string settingsFile) {
         if (System.IO.File.Exists(settingsFile)) {
+            context.Information(log => log($"Loading settings from {System.IO.Path.GetFullPath(settingsFile)}"));
             return JsonConvert.DeserializeObject<LocalSettings>(Utilities.ReadFile(settingsFile));
         } else {
+            context.Information(log => log($"Did not find settings file {System.IO.Path.GetFullPath(settingsFile)}"));
             return new LocalSettings();
         }
     }

--- a/Build/Cake/build.cs
+++ b/Build/Cake/build.cs
@@ -51,7 +51,7 @@ public class Context : FrostingContext
             
             this.sqlDataProviderExists = false;
 
-            var settingsFile = "../settings.local.json";
+            var settingsFile = "./settings.local.json";
             this.Settings = this.LoadSettings(settingsFile);
             WriteSettings(settingsFile);
 

--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -12,7 +12,6 @@ public class Program
             .UseLifetime<Lifetime>()
             .UseWorkingDirectory("..")
             .UseModule<AzurePipelinesModule>()
-            .SetToolPath("../tools")
             .InstallTool(new Uri("nuget:?package=GitVersion.CommandLine&version=5.0.1"))
             .InstallTool(new Uri("nuget:?package=Microsoft.TestPlatform&version=16.8.0"))
             .InstallTool(new Uri("nuget:?package=NUnitTestAdapter&version=2.3.0"))


### PR DESCRIPTION
## Summary
Cake and its various modules have released updates, this PR applies those updates.

One fixed bug has to do with when a working directory change takes affect, so a couple of paths needed to be adjusted (in general, everything is now always automatically using the correct root directory).