### PR TITLE
Pass the Package Version to XmlMerge when updating AssemblyInstaller bindings.

### DIFF
--- a/DNN Platform/Library/Services/Installer/Installers/AssemblyInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/AssemblyInstaller.cs
@@ -308,7 +308,7 @@ namespace DotNetNuke.Services.Installer.Installers
 
             var xmlMergePath = Path.Combine(Globals.InstallMapPath, "Config", xmlMergeFile);
             var xmlMergeDoc = GetXmlMergeDoc(xmlMergePath, name, publicKeyToken, OldVersion, newVersion);
-            var xmlMerge = new XmlMerge(xmlMergeDoc, file.Version.ToString(), this.Package.Name);
+            var xmlMerge = new XmlMerge(xmlMergeDoc, this.Package.Version.ToString(), this.Package.Name);
             xmlMerge.UpdateConfigs();
 
             return true;


### PR DESCRIPTION
Fixes #4872

## Summary
Change to using the Package Version instead of the File Version for the XmlMerge that updates the assembly bindings in AssemblyInstaller.
