### PR TITLE
Update DNN Documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://dnncommunity.org/forums
     about: Get help, solicit feedback and discuss new ideas regarding DNN Platform.
   - name: DNN Documentation
-    url: https://dnndocs.com
+    url: https://docs.dnncommunity.org
     about: Learn more about DNN Platform.


### PR DESCRIPTION
## Summary
Changes DNN Docs link from `dnndocs.com` to `docs.dnncommunity.org`
