### PR TITLE
Avoid HTML module using Globals.DependencyProvider

### DIFF
--- a/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
+++ b/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
@@ -50,8 +50,13 @@ namespace DotNetNuke.Modules.Html
         private const string PortalRootToken = "{{PortalRoot}}";
 
         public HtmlTextController()
+            : this(Globals.DependencyProvider.GetRequiredService<INavigationManager>())
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        public HtmlTextController(INavigationManager navigationManager)
+        {
+            this.NavigationManager = navigationManager;
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/DNN Platform/Modules/HTML/EditHtml.ascx.cs
+++ b/DNN Platform/Modules/HTML/EditHtml.ascx.cs
@@ -33,13 +33,14 @@ namespace DotNetNuke.Modules.Html
     {
         private readonly INavigationManager _navigationManager;
 
-        private readonly HtmlTextController _htmlTextController = new HtmlTextController();
+        private readonly HtmlTextController _htmlTextController;
         private readonly HtmlTextLogController _htmlTextLogController = new HtmlTextLogController();
         private readonly WorkflowStateController _workflowStateController = new WorkflowStateController();
 
         public EditHtml()
         {
             this._navigationManager = this.DependencyProvider.GetRequiredService<INavigationManager>();
+            this._htmlTextController = new HtmlTextController(this._navigationManager);
         }
 
         private enum WorkflowType

--- a/DNN Platform/Modules/HTML/HtmlModule.ascx.cs
+++ b/DNN Platform/Modules/HTML/HtmlModule.ascx.cs
@@ -65,7 +65,7 @@ namespace DotNetNuke.Modules.Html
                     false);
 
                 // get the content
-                var objHTML = new HtmlTextController();
+                var objHTML = new HtmlTextController(this._navigationManager);
                 var objWorkflow = new WorkflowStateController();
                 this.WorkflowID = objHTML.GetWorkflow(this.ModuleId, this.TabId, this.PortalId).Value;
 
@@ -159,7 +159,7 @@ namespace DotNetNuke.Modules.Html
             this.EditorEnabled = this.PortalSettings.InlineEditorEnabled;
             try
             {
-                this.WorkflowID = new HtmlTextController().GetWorkflow(this.ModuleId, this.TabId, this.PortalId).Value;
+                this.WorkflowID = new HtmlTextController(this._navigationManager).GetWorkflow(this.ModuleId, this.TabId, this.PortalId).Value;
 
                 // Add an Action Event Handler to the Skin
                 this.AddActionHandler(this.ModuleAction_Click);
@@ -182,7 +182,7 @@ namespace DotNetNuke.Modules.Html
             base.OnLoad(e);
             try
             {
-                var objHTML = new HtmlTextController();
+                var objHTML = new HtmlTextController(this._navigationManager);
 
                 // edit in place
                 if (this.EditorEnabled && this.IsEditable && Personalization.GetUserMode() == PortalSettings.Mode.Edit)
@@ -290,7 +290,7 @@ if(typeof dnn !== 'undefined' && typeof dnn.controls !== 'undefined' && typeof d
                 else if (this.EditorEnabled && this.IsEditable && Personalization.GetUserMode() == PortalSettings.Mode.Edit)
                 {
                     // get content
-                    var objHTML = new HtmlTextController();
+                    var objHTML = new HtmlTextController(this._navigationManager);
                     var objWorkflow = new WorkflowStateController();
                     HtmlTextInfo objContent = objHTML.GetTopHtmlText(this.ModuleId, false, this.WorkflowID);
                     if (objContent == null)
@@ -336,7 +336,7 @@ if(typeof dnn !== 'undefined' && typeof dnn.controls !== 'undefined' && typeof d
                     if (this.IsEditable && Personalization.GetUserMode() == PortalSettings.Mode.Edit)
                     {
                         // get content
-                        var objHTML = new HtmlTextController();
+                        var objHTML = new HtmlTextController(this._navigationManager);
                         HtmlTextInfo objContent = objHTML.GetTopHtmlText(this.ModuleId, false, this.WorkflowID);
 
                         var objWorkflow = new WorkflowStateController();

--- a/DNN Platform/Modules/HTML/Settings.ascx.cs
+++ b/DNN Platform/Modules/HTML/Settings.ascx.cs
@@ -7,9 +7,12 @@ namespace DotNetNuke.Modules.Html
     using System.Collections;
     using System.Collections.Generic;
 
+    using DotNetNuke.Abstractions;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Modules.Html.Components;
     using DotNetNuke.Services.Exceptions;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     ///   The Settings ModuleSettingsBase is used to manage the
@@ -20,6 +23,13 @@ namespace DotNetNuke.Modules.Html
     public partial class Settings : ModuleSettingsBase
     {
         private HtmlModuleSettings _moduleSettings;
+
+        private readonly INavigationManager _navigationManager;
+
+        public Settings()
+        {
+            this._navigationManager = this.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
 
         private new HtmlModuleSettings ModuleSettings
         {
@@ -40,7 +50,7 @@ namespace DotNetNuke.Modules.Html
             {
                 if (!this.Page.IsPostBack)
                 {
-                    var htmlTextController = new HtmlTextController();
+                    var htmlTextController = new HtmlTextController(this._navigationManager);
                     var workflowStateController = new WorkflowStateController();
 
                     this.chkReplaceTokens.Checked = this.ModuleSettings.ReplaceTokens;
@@ -89,7 +99,7 @@ namespace DotNetNuke.Modules.Html
         {
             try
             {
-                var htmlTextController = new HtmlTextController();
+                var htmlTextController = new HtmlTextController(this._navigationManager);
 
                 // update replace token setting
                 this.ModuleSettings.ReplaceTokens = this.chkReplaceTokens.Checked;


### PR DESCRIPTION
## Summary
Based on [a question on the forums](https://dnncommunity.org/forums/aft/2588) I thought it might be helpful to remove some of the `internal` usages of `Globals.DependencyProvider`, since 3rd party modules can't copy that pattern.