### PR TITLE
Resolved an issue with redirect tabIds on non-localized sites

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
@@ -319,11 +319,11 @@ namespace Dnn.PersonaBar.SiteSettings.Services
                 }
 
                 var portal = PortalController.Instance.GetPortal(pid, cultureCode);
-                var localizedPortalSettings = PortalController.Instance.GetPortalSettings(portal.PortalID, cultureCode);
+                var localizedPortalSettings = PortalController.Instance.GetPortalSettings(pid, cultureCode);
 
-                int redirectAfterLoginTabId = int.TryParse(localizedPortalSettings["Redirect_AfterLogin"], out redirectAfterLoginTabId) ? redirectAfterLoginTabId : -1;
-                int redirectAfterLogoutTabId = int.TryParse(localizedPortalSettings["Redirect_AfterLogout"], out redirectAfterLogoutTabId) ? redirectAfterLogoutTabId : -1;
-                int redirectAfterRegistrationTabId = int.TryParse(localizedPortalSettings["Redirect_AfterRegistration"], out redirectAfterRegistrationTabId) ? redirectAfterRegistrationTabId : -1;
+                int redirectAfterLoginTabId = this.GetLocalizedTabIdSetting(localizedPortalSettings, "Redirect_AfterLogin");
+                int redirectAfterLogoutTabId = this.GetLocalizedTabIdSetting(localizedPortalSettings, "Redirect_AfterLogout");
+                int redirectAfterRegistrationTabId = this.GetLocalizedTabIdSetting(localizedPortalSettings, "Redirect_AfterRegistration");
 
                 return this.Request.CreateResponse(HttpStatusCode.OK, new
                 {
@@ -3581,6 +3581,18 @@ namespace Dnn.PersonaBar.SiteSettings.Services
         {
             var tab = TabController.Instance.GetTab(tabId, portalId);
             return tab != null && !tab.IsDeleted ? tab.TabID : Null.NullInteger;
+        }
+
+        private int GetLocalizedTabIdSetting(Dictionary<string, string> localizedPortalSettings, string settingKey)
+        {
+            var settingValue = string.Empty;
+            if (localizedPortalSettings.TryGetValue(settingKey, out settingValue))
+            {
+                int tabId = int.TryParse(settingValue, out tabId) ? tabId : -1;
+                return tabId;
+            }
+
+            return -1;
         }
     }
 }


### PR DESCRIPTION
This is a follow up on #4851

All my testing had been done on a localized site and after having those settings exist in the database.

@david-poindexter just found out it was problematic on a clean install as those settings simply do not exists and the code failed getting those settings values from the dictionary of settings. This PR solves that.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
