### PR TITLE
Issue-4684 - Exporting a page after changing a module's order within the same pane doesn't reflect in imported site

### DIFF
--- a/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
@@ -983,7 +983,7 @@ namespace Dnn.ExportImport.Components.Services
                         {
                             var localExpModule = localExportModules.FirstOrDefault(
                                 m => m.ModuleID == local.ModuleID && m.FriendlyName == local.ModuleDefinition.FriendlyName);
-                            var hasPaneChanged = local.PaneName != other.PaneName;
+                            var hasPaneChanged = local.PaneName != other.PaneName || local.ModuleOrder != other.ModuleOrder;
 
                             if (localExpModule == null || hasPaneChanged)
                             {


### PR DESCRIPTION
Fixes #4684 

## Summary
The bug was very similar to #4143 and the code to check the order of modules is added on top of the fix provided for #4143's PR (#4144).

