### PR TITLE
Removal of "Dummy" from code

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Deprecated/UI/WebControls/TermsSelector.cs
+++ b/DNN Platform/DotNetNuke.Web.Deprecated/UI/WebControls/TermsSelector.cs
@@ -159,7 +159,7 @@ namespace DotNetNuke.Web.UI.WebControls
         {
             ITermController termRep = Util.GetTermController();
 
-            // Add a dummy parent term if simple vocabulary
+            // Add a blank parent term if simple vocabulary
             if (v.Type == VocabularyType.Simple)
             {
                 terms.Add(new { termId = -v.VocabularyId, name = v.Name, parentTermId = Null.NullInteger });

--- a/DNN Platform/DotNetNuke.WebUtility/js/MicrosoftAjax.js
+++ b/DNN Platform/DotNetNuke.WebUtility/js/MicrosoftAjax.js
@@ -3392,9 +3392,9 @@ Sys._ScriptLoader.getInstance = function Sys$_ScriptLoader$getInstance() {
 }
 
 Sys._ScriptLoader.isScriptLoaded = function Sys$_ScriptLoader$isScriptLoaded(scriptSrc) {
-                    var dummyScript = document.createElement('script');
-    dummyScript.src = scriptSrc;
-    return Array.contains(Sys._ScriptLoader._getLoadedScripts(), dummyScript.src);
+    var scriptElement = document.createElement('script');
+    scriptElement.src = scriptSrc;
+    return Array.contains(Sys._ScriptLoader._getLoadedScripts(), scriptElement.src);
 }
 
 Sys._ScriptLoader.readLoadedScripts = function Sys$_ScriptLoader$readLoadedScripts() {

--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -70,7 +70,7 @@ namespace DotNetNuke.Entities.Modules
         {
             var moduleDefinition = GetModuleDefinition(nodeModule);
 
-            // Create dummy pane node for private DeserializeModule method
+            // Create pane node for private DeserializeModule method
             var docPane = new XmlDocument { XmlResolver = null };
             docPane.LoadXml(string.Format("<pane><name>{0}</name></pane>", module.PaneName));
 

--- a/DNN Platform/Library/Entities/Urls/TabPathController.cs
+++ b/DNN Platform/Library/Entities/Urls/TabPathController.cs
@@ -215,9 +215,8 @@ namespace DotNetNuke.Entities.Urls
                 }
                 else
                 {
+                    // create empty dictionary for host tabs
                     urlDict = new SharedDictionary<int, SharedDictionary<string, string>>();
-
-                    // create dummy dictionary for this tab
                 }
 
                 if (ignoreCustomRedirects == false)

--- a/DNN Platform/Library/Security/Roles/RoleController.cs
+++ b/DNN Platform/Library/Security/Roles/RoleController.cs
@@ -248,7 +248,7 @@ namespace DotNetNuke.Security.Roles
             var globalRoleGroup = new RoleGroupInfo(Null.NullInteger, portalID, true)
             {
                 RoleGroupName = "GlobalRoles",
-                Description = "A dummy role group that represents the Global roles",
+                Description = "A role group that represents the Global roles",
             };
             CBO.SerializeObject(globalRoleGroup, writer);
             writer.WriteEndElement();

--- a/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
@@ -446,10 +446,10 @@ namespace DotNetNuke.Services.GeneratedImage
             }
 
             // We start the chain with an empty image
-            var dummy = new Bitmap(1, 1);
+            var emptyImage = new Bitmap(1, 1);
             using (var ms = new MemoryStream())
             {
-                dummy.Save(ms, this.ContentType);
+                emptyImage.Save(ms, this.ContentType);
                 return new ImageInfo(ms.ToArray());
             }
         }

--- a/DNN Platform/Library/Services/Search/ModuleIndexer.cs
+++ b/DNN Platform/Library/Services/Search/ModuleIndexer.cs
@@ -296,7 +296,7 @@ namespace DotNetNuke.Services.Search
 
             var searchDoc = new SearchDocument
             {
-                // Assigns as a Search key the SearchItems' GUID, if not it creates a dummy guid.
+                // Assigns as a Search key the SearchItems' GUID, if not it creates a new guid.
                 UniqueKey = (searchItem.SearchKey.Trim() != string.Empty) ? searchItem.SearchKey : Guid.NewGuid().ToString(),
                 QueryString = searchItem.GUID,
                 Title = searchItem.Title,

--- a/DNN Platform/Providers/ClientCapabilityProviders/Provider.AspNetCCP/AspNetClientCapabilityProvider.cs
+++ b/DNN Platform/Providers/ClientCapabilityProviders/Provider.AspNetCCP/AspNetClientCapabilityProvider.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Providers.AspNetClientCapabilityProvider
         private static IQueryable<IClientCapability> allCapabilities;
         private static Dictionary<string, List<string>> allClientCapabilityValues;
         private static IDictionary<string, int> highPiorityCapabilityValues;
-        private static IDictionary<string, string> dummyProperies;
+        private static IDictionary<string, string> sampleProperies;
 
         /// <inheritdoc/>
         public override bool SupportsTabletDetection
@@ -108,12 +108,12 @@ namespace DotNetNuke.Providers.AspNetClientCapabilityProvider
             }
         }
 
