### PR TITLE
Added support for absolute and relative URLs

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1226,7 +1226,8 @@ namespace Dnn.PersonaBar.Pages.Components
 
             if (url.StartsWith("//"))
             {
-                return Globals.AddHTTP(url.Remove(0, 2));
+                return url;
+
             }
 
             if (url.ToLower().StartsWith("http"))

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1230,7 +1230,8 @@ namespace Dnn.PersonaBar.Pages.Components
 
             }
 
-            if (url.ToLower().StartsWith("http"))
+            if (url.IndexOf("://") != -1)
+
             {
                 return Globals.AddHTTP(url);
             }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1236,10 +1236,6 @@ namespace Dnn.PersonaBar.Pages.Components
                 return Globals.AddHTTP(url);
             }
 
-            if (!url.StartsWith("/"))
-            {
-                return "/" + url;
-            }
 
             return url;
         }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1219,7 +1219,27 @@ namespace Dnn.PersonaBar.Pages.Components
                 return null;
             }
 
-            return url.ToLower() == "http://" ? "" : Globals.AddHTTP(url);
+            if (url.ToLower() == "http://")
+            {
+                return string.Empty;
+            }
+
+            if (url.StartsWith("//"))
+            {
+                return Globals.AddHTTP(url.Remove(0, 2));
+            }
+
+            if (url.ToLower().StartsWith("http"))
+            {
+                return Globals.AddHTTP(url);
+            }
+
+            if (!url.StartsWith("/"))
+            {
+                return "/" + url;
+            }
+
+            return url;
         }
 
         private static Func<RolePermission, bool> NoLocked()

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -382,10 +382,10 @@
     <value>Redirect to an existing page on your site.</value>
   </data>
   <data name="ExternalUrl.Text" xml:space="preserve">
-    <value>External Url</value>
+    <value>URL</value>
   </data>
   <data name="ExternalUrlTooltip.Text" xml:space="preserve">
-    <value>Redirect to an External URL Resource.</value>
+    <value>Redirect to an absolute or relative URL.</value>
   </data>
   <data name="PermanentRedirect.Text" xml:space="preserve">
     <value>Permanent Redirect</value>
@@ -1691,7 +1691,7 @@
     <value>Wrong Format</value>
   </data>
   <data name="ExternalRedirectionUrlRequired.Text" xml:space="preserve">
-    <value>The URL is required.</value>
+    <value>An absolute or relative URL is required.</value>
   </data>
   <data name="NoPermissionViewRedirectPage.Text" xml:space="preserve">
     <value>You don't have permission to view the redirect page.</value>


### PR DESCRIPTION
Resolves #3111

## Summary
URL page types now support absolute and relative URLs.  Furthermore, better handling has been added for URLs that begin with `//` or have not including a leading `/` (e.g., `PageName`, `PageName#AnchorName`).