### PR TITLE
Custom Analyzer types generate System.MissingMethodException

### DIFF
--- a/DNN Platform/Library/Framework/Reflection.cs
+++ b/DNN Platform/Library/Framework/Reflection.cs
@@ -303,9 +303,14 @@ namespace DotNetNuke.Framework
 
         public static object CreateInstance(Type Type)
         {
+            return CreateInstance(Type, null);
+        }
+
+        public static object CreateInstance(Type Type, object[] args)
+        {
             if (Type != null)
             {
-                return Type.InvokeMember(string.Empty, BindingFlags.CreateInstance, null, null, null, null);
+                return Type.InvokeMember(string.Empty, BindingFlags.CreateInstance, null, null, args, null);
             }
             else
             {

--- a/DNN Platform/Library/Services/Search/Internals/LuceneControllerImpl.cs
+++ b/DNN Platform/Library/Services/Search/Internals/LuceneControllerImpl.cs
@@ -378,11 +378,11 @@ namespace DotNetNuke.Services.Search.Internals
                         var analyzerType = Reflection.CreateType(customAnalyzerType);
 
                         // If parameterless ctor exists, use that; if not, pass the Lucene Version.
-                        if (analyzerType.GetConstructor(Type.EmptyTypes) != null)
+                        if (analyzerType?.GetConstructor(Type.EmptyTypes) != null)
                         {
                             analyzer = Reflection.CreateInstance(analyzerType) as Analyzer;
                         }
-                        else if (analyzerType.GetConstructor(new Type[] { typeof(Lucene.Net.Util.Version) }) != null)
+                        else if (analyzerType?.GetConstructor(new Type[] { typeof(Lucene.Net.Util.Version) }) != null)
                         {
                             analyzer = Reflection.CreateInstance(analyzerType, new object[] { Constants.LuceneVersion }) as Analyzer;
                         }

--- a/DNN Platform/Library/Services/Search/Internals/LuceneControllerImpl.cs
+++ b/DNN Platform/Library/Services/Search/Internals/LuceneControllerImpl.cs
@@ -376,7 +376,17 @@ namespace DotNetNuke.Services.Search.Internals
                     try
                     {
                         var analyzerType = Reflection.CreateType(customAnalyzerType);
-                        analyzer = Reflection.CreateInstance(analyzerType) as Analyzer;
+
+                        // If parameterless ctor exists, use that; if not, pass the Lucene Version.
+                        if (analyzerType.GetConstructor(Type.EmptyTypes) != null)
+                        {
+                            analyzer = Reflection.CreateInstance(analyzerType) as Analyzer;
+                        }
+                        else if (analyzerType.GetConstructor(new Type[] { typeof(Lucene.Net.Util.Version) }) != null)
+                        {
+                            analyzer = Reflection.CreateInstance(analyzerType, new object[] { Constants.LuceneVersion }) as Analyzer;
+                        }
+
                         if (analyzer == null)
                         {
                             throw new ArgumentException(string.Format(

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Entities\Tabs\TabChangeTrackerTests.cs" />
     <Compile Include="Entities\Urls\AdvancedUrlRewriterTests.cs" />
     <Compile Include="Entities\Urls\FriendlyUrlControllerTests.cs" />
+    <Compile Include="Framework\ReflectionTests.cs" />
     <Compile Include="Framework\ServicesFrameworkTests.cs" />
     <Compile Include="Framework\JavaScriptLibraries\JavaScriptTests.cs" />
     <Compile Include="Providers\Builders\FolderInfoBuilder.cs" />
@@ -205,6 +206,7 @@
     <Compile Include="Services\Localization\LocalizationTests.cs" />
     <Compile Include="Services\Mobile\PreviewProfileControllerTests.cs" />
     <Compile Include="Services\Mobile\RedirectionControllerTests.cs" />
+    <Compile Include="Services\Search\Internals\LuceneControllerImplTests.cs" />
     <Compile Include="Services\Tokens\TokenReplaceTests.cs" />
     <Compile Include="Services\Tokens\PropertyAccessTests.cs" />
     <Compile Include="FileSystemUtilsTests.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ReflectionTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ReflectionTests.cs
@@ -11,13 +11,13 @@
         {
             // Arrange
             var typeToCreate = typeof(StringBuilder);
-            var argToPass = new object[] { 1 };
+            var argToPass = new object[] { "one" };
 
             // Act
-            var result = Reflection.CreateInstance(typeToCreate, argToPass) as StringBuilder;
+            var result = (StringBuilder)Reflection.CreateInstance(typeToCreate, argToPass);
 
             // Assert
-            Assert.AreEqual(1, result.Capacity);
+            Assert.AreEqual("one", result.ToString());
         }
 
         [Test]
@@ -27,10 +27,10 @@
             var typeToCreate = typeof(StringBuilder);
 
             // Act
-            var result = Reflection.CreateInstance(typeToCreate) as StringBuilder;
+            var result = (StringBuilder)Reflection.CreateInstance(typeToCreate);
 
             // Assert
-            Assert.AreEqual(16, result.Capacity);
+            Assert.AreEqual(string.Empty, result.ToString());
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ReflectionTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ReflectionTests.cs
@@ -1,0 +1,36 @@
+﻿namespace DotNetNuke.Tests.Core.Framework
+{
+    using System.Text;
+    using DotNetNuke.Framework;
+    using NUnit.Framework;
+
+    public class ReflectionTests
+    {
+        [Test]
+        public void CreateInstance_WithArgs_WorksCorrectly()
+        {
+            // Arrange
+            var typeToCreate = typeof(StringBuilder);
+            var argToPass = new object[] { 1 };
+
+            // Act
+            var result = Reflection.CreateInstance(typeToCreate, argToPass) as StringBuilder;
+
+            // Assert
+            Assert.AreEqual(1, result.Capacity);
+        }
+
+        [Test]
+        public void CreateInstance_WithoutArgs_WorksCorrectly()
+        {
+            // Arrange
+            var typeToCreate = typeof(StringBuilder);
+
+            // Act
+            var result = Reflection.CreateInstance(typeToCreate) as StringBuilder;
+
+            // Assert
+            Assert.AreEqual(16, result.Capacity);
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
@@ -1,0 +1,52 @@
+﻿namespace DotNetNuke.Tests.Core.Services.Search.Internals
+{
+    using System.Data;
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Common;
+    using DotNetNuke.Services.Search.Internals;
+    using DotNetNuke.Tests.Utilities.Mocks;
+    using Lucene.Net.Analysis.Cz;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
+    using NUnit.Framework;
+
+    public class LuceneControllerImplTests
+    {
+        [Test]
+        public void GetCustomAnalyzer_WithTheProvidedAnalyzer_ReturnsTheAnalyzerCorrectly()
+        {
+            // Arrange
+            const string HostSettingsTableName = "HostSettings";
+            const string SettingNameColumnName = "SettingName";
+            const string SettingValueColumnName = "SettingValue";
+            const string SettingIsSecureColumnName = "SettingIsSecure";
+            const string CustomAnalyzerCacheKeyName = "Search_CustomAnalyzer";
+            const string CzechAnalyzerTypeName = "Lucene.Net.Analysis.Cz.CzechAnalyzer, Lucene.Net.Contrib.Analyzers";
+            var services = new ServiceCollection();
+            var mockData = MockComponentProvider.CreateDataProvider();
+            var hostSettings = new DataTable(HostSettingsTableName);
+            var nameCol = hostSettings.Columns.Add(SettingNameColumnName);
+            hostSettings.Columns.Add(SettingValueColumnName);
+            hostSettings.Columns.Add(SettingIsSecureColumnName);
+            hostSettings.PrimaryKey = new[] { nameCol };
+            hostSettings.Rows.Add(CustomAnalyzerCacheKeyName, CzechAnalyzerTypeName, true);
+            mockData.Setup(c => c.GetHostSettings()).Returns(hostSettings.CreateDataReader());
+            var mockedApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+            mockedApplicationStatusInfo.Setup(s => s.Status).Returns(UpgradeStatus.Install);
+            mockedApplicationStatusInfo.Setup(s => s.ApplicationMapPath).Returns(string.Empty);
+            services.AddTransient(container => Mock.Of<IHostSettingsService>());
+            services.AddTransient(container => mockedApplicationStatusInfo.Object);
+            services.AddTransient(container => Mock.Of<INavigationManager>());
+            Globals.DependencyProvider = services.BuildServiceProvider();
+            var cachingProvider = MockComponentProvider.CreateDataCacheProvider();
+            var luceneController = new LuceneControllerImpl();
+
+            // Act
+            var analyzer = luceneController.GetCustomAnalyzer();
+
+            // Assert
+            Assert.IsInstanceOf<CzechAnalyzer>(analyzer);
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
@@ -4,6 +4,7 @@
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Services.Search.Internals;
     using DotNetNuke.Tests.Utilities.Mocks;
     using Lucene.Net.Analysis.Cz;
@@ -39,7 +40,8 @@
             services.AddTransient(container => mockedApplicationStatusInfo.Object);
             services.AddTransient(container => Mock.Of<INavigationManager>());
             Globals.DependencyProvider = services.BuildServiceProvider();
-            var cachingProvider = MockComponentProvider.CreateDataCacheProvider();
+            MockComponentProvider.CreateDataCacheProvider();
+            DataCache.ClearCache();
             var luceneController = new LuceneControllerImpl();
 
             // Act


### PR DESCRIPTION
Fixes #4823

## Summary
If a parameterless constructor doesn't exist, the constructor with "Version" parameter is used instead if exists.