### PR TITLE
No module message should be able to contain any scripts

### DIFF
--- a/DNN Platform/Library/UI/Skins/Skin.cs
+++ b/DNN Platform/Library/UI/Skins/Skin.cs
@@ -299,7 +299,7 @@ namespace DotNetNuke.UI.Skins
             var s = new Skin();
             var moduleMessage = (ModuleMessage)s.LoadControl("~/admin/skins/ModuleMessage.ascx");
             moduleMessage.Heading = heading;
-            moduleMessage.Text = message;
+            moduleMessage.Text = new Security.PortalSecurity().InputFilter(message, Security.PortalSecurity.FilterFlag.NoScripting);
             moduleMessage.IconImage = iconImage;
             moduleMessage.IconType = moduleMessageType;
             return moduleMessage;


### PR DESCRIPTION
In the framework we can push a message to the UI which appears in a colored box. This message should not be able to contain any scripts.