### PR TITLE
Adjust release merge workflow

### DIFF
--- a/.github/workflows/open-merged-pr-to-future-9.11.0.yml
+++ b/.github/workflows/open-merged-pr-to-future-9.11.0.yml
@@ -7,7 +7,7 @@ on:
       - develop
 
 jobs:
-  open-merged-pr-to-ten-branch:
+  open-merged-pr-to-release-branch:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged }}
     steps:
@@ -17,12 +17,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: v9.11.0/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.merge_commit_sha }}
+          branch: v9.11.0/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
 
       - name: Create Pull Request
         uses: repo-sync/pull-request@v2.6
         with:
-          source_branch: v9.11.0/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.merge_commit_sha }}
+          source_branch: v9.11.0/${{ github.event.pull_request.head.ref }}-${{ github.event.pull_request.head.sha }}
           destination_branch: release/9.11.0
           pr_title: v9.11.0 ${{ github.event.pull_request.title }}
           pr_body: |


### PR DESCRIPTION
The [workflow triggered](https://github.com/dnnsoftware/Dnn.Platform/runs/4382542237) by the merge/rebase of #4925 failed, presumably because it was accessing the `merge_commit_sha` but the PR was closed via rebase. I've updated the workflow to just use `sha`, which still points to the rebased commit, and [tested on my repo](https://github.com/bdukes/Dnn.Platform/pull/4).