-        private static IDictionary<string, string> DummyProperties
+        private static IDictionary<string, string> SampleProperties
         {
             get
             {
-                return dummyProperies ??
-                       (dummyProperies = new Dictionary<string, string>
+                return sampleProperies ??
+                       (sampleProperies = new Dictionary<string, string>
                        {
                            { "Id", "UNKNOWN" },
                            { "IsMobile", "false" },
@@ -148,7 +148,7 @@ namespace DotNetNuke.Providers.AspNetClientCapabilityProvider
         {
             if (string.IsNullOrEmpty(userAgent))
             {
-                return new AspNetClientCapability(DummyProperties);
+                return new AspNetClientCapability(SampleProperties);
             }
 
             return new AspNetClientCapability(userAgent, GetHttpBrowserCapabilities(new NameValueCollection(), userAgent));

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Services/CloudServicesController.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Services/CloudServicesController.cs
@@ -4,18 +4,11 @@
 
 namespace DNNConnect.CKEditorProvider.Services
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Web;
     using System.Web.Http;
-
-    using DotNetNuke.Common;
-    using DotNetNuke.Services.Installer.Log;
+    
     using DotNetNuke.Web.Api;
-    using DotNetNuke.Web.Api.Internal;
 
     /// <summary>
     /// WebAPI controller to enable the CKE cloudservices plugin.
@@ -23,14 +16,14 @@ namespace DNNConnect.CKEditorProvider.Services
     public class CloudServicesController : DnnApiController
     {
         /// <summary>
-        /// Provides a dummy token the cloudservices plugin needs.
+        /// Provides a fake token the cloudservices plugin needs.
         /// </summary>
-        /// <returns>A dummy token.</returns>
+        /// <returns>A fake token.</returns>
         [AllowAnonymous]
         [HttpGet]
         public HttpResponseMessage GetToken()
         {
-            return this.Request.CreateResponse(HttpStatusCode.OK, "dummytoken");
+            return this.Request.CreateResponse(HttpStatusCode.OK, "faketoken");
         }
     }
 }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/Utility.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/Utility.cs
@@ -133,10 +133,10 @@ namespace DNNConnect.CKEditorProvider.Utilities
         /// </returns>
         public static bool IsNumeric(object valueToCheck)
         {
-            double dummy;
+            double resultValue;
             string inputValue = Convert.ToString(valueToCheck);
 
-            bool numeric = double.TryParse(inputValue, NumberStyles.Any, null, out dummy);
+            bool numeric = double.TryParse(inputValue, NumberStyles.Any, null, out resultValue);
 
             return numeric;
         }

--- a/DNN Platform/Website/DesktopModules/Admin/Security/ProfileDefinitions.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/ProfileDefinitions.ascx.cs
@@ -267,8 +267,8 @@ namespace DotNetNuke.Modules.Admin.Users
                             break;
                         case "Edit":
                             // The Friendly URL parser does not like non-alphanumeric characters
-                            // so first create the format string with a dummy value and then
-                            // replace the dummy value with the FormatString place holder
+                            // so first create the format string with a fake value and then
+                            // replace the fake value with the FormatString place holder
                             string formatString = this.EditUrl("PropertyDefinitionID", "KEYFIELD", "EditProfileProperty");
                             formatString = formatString.Replace("KEYFIELD", "{0}");
                             imageColumn.NavigateURLFormatString = formatString;

--- a/DNN Platform/Website/js/Debug/MicrosoftAjax.js
+++ b/DNN Platform/Website/js/Debug/MicrosoftAjax.js
@@ -3392,9 +3392,9 @@ Sys._ScriptLoader.getInstance = function Sys$_ScriptLoader$getInstance() {
 }
 
 Sys._ScriptLoader.isScriptLoaded = function Sys$_ScriptLoader$isScriptLoaded(scriptSrc) {
-                    var dummyScript = document.createElement('script');
-    dummyScript.src = scriptSrc;
-    return Array.contains(Sys._ScriptLoader._getLoadedScripts(), dummyScript.src);
+    var scriptElement = document.createElement('script');
+    scriptElement.src = scriptSrc;
+    return Array.contains(Sys._ScriptLoader._getLoadedScripts(), scriptElement.src);
 }
 
 Sys._ScriptLoader.readLoadedScripts = function Sys$_ScriptLoader$readLoadedScripts() {


### PR DESCRIPTION
Closes #4836 by removing the word "Dummy" from all DNN Platform SOurce code.

*NOTE* References inside third-party referenced scripts were not changed.
