### PR TITLE
Fix for #4672: Cache-Setting 'NoCaching' not saved

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Servers.Web/src/components/Tabs/Performance.jsx
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/src/components/Tabs/Performance.jsx
@@ -72,7 +72,7 @@ class Performance extends Component {
         let value = event;
         if (event && event.value !== undefined) {
             value = event.value;
-        } else if (event && event.target && event.target.value) {
+        } else if (event && event.target && event.target.value !== undefined) {
             value = event.target.value;
         }
 

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/src/components/Tabs/Performance.jsx
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/src/components/Tabs/Performance.jsx
@@ -70,7 +70,7 @@ class Performance extends Component {
 
     onChangeField(key, event) {
         let value = event;
-        if (event && event.value) {
+        if (event && event.value !== undefined) {
             value = event.value;
         } else if (event && event.target && event.target.value) {
             value = event.target.value;


### PR DESCRIPTION
## Summary
Fixed onchange event handler for 'Cache-Settings' dropdown 

UI was not sending the request in the correct format to UpdatePerformanceSettings() API, when "No Caching" value is selected.

The root cause being in the Performance component's onChangeField(). The value selected in the 'Cache-Settings' dropdown was not validated correctly.

Fixed code in the if clause. When "No Caching" is selected, "event.value" is "0". The updated code makes sure that if function evaluates to true when caching value is "0". So API request sends correct value for "CacheSetting" parameter.

Fixes #4672