### PR TITLE
Fixed an issue where UserInfo.UserName was wrong with "Use email as username" setting turned on

### DIFF
--- a/DNN Platform/Library/Entities/Users/UserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/UserInfo.cs
@@ -421,7 +421,12 @@ namespace DotNetNuke.Entities.Users
                         return PropertyAccess.ContentLocked;
                     }
 
-                    return PropertyAccess.FormatString(this.Username, format);
+                    var settings = PortalController.Instance.GetPortalSettings(this.PortalID);
+                    var regSettings = new RegistrationSettings(settings);
+
+                    return regSettings.UseEmailAsUserName ?
+                        PropertyAccess.FormatString(this.Email, format) :
+                        PropertyAccess.FormatString(this.Username, format);
                 case "fullname": // fullname is obsolete, it will return DisplayName
                     if (internScope < Scope.Configuration)
                     {


### PR DESCRIPTION
When an email goes out that uses the [user:username] property, it doesn't properly fill in the username if the site is set to use email as username. This PR fixes that.