### PR TITLE
Add initial dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
With [the announcement of General Availability for Dependabot version updates](https://github.blog/changelog/2021-03-31-dependabot-version-updates-are-now-generally-available/), I thought it would be good to setup a basic config. I added npm and NuGet at monthly for now. We can also disable them altogether, or set them up for a different branch.