### PR TITLE
Fixed an issue that prevented MailKit configuration upon upgrades

### DIFF
--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.00.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.09.00.SqlDataProvider
@@ -1,0 +1,9 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/


### PR DESCRIPTION
Config code (09.09.00.config) only runs if we have a matching 09.09.00.SqlDataProvider present. Some time ago we added generating an empty one to prevent these kind of issues in many upgrade areas during build. But it does not commit that file so it only fixes it for that release version and we are lacking a 09.09.00.SqlDataProvider in 09.09.01.

For that reason the code that modifies the web.config file to add the MailKit provider does not fire when upgrade from <9.9.0 to 9.9.1

This PR solves this but in DNN10 it would be nice to look into the upgrade code so that it does not rely on xx.xx.xx.SqlDataProvider as the single source to know if there is any upgrade to do as we don't always have slq changes, it would be nice to look at multiple versioned files like config and IUpgradeable information to determine that.
