### PR TITLE
Add workflow to auto-open PRs to v10 branch

### DIFF
--- a/.github/workflows/open-merged-pr-to-future.yml
+++ b/.github/workflows/open-merged-pr-to-future.yml
@@ -7,7 +7,7 @@ on:
       - develop
 
 jobs:
-  open-merged-pr-to-ten-branch:
+  open-merged-pr-to-release-branch:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged }}
     steps:
@@ -17,12 +17,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: v10/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.merge_commit_sha }}
+          branch: v10/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
 
       - name: Create Pull Request
         uses: repo-sync/pull-request@v2.6
         with:
-          source_branch: v10/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.merge_commit_sha }}
+          source_branch: v10/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
           destination_branch: release/10.0.0
           pr_title: v10 ${{ github.event.pull_request.title }}
           pr_body: |

--- a/.github/workflows/open-merged-pr-to-future.yml
+++ b/.github/workflows/open-merged-pr-to-future.yml
@@ -1,0 +1,32 @@
+name: Open Merged PR to release/10.0.0 Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  open-merged-pr-to-ten-branch:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: v10/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.merge_commit_sha }}
+
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2.6
+        with:
+          source_branch: v10/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.merge_commit_sha }}
+          destination_branch: release/10.0.0
+          pr_title: v10 ${{ github.event.pull_request.title }}
+          pr_body: |
+            Applying #${{ github.event.pull_request.number }} to release/10.0.0
+            ${{ github.event.pull_request.body }}
+          pr_label: ${{ join(github.event.pull_request.labels.*.name) }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This GitHub Actions workflow should open a PR to the `release/10.0.0` branch whenever any PR is merged into the `develop` branch.

## Considerations
The `release/10.0.0` branch should be created before this is merged.

I'm not sure if there's a good way to test this without truly enabling it.

This copies the labels from the original PR. Do we want that, or do we want these v10 merges to always be labelled _Type: Maintenance_?