### PR TITLE
Updated Module.css to fix #4928

### DIFF
--- a/DNN Platform/Modules/ResourceManager/module.css
+++ b/DNN Platform/Modules/ResourceManager/module.css
@@ -1,3 +1,6 @@
 ﻿.ReactModalPortal .modal-header {
     padding: 0;
 }
+.rm-container *{
+   box-sizing: border-box; 
+}


### PR DESCRIPTION
## Summary
Made sure that all HTML elements in the Resource Manager use 
box-sizing: border-box, independent of the Theme.

fixes #4928
