### PR TITLE
Setup the localization for partial MVC view requests.

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcHandler.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcHandler.cs
@@ -10,7 +10,9 @@ namespace DotNetNuke.Web.Mvc
     using System.Web.SessionState;
 
     using DotNetNuke.ComponentModel;
+    using DotNetNuke.Entities.Portals;
     using DotNetNuke.HttpModules.Membership;
+    using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.Web.Mvc.Common;
     using DotNetNuke.Web.Mvc.Framework.Modules;
@@ -66,6 +68,7 @@ namespace DotNetNuke.Web.Mvc
 
         void IHttpHandler.ProcessRequest(HttpContext httpContext)
         {
+            this.SetThreadCulture();
             MembershipModule.AuthenticateRequest(this.RequestContext.HttpContext, allowUnknownExtensions: true);
             this.ProcessRequest(httpContext);
         }
@@ -91,6 +94,23 @@ namespace DotNetNuke.Web.Mvc
         {
             HttpContextBase httpContextBase = new HttpContextWrapper(httpContext);
             this.ProcessRequest(httpContextBase);
+        }
+
+        private void SetThreadCulture()
+        {
+            var portalSettings = PortalController.Instance.GetCurrentSettings();
+            if (portalSettings is null)
+            {
+                return;
+            }
+
+            var pageLocale = Localization.GetPageLocale(portalSettings);
+            if (pageLocale is null)
+            {
+                return;
+            }
+
+            Localization.SetThreadCultures(pageLocale, portalSettings);
         }
 
         private IModuleExecutionEngine GetModuleExecutionEngine()


### PR DESCRIPTION
Fixes #5003

## Summary
Sets up the thread culture info for partially rendered MVC views, similar to how it is done for normal page requests (WebForms and MVC) and WebAPI requests.