### PR TITLE
Issue-4760 - Deleting the parent page while the child page is open doesn't redirect

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/actions/__test__/pageActions.test.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/actions/__test__/pageActions.test.js
@@ -1,0 +1,34 @@
+jest.mock('../../services/pageService');
+jest.mock('../../utils');
+import pageActions from '../pageActions';
+import utils from "../../utils";
+import PagesService from "../../services/pageService";
+
+describe('Dnn Page Actions', () => {
+    it('Redirects when parent page is deleted and the child page is the current page', done => {
+        // Arrange
+        const pageToDelete = {
+            tabId: 1,
+            hasChild: true
+        };
+        const defaultUrl = 'http://localhost';
+        const redirectUrl = 'http://localhost/test';
+        PagesService.deletePage.mockResolvedValue({});
+        PagesService.getPageHierarchy.mockResolvedValue([1, 2]);
+        utils.getCurrentPageId.mockReturnValue(2);
+        utils.getDefaultPageUrl.mockReturnValue(redirectUrl);
+        delete window.top.location;
+        window.top.location = new URL(defaultUrl);
+        Object.defineProperty(window.top.location, 'href', {
+            set: (value) => {
+                // Assert
+                expect(value).toBe(redirectUrl)
+                done();
+            }
+        });
+        expect.assertions(1);
+
+        // Act
+        pageActions.deletePage(pageToDelete, null)(() => {});
+    });
+});

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/actions/pageActions.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/actions/pageActions.js
@@ -58,6 +58,10 @@ const loadPage = function (dispatch, pageId, callback) {
     });
 };
 
+const redirectFromNonExistingPage = function (redirectUrl) {
+    window.top.location.href = redirectUrl ? redirectUrl : utils.getDefaultPageUrl();
+};
+
 const pageActions = {
     getPageList(id) {
         return (dispatch) => PagesService.getPageList(id).then(pageList => {
@@ -224,7 +228,15 @@ const pageActions = {
                     type: ActionTypes.DELETED_PAGE
                 });
                 if (page.tabId !== 0 && (page.tabId === utils.getCurrentPageId()) || redirectUrl) {
-                    window.top.location.href = redirectUrl ? redirectUrl : utils.getDefaultPageUrl();
+                    redirectFromNonExistingPage(redirectUrl);
+                }
+                else if (page.hasChild === true) {
+                    let currentPageId = utils.getCurrentPageId();
+                    PagesService.getPageHierarchy(currentPageId).then(hierarchy => {
+                        if (Array.isArray(hierarchy) && hierarchy.indexOf(page.tabId) > -1) {
+                            redirectFromNonExistingPage(redirectUrl);
+                        }
+                    });
                 }
             }).catch((error) => {
                 dispatch({


### PR DESCRIPTION
Fixes #4760 

## Summary
If the deleted page has any children, the page hierarchy is fetched and if the currently displayed page is in the child list of the deleted page, the page gets redirected.