### PR TITLE
Allow multiple DesktopModules per PackageID

### DIFF
--- a/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
@@ -409,6 +409,12 @@ namespace DotNetNuke.Entities.Modules
                         case "moduleName":
                             this.ModuleName = reader.ReadElementContentAsString();
                             break;
+                        case "friendlyName":
+                            this.FriendlyName = reader.ReadElementContentAsString();
+                            break;
+                        case "description":
+                            this.Description = reader.ReadElementContentAsString();
+                            break;
                         case "foldername":
                             this.FolderName = reader.ReadElementContentAsString();
                             break;

--- a/DNN Platform/Library/Services/Installer/Installers/ModuleInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/ModuleInstaller.cs
@@ -3,19 +3,19 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Services.Installer.Installers
 {
-    using System;
-    using System.IO;
-    using System.Xml.XPath;
+using System;
+using System.IO;
+using System.Xml.XPath;
 
-    using DotNetNuke.Common;
-    using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Modules;
-    using DotNetNuke.Entities.Modules.Definitions;
-    using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Entities.Tabs;
-    using DotNetNuke.Entities.Tabs.TabVersions;
-    using DotNetNuke.Security.Permissions;
-    using DotNetNuke.Services.EventQueue;
+using DotNetNuke.Common;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Modules;
+using DotNetNuke.Entities.Modules.Definitions;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Entities.Tabs.TabVersions;
+using DotNetNuke.Security.Permissions;
+using DotNetNuke.Services.EventQueue;
 
     /// -----------------------------------------------------------------------------
     /// <summary>
@@ -180,8 +180,19 @@ namespace DotNetNuke.Services.Installer.Installers
             // Load the Desktop Module from the manifest
             this._desktopModule = CBO.DeserializeObject<DesktopModuleInfo>(new StringReader(manifestNav.InnerXml));
 
-            this._desktopModule.FriendlyName = this.Package.FriendlyName;
-            this._desktopModule.Description = this.Package.Description;
+            // Allow a <component type="Module"> (i.e. a DesktopModule) to have its own friendlyname / description.
+            // This allows multiple DesktopModules in one Package, allowing large MVC packages which share one assembly
+            // but have many functions.
+            if (this._desktopModule.FriendlyName == null || this._desktopModule.FriendlyName.Trim().Length == 0)
+            {
+                this._desktopModule.FriendlyName = this.Package.FriendlyName;
+            }
+
+            if (this._desktopModule.Description == null || this._desktopModule.Description.Trim().Length == 0)
+            {
+                this._desktopModule.Description = this.Package.Description;
+            }
+
             this._desktopModule.Version = Globals.FormatVersion(this.Package.Version, "00", 4, ".");
             this._desktopModule.CompatibleVersions = Null.NullString;
             this._desktopModule.Dependencies = Null.NullString;
@@ -192,7 +203,7 @@ namespace DotNetNuke.Services.Installer.Installers
             }
 
             this._eventMessage = this.ReadEventMessageNode(manifestNav);
-
+			
             // Load permissions (to add)
             foreach (XPathNavigator moduleDefinitionNav in manifestNav.Select("desktopModule/moduleDefinitions/moduleDefinition"))
             {


### PR DESCRIPTION
By allowing a DesktopModule to have an explicit FriendlyName and
Description set by the install manifest, instead of using the Package
FriendlyName and Description, allows multiple DesktopModules per Package

Fixes #2887
Reimplementation of #2887 and #2886