### PR TITLE
Update BreadCrumb.ascx.cs

### DIFF
--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -175,7 +175,7 @@ namespace DotNetNuke.UI.Skins.Controls
                 // Is this tab disabled? If so, only render a span
                 if (tab.DisableLink)
                 {
-                    this._breadcrumb.Append("<span class=\"" + this._cssClass + "\">" + tabName + "</span>");
+                    this._breadcrumb.Append("<span><span class=\"" + this._cssClass + "\">" + tabName + "</span></span>");
                 }
                 else
                 {

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -32,7 +32,7 @@ namespace DotNetNuke.UI.Skins.Controls
         public BreadCrumb()
         {
             this._navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
-            this.LegacyMode = true;
+            this.CleanerMarkup = true;
         }
 
         public int ProfileUserId

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -32,6 +32,7 @@ namespace DotNetNuke.UI.Skins.Controls
         public BreadCrumb()
         {
             this._navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.LegacyMode = true;
         }
 
         public int ProfileUserId
@@ -90,6 +91,11 @@ namespace DotNetNuke.UI.Skins.Controls
 
         // Do not show when there is no breadcrumb (only has current tab)
         public bool HideWithNoBreadCrumb { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether set this to false in the skin to take advantage of the enhanced markup.
+        /// </summary>
+        public bool LegacyMode { get; set; }
 
         protected override void OnLoad(EventArgs e)
         {
@@ -175,7 +181,10 @@ namespace DotNetNuke.UI.Skins.Controls
                 // Is this tab disabled? If so, only render a span
                 if (tab.DisableLink)
                 {
-                    this._breadcrumb.Append("<span><span class=\"" + this._cssClass + "\">" + tabName + "</span></span>");
+                    if (this.LegacyMode)
+                        this._breadcrumb.Append("<span><span class=\"" + this._cssClass + "\">" + tabName + "</span></span>");
+                    else
+                        this._breadcrumb.Append("<span class=\"" + this._cssClass + "\">" + tabName + "</span>");
                 }
                 else
                 {

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -93,9 +93,9 @@ namespace DotNetNuke.UI.Skins.Controls
         public bool HideWithNoBreadCrumb { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether set this to false in the skin to take advantage of the enhanced markup.
+        /// Gets or sets a value indicating whether to take advantage of the enhanced markup (remove extra wrapping elements).
         /// </summary>
-        public bool LegacyMode { get; set; }
+        public bool CleanerMarkup { get; set; }
 
         protected override void OnLoad(EventArgs e)
         {

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -181,10 +181,14 @@ namespace DotNetNuke.UI.Skins.Controls
                 // Is this tab disabled? If so, only render a span
                 if (tab.DisableLink)
                 {
-                    if (this.LegacyMode)
-                        this._breadcrumb.Append("<span><span class=\"" + this._cssClass + "\">" + tabName + "</span></span>");
-                    else
+                    if (this.CleanerMarkup)
+                    {
                         this._breadcrumb.Append("<span class=\"" + this._cssClass + "\">" + tabName + "</span>");
+                    }
+                    else
+                    {
+                        this._breadcrumb.Append("<span><span class=\"" + this._cssClass + "\">" + tabName + "</span></span>");
+                    }
                 }
                 else
                 {

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -172,9 +172,6 @@ namespace DotNetNuke.UI.Skins.Controls
                     tabUrl = this._navigationManager.NavigateURL(tab.TabID, string.Empty, "GroupId=" + this.GroupId);
                 }
 
-                // Begin breadcrumb
-                this._breadcrumb.Append("<span itemprop=\"itemListElement\" itemscope itemtype=\"http://schema.org/ListItem\">");
-
                 // Is this tab disabled? If so, only render a span
                 if (tab.DisableLink)
                 {

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -32,7 +32,7 @@ namespace DotNetNuke.UI.Skins.Controls
         public BreadCrumb()
         {
             this._navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
-            this.CleanerMarkup = true;
+            this.CleanerMarkup = false;
         }
 
         public int ProfileUserId

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -175,18 +175,19 @@ namespace DotNetNuke.UI.Skins.Controls
                 // Begin breadcrumb
                 this._breadcrumb.Append("<span itemprop=\"itemListElement\" itemscope itemtype=\"http://schema.org/ListItem\">");
 
-                // Is this tab disabled? If so, only render the text
+                // Is this tab disabled? If so, only render a span
                 if (tab.DisableLink)
                 {
-                    this._breadcrumb.Append("<span class=\"" + this._cssClass + "\" itemprop=\"name\">" + tabName + "</span>");
+                    this._breadcrumb.Append("<span class=\"" + this._cssClass + "\">" + tabName + "</span>");
                 }
                 else
                 {
+                    // An enabled page, render the breadcrumb
+                    this._breadcrumb.Append("<span itemprop=\"itemListElement\" itemscope itemtype=\"http://schema.org/ListItem\">");
                     this._breadcrumb.Append("<a href=\"" + tabUrl + "\" class=\"" + this._cssClass + "\" itemprop=\"item\"><span itemprop=\"name\">" + tabName + "</span></a>");
+                    this._breadcrumb.Append("<meta itemprop=\"position\" content=\"" + position++ + "\" />"); // Notice we post-increment the position variable
+                    this._breadcrumb.Append("</span>");
                 }
-
-                this._breadcrumb.Append("<meta itemprop=\"position\" content=\"" + position++ + "\" />"); // Notice we post-increment the position variable
-                this._breadcrumb.Append("</span>");
             }
 
             this._breadcrumb.Append("</span>"); // End of BreadcrumbList

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.xml
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.xml
@@ -23,4 +23,10 @@
     <Help>Defines whether to use the page Name or the page Title</Help>
     <Value>True,False</Value>
   </Setting>
+  <Setting>
+    <Name>LegacyMode</Name>
+    <Type>Boolean</Type>
+    <Help>Defines whether to wrap span rendered for disabled pages in additional span for skin CSS compatibility (True) or not (False)</Help>
+    <Value>True,False</Value>
+  </Setting>
 </Settings>

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.xml
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.xml
@@ -24,9 +24,9 @@
     <Value>True,False</Value>
   </Setting>
   <Setting>
-    <Name>LegacyMode</Name>
+    <Name>CleanerMarkup</Name>
     <Type>Boolean</Type>
-    <Help>Defines whether to wrap span rendered for disabled pages in additional span for skin CSS compatibility (True) or not (False)</Help>
+    <Help>Defines whether to take advantage of the enhanced markup (remove extra wrapping elements).)</Help>
     <Value>True,False</Value>
   </Setting>
 </Settings>


### PR DESCRIPTION
Invalid Breadcrumb Metadata for Disabled Pages Fixes #4667

Google Search Console complains about invalid metadata for disabled pages (Missing field "item"). The metadata for disabled pages should not be rendered as an "itemListElement". "itemListElement" lists need to have at least one "item", but there is no item getting rendered in case the page is disabled.

Issue https://github.com/dnnsoftware/Dnn.Platform/issues/4667