### PR TITLE
Journal Module: Updates PrepareUrl() to use secured links - Fixes #2314

### DIFF
--- a/DNN Platform/Modules/Journal/Components/Utilities.cs
+++ b/DNN Platform/Modules/Journal/Components/Utilities.cs
@@ -95,7 +95,7 @@ namespace DotNetNuke.Modules.Journal.Components
             sText = HttpUtility.HtmlEncode(sText);
             return sText;
         }
-
+        
         public static bool AreFriends(UserInfo profileUser, UserInfo currentUser)
         {
             var friendsRelationShip = RelationshipController.Instance.GetFriendRelationship(profileUser, currentUser);
@@ -154,35 +154,31 @@ namespace DotNetNuke.Modules.Journal.Components
             url = url.Trim();
             if (!url.StartsWith("http"))
             {
-                url = "https://" + url;
+                url = "http://" + url;
             }
 
-            if (url.Contains("http://"))
+            if (url.Contains("https://"))
             {
-                url = url.Replace("http://", "https://");
+                url = url.Replace("https://", "http://");
             }
 
             if (url.Contains("http://http://"))
             {
-                url = url.Replace("http://http://", "https://");
+                url = url.Replace("http://http://", "http://");
             }
 
-            if (url.Contains("https://https://"))
+            if (!(url.IndexOf("http://") == 0))
             {
-                url = url.Replace("https://https://", "https://");
-            }
-
-            if (!(url.IndexOf("https://") == 0))
-            {
-                url = "https://" + url;
+                url = "http://" + url;
             }
 
             Uri objURI = null;
 
             objURI = new Uri(url);
+
             return url;
         }
-        
+
         internal static LinkInfo GetLinkData(string URL)
         {
             string sPage = GetPageFromURL(ref URL, string.Empty, string.Empty);
@@ -195,6 +191,16 @@ namespace DotNetNuke.Modules.Journal.Components
             string sTitle = string.Empty;
             string sDescription = string.Empty;
             string sImage = string.Empty;
+
+            if (URL.Contains("http://"))
+            {
+                URL = URL.Replace("http://", "//");
+            }
+
+            if (URL.Contains("https://"))
+            {
+                URL = URL.Replace("https://", "//");
+            }
 
             link.URL = URL;
             link.Images = new List<ImageInfo>();
@@ -230,6 +236,14 @@ namespace DotNetNuke.Modules.Journal.Components
                     {
                         sImage = subM.Groups[9].Value;
                         ImageInfo img = new ImageInfo();
+                        if (sImage.Contains("http://"))
+                        {
+                            sImage = sImage.Replace("http://", "//");
+                        }
+                        if (sImage.Contains("https://"))
+                        {
+                            sImage = sImage.Replace("https://", "//");
+                        }
                         img.URL = sImage;
                         link.Images.Add(img);
                         i += 1;
@@ -255,18 +269,18 @@ namespace DotNetNuke.Modules.Journal.Components
             string hostUrl = string.Empty;
             if (!URL.Contains("http"))
             {
-                URL = "http://" + URL;
+                URL = "//" + URL;
             }
 
             Uri uri = new Uri(URL);
             hostUrl = uri.Host;
             if (URL.Contains("https:"))
             {
-                hostUrl = "https://" + hostUrl;
+                hostUrl = "//" + hostUrl;
             }
             else
             {
-                hostUrl = "http://" + hostUrl;
+                hostUrl = "//" + hostUrl;
             }
 
             foreach (Match match in matches)
@@ -281,7 +295,7 @@ namespace DotNetNuke.Modules.Journal.Components
                 {
                     if (!sImg.Contains("http"))
                     {
-                        sImg = hostUrl + sImg;
+                        sImg = "//" + hostUrl + sImg;
                     }
 
                     ImageInfo img = new ImageInfo();

--- a/DNN Platform/Modules/Journal/Components/Utilities.cs
+++ b/DNN Platform/Modules/Journal/Components/Utilities.cs
@@ -154,22 +154,27 @@ namespace DotNetNuke.Modules.Journal.Components
             url = url.Trim();
             if (!url.StartsWith("http"))
             {
-                url = "http://" + url;
+                url = "https://" + url;
             }
 
-            if (url.Contains("https://"))
+            if (url.Contains("http://"))
             {
-                url = url.Replace("https://", "http://");
+                url = url.Replace("http://", "https://");
             }
 
             if (url.Contains("http://http://"))
             {
-                url = url.Replace("http://http://", "http://");
+                url = url.Replace("http://http://", "https://");
             }
 
-            if (!(url.IndexOf("http://") == 0))
+            if (url.Contains("https://https://"))
             {
-                url = "http://" + url;
+                url = url.Replace("https://https://", "https://");
+            }
+
+            if (!(url.IndexOf("https://") == 0))
+            {
+                url = "https://" + url;
             }
 
             Uri objURI = null;
@@ -177,7 +182,7 @@ namespace DotNetNuke.Modules.Journal.Components
             objURI = new Uri(url);
             return url;
         }
-
+        
         internal static LinkInfo GetLinkData(string URL)
         {
             string sPage = GetPageFromURL(ref URL, string.Empty, string.Empty);

--- a/DNN Platform/Modules/Journal/Components/Utilities.cs
+++ b/DNN Platform/Modules/Journal/Components/Utilities.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

Fixes #2314 and should be included with fix #4956 

![image](https://user-images.githubusercontent.com/13577556/145736110-62a46aff-2fe7-479c-bc06-e00b74a9ed14.png)

Should be included with fix #4956 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Updates PrepareUrl() method in the Utilities.cs file of the Journal module to use HTTPS instead of HTTP.

I can make a switch according to portal SSLEnabled setting to use the old way.  Since us small time community members are probably the only ones using this, not sure if it matters unless under an HTTP Load balancer potentially.

The reason I mention the above is because http://www.msn.com will be recreated as https://www.msn.com.  In todays world this is how it should act.  However if you want it to stay HTTP:// we will need to adjust things more.

Here are my test results with the last Url being copied and pasted from the link in journal post below (test this with fix #4956):
![image](https://user-images.githubusercontent.com/13577556/145735857-52e0695b-8062-4fe1-80f9-62e35c48bd1a.png)

