### PR TITLE
Fixed SEO tab not updating correctly after deleting a URL

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/Table.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/Table.jsx
@@ -15,9 +15,9 @@ class Table extends Component {
 
         const { siteAliases, primaryAliasId, onSave, onCancel, onDelete, onChange, editedUrl,
             pageHasParent, editingUrl, onOpenEditForm } = this.props;
-        return pageUrls.map(url => {
+        return pageUrls.map((url, index) => {
             return <UrlRow 
-                key={url.id}
+                key={url.id === -1 ? -1 - index : url.id}
                 url={url}
                 editedUrl={editedUrl}
                 onOpenEditForm={onOpenEditForm}


### PR DESCRIPTION
Fixes #4924

## Summary
The S.E.O. view doesn't update correctly after changing the state because all automatic URLs are returned by the backend with the same `id` of -1. And this `id` property is used as the React component key, which needs to be unique.
This is a typical pitfall with React.

My fix consists of using the array index to generate a negative sequence so that the first automatic URL gets -1, the second -2 and so on.