### PR TITLE
Deprecating DisplayCopyright Host Setting

### DIFF
--- a/DNN Platform/Library/Entities/Host/Host.cs
+++ b/DNN Platform/Library/Entities/Host/Host.cs
@@ -356,6 +356,7 @@ namespace DotNetNuke.Entities.Host
         ///   Defaults to True.
         /// </remarks>
         /// -----------------------------------------------------------------------------
+        [Obsolete("Deprecated in 9.9.2. Scheduled for removal in v11.0.0")]
         public static bool DisplayCopyright
         {
             get


### PR DESCRIPTION
Fixes #3526

## Summary
Deprecates the Host Setting property DisplayCopyright so that it can be removed in v11

## How to Test
Nothing to really test here. Minimal, low-risk change

