### PR TITLE
Use binary logger instead of console logger for speedier builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ yarn-error.log
 /Build/bin/
 /.dotnet/
 /Build/Tools/
+
+*.binlog

--- a/.gitignore
+++ b/.gitignore
@@ -138,5 +138,3 @@ yarn-error.log
 /Build/bin/
 /.dotnet/
 /Build/Tools/
-
-*.binlog

--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Cake.FileHelpers" Version="4.0.0" />
     <PackageReference Include="Cake.Frosting" Version="1.1.0" />
     <PackageReference Include="Cake.Git" Version="1.0.1" />
+    <PackageReference Include="Cake.Issues" Version="0.9.1" />
+    <PackageReference Include="Cake.Issues.MsBuild" Version="0.9.1" />
+    <PackageReference Include="Cake.Issues.Recipe" Version="0.4.4" />
     <PackageReference Include="Cake.Json" Version="6.0.0" />
     <PackageReference Include="Cake.XdtTransform" Version="1.0.0" />
     <PackageReference Include="Dnn.CakeUtils" Version="2.0.0" />

--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -25,6 +25,7 @@ namespace DotNetNuke.Build
                 .InstallTool(new Uri("nuget:?package=Microsoft.TestPlatform&version=16.8.0"))
                 .InstallTool(new Uri("nuget:?package=NUnitTestAdapter&version=2.3.0"))
                 .InstallTool(new Uri("nuget:?package=NuGet.CommandLine&version=5.8.0"))
+                .InstallTool(new Uri("nuget:?package=Cake.Issues.MsBuild&version=0.9.1"))
                 .Run(args);
         }
     }

--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -6,8 +6,12 @@ namespace DotNetNuke.Build.Tasks
     using System;
     using System.Linq;
 
+    using Cake.Common.Build;
+    using Cake.Common.Build.AzurePipelines.Data;
     using Cake.Common.Tools.MSBuild;
     using Cake.Frosting;
+    using Cake.Issues;
+    using Cake.Issues.MsBuild;
 
     using DotNetNuke.Build;
 
@@ -19,21 +23,49 @@ namespace DotNetNuke.Build.Tasks
         /// <inheritdoc/>
         public override void Run(Context context)
         {
+            // TODO: when Cake.Issues.MsBuild is updated to support Binary Log version 9, can use .EnableBinaryLogger() instead of .WithLogger(…)
+            // TODO: also can remove the .InstallTool(…) call for Cake.Issues.MsBuild in Program.cs at that point
+            var cleanLog = context.ArtifactsDir.Path.CombineWithFilePath("clean.binlog");
             var cleanSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .WithTarget("Clean")
                 .SetMaxCpuCount(0)
-                .EnableBinaryLogger("Artifacts/clean.binlog")
+                .WithLogger(context.Tools.Resolve("Cake.Issues.MsBuild*/**/StructuredLogger.dll").FullPath, "BinaryLogger", cleanLog.FullPath)
                 .SetNoConsoleLogger(context.IsRunningInCI);
             context.MSBuild(context.DnnSolutionPath, cleanSettings);
 
+            var buildLog = context.ArtifactsDir.Path.CombineWithFilePath("rebuild.binlog");
             var buildSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .SetPlatformTarget(PlatformTarget.MSIL)
                 .WithTarget("Rebuild")
                 .SetMaxCpuCount(0)
                 .WithProperty("SourceLinkCreate", "true")
-                .EnableBinaryLogger("Artifacts/rebuild.binlog")
+                .WithLogger(context.Tools.Resolve("Cake.Issues.MsBuild*/**/StructuredLogger.dll").FullPath, "BinaryLogger", buildLog.FullPath)
                 .SetNoConsoleLogger(context.IsRunningInCI);
             context.MSBuild(context.DnnSolutionPath, buildSettings);
+
+            // TODO: when Cake.Issues.Recipe is updated to support Frosting, we can switch to their more robust issue processing and reporting features
+            if (!context.IsRunningInCI)
+            {
+                return;
+            }
+
+            var issueProviders = new[]
+            {
+                context.MsBuildIssuesFromFilePath(cleanLog, context.MsBuildBinaryLogFileFormat()),
+                context.MsBuildIssuesFromFilePath(buildLog, context.MsBuildBinaryLogFileFormat()),
+            };
+            foreach (var issue in context.ReadIssues(issueProviders, context.Environment.WorkingDirectory))
+            {
+                var messageData = new AzurePipelinesMessageData { SourcePath = issue.AffectedFileRelativePath?.FullPath, LineNumber = issue.Line, };
+                if (issue.Priority == (int)IssuePriority.Error)
+                {
+                    context.AzurePipelines().Commands.WriteError(issue.MessageText, messageData);
+                }
+                else
+                {
+                    context.AzurePipelines().Commands.WriteWarning(issue.MessageText, messageData);
+                }
+            }
         }
     }
 }

