### PR TITLE
Always upload build artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,4 +107,4 @@ steps:
     condition: always()
 
 - publish: 'Artifacts'
-  continueOnError: true
+  condition: always()


### PR DESCRIPTION
This allows access to the MSBuild log for failed builds
