### PR TITLE
Fixed an issue when joining by RSVP would set the end date to today

### DIFF
--- a/DNN Platform/Library/Security/Roles/RoleController.cs
+++ b/DNN Platform/Library/Security/Roles/RoleController.cs
@@ -507,8 +507,8 @@ namespace DotNetNuke.Security.Roles
             else
             {
                 int UserRoleId = -1;
-                DateTime ExpiryDate = DateTime.Now;
-                DateTime EffectiveDate = Null.NullDate;
+                DateTime EffectiveDate = DateTime.Now;
+                DateTime ExpiryDate = Null.NullDate;
                 bool IsTrialUsed = false;
                 int Period = 0;
                 string Frequency = string.Empty;
@@ -542,7 +542,7 @@ namespace DotNetNuke.Security.Roles
 
                 if (ExpiryDate < DateTime.Now)
                 {
-                    ExpiryDate = DateTime.Now;
+                    ExpiryDate = Null.NullDate;
                 }
 
                 if (Period == Null.NullInteger)


### PR DESCRIPTION
## Summary
It looked like the effective date and expiration date were switched; so I switched them back so the effective date was set to the current date; instead of the expiration date being set to today, thus having the user not added to the role when the rsvp code is entered.  This alone did not fix it though.  I'm unsure what the other if statement was for; but I just set to to set the value to Null.NullData as the ExpiryDate will always be < DateTime.Now since it is not defaulted to Null.  Hopefully someone else more familiar with this knows what this was supposed to do.  Was it meant for EffectiveDate too?

Fixes #2543