### PR TITLE
Fix for #4733: Profile image for anonymous user is not displayed.

### DIFF
--- a/DNN Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs
@@ -260,7 +260,8 @@ namespace DotNetNuke.Services.GeneratedImage
             // Handle Server cache
             if (this.EnableServerCache)
             {
-                if (isProfilePic && !this.IsPicVisibleToCurrentUser(userId))
+                var isAnonymousUser = userId <= 0 ? true : false;
+                if (isProfilePic && !isAnonymousUser && !this.IsPicVisibleToCurrentUser(userId))
                 {
                     string message = "Not allowed to see profile picture";
 


### PR DESCRIPTION
## Summary
Added an additional check before calling IsPicVisibleToCurrentUser(userId)

For anonymous user, userId is invalid i.e. less than or equal to zero. For invalid user, IsPicVisibleToCurrentUser() returns false and 403 code is sent to UI.

The additional check of isAnonymousUser, avoids the call to IsPicVisibleToCurrentUser() and image is returned for the anonymous user.
 
Fixes #4733