### PR TITLE
add email to password sent message for error tracing, fixes #4605

### DIFF
--- a/DNN Platform/Website/admin/Security/App_LocalResources/SendPassword.ascx.resx
+++ b/DNN Platform/Website/admin/Security/App_LocalResources/SendPassword.ascx.resx
@@ -136,7 +136,7 @@
     <value>This account has been locked out after too many unsuccessful login attempts.  Please wait 10 minutes before trying to login again.  If you have forgotten your password, please try the Password Reminder option before contacting an Administrator.</value>
   </data>
   <data name="PasswordSent.Text" xml:space="preserve">
-    <value>If the details entered were correct, you should receive an email message shortly with a link to reset your password.</value>
+    <value>If the details entered for {0} were correct, you should receive an email message shortly with a link to reset your password.</value>
   </data>
   <data name="EnterUsername.Text" xml:space="preserve">
     <value>Enter your user name.</value>

--- a/DNN Platform/Website/admin/Security/SendPassword.ascx.cs
+++ b/DNN Platform/Website/admin/Security/SendPassword.ascx.cs
@@ -277,6 +277,9 @@ namespace DotNetNuke.Modules.Admin.Security
                             message = Localization.GetString("MultipleUsers", this.LocalResourceFile);
                         }
 
+                        // no user found so include email or username to help explain why
+                        message += " " + this.txtEmail.Text ?? this.txtUsername.Text;
+
                         canSend = false;
                     }
 

--- a/DNN Platform/Website/admin/Security/SendPassword.ascx.cs
+++ b/DNN Platform/Website/admin/Security/SendPassword.ascx.cs
@@ -198,8 +198,9 @@ namespace DotNetNuke.Modules.Admin.Security
         /// </remarks>
         protected void OnSendPasswordClick(object sender, EventArgs e)
         {
-            // pretty much alwasy display the same message to avoid hinting on the existance of a user name
-            var message = Localization.GetString("PasswordSent", this.LocalResourceFile);
+            // pretty much always display the same message to avoid hinting on the existance of a user name
+            var input = string.IsNullOrEmpty(this.txtUsername.Text) ? this.txtEmail.Text : this.txtUsername.Text;
+            var message = string.Format(Localization.GetString("PasswordSent", this.LocalResourceFile), input);
             var moduleMessageType = ModuleMessage.ModuleMessageType.GreenSuccess;
             var canSend = true;
 
@@ -276,9 +277,6 @@ namespace DotNetNuke.Modules.Admin.Security
                         {
                             message = Localization.GetString("MultipleUsers", this.LocalResourceFile);
                         }
-
-                        // no user found so include email or username to help explain why
-                        message += " " + this.txtEmail.Text ?? this.txtUsername.Text;
 
                         canSend = false;
                     }


### PR DESCRIPTION
#4605

## Summary
Includes the email address or username in the password reset message for better visibility into PASSWORD_SENT_FAILURE events.