### PR TITLE
Produce snupkg format for NuGet

### DIFF
--- a/Build/Tasks/CreateNugetPackages.cs
+++ b/Build/Tasks/CreateNugetPackages.cs
@@ -11,8 +11,8 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Common.IO;
     using Cake.Common.Tools.NuGet;
     using Cake.Common.Tools.NuGet.Pack;
+    using Cake.Core;
     using Cake.Frosting;
-
     using DotNetNuke.Build;
 
     /// <summary>A cake task to create the platform's NuGet packages.</summary>
@@ -35,6 +35,7 @@ namespace DotNetNuke.Build.Tasks
                                         IncludeReferencedProjects = true,
                                         Symbols = true,
                                         Properties = new Dictionary<string, string> { { "Configuration", "Release" } },
+                                        ArgumentCustomization = args => args.Append("-SymbolPackageFormat snupkg"),
                                     };
 
             // loop through each nuspec file and create the package

--- a/Build/Tasks/CreateNugetPackages.cs
+++ b/Build/Tasks/CreateNugetPackages.cs
@@ -24,6 +24,7 @@ namespace DotNetNuke.Build.Tasks
         {
             // look for solutions and start building them
             var nuspecFiles = context.GetFiles("./Build/Tools/NuGet/*.nuspec");
+            var noSymbolsNuspecFiles = context.GetFiles("./Build/Tools/NuGet/DotNetNuke.WebApi.nuspec");
 
             context.Information("Found {0} nuspec files.", nuspecFiles.Count);
 
@@ -38,13 +39,19 @@ namespace DotNetNuke.Build.Tasks
                                         ArgumentCustomization = args => args.Append("-SymbolPackageFormat snupkg"),
                                     };
 
-            // loop through each nuspec file and create the package
+            nuspecFiles -= noSymbolsNuspecFiles;
             foreach (var spec in nuspecFiles)
             {
-                var specPath = spec.ToString();
+                context.Information("Starting to pack: {0}", spec);
+                context.NuGetPack(spec.FullPath, nuGetPackSettings);
+            }
 
-                context.Information("Starting to pack: {0}", specPath);
-                context.NuGetPack(specPath, nuGetPackSettings);
+            nuGetPackSettings.Symbols = false;
+            nuGetPackSettings.ArgumentCustomization = null;
+            foreach (var spec in noSymbolsNuspecFiles)
+            {
+                context.Information("Starting to pack: {0}", spec);
+                context.NuGetPack(spec.FullPath, nuGetPackSettings);
             }
         }
     }


### PR DESCRIPTION
## Summary
We're currently producing ["legacy" symbols packages](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages) for NuGet, which is causing issues with automated pushing of NuGet packages (the ordering matters of whether you push the non-symbols or symbols package first and we're getting a conflict error).

This PR tells NuGet to produce the [newer symbols package format, `*.snupkg`](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg), which should resolve that issue.

I've had unrelated issues getting my build to finish locally, so this change still needs confirmation from the PR build.