--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -19,13 +19,19 @@ namespace DotNetNuke.Build.Tasks
         /// <inheritdoc/>
         public override void Run(Context context)
         {
-            context.MSBuild(context.DnnSolutionPath, settings => settings.WithTarget("Clean"));
+            var cleanSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
+                .WithTarget("Clean")
+                .EnableBinaryLogger("clean.binlog")
+                .SetNoConsoleLogger(context.IsRunningInCI);
+            context.MSBuild(context.DnnSolutionPath, cleanSettings);
 
             var buildSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .SetPlatformTarget(PlatformTarget.MSIL)
                 .WithTarget("Rebuild")
                 .SetMaxCpuCount(4)
-                .WithProperty("SourceLinkCreate", "true");
+                .WithProperty("SourceLinkCreate", "true")
+                .EnableBinaryLogger("rebuild.binlog")
+                .SetNoConsoleLogger(context.IsRunningInCI);
             context.MSBuild(context.DnnSolutionPath, buildSettings);
         }
     }

--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -21,6 +21,7 @@ namespace DotNetNuke.Build.Tasks
         {
             var cleanSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .WithTarget("Clean")
+                .SetMaxCpuCount(0)
                 .EnableBinaryLogger("clean.binlog")
                 .SetNoConsoleLogger(context.IsRunningInCI);
             context.MSBuild(context.DnnSolutionPath, cleanSettings);
@@ -28,7 +29,7 @@ namespace DotNetNuke.Build.Tasks
             var buildSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .SetPlatformTarget(PlatformTarget.MSIL)
                 .WithTarget("Rebuild")
-                .SetMaxCpuCount(4)
+                .SetMaxCpuCount(0)
                 .WithProperty("SourceLinkCreate", "true")
                 .EnableBinaryLogger("rebuild.binlog")
                 .SetNoConsoleLogger(context.IsRunningInCI);

--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Build.Tasks
             var cleanSettings = new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .WithTarget("Clean")
                 .SetMaxCpuCount(0)
-                .EnableBinaryLogger("clean.binlog")
+                .EnableBinaryLogger("Artifacts/clean.binlog")
                 .SetNoConsoleLogger(context.IsRunningInCI);
             context.MSBuild(context.DnnSolutionPath, cleanSettings);
 
@@ -31,7 +31,7 @@ namespace DotNetNuke.Build.Tasks
                 .WithTarget("Rebuild")
                 .SetMaxCpuCount(0)
                 .WithProperty("SourceLinkCreate", "true")
-                .EnableBinaryLogger("rebuild.binlog")
+                .EnableBinaryLogger("Artifacts/rebuild.binlog")
                 .SetNoConsoleLogger(context.IsRunningInCI);
             context.MSBuild(context.DnnSolutionPath, buildSettings);
         }


### PR DESCRIPTION
See https://msbuildlog.com/ for the log viewer and other details on binary logs.