### PR TITLE
Marked nuget dependency from DotNetNuke.Web on Microsoft.AspNet.WebApi.Core

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -16,6 +16,7 @@
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="DotNetNuke.Core" version="$version$" />
+      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.7" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
I am not 100% if what I am doing is correct, but when upgrading a module to depend on DNN 9.10.1, the build fails saying that DotNetNuke.Web uses System.Web.Http v5.2.7 but the project references v5.2.3. I usually just update the dependency manually, but though we could declare it so it updates it automatically.

I am no nuget expert, so not sure if this is the right way to do it, looking at the nuget experts (you know who you are) :P

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
