### PR TITLE
Journal: Website Url for journal link posts not being saved to ItemData in Journal database - Fixes #3308 

### DIFF
--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -31,7 +31,6 @@ namespace DotNetNuke.Modules.Journal
     [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
     [SupportedModules("Journal")]
 
-
     public class ServicesController : DnnApiController
     {
         private const int MentionNotificationLength = 100;

--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -318,7 +318,9 @@ namespace DotNetNuke.Modules.Journal
 
         private static bool IsAllowedLink(string url)
         {
-            return !string.IsNullOrEmpty(url) && (url.Contains("https://") || url.Contains("http://") || url.Contains("www."));
+            Uri uriResult;
+            return Uri.TryCreate(url, UriKind.Absolute, out uriResult)
+                && uriResult.Scheme != Uri.UriSchemeFile;
         }
 
         // Check if a user can post content on a specific profile's page

--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 
@@ -30,6 +30,8 @@ namespace DotNetNuke.Modules.Journal
 
     [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
     [SupportedModules("Journal")]
+
+
     public class ServicesController : DnnApiController
     {
         private const int MentionNotificationLength = 100;
@@ -55,11 +57,11 @@ namespace DotNetNuke.Modules.Journal
                     postData.ProfileId = userId;
                 }
 
-                this.checkProfileAccess(postData.ProfileId, this.UserInfo);
+                this.CheckProfileAccess(postData.ProfileId, this.UserInfo);
 
-                this.checkGroupAccess(postData);
+                this.CheckGroupAccess(postData);
 
-                var journalItem = this.prepareJournalItem(postData, mentionedUsers);
+                var journalItem = this.PrepareJournalItem(postData, mentionedUsers);
 
                 JournalController.Instance.SaveJournalItem(journalItem, this.ActiveModule);
 
@@ -317,11 +319,11 @@ namespace DotNetNuke.Modules.Journal
 
         private static bool IsAllowedLink(string url)
         {
-            return !string.IsNullOrEmpty(url) && !url.Contains("//");
+            return !string.IsNullOrEmpty(url) && (url.Contains("https://") || url.Contains("http://") || url.Contains("www."));
         }
 
         // Check if a user can post content on a specific profile's page
-        private void checkProfileAccess(int profileId, UserInfo currentUser)
+        private void CheckProfileAccess(int profileId, UserInfo currentUser)
         {
             if (profileId != currentUser.UserID)
             {
@@ -333,7 +335,7 @@ namespace DotNetNuke.Modules.Journal
             }
         }
 
-        private void checkGroupAccess(CreateDTO postData)
+        private void CheckGroupAccess(CreateDTO postData)
         {
             if (postData.GroupId > 0)
             {
@@ -355,7 +357,7 @@ namespace DotNetNuke.Modules.Journal
             }
         }
 
-        private JournalItem prepareJournalItem(CreateDTO postData, IDictionary<string, UserInfo> mentionedUsers)
+        private JournalItem PrepareJournalItem(CreateDTO postData, IDictionary<string, UserInfo> mentionedUsers)
         {
             var journalTypeId = 1;
             switch (postData.JournalType)

--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -319,14 +319,14 @@ namespace DotNetNuke.Modules.Journal
         {
             Uri uriResult;
             return Uri.TryCreate(url, UriKind.Absolute, out uriResult)
-                && (
-                    uriResult.Scheme == Uri.UriSchemeHttp ||
-                    uriResult.Scheme == Uri.UriSchemeHttps ||
-                    uriResult.Scheme == Uri.UriSchemeFtp ||
-                    uriResult.Scheme == Uri.UriSchemeMailto ||
-                    uriResult.Scheme == Uri.UriSchemeNews ||
-                    uriResult.Scheme == Uri.UriSchemeNntp
-                );
+                    && ((
+                        uriResult.Scheme == Uri.UriSchemeHttp ||
+                        uriResult.Scheme == Uri.UriSchemeHttps ||
+                        uriResult.Scheme == Uri.UriSchemeFtp ||
+                        uriResult.Scheme == Uri.UriSchemeMailto ||
+                        uriResult.Scheme == Uri.UriSchemeNews ||
+                        uriResult.Scheme == Uri.UriSchemeNntp)
+                        || url.StartsWith("//"));
         }
 
         // Check if a user can post content on a specific profile's page

--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -319,7 +319,14 @@ namespace DotNetNuke.Modules.Journal
         {
             Uri uriResult;
             return Uri.TryCreate(url, UriKind.Absolute, out uriResult)
-                && uriResult.Scheme != Uri.UriSchemeFile;
+                && (
+                    uriResult.Scheme == Uri.UriSchemeHttp ||
+                    uriResult.Scheme == Uri.UriSchemeHttps ||
+                    uriResult.Scheme == Uri.UriSchemeFtp ||
+                    uriResult.Scheme == Uri.UriSchemeMailto ||
+                    uriResult.Scheme == Uri.UriSchemeNews ||
+                    uriResult.Scheme == Uri.UriSchemeNntp
+                );
         }
 
         // Check if a user can post content on a specific profile's page

--- a/DNN Platform/Modules/Journal/ServicesController.cs
+++ b/DNN Platform/Modules/Journal/ServicesController.cs
@@ -30,7 +30,6 @@ namespace DotNetNuke.Modules.Journal
 
     [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
     [SupportedModules("Journal")]
-
     public class ServicesController : DnnApiController
     {
         private const int MentionNotificationLength = 100;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Fixes #3308 

`url` string was being checked if it had `//` so any address with it would get denied.  

I changed the statement that did NOT allow urls with `//` to allow  `HTTPS://`, `HTTP://` and `www.`

![image](https://user-images.githubusercontent.com/13577556/145308667-6b5951d6-3b18-4b98-8c1c-8a0a61dfee5f.png)


Sure seems to show up the links now in the database and when testing.

I am seeing the effects of my changes after rebuilding the project.  This is also my first attempt in long time to do a PR.  I found it easiest since only 1 file to copy and paste the changed file contents until I get used to github branches again.

I changed the not allow to allow urls with `HTTPS://`, `HTTP://` and `www.`

I will try to make these also create a link for the address typed in the message.  I hope this is acceptable.  I also changed a few names to have UppercaseFormat and was going to document what I could but I need to learn how AND I wanted to do some dependency injection fixes on that same file.

If I do before this gets applied, if it does, I will resubmit a new PR with all the changes made.