### PR TITLE
Fix some conflicts with ASP.NET dependencies

### DIFF
--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -37,6 +37,8 @@
     "/bin/System.Web.WebPages.dll",
     "/bin/System.Web.WebPages.Deployment.dll",
     "/bin/System.Web.WebPages.Razor.dll",
+    "/bin/WebMatrix.Data.dll",
+    "/bin/WebMatrix.WebData.dll",
     "/Install/Module/DNNCE_Website.Deprecated_*_Install.zip"
   ],
   "installInclude": ["/Install/InstallWizard.aspx.cs"],

--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -30,6 +30,7 @@
     "/bin/System.Net.Http.Formatting.dll",
     "/bin/System.Web.Http.dll",
     "/bin/System.Web.Http.WebHost.dll",
+    "/bin/DotNetNuke.Web.Mvc.dll",
     "/bin/System.Web.Mvc.dll",
     "/bin/System.Web.Helpers.dll",
     "/bin/Microsoft.Web.Helpers.dll",

--- a/DNN Platform/Components/Microsoft.AspNetMvc/Microsoft.AspNetMvc.dnn
+++ b/DNN Platform/Components/Microsoft.AspNetMvc/Microsoft.AspNetMvc.dnn
@@ -22,6 +22,27 @@
             </assembly>
           </assemblies>
         </component>
+        <component type="Config">
+          <config>
+            <configFile>web.config</configFile>
+            <install>
+              <configuration>
+                <nodes>
+                  <node path="/configuration/system.webServer/modules" action="update" key="name" collision="ignore">
+                    <add name="MVCModules" type="DotNetNuke.Web.Mvc.MvcHttpModule, DotNetNuke.Web.Mvc" preCondition="managedHandler" />
+                  </node>
+                </nodes>
+              </configuration>
+            </install>
+            <uninstall>
+              <configuration>
+                <nodes>
+                  <node path="/configuration/system.webServer/modules/add[@name='MVCModules']" action="remove" />
+                </nodes>
+              </configuration>
+            </uninstall>
+          </config>
+        </component>
       </components>
     </package>
   </packages>

--- a/DNN Platform/Components/Microsoft.AspNetMvc/Microsoft.AspNetMvc.dnn
+++ b/DNN Platform/Components/Microsoft.AspNetMvc/Microsoft.AspNetMvc.dnn
@@ -17,6 +17,11 @@
           <assemblies>
             <assembly>
               <path>bin</path>
+              <name>DotNetNuke.Web.Mvc.dll</name>
+              <version>9.10.0</version>
+            </assembly>
+            <assembly>
+              <path>bin</path>
               <name>System.Web.Mvc.dll</name>
               <version>5.2.7</version>
             </assembly>

--- a/DNN Platform/Components/Microsoft.AspNetWebPages/Microsoft.AspNetWebPages.dnn
+++ b/DNN Platform/Components/Microsoft.AspNetWebPages/Microsoft.AspNetWebPages.dnn
@@ -45,6 +45,16 @@
               <name>System.Web.WebPages.Razor.dll</name>
               <version>3.2.7</version>
             </assembly>
+            <assembly>
+              <path>bin</path>
+              <name>WebMatrix.Data.dll</name>
+              <version>3.2.7</version>
+            </assembly>
+            <assembly>
+              <path>bin</path>
+              <name>WebMatrix.WebData.dll</name>
+              <version>3.2.7</version>
+            </assembly>
           </assemblies>
         </component>
       </components>

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -59,9 +59,9 @@
         <add key="UsePortNumber" value="true" /> -->
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
-    <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
     <add key="PreserveLoginUrl" value="true" />
-    <add key="loginUrl" value="~/Login.aspx" />
+	  <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />
@@ -131,7 +131,7 @@
       </buildProviders>
       <assemblies>
         <add assembly="Microsoft.VisualBasic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
-        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+		<add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       </assemblies>
       <expressionBuilders >
         <add expressionPrefix="dnnLoc" type="DotNetNuke.Services.Localization.LocalizationExpressionBuilder, DotNetNuke"/>
@@ -149,7 +149,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false" requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.
@@ -158,7 +158,7 @@
     UTF-8 is recommended for complex languages
     -->
     <globalization culture="en-US" uiCulture="en" requestEncoding="UTF-8" responseEncoding="UTF-8" fileEncoding="UTF-8"/>
-    <!--<globalization culture="en-US" uiCulture="en" fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
+    <!--<globalization culture="en-US" uiCulture="en"  fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
     <!-- page level options -->
     <pages validateRequest="false" enableViewStateMac="true" enableEventValidation="true" viewStateEncryptionMode="Always">
       <namespaces>
@@ -187,13 +187,33 @@
       </controls>
     </pages>
     <!-- ASP.NET 2 Membership/Profile/Role and AnonymousAuthentication Providers -->
