### PR TITLE
Resolve serialization issue

### DIFF
--- a/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
@@ -34,7 +34,6 @@ namespace DotNetNuke.Services.Authentication
         public int PortalID { get; set; }
 
         /// <summary>Gets the Dependency Provider to resolve registered services with the container.</summary>
-        [NonSerialized]
         protected IServiceProvider DependencyProvider => Globals.DependencyProvider;
     }
 }

--- a/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
@@ -17,18 +17,13 @@ namespace DotNetNuke.Services.Authentication
     [Serializable]
     public abstract class AuthenticationConfigBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthenticationConfigBase"/> class.
-        /// </summary>
+        /// <summary>Initializes a new instance of the <see cref="AuthenticationConfigBase"/> class.</summary>
         public AuthenticationConfigBase()
         {
-            this.DependencyProvider = Globals.DependencyProvider;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthenticationConfigBase"/> class.
-        /// </summary>
-        /// <param name="portalID"></param>
+        /// <summary>Initializes a new instance of the <see cref="AuthenticationConfigBase"/> class.</summary>
+        /// <param name="portalID">The portal ID.</param>
         protected AuthenticationConfigBase(int portalID)
             : this()
         {
@@ -38,13 +33,8 @@ namespace DotNetNuke.Services.Authentication
         [Browsable(false)]
         public int PortalID { get; set; }
 
-        /// <summary>
-        /// Gets the Dependency Provider to resolve registered
-        /// services with the container.
-        /// </summary>
-        /// <value>
-        /// The Dependency Service.
-        /// </value>
-        protected IServiceProvider DependencyProvider { get; }
+        /// <summary>Gets the Dependency Provider to resolve registered services with the container.</summary>
+        [NonSerialized]
+        protected IServiceProvider DependencyProvider => Globals.DependencyProvider;
     }
 }


### PR DESCRIPTION
## Summary
`AuthenticationConfigBase` is marked as `Serializable` but has an `IServiceProvider` property which cannot be serialized (it's a type defined outside of DNN and is not marked as `Serializable`). This causes an issue when using a caching provider that uses serialization, e.g. https://github.com/davidjrh/dnn.rediscachingprovider

This PR ~adds the `NonSerialized` attribute to the property and~ makes it retrieve the `IServiceProvider` dynamically (so that it always has a valid value, even after going through serialization).

Fixes #3592
