### PR TITLE
Added lint task to all node projects 

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/package.json
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/package.json
@@ -8,7 +8,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "author": "",
   "license": "MIT",

--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p --progress",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "webpack": "webpack-dev-server -d --port 8070 --hot --inline --content-base dist/ --history-api-fallback",
-    "analyze": "set NODE_ENV=production&&webpack --config webpack.config.js --profile --json > stats.json&&webpack-bundle-analyzer stats.json"
+    "analyze": "set NODE_ENV=production&&webpack --config webpack.config.js --profile --json > stats.json&&webpack-bundle-analyzer stats.json",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -17,7 +17,7 @@
     "Persona Bar"
   ],
   "scripts": {
-    "eslint": "eslint ./src/**/*.jsx --fix",
+    "lint": "eslint --fix",
     "test": "echo \"No tests script specified to run.\"",
     "build": "set NODE_ENV=production && webpack -p --config dist.webpack.config.js",
     "debug": "set NODE_ENV=debug && webpack -p --config dist.webpack.config.js",

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
@@ -10,7 +10,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server --host localhost -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "./src/jest.config.js"

--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
@@ -9,7 +9,8 @@
     "webpack": "webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=analyze&&webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Security.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --host localhost --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/SiteGroups.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteGroups.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "7.1.6",

--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
@@ -9,7 +9,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8085 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "7.1.6",

--- a/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/Dnn.AdminExperience/ClientSide/Users.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/package.json
@@ -9,7 +9,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",

--- a/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
@@ -7,7 +7,8 @@
     "debug": "set NODE_ENV=debug&&webpack -p",
     "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "lint": "eslint --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",


### PR DESCRIPTION
This adds a `lint` task into all projects with autofix enabled. This will make it easier to auto-fix eslint warnings if we change the configs or while updating eslint dependency in batch using lerna or yarn workspaces. Unfortunately (well fortunately) there were no autofixable warnings to resolve after this change which was my main goal with this PR, anyway, it's still good to have I believe for the future.

Also, this PR includes the commits in #4770 so if it is merged first, this becomes easier to review. If this one gets merged first than dependabot should close #4770 automatically too.