-    <!-- anonymousIdentification configuration: enabled="[true|false]"                              Feature is enabled? cookieName=".ASPXANONYMOUS"                         Cookie Name cookieTimeout="100000"                              Cookie Timeout in minutes cookiePath="/"                                      Cookie Path cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie cookieSlidingExpiration="[true|false]"              Reissue expiring cookies? cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
+    <!-- anonymousIdentification configuration:
+          enabled="[true|false]"                              Feature is enabled?
+          cookieName=".ASPXANONYMOUS"                         Cookie Name
+          cookieTimeout="100000"                              Cookie Timeout in minutes
+          cookiePath="/"                                      Cookie Path
+          cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie
+          cookieSlidingExpiration="[true|false]"              Reissue expiring cookies?
+          cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered
+          domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
     <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain=""/>
     <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
       <providers>
         <clear/>
-        <!-- Configuration for AspNetSqlMembershipProvider: connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals enablePasswordReset="[true|false]"          Should the provider support password resets requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A minRequiredPasswordLength="int"		        The minimum password length minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES) description="string"                        Description of what the provider does
+        <!-- Configuration for AspNetSqlMembershipProvider:
+                connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified
+                maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account
+                passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked
+                enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals
+                enablePasswordReset="[true|false]"          Should the provider support password resets
+                requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A
+                minRequiredPasswordLength="int"		        The minimum password length
+                minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters
+                applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path
+                requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified
+                passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES)
+                description="string"                        Description of what the provider does
                 -->
         <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="SiteSqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="0" requiresUniqueEmail="false" passwordFormat="Hashed" applicationName="DotNetNuke" description="Stores and retrieves membership data from the local Microsoft SQL Server database"/>
       </providers>

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -59,9 +59,9 @@
         <add key="UsePortNumber" value="true" /> -->
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
-	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+    <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
     <add key="PreserveLoginUrl" value="true" />
-	  <add key="loginUrl" value="~/Login.aspx" />
+    <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />
@@ -91,7 +91,6 @@
       <add name="Services" type="DotNetNuke.HttpModules.Services.ServicesModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <remove name="UrlRoutingModule-4.0" />
       <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler" />
-      <add name="MVCModules" type="DotNetNuke.Web.Mvc.MvcHttpModule, DotNetNuke.Web.Mvc" preCondition="managedHandler" />
       <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core" preCondition="managedHandler" />
       <add name="OutputCaching" type="DotNetNuke.HttpModules.OutputCaching.OutputCacheModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
     </modules>
@@ -132,7 +131,7 @@
       </buildProviders>
       <assemblies>
         <add assembly="Microsoft.VisualBasic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
-		<add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       </assemblies>
       <expressionBuilders >
         <add expressionPrefix="dnnLoc" type="DotNetNuke.Services.Localization.LocalizationExpressionBuilder, DotNetNuke"/>
@@ -150,7 +149,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false" requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.
@@ -159,7 +158,7 @@
     UTF-8 is recommended for complex languages
     -->
     <globalization culture="en-US" uiCulture="en" requestEncoding="UTF-8" responseEncoding="UTF-8" fileEncoding="UTF-8"/>
-    <!--<globalization culture="en-US" uiCulture="en"  fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
+    <!--<globalization culture="en-US" uiCulture="en" fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
     <!-- page level options -->
     <pages validateRequest="false" enableViewStateMac="true" enableEventValidation="true" viewStateEncryptionMode="Always">
       <namespaces>
@@ -188,33 +187,13 @@
       </controls>
     </pages>
     <!-- ASP.NET 2 Membership/Profile/Role and AnonymousAuthentication Providers -->
-    <!-- anonymousIdentification configuration:
-          enabled="[true|false]"                              Feature is enabled?
-          cookieName=".ASPXANONYMOUS"                         Cookie Name
-          cookieTimeout="100000"                              Cookie Timeout in minutes
-          cookiePath="/"                                      Cookie Path
-          cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie
-          cookieSlidingExpiration="[true|false]"              Reissue expiring cookies?
-          cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered
-          domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
+    <!-- anonymousIdentification configuration: enabled="[true|false]"                              Feature is enabled? cookieName=".ASPXANONYMOUS"                         Cookie Name cookieTimeout="100000"                              Cookie Timeout in minutes cookiePath="/"                                      Cookie Path cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie cookieSlidingExpiration="[true|false]"              Reissue expiring cookies? cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
     <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain=""/>
     <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
       <providers>
         <clear/>
-        <!-- Configuration for AspNetSqlMembershipProvider:
-                connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified
-                maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account
-                passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked
-                enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals
-                enablePasswordReset="[true|false]"          Should the provider support password resets
-                requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A
-                minRequiredPasswordLength="int"		        The minimum password length
-                minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters
-                applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path
-                requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified
-                passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES)
-                description="string"                        Description of what the provider does
+        <!-- Configuration for AspNetSqlMembershipProvider: connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals enablePasswordReset="[true|false]"          Should the provider support password resets requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A minRequiredPasswordLength="int"		        The minimum password length minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES) description="string"                        Description of what the provider does
                 -->
         <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="SiteSqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="0" requiresUniqueEmail="false" passwordFormat="Hashed" applicationName="DotNetNuke" description="Stores and retrieves membership data from the local Microsoft SQL Server database"/>
       </providers>

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -59,9 +59,9 @@
         <add key="UsePortNumber" value="true" /> -->
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
-    <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
     <add key="PreserveLoginUrl" value="true" />
-    <add key="loginUrl" value="~/Login.aspx" />
+	  <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />
@@ -132,7 +132,7 @@
       </buildProviders>
       <assemblies>
         <add assembly="Microsoft.VisualBasic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
-        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+		<add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       </assemblies>
       <expressionBuilders >
         <add expressionPrefix="dnnLoc" type="DotNetNuke.Services.Localization.LocalizationExpressionBuilder, DotNetNuke"/>
@@ -150,7 +150,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false" requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.
@@ -159,9 +159,9 @@
     UTF-8 is recommended for complex languages
     -->
     <globalization culture="en-US" uiCulture="en" requestEncoding="UTF-8" responseEncoding="UTF-8" fileEncoding="UTF-8"/>
-    <!--<globalization culture="en-US" uiCulture="en" fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
+    <!--<globalization culture="en-US" uiCulture="en"  fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
     <!-- page level options -->
-    <pages validateRequest="false" enableViewStateMac="true" enableEventValidation="true" viewStateEncryptionMode="Always">
+    <pages validateRequest="false" enableViewStateMac="true" enableEventValidation="true"  viewStateEncryptionMode="Always">
       <namespaces>
         <add namespace="System.ComponentModel"/>
         <add namespace="System.Data"/>
@@ -188,13 +188,33 @@
       </controls>
     </pages>
     <!-- ASP.NET 2 Membership/Profile/Role and AnonymousAuthentication Providers -->
-    <!-- anonymousIdentification configuration: enabled="[true|false]"                              Feature is enabled? cookieName=".ASPXANONYMOUS"                         Cookie Name cookieTimeout="100000"                              Cookie Timeout in minutes cookiePath="/"                                      Cookie Path cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie cookieSlidingExpiration="[true|false]"              Reissue expiring cookies? cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
+    <!-- anonymousIdentification configuration:
+          enabled="[true|false]"                              Feature is enabled?
+          cookieName=".ASPXANONYMOUS"                         Cookie Name
+          cookieTimeout="100000"                              Cookie Timeout in minutes
+          cookiePath="/"                                      Cookie Path
+          cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie
+          cookieSlidingExpiration="[true|false]"              Reissue expiring cookies?
+          cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered
+          domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
     <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain=""/>
     <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
       <providers>
         <clear/>
-        <!-- Configuration for AspNetSqlMembershipProvider: connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals enablePasswordReset="[true|false]"          Should the provider support password resets requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A minRequiredPasswordLength="int"		        The minimum password length minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES) description="string"                        Description of what the provider does
+        <!-- Configuration for AspNetSqlMembershipProvider:
+                connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified
+                maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account
+                passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked
+                enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals
+                enablePasswordReset="[true|false]"          Should the provider support password resets
+                requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A
+                minRequiredPasswordLength="int"		        The minimum password length
+                minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters
+                applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path
+                requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified
+                passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES)
+                description="string"                        Description of what the provider does
                 -->
         <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="SiteSqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="0" requiresUniqueEmail="false" passwordFormat="Hashed" applicationName="DotNetNuke" description="Stores and retrieves membership data from the local Microsoft SQL Server database"/>
       </providers>

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -59,9 +59,9 @@
         <add key="UsePortNumber" value="true" /> -->
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
-	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+    <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
     <add key="PreserveLoginUrl" value="true" />
-	  <add key="loginUrl" value="~/Login.aspx" />
+    <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />
@@ -91,7 +91,6 @@
       <add name="Services" type="DotNetNuke.HttpModules.Services.ServicesModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <remove name="UrlRoutingModule-4.0" />
       <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler" />
-      <add name="MVCModules" type="DotNetNuke.Web.Mvc.MvcHttpModule, DotNetNuke.Web.Mvc" preCondition="managedHandler" />
       <add name="ClientDependencyModule" type="ClientDependency.Core.Module.ClientDependencyModule, ClientDependency.Core" preCondition="managedHandler" />
       <add name="OutputCaching" type="DotNetNuke.HttpModules.OutputCaching.OutputCacheModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
     </modules>
