### PR TITLE
Fix for #4566 in SiteSettingsController

### DIFF
--- a/DNN Platform/Website/admin/Security/PasswordReset.ascx
+++ b/DNN Platform/Website/admin/Security/PasswordReset.ascx
@@ -12,8 +12,8 @@
             <asp:RequiredFieldValidator ID="valUsername" CssClass="dnnFormMessage dnnFormError dnnRequired" runat="server" Display="Dynamic" ControlToValidate="txtUsername" />
         </div>
         <div class="dnnFormItem">
-            <asp:Panel ID="passwordContainer" runat="server" CssClass="password-strength-container">
-                <asp:TextBox ID="txtPassword" runat="server" TextMode="Password" size="12" MaxLength="39" AutoCompleteType="Disabled" CssClass="password-strength" />
+            <asp:Panel ID="passwordContainer" runat="server">
+                <asp:TextBox ID="txtPassword" runat="server" TextMode="Password" size="12" MaxLength="39" AutoCompleteType="Disabled" />
             </asp:Panel>
             <asp:RegularExpressionValidator ID="valPassword" CssClass="dnnFormMessage dnnFormError dnnRequired" runat="server" resourcekey="Password.Required" Display="Dynamic" ControlToValidate="txtPassword" ValidationExpression="[\w\W]{7,}" />
         </div>

--- a/DNN Platform/Website/admin/Security/PasswordReset.ascx.cs
+++ b/DNN Platform/Website/admin/Security/PasswordReset.ascx.cs
@@ -27,6 +27,8 @@ namespace DotNetNuke.Modules.Admin.Security
     using DotNetNuke.Web.UI.WebControls;
     using Microsoft.Extensions.DependencyInjection;
 
+    using Host = DotNetNuke.Entities.Host.Host;
+
     public partial class PasswordReset : UserModuleBase
     {
         private const int RedirectTimeout = 3000;
@@ -114,20 +116,24 @@ namespace DotNetNuke.Modules.Admin.Security
                 this.resetMessages.Visible = true;
             }
 
-            var options = new DnnPaswordStrengthOptions();
-            var optionsAsJsonString = Json.Serialize(options);
-            var script = string.Format(
-                "dnn.initializePasswordStrength('.{0}', {1});{2}",
-                "password-strength", optionsAsJsonString, Environment.NewLine);
+            if (Host.EnableStrengthMeter)
+            {
+                this.passwordContainer.CssClass = "password-strength-container";
+                this.txtPassword.CssClass = "password-strength";
 
-            if (ScriptManager.GetCurrent(this.Page) != null)
-            {
-                // respect MS AJAX
-                ScriptManager.RegisterStartupScript(this.Page, this.GetType(), "PasswordStrength", script, true);
-            }
-            else
-            {
-                this.Page.ClientScript.RegisterStartupScript(this.GetType(), "PasswordStrength", script, true);
+                var options = new DnnPaswordStrengthOptions();
+                var optionsAsJsonString = Json.Serialize(options);
+                var script = string.Format("dnn.initializePasswordStrength('.{0}', {1});{2}", "password-strength", optionsAsJsonString, Environment.NewLine);
+
+                if (ScriptManager.GetCurrent(this.Page) != null)
+                {
+                    // respect MS AJAX
+                    ScriptManager.RegisterStartupScript(this.Page, this.GetType(), "PasswordStrength", script, true);
+                }
+                else
+                {
+                    this.Page.ClientScript.RegisterStartupScript(this.GetType(), "PasswordStrength", script, true);
+                }
             }
 
             var confirmPasswordOptions = new DnnConfirmPasswordOptions()
@@ -139,17 +145,17 @@ namespace DotNetNuke.Modules.Admin.Security
                 MatchedCssClass = "matched",
             };
 
-            optionsAsJsonString = Json.Serialize(confirmPasswordOptions);
-            script = string.Format("dnn.initializePasswordComparer({0});{1}", optionsAsJsonString, Environment.NewLine);
+            var confirmOptionsAsJsonString = Json.Serialize(confirmPasswordOptions);
+            var confirmScript = string.Format("dnn.initializePasswordComparer({0});{1}", confirmOptionsAsJsonString, Environment.NewLine);
 
             if (ScriptManager.GetCurrent(this.Page) != null)
             {
                 // respect MS AJAX
-                ScriptManager.RegisterStartupScript(this.Page, this.GetType(), "ConfirmPassword", script, true);
+                ScriptManager.RegisterStartupScript(this.Page, this.GetType(), "ConfirmPassword", confirmScript, true);
             }
             else
             {
-                this.Page.ClientScript.RegisterStartupScript(this.GetType(), "ConfirmPassword", script, true);
+                this.Page.ClientScript.RegisterStartupScript(this.GetType(), "ConfirmPassword", confirmScript, true);
             }
         }
 

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
@@ -395,9 +395,9 @@ namespace Dnn.PersonaBar.SiteSettings.Services
                 portalInfo.PrivacyTabId = this.ValidateTabId(request.PrivacyTabId, pid);
                 PortalController.Instance.UpdatePortalInfo(portalInfo);
 
-                PortalController.UpdatePortalSetting(pid, "Redirect_AfterLogin", request.RedirectAfterLoginTabId.ToString(), false, cultureCode);
-                PortalController.UpdatePortalSetting(pid, "Redirect_AfterLogout", request.RedirectAfterLogoutTabId.ToString(), false, cultureCode);
-                PortalController.UpdatePortalSetting(pid, "Redirect_AfterRegistration", request.RedirectAfterRegistrationTabId.ToString(), false, cultureCode);
+                PortalController.UpdatePortalSetting(pid, "Redirect_AfterLogin", this.ValidateTabId(request.RedirectAfterLoginTabId, pid).ToString(), false, cultureCode);
+                PortalController.UpdatePortalSetting(pid, "Redirect_AfterLogout", this.ValidateTabId(request.RedirectAfterLogoutTabId, pid).ToString(), false, cultureCode);
+                PortalController.UpdatePortalSetting(pid, "Redirect_AfterRegistration", this.ValidateTabId(request.RedirectAfterRegistrationTabId, pid).ToString(), false, cultureCode);
                 PortalController.UpdatePortalSetting(pid, "PageHeadText", string.IsNullOrEmpty(request.PageHeadText) ? "false" : request.PageHeadText);
 
                 return this.Request.CreateResponse(HttpStatusCode.OK, new { Success = true });


### PR DESCRIPTION
Fix for #4566.  

## Summary
ValidateTabId used for the 3 redirect settings, "Redirect_AfterLogin", "Redirect_AfterLogout" and "Redirect_AfterRegistration".
