### PR TITLE
Clarified text on module anchor feature

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteSettings/App_LocalResources/SiteSettings.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteSettings/App_LocalResources/SiteSettings.resx
@@ -1480,10 +1480,10 @@
     <value>Enable Popups</value>
   </data>
   <data name="plInjectModuleHyperLink.Help" xml:space="preserve">
-    <value>When switched on DNN will insert a hyperlink at the start of each module with a name of the module id.</value>
+    <value>When switched on DNN will insert an anchor at the start of each module with the module id for its name.</value>
   </data>
   <data name="plInjectModuleHyperLink.Text" xml:space="preserve">
-    <value>Inject Module Hyperlink</value>
+    <value>Inject Module Anchor</value>
   </data>
   <data name="plInlineEditorEnabled.Help" xml:space="preserve">
     <value>When switched on DNN allows editors to edit HTML module content directly on the page instead of having to go through the edit control.</value>


### PR DESCRIPTION
The feature does not create a hyperlink (which would have an href parameter), when an `<a>` tag has no href, it is called an anchor (hence the `<a>`). Also the phrasing was a bit unclear and this new way to phrase it explains the feature a little better.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