@@ -133,7 +132,7 @@
       </buildProviders>
       <assemblies>
         <add assembly="Microsoft.VisualBasic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
-		<add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       </assemblies>
       <expressionBuilders >
         <add expressionPrefix="dnnLoc" type="DotNetNuke.Services.Localization.LocalizationExpressionBuilder, DotNetNuke"/>
@@ -151,7 +150,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false" requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.
@@ -160,9 +159,9 @@
     UTF-8 is recommended for complex languages
     -->
     <globalization culture="en-US" uiCulture="en" requestEncoding="UTF-8" responseEncoding="UTF-8" fileEncoding="UTF-8"/>
-    <!--<globalization culture="en-US" uiCulture="en"  fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
+    <!--<globalization culture="en-US" uiCulture="en" fileEncoding="iso-8859-1" requestEncoding="iso-8859-1" responseEncoding="iso-8859-1"/>-->
     <!-- page level options -->
-    <pages validateRequest="false" enableViewStateMac="true" enableEventValidation="true"  viewStateEncryptionMode="Always">
+    <pages validateRequest="false" enableViewStateMac="true" enableEventValidation="true" viewStateEncryptionMode="Always">
       <namespaces>
         <add namespace="System.ComponentModel"/>
         <add namespace="System.Data"/>
@@ -189,33 +188,13 @@
       </controls>
     </pages>
     <!-- ASP.NET 2 Membership/Profile/Role and AnonymousAuthentication Providers -->
-    <!-- anonymousIdentification configuration:
-          enabled="[true|false]"                              Feature is enabled?
-          cookieName=".ASPXANONYMOUS"                         Cookie Name
-          cookieTimeout="100000"                              Cookie Timeout in minutes
-          cookiePath="/"                                      Cookie Path
-          cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie
-          cookieSlidingExpiration="[true|false]"              Reissue expiring cookies?
-          cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered
-          domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
+    <!-- anonymousIdentification configuration: enabled="[true|false]"                              Feature is enabled? cookieName=".ASPXANONYMOUS"                         Cookie Name cookieTimeout="100000"                              Cookie Timeout in minutes cookiePath="/"                                      Cookie Path cookieRequireSSL="[true|false]"                     Set Secure bit in Cookie cookieSlidingExpiration="[true|false]"              Reissue expiring cookies? cookieProtection="[None|Validation|Encryption|All]" How to protect cookies from being read/tampered domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
     <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain=""/>
     <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
       <providers>
         <clear/>
-        <!-- Configuration for AspNetSqlMembershipProvider:
-                connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified
-                maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account
-                passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked
-                enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals
-                enablePasswordReset="[true|false]"          Should the provider support password resets
-                requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A
-                minRequiredPasswordLength="int"		        The minimum password length
-                minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters
-                applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path
-                requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified
-                passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES)
-                description="string"                        Description of what the provider does
+        <!-- Configuration for AspNetSqlMembershipProvider: connectionStringName="string"               Name corresponding to the entry in <connectionStrings> section where the connection string for the provider is specified maxInvalidPasswordAttempts="int"            The number of failed password attempts, or failed password answer attempts that are allowed before locking out a user?s account passwordAttemptWindow="int"                 The time window, in minutes, during which failed password attempts and failed password answer attempts are tracked enablePasswordRetrieval="[true|false]"      Should the provider support password retrievals enablePasswordReset="[true|false]"          Should the provider support password resets requiresQuestionAndAnswer="[true|false]"    Should the provider require Q & A minRequiredPasswordLength="int"		        The minimum password length minRequiredNonalphanumericCharacters="int"  The minimum number of non-alphanumeric characters applicationName="string"                    Optional string to identity the application: defaults to Application Metabase path requiresUniqueEmail="[true|false]"          Should the provider require a unique email to be specified passwordFormat="[Clear|Hashed|Encrypted]"   Storage format for the password: Hashed (SHA1), Clear or Encrypted (Triple-DES) description="string"                        Description of what the provider does
                 -->
         <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="SiteSqlServer" enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" minRequiredPasswordLength="7" minRequiredNonalphanumericCharacters="0" requiresUniqueEmail="false" passwordFormat="Hashed" applicationName="DotNetNuke" description="Stores and retrieves membership data from the local Microsoft SQL Server database"/>
       </providers>


### PR DESCRIPTION
## Summary
The original PR #4716 missed a few pieces.

1) Need to include the WebMatrix DLLs in the new AspNetWebPages package, they were also updated.
2) Need to include DotNetNuke.Web.Mvc in the AspNetMvc package, since it relies on a particular version of MVC (another option would be adjusting the version range on the binding redirect, but that would only fix subsequent upgrades).
3) Move the HTTP module for MVC into the AspNetMvc package, since the pieces it relies on aren't included until after install.