### PR TITLE
Removed the logo from the Under Construction page

### DIFF
--- a/DNN Platform/Website/Install/UnderConstruction.template.htm
+++ b/DNN Platform/Website/Install/UnderConstruction.template.htm
@@ -4,7 +4,6 @@
     <link rel="stylesheet" type="text/css" href="Install.css">
 </head>
 <body bottommargin="5" leftmargin="5" topmargin="5" rightmargin="5" marginwidth="0" marginheight="0">
-    <img src="..\images\branding\DNN_logo.png" border="0" alt=""/>
     <h1 align="center">&nbsp;</h1>
     <h1 align="center">&nbsp;</h1>
     <h1 align="center">This site is currently Unavailable</h1>


### PR DESCRIPTION
Fixes #4650

## Summary
Removed the logo from the UnderConstruction page

## How to Test

- Start with a previous version of DNN prior to the current release
- Once installed/setup, unzip the DNN upgrade package in the website root
- Before running the upgrade, update the following keys to false in the web.config, 
```
<add key="AutoUpgrade" value="false" />
<add key="UseInstallWizard" value="false" />
```
- Navigate to the homepage of your DNN Install
- This will trigger the UnderConstruction page to be displayed. 
- You should not see a logo displayed on the page. 
   ![image](https://user-images.githubusercontent.com/13650025/123451081-607f2000-d5ab-11eb-8c4d-e29ad753ce35.png)
 
