### PR TITLE
Fix for #4654: Unable to Upload File into Assets On Turkish Localization

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/FileUploadController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/FileUploadController.cs
@@ -343,7 +343,7 @@ namespace DotNetNuke.Web.InternalServices
                     foreach (var item in provider.Contents)
                     {
                         var name = item.Headers.ContentDisposition.Name;
-                        switch (name.ToUpper())
+                        switch (name.ToUpperInvariant())
                         {
                             case "\"FOLDER\"":
                                 folder = item.ReadAsStringAsync().Result ?? string.Empty;

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Mocks/MockComponentProvider.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Mocks/MockComponentProvider.cs
@@ -103,6 +103,11 @@ namespace DotNetNuke.Tests.Utilities.Mocks
             return CreateNew<RoleProvider>();
         }
 
+        public static Mock<IPortalController> CreatePortalController()
+        {
+            return CreateNew<IPortalController>();
+        }
+
         public static void ResetContainer()
         {
             ComponentFactory.Container = new SimpleContainer();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
@@ -108,6 +108,7 @@
     <Compile Include="DependencyInjection\BuildUpExtensionsTests.cs" />
     <Compile Include="DependencyInjection\BuildUpExtensions_SampleFilters.cs" />
     <Compile Include="InternalServices\FakeModuleCrawlerController.cs" />
+    <Compile Include="InternalServices\FileUploadControllerTests.cs" />
     <Compile Include="InternalServices\SearchServiceControllerTests.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -138,6 +139,10 @@
     <ProjectReference Include="..\..\DotNetNuke.DependencyInjection\DotNetNuke.DependencyInjection.csproj">
       <Project>{0FCA217A-5F9A-4F5B-A31B-86D64AE65198}</Project>
       <Name>DotNetNuke.DependencyInjection</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
+      <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>
+      <Name>DotNetNuke.Instrumentation</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\DotNetNuke.Log4net\DotNetNuke.Log4Net.csproj">
       <Project>{04f77171-0634-46e0-a95e-d7477c88712e}</Project>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -55,9 +55,9 @@
         }
 
         [Test]
+        [SetCulture("tr-TR")]
         public async Task UploadFromLocal_ShouldUploadFile_WithTrCultureAsync()
         {
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
             var formDataContent = new MultipartFormDataContent();
             formDataContent.Add(new StringContent("Hello World!"), "\"postfile\"", "\"testing\"");
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -11,11 +11,9 @@
 
     using Common;
     using Common.Lists;
-    using Common.Utilities;
 
     using Data;
     using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Instrumentation;
     using DotNetNuke.Web.InternalServices;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -33,9 +31,7 @@
     [TestFixture]
     public class FileUploadControllerTests
     {
-        private Mock<ILoggerSource> _mockLoggerSource = new Mock<ILoggerSource>();
         private Mock<DataProvider> _mockDataProvider;
-        private Mock<ICBO> _mockCBO = new Mock<ICBO>();
         private FileUploadController _testInstance;
         private Mock<CachingProvider> _mockCachingProvider;
         private Mock<IPortalController> _mockPortalController;
@@ -44,21 +40,14 @@
         [SetUp]
         public void SetUp()
         {
-            LoggerSource.SetTestableInstance(this._mockLoggerSource.Object);
-            CBO.SetTestableInstance(this._mockCBO.Object);
+
             this.SetupDataProvider();
+
             this.SetupCachingProvider();
+
             this.SetupPortalSettings();
             this.SetupServiceProvider();
             this.SetupSynchronizationContext();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            PortalController.ClearInstance();
-            Globals.DependencyProvider = null;
-            CBO.ClearInstance();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace DotNetNuke.Tests.Web.InternalServices
 {
     using System.Data;
-    using System.Globalization;
     using System.Linq;
     using System.Net.Http;
     using System.Threading;
@@ -54,6 +53,7 @@
             this.SetupSynchronizationContext();
         }
 
+        [TearDown]
         public void TearDown()
         {
             PortalController.ClearInstance();
@@ -101,7 +101,7 @@
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddTransient<IApplicationStatusInfo>(
-                container => new Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            container => new Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
             serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
             serviceCollection.AddTransient(container => Mock.Of<IEventLogger>());
             Globals.DependencyProvider = serviceCollection.BuildServiceProvider();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -54,6 +54,13 @@
             this.SetupSynchronizationContext();
         }
 
+        public void TearDown()
+        {
+            PortalController.ClearInstance();
+            Globals.DependencyProvider = null;
+            CBO.ClearInstance();
+        }
+
         [Test]
         [SetCulture("tr-TR")]
         public async Task UploadFromLocal_ShouldUploadFile_WithTrCultureAsync()
@@ -64,7 +71,7 @@
             var request = new HttpRequestMessage();
             request.Content = formDataContent;
             this._testInstance.Request = request;
-            await this._testInstance.UploadFromLocal();
+            await this._testInstance.UploadFromLocal(-1);
 
             Assert.IsTrue(_synchronizationContext.IsUploadFileCalled());
         }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -1,0 +1,129 @@
+﻿namespace DotNetNuke.Tests.Web.InternalServices
+{
+    using System.Data;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Abstractions;
+    using Abstractions.Application;
+    using Abstractions.Logging;
+
+    using Common;
+    using Common.Lists;
+    using Common.Utilities;
+
+    using Data;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Instrumentation;
+    using DotNetNuke.Web.InternalServices;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using Services.Cache;
+
+    using Utilities.Mocks;
+    /// <summary>
+    /// Tests FileUploadController methods
+    /// </summary>
+    [TestFixture]
+    public class FileUploadControllerTests
+    {
+        private Mock<ILoggerSource> _mockLoggerSource = new Mock<ILoggerSource>();
+        private Mock<DataProvider> _mockDataProvider;
+        private Mock<ICBO> _mockCBO = new Mock<ICBO>();
+        private FileUploadController _testInstance;
+        private Mock<CachingProvider> _mockCachingProvider;
+        private Mock<IPortalController> _mockPortalController;
+        private TestSynchronizationContext _synchronizationContext = new TestSynchronizationContext();
+
+        [SetUp]
+        public void SetUp()
+        {
+            LoggerSource.SetTestableInstance(this._mockLoggerSource.Object);
+            CBO.SetTestableInstance(this._mockCBO.Object);
+            this.SetupDataProvider();
+            this.SetupCachingProvider();
+            this.SetupPortalSettings();
+            this.SetupServiceProvider();
+            this.SetupSynchronizationContext();
+        }
+
+        [Test]
+        public async Task UploadFromLocal_ShouldUploadFile_WithTrCultureAsync()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+            var formDataContent = new MultipartFormDataContent();
+            formDataContent.Add(new StringContent("Hello World!"), "\"postfile\"", "\"testing\"");
+
+            var request = new HttpRequestMessage();
+            request.Content = formDataContent;
+            this._testInstance.Request = request;
+            await this._testInstance.UploadFromLocal();
+
+            Assert.IsTrue(_synchronizationContext.IsUploadFileCalled());
+        }
+
+        private void SetupPortalSettings()
+        {
+            _mockPortalController = MockComponentProvider.CreatePortalController();
+            _mockPortalController.Setup(x => x.GetCurrentPortalSettings()).Returns(new PortalSettings() { PortalId = 0 });
+            PortalController.SetTestableInstance(_mockPortalController.Object);
+        }
+
+        private void SetupDataProvider()
+        {
+            this._mockDataProvider = MockComponentProvider.CreateDataProvider();
+            this._mockDataProvider.Setup(x => x.GetListEntriesByListName("ImageTypes", string.Empty, It.IsAny<int>()))
+                .Returns(Mock.Of<IDataReader>());
+        }
+
+        private void SetupCachingProvider()
+        {
+            this._mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
+            this._mockCachingProvider.Setup(x => x.GetItem(It.IsAny<string>()))
+                .Returns(Enumerable.Empty<ListEntryInfo>());
+        }
+
+        private void SetupServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IApplicationStatusInfo>(
+                container => new Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
+            serviceCollection.AddTransient(container => Mock.Of<IEventLogger>());
+            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        }
+
+        private void SetupSynchronizationContext()
+        {
+            _synchronizationContext = new TestSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
+            this._testInstance = new FileUploadController();
+        }
+
+        private class TestSynchronizationContext : SynchronizationContext
+        {
+            private bool isUploadFileCalled;
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                d(state);
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                isUploadFileCalled = true;
+            }
+
+            public bool IsUploadFileCalled()
+            {
+                return isUploadFileCalled;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Request content is compared using culture dependent string comparison

The string comparison code breaks when culture is “tr-TR”. 
The fileName parameter does not get set and UploadFile() helper method does not get called.
Fixed by changing the comparison to invariant culture.
Added unit tests covering the code changes.

Fixes #4654