### PR TITLE
Adjust labels used by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     labels:
       - "Type: Build/Release"
       - "Type: Maintenance"
-      - "Priority: Low"
-      - "Status: Testing"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -17,8 +15,6 @@ updates:
     labels:
       - "javascript"
       - "Type: Maintenance"
-      - "Priority: Low"
-      - "Status: Testing"
 
   - package-ecosystem: "nuget"
     directory: "/"
@@ -27,5 +23,3 @@ updates:
     labels:
       - ".NET"
       - "Type: Maintenance"
-      - "Priority: Low"
-      - "Status: Testing"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,28 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "Type: Build/Release"
+      - "Type: Maintenance"
+      - "Priority: Low"
+      - "Status: Testing"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "javascript"
+      - "Type: Maintenance"
+      - "Priority: Low"
+      - "Status: Testing"
 
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - ".NET"
+      - "Type: Maintenance"
+      - "Priority: Low"
+      - "Status: Testing"


### PR DESCRIPTION
## Summary
This adjusts the Dependabot config to add the following labels to all dependency PRs:

* [_Type: Maintenance_](https://github.com/dnnsoftware/Dnn.Platform/labels/Type%3A%20Maintenance)
* [_Priority: Low_](https://github.com/dnnsoftware/Dnn.Platform/labels/Priority%3A%20Low)
* [_Status: Testing_](https://github.com/dnnsoftware/Dnn.Platform/labels/Status%3A%20Testing)

It also adds [_Type: Build/Release_](https://github.com/dnnsoftware/Dnn.Platform/labels/Type%3A%20Build%2FRelease) to PRs for GitHub Actions updates.

Let me know if any of those don't make sense to y'all and we can adjust or remove.  Thanks!