### PR TITLE
ICommand* refactor

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// This is used to retrieve and keep a list of all commands found in the installation.
     /// </summary>
-    [Obsolete("Deprecated in favor of IDnnCommand. Will be removed in a future release.", false)]
+    [Obsolete("Deprecated in v9.9.1. Use IDnnCommand instead. Will be removed in v11.", false)]
     public interface ICommand : IDnnCommand
     {
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace DotNetNuke.Abstractions.Prompt
+{
+    /// <summary>
+    /// This is used to retrieve and keep a list of all commands found in the installation.
+    /// </summary>
+    [Obsolete("Deprecated in favor of IDnnCommand. Will be removed in a future release.", false)]
+    public interface ICommand : IDnnCommand
+    {
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommand.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
-using System;
-
 namespace DotNetNuke.Abstractions.Prompt
 {
+    using System;
+
     /// <summary>
     /// This is used to retrieve and keep a list of all commands found in the installation.
     /// </summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// This is used to send the result back to the client when a user asks help for a command.
     /// </summary>
-    [Obsolete("Deprecated in favor of IDnnCommandHelp. Will be removed in a future release.", false)]
+    [Obsolete("Deprecated in v9.9.1. Use IDnnCommandHelp instead. Will be removed in v11.", false)]
     public interface ICommandHelp : IDnnCommandHelp
     {
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
-using System;
-
 namespace DotNetNuke.Abstractions.Prompt
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandHelp.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace DotNetNuke.Abstractions.Prompt
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// This is used to send the result back to the client when a user asks help for a command.
+    /// </summary>
+    [Obsolete("Deprecated in favor of IDnnCommandHelp. Will be removed in a future release.", false)]
+    public interface ICommandHelp : IDnnCommandHelp
+    {
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
@@ -4,7 +4,7 @@
 namespace DotNetNuke.Abstractions.Prompt
 {
     /// <summary>
-    /// This is used in the ICommandHelp to send a list of command parameters to the client for explanatory help.
+    /// This is used in the IDnnCommandHelp to send a list of command parameters to the client for explanatory help.
     /// </summary>
     public interface ICommandOption
     {

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// This is used in the ICommandHelp to send a list of command parameters to the client for explanatory help.
     /// </summary>
-    [Obsolete("Deprecated in favor of IDnnCommandOption. Will be removed in a future release.", false)]
+    [Obsolete("Deprecated in v9.9.1. Use IDnnCommandOption instead. Will be removed in v11.", false)]
     public interface ICommandOption : IDnnCommandOption
     {
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
-using System;
-
 namespace DotNetNuke.Abstractions.Prompt
 {
+    using System;
+
     /// <summary>
     /// This is used in the ICommandHelp to send a list of command parameters to the client for explanatory help.
     /// </summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandOption.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace DotNetNuke.Abstractions.Prompt
+{
+    /// <summary>
+    /// This is used in the ICommandHelp to send a list of command parameters to the client for explanatory help.
+    /// </summary>
+    [Obsolete("Deprecated in favor of IDnnCommandOption. Will be removed in a future release.", false)]
+    public interface ICommandOption : IDnnCommandOption
+    {
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
@@ -13,8 +13,8 @@ namespace DotNetNuke.Abstractions.Prompt
         /// <summary>
         /// Gets a list of all found commands.
         /// </summary>
-        /// <returns>List of ICommand.</returns>
-        IEnumerable<ICommand> GetCommands();
+        /// <returns>List of IDnnCommand.</returns>
+        IEnumerable<IDnnCommand> GetCommands();
 
         /// <summary>
         /// Get the command. Returns null if no command found for the name.

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// The repository handles retrieving of commands from the entire DNN installation.
     /// </summary>
-    [Obsolete("Deprecated in favor of IDnnCommandRepository. Will be removed in a future release.", false)]
+    [Obsolete("Deprecated in v9.9.1. Use IDnnCommandRepository instead. Will be removed in v11.", false)]
     public interface ICommandRepository : IDnnCommandRepository
     {
     }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
-using System;
-
 namespace DotNetNuke.Abstractions.Prompt
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace DotNetNuke.Abstractions.Prompt
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The repository handles retrieving of commands from the entire DNN installation.
+    /// </summary>
+    [Obsolete("Deprecated in favor of IDnnCommandRepository. Will be removed in a future release.", false)]
+    public interface ICommandRepository : IDnnCommandRepository
+    {
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommand.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommand.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// This is used to retrieve and keep a list of all commands found in the installation.
     /// </summary>
-    public interface ICommand
+    public interface IDnnCommand
     {
         /// <summary>
         /// Gets or sets the name of the command.

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandHelp.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Abstractions.Prompt
         /// <summary>
         /// Gets or sets the Command parameter list, each with their own help text.
         /// </summary>
-        IEnumerable<ICommandOption> Options { get; set; }
+        IEnumerable<IDnnCommandOption> Options { get; set; }
 
         /// <summary>
         /// Gets or sets the html formatted block of text that describes what this command does.

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandHelp.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandHelp.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// This is used to send the result back to the client when a user asks help for a command.
     /// </summary>
-    public interface ICommandHelp
+    public interface IDnnCommandHelp
     {
         /// <summary>
         /// Gets or sets the name of the command.

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandOption.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandOption.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// This is used in the IDnnCommandHelp to send a list of command parameters to the client for explanatory help.
     /// </summary>
-    public interface ICommandOption
+    public interface IDnnCommandOption
     {
         /// <summary>
         /// Gets or sets the name of the parameter.

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandRepository.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Abstractions.Prompt
         /// Get help for the specified command.
         /// </summary>
         /// <param name="consoleCommand">Command to get help for.</param>
-        /// <returns>ICommandHelp class that can be used by the client to compile a help text.</returns>
-        ICommandHelp GetCommandHelp(IConsoleCommand consoleCommand);
+        /// <returns>IDnnCommandHelp class that can be used by the client to compile a help text.</returns>
+        IDnnCommandHelp GetCommandHelp(IConsoleCommand consoleCommand);
     }
 }

--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/IDnnCommandRepository.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Abstractions.Prompt
     /// <summary>
     /// The repository handles retrieving of commands from the entire DNN installation.
     /// </summary>
-    public interface ICommandRepository
+    public interface IDnnCommandRepository
     {
         /// <summary>
         /// Gets a list of all found commands.

--- a/DNN Platform/Library/Prompt/Command.cs
+++ b/DNN Platform/Library/Prompt/Command.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Prompt
 {
     [Serializable]
     [JsonObject]
-    public class Command : ICommand
+    public class Command : IDnnCommand
     {
         /// <inheritdoc/>
         public string Key { get; set; }

--- a/DNN Platform/Library/Prompt/CommandRepository.cs
+++ b/DNN Platform/Library/Prompt/CommandRepository.cs
@@ -16,10 +16,10 @@ using System.Web.Caching;
 
 namespace DotNetNuke.Prompt
 {
-    public class CommandRepository : ServiceLocator<ICommandRepository, CommandRepository>, ICommandRepository
+    public class CommandRepository : ServiceLocator<IDnnCommandRepository, CommandRepository>, IDnnCommandRepository
     {
         /// <inheritdoc/>
-        protected override Func<ICommandRepository> GetFactory()
+        protected override Func<IDnnCommandRepository> GetFactory()
         {
             return () => new CommandRepository();
         }

--- a/DNN Platform/Library/Prompt/CommandRepository.cs
+++ b/DNN Platform/Library/Prompt/CommandRepository.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Prompt
         }
 
         /// <inheritdoc/>
-        public IEnumerable<ICommand> GetCommands()
+        public IEnumerable<IDnnCommand> GetCommands()
         {
             return this.CommandList().Values;
         }
@@ -42,17 +42,17 @@ namespace DotNetNuke.Prompt
             return null;
         }
 
-        private SortedDictionary<string, ICommand> CommandList()
+        private SortedDictionary<string, IDnnCommand> CommandList()
         {
             return
-                DataCache.GetCachedData<SortedDictionary<string, ICommand>>(
+                DataCache.GetCachedData<SortedDictionary<string, IDnnCommand>>(
                     new CacheItemArgs("DnnPromptCommandList", CacheItemPriority.Default),
                     c => GetCommandsInternal());
         }
 
-        private static SortedDictionary<string, ICommand> GetCommandsInternal()
+        private static SortedDictionary<string, IDnnCommand> GetCommandsInternal()
         {
-            var commands = new SortedDictionary<string, ICommand>();
+            var commands = new SortedDictionary<string, IDnnCommand>();
             var typeLocator = new TypeLocator();
             var allCommandTypes = typeLocator.GetAllMatchingTypes(
                 t => t != null &&

--- a/DNN Platform/Library/Prompt/CommandRepository.cs
+++ b/DNN Platform/Library/Prompt/CommandRepository.cs
@@ -82,14 +82,14 @@ namespace DotNetNuke.Prompt
         }
 
         /// <inheritdoc/>
-        public ICommandHelp GetCommandHelp(IConsoleCommand consoleCommand)
+        public IDnnCommandHelp GetCommandHelp(IConsoleCommand consoleCommand)
         {
             var cacheKey = $"{consoleCommand.GetType().Name}-{System.Threading.Thread.CurrentThread.CurrentUICulture.Name}";
-            return DataCache.GetCachedData<ICommandHelp>(new CacheItemArgs(cacheKey, CacheItemPriority.Low),
+            return DataCache.GetCachedData<IDnnCommandHelp>(new CacheItemArgs(cacheKey, CacheItemPriority.Low),
                 c => this.GetCommandHelpInternal(consoleCommand));
         }
 
-        private ICommandHelp GetCommandHelpInternal(IConsoleCommand consoleCommand)
+        private IDnnCommandHelp GetCommandHelpInternal(IConsoleCommand consoleCommand)
         {
             var commandHelp = new CommandHelp();
             if (consoleCommand != null)

--- a/DNN Platform/Library/Prompt/Output/CommandHelp.cs
+++ b/DNN Platform/Library/Prompt/Output/CommandHelp.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Prompt
 
         /// <inheritdoc/>
         [JsonProperty(PropertyName = "options")]
-        public IEnumerable<ICommandOption> Options { get; set; }
+        public IEnumerable<IDnnCommandOption> Options { get; set; }
 
         /// <inheritdoc/>
         [JsonProperty(PropertyName = "resultHtml")]

--- a/DNN Platform/Library/Prompt/Output/CommandHelp.cs
+++ b/DNN Platform/Library/Prompt/Output/CommandHelp.cs
@@ -11,7 +11,7 @@ namespace DotNetNuke.Prompt
 {
     [Serializable]
     [JsonObject]
-    public class CommandHelp : ICommandHelp
+    public class CommandHelp : IDnnCommandHelp
     {
         /// <inheritdoc/>
         [JsonProperty(PropertyName = "name")]

--- a/DNN Platform/Library/Prompt/Output/CommandOption.cs
+++ b/DNN Platform/Library/Prompt/Output/CommandOption.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Prompt
 {
     [Serializable]
     [JsonObject]
-    public class CommandOption : ICommandOption
+    public class CommandOption : IDnnCommandOption
     {
         /// <summary>
         /// Name of the parameter.


### PR DESCRIPTION

## Summary
Fixes #4042. 

Release note: Renamed DotNetNuke.Abstractions.Prompt.ICommand, ICommandRepository, ICommandHelp, and ICommandOption to IDnnCommand, IDnnCommandRepository, IDnnCommandHelp, and IDnnCommandOption to address a conflict with System.Windows.Input.ICommand.

Testing steps: Not too sure what all may be useful--my inclination is that the CI pipeline may be sufficient?

First PR ever...hopefully this is on the right track and useful :D 