### PR TITLE
Add JsonIgnore Attribute

### DIFF
--- a/DNN Platform/Library/Entities/BaseEntityInfo.cs
+++ b/DNN Platform/Library/Entities/BaseEntityInfo.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Entities
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Users;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// BaseEntityInfo provides auditing fields for Core tables.
@@ -32,6 +33,7 @@ namespace DotNetNuke.Entities
         /// <returns>An Integer.</returns>
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public int CreatedByUserID { get; internal set; }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace DotNetNuke.Entities
         /// <returns>A DateTime.</returns>
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public DateTime CreatedOnDate { get; private set; }
 
         /// <summary>
@@ -48,6 +51,7 @@ namespace DotNetNuke.Entities
         /// <returns>An Integer.</returns>
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public int LastModifiedByUserID { get; internal set; }
 
         /// <summary>
@@ -56,6 +60,7 @@ namespace DotNetNuke.Entities
         /// <returns>A DateTime.</returns>
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public DateTime LastModifiedOnDate { get; private set; }
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Content/ContentItem.cs
+++ b/DNN Platform/Library/Entities/Content/ContentItem.cs
@@ -16,6 +16,7 @@ namespace DotNetNuke.Entities.Content
     using DotNetNuke.Entities.Content.Taxonomy;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Services.FileSystem;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// The ContentItem class which itself inherits from BaseEntityInfo paves the way for easily adding support for taxonomy,
@@ -86,6 +87,7 @@ namespace DotNetNuke.Entities.Content
         /// <value>metadata collection.</value>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public NameValueCollection Metadata
         {
             get
@@ -100,6 +102,7 @@ namespace DotNetNuke.Entities.Content
         /// <value>Terms Collection.</value>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public List<Term> Terms
         {
             get
@@ -113,6 +116,7 @@ namespace DotNetNuke.Entities.Content
         /// </summary>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public List<IFileInfo> Files
         {
             get { return this._files ?? (this._files = AttachmentController.DeserializeFileInfo(this.Metadata[AttachmentController.FilesKey]).ToList()); }
@@ -123,6 +127,7 @@ namespace DotNetNuke.Entities.Content
         /// </summary>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public List<IFileInfo> Videos
         {
             get { return this._videos ?? (this._videos = AttachmentController.DeserializeFileInfo(this.Metadata[AttachmentController.VideoKey]).ToList()); }
@@ -133,6 +138,7 @@ namespace DotNetNuke.Entities.Content
         /// </summary>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public List<IFileInfo> Images
         {
             get { return this._images ?? (this._images = AttachmentController.DeserializeFileInfo(this.Metadata[AttachmentController.ImageKey]).ToList()); }
@@ -146,6 +152,7 @@ namespace DotNetNuke.Entities.Content
         /// </value>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int ContentItemId { get; set; }
 
         /// <summary>
@@ -175,6 +182,7 @@ namespace DotNetNuke.Entities.Content
         /// <see cref="ContentType"/>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int ContentTypeId { get; set; }
 
         /// <summary>
@@ -185,6 +193,7 @@ namespace DotNetNuke.Entities.Content
         /// </value>
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public bool Indexed { get; set; }
 
         /// <summary>
@@ -227,6 +236,7 @@ namespace DotNetNuke.Entities.Content
         /// The Content Workflow State ID.
         /// </value>
         [XmlIgnore]
+        [JsonIgnore]
         public int StateID { get; set; }
 
         /// <summary>
@@ -239,6 +249,7 @@ namespace DotNetNuke.Entities.Content
         /// If you derive class has its own key id, please override this property and set the value to your own key id.
         /// </remarks>
         [XmlIgnore]
+        [JsonIgnore]
         public virtual int KeyID
         {
             get

--- a/DNN Platform/Library/Entities/Content/Taxonomy/Term.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/Term.cs
@@ -14,6 +14,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
     using DotNetNuke.Entities.Content.Common;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Security;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Major class of Taxonomy.
@@ -118,6 +119,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public List<Term> ChildTerms
         {
             get
@@ -133,6 +135,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public bool IsHeirarchical
         {
             get
@@ -143,6 +146,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int Left
         {
             get
@@ -153,6 +157,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int Right
         {
             get
@@ -163,6 +168,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public List<string> Synonyms
         {
             get
@@ -173,6 +179,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public Vocabulary Vocabulary
         {
             get
@@ -188,6 +195,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int VocabularyId
         {
             get
@@ -198,6 +206,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public string Description
         {
             get
@@ -213,6 +222,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public string Name
         {
             get
@@ -238,6 +248,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int? ParentTermId
         {
             get
@@ -253,6 +264,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int TermId
         {
             get
@@ -268,6 +280,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
 
         [XmlIgnore]
         [ScriptIgnore]
+        [JsonIgnore]
         public int Weight
         {
             get

--- a/DNN Platform/Library/Entities/Modules/ModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleInfo.cs
@@ -23,6 +23,7 @@ namespace DotNetNuke.Entities.Modules
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.ModuleCache;
     using DotNetNuke.Services.Tokens;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -98,6 +99,7 @@ namespace DotNetNuke.Entities.Modules
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public DesktopModuleInfo DesktopModule
         {
             get
@@ -110,6 +112,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool HideAdminBorder
         {
             get
@@ -127,6 +130,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsShared
         {
             get { return this.OwnerPortalID != this.PortalID; }
@@ -150,6 +154,7 @@ namespace DotNetNuke.Entities.Modules
         /// <returns>A ModuleDefinitionInfo.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public ModuleDefinitionInfo ModuleDefinition
         {
             get
@@ -162,6 +167,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public Hashtable ModuleSettings
         {
             get
@@ -183,6 +189,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public Hashtable TabModuleSettings
         {
             get
@@ -204,6 +211,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public ModuleInfo DefaultLanguageModule
         {
             get
@@ -250,6 +258,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsTranslated
         {
             get
@@ -266,6 +275,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<string, ModuleInfo> LocalizedModules
         {
             get
@@ -325,6 +335,7 @@ namespace DotNetNuke.Entities.Modules
         public string Alignment { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool AllModules { get; set; }
 
         [XmlElement("alltabs")]
@@ -343,6 +354,7 @@ namespace DotNetNuke.Entities.Modules
         public string Color { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public string ContainerPath { get; set; }
 
         [XmlElement("containersrc")]
@@ -355,6 +367,7 @@ namespace DotNetNuke.Entities.Modules
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int DesktopModuleID { get; set; }
 
         [XmlElement("displayprint")]
@@ -382,15 +395,18 @@ namespace DotNetNuke.Entities.Modules
         public bool InheritViewPermissions { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsDefaultModule { get; set; }
 
         [XmlElement("isdeleted")]
         public bool IsDeleted { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsShareable { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsShareableViewOnly { get; set; }
 
         [Obsolete("WebSlice functionality is no longer used.  Will be removed in v10.0.0")]
@@ -398,9 +414,11 @@ namespace DotNetNuke.Entities.Modules
         public bool IsWebSlice { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public DateTime LastContentModifiedOnDate { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int ModuleControlId { get; set; }
 
         /// -----------------------------------------------------------------------------
@@ -410,6 +428,7 @@ namespace DotNetNuke.Entities.Modules
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int ModuleDefID { get; set; }
 
         [XmlElement("moduleorder")]
@@ -444,15 +463,19 @@ namespace DotNetNuke.Entities.Modules
         public string ModuleTitle { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int ModuleVersion { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int OwnerPortalID { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int PaneModuleCount { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int PaneModuleIndex { get; set; }
 
         [XmlElement("panename")]
@@ -537,6 +560,7 @@ namespace DotNetNuke.Entities.Modules
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public override int KeyID
         {
             get

--- a/DNN Platform/Library/Entities/Modules/PortalDesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/PortalDesktopModuleInfo.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Entities.Modules
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Security.Permissions;
+    using Newtonsoft.Json;
 
     [Serializable]
     public class PortalDesktopModuleInfo : BaseEntityInfo
@@ -16,6 +17,7 @@ namespace DotNetNuke.Entities.Modules
         private DesktopModulePermissionCollection _permissions;
 
         [XmlIgnore]
+        [JsonIgnore]
         public DesktopModuleInfo DesktopModule
         {
             get
@@ -43,17 +45,21 @@ namespace DotNetNuke.Entities.Modules
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int PortalDesktopModuleID { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int DesktopModuleID { get; set; }
 
         public string FriendlyName { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int PortalID { get; set; }
 
         [XmlIgnore]
+        [JsonIgnore]
         public string PortalName { get; set; }
     }
 }

--- a/DNN Platform/Library/Entities/Portals/PortalInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalInfo.cs
@@ -15,6 +15,7 @@ namespace DotNetNuke.Entities.Portals
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Security.Roles;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// PortalInfo provides a base class for Portal information
@@ -93,6 +94,7 @@ namespace DotNetNuke.Entities.Portals
 
         /// <inheritdoc />
         [XmlIgnore]
+        [JsonIgnore]
         public string HomeDirectoryMapPath
         {
             get
@@ -103,6 +105,7 @@ namespace DotNetNuke.Entities.Portals
 
         /// <inheritdoc />
         [XmlIgnore]
+        [JsonIgnore]
         public string HomeSystemDirectoryMapPath
         {
             get
@@ -173,6 +176,7 @@ namespace DotNetNuke.Entities.Portals
 
         /// <inheritdoc />
         [XmlIgnore]
+        [JsonIgnore]
         public Guid GUID { get; set; }
 
         /// <inheritdoc />
@@ -414,6 +418,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         [Obsolete("Deprecated in DNN 6.0. Scheduled removal in v10.0.0.")]
         public int TimeZoneOffset { get; set; }
 

--- a/DNN Platform/Library/Entities/Profile/ProfilePropertyDefinition.cs
+++ b/DNN Platform/Library/Entities/Profile/ProfilePropertyDefinition.cs
@@ -12,6 +12,7 @@ namespace DotNetNuke.Entities.Profile
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.UI.WebControls;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -84,6 +85,7 @@ namespace DotNetNuke.Entities.Profile
         [Required(true)]
         [SortOrder(1)]
         [XmlIgnore]
+        [JsonIgnore]
         public int DataType
         {
             get
@@ -109,6 +111,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [SortOrder(4)]
         [XmlIgnore]
+        [JsonIgnore]
         public string DefaultValue
         {
             get
@@ -134,6 +137,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [SortOrder(10)]
         [XmlIgnore]
+        [JsonIgnore]
         public UserVisibilityMode DefaultVisibility
         {
             get
@@ -159,6 +163,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public bool Deleted
         {
             get
@@ -179,6 +184,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsDirty { get; private set; }
 
         /// -----------------------------------------------------------------------------
@@ -213,6 +219,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public int ModuleDefId
         {
             get
@@ -233,6 +240,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public int PortalId
         {
             get
@@ -279,6 +287,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public int PropertyDefinitionId { get; set; }
 
         /// -----------------------------------------------------------------------------
@@ -316,6 +325,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public string PropertyValue
         {
             get
@@ -341,6 +351,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [SortOrder(7)]
         [XmlIgnore]
+        [JsonIgnore]
         public bool ReadOnly
         {
             get
@@ -366,6 +377,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [SortOrder(6)]
         [XmlIgnore]
+        [JsonIgnore]
         public bool Required
         {
             get
@@ -391,6 +403,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [SortOrder(5)]
         [XmlIgnore]
+        [JsonIgnore]
         public string ValidationExpression
         {
             get
@@ -417,6 +430,7 @@ namespace DotNetNuke.Entities.Profile
         [IsReadOnly(true)]
         [SortOrder(9)]
         [XmlIgnore]
+        [JsonIgnore]
         public int ViewOrder
         {
             get
@@ -442,6 +456,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [SortOrder(8)]
         [XmlIgnore]
+        [JsonIgnore]
         public bool Visible
         {
             get
@@ -467,6 +482,7 @@ namespace DotNetNuke.Entities.Profile
         /// -----------------------------------------------------------------------------
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public ProfileVisibility ProfileVisibility
         {
             get
@@ -488,6 +504,7 @@ namespace DotNetNuke.Entities.Profile
         [Obsolete("Deprecated in 6.2 as profile visibility has been extended, keep for compatible with upgrade.. Scheduled removal in v10.0.0.")]
         [Browsable(false)]
         [XmlIgnore]
+        [JsonIgnore]
         public UserVisibilityMode Visibility
         {
             get

--- a/DNN Platform/Library/Entities/Tabs/TabInfo.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabInfo.cs
@@ -30,6 +30,7 @@ namespace DotNetNuke.Entities.Tabs
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Tokens;
+    using Newtonsoft.Json;
 
     /// <summary>Information about a page within a DNN site.</summary>
     /// <seealso cref="ContentItem" />
@@ -107,6 +108,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a value indicating whether this page has a version that is visible to the current user.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool HasAVisibleVersion
         {
             get
@@ -117,6 +119,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a value indicating whether DNN's search index should include this page.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool AllowIndex
         {
             get
@@ -129,6 +132,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets the modules on this page.</summary>
         /// <value>A <see cref="Dictionary{TKey,TValue}"/> mapping between Module ID and <see cref="ModuleInfo"/>.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<int, ModuleInfo> ChildModules
         {
             get
@@ -140,6 +144,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets info for the default language version of this page, if it exists.</summary>
         /// <value>A <see cref="TabInfo"/> instance, or <c>null</c>.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public TabInfo DefaultLanguageTab
         {
             get
@@ -155,6 +160,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a value indicating whether this page is configured not to redirect.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool DoNotRedirect
         {
             get
@@ -175,6 +181,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets the indented name of this page (i.e. with <c>"..."</c> at the beginning based on the page's <see cref="Level"/>).</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string IndentedTabName
         {
             get
@@ -192,6 +199,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a value indicating whether this page is the default language version.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsDefaultLanguage
         {
             get
@@ -202,6 +210,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a value indicating whether this page is not for any specific culture/language.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsNeutralCulture
         {
             get
@@ -212,6 +221,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a value indicating whether this page is translated.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsTranslated
         {
             get
@@ -229,6 +239,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets the name of the page for the current culture.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string LocalizedTabName
         {
             get
@@ -269,6 +280,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets a collection of pages that are localized children of this page.</summary>
         /// <value>A <see cref="Dictionary{TKey,TValue}"/> mapping from <see cref="CultureCode"/> to <see cref="TabInfo"/>.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<string, TabInfo> LocalizedTabs
         {
             get
@@ -298,6 +310,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets the settings collection for the page.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public Hashtable TabSettings
         {
             get
@@ -309,6 +322,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets the <see cref="Tabs.TabType"/> for the page.</summary>
         /// <seealso cref="Tabs.TabType"/>
         [XmlIgnore]
+        [JsonIgnore]
         public TabType TabType
         {
             get
@@ -319,6 +333,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a collection of <seealso cref="TabAliasSkinInfo"/> for this page.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public List<TabAliasSkinInfo> AliasSkins
         {
             get
@@ -330,6 +345,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets a collection of custom aliases for this page.</summary>
         /// <value>A <see cref="Dictionary{TKey,TValue}"/> mapping from <see cref="CultureCode"/> to HTTP Alias.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<string, string> CustomAliases
         {
             get
@@ -340,6 +356,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets the full URL for this page.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string FullUrl
         {
             get
@@ -394,6 +411,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets a value indicating whether the tab permissions are specified.</summary>
         [Obsolete("Deprecated in DNN 9.7.0, as this provides no use and always returns false.  Scheduled removal in v11.0.0.")]
         [XmlIgnore]
+        [JsonIgnore]
         public bool TabPermissionsSpecified
         {
             get { return false; }
@@ -401,6 +419,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets a collection of page-specific URLs.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public List<TabUrlInfo> TabUrls
         {
             get
@@ -421,10 +440,12 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets or sets the collection of bread crumb pages (i.e. the parent, grandparent, etc. of this page).</summary>
         /// <value>An <see cref="ArrayList"/> with <see cref="TabInfo"/> instances.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public ArrayList BreadCrumbs { get; set; }
 
         /// <summary>Gets or sets the path to the directory with <see cref="ContainerSrc"/>.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string ContainerPath { get; set; }
 
         /// <summary>Gets or sets the path to the default container for this page, if there is one.</summary>
@@ -457,10 +478,12 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets the icon file URL, as it is stored in the database.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string IconFileRaw { get; private set; }
 
         /// <summary>Gets the large icon file URL, as it is stored in the database.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string IconFileLargeRaw { get; private set; }
 
         /// <summary>Gets or sets a value indicating whether this page is deleted.</summary>
@@ -481,6 +504,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets or sets a value indicating whether this page has been published.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool HasBeenPublished { get; set; }
 
         /// <summary>Gets or sets the meta keywords for the page.</summary>
@@ -489,6 +513,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets or sets the level of the page, i.e. how may ancestors (parent, grandparent, etc.) it has.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int Level { get; set; }
 
         /// <summary>Gets or sets the <see cref="Guid"/> for the localized version.</summary>
@@ -498,6 +523,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets or sets a collection of the modules on this page.</summary>
         /// <value>An <see cref="ArrayList"/> of <see cref="ModuleInfo"/>.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public ArrayList Modules
         {
             get
@@ -518,6 +544,7 @@ namespace DotNetNuke.Entities.Tabs
         /// <summary>Gets a list of the names of the panes available to the page.</summary>
         /// <value>An <see cref="ArrayList"/> of <see cref="string"/> values with the IDs of the panes on the page.</value>
         [XmlIgnore]
+        [JsonIgnore]
         public ArrayList Panes { get; private set; }
 
         /// <summary>Gets or sets the ID of this page's parent page (or <see cref="Null.NullInteger"/> if it has no parent).</summary>
@@ -543,6 +570,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets or sets the path to the directory with <see cref="SkinSrc"/>.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public string SkinPath { get; set; }
 
         /// <summary>Gets or sets the path to the skin control for this page.</summary>
@@ -613,6 +641,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets or sets a value indicating whether this page is a host level page that doesn't belong to any portal.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsSuperTab
         {
             get
@@ -634,6 +663,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <inheritdoc />
         [XmlIgnore]
+        [JsonIgnore]
         public override int KeyID
         {
             get
@@ -677,6 +707,7 @@ namespace DotNetNuke.Entities.Tabs
 
         /// <summary>Gets or sets a value indicating whether this page uses friendly URLs.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool UseBaseFriendlyUrls { get; set; }
 
         /// <inheritdoc />

--- a/DNN Platform/Library/Entities/Users/Profile/UserProfile.cs
+++ b/DNN Platform/Library/Entities/Users/Profile/UserProfile.cs
@@ -19,6 +19,7 @@ namespace DotNetNuke.Entities.Users
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Profile;
     using DotNetNuke.Services.FileSystem;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// The UserProfile class provides a Business Layer entity for the Users Profile.
@@ -410,6 +411,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets or sets the preferred time zone.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public TimeZoneInfo PreferredTimeZone
         {
             get

--- a/DNN Platform/Library/Entities/Users/Social/Relationship.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Relationship.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Entities.Users.Social
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -39,6 +40,7 @@ namespace DotNetNuke.Entities.Users.Social
         /// Gets a value indicating whether is this a Portal-Level Relationship.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsPortalList
         {
             get
@@ -51,6 +53,7 @@ namespace DotNetNuke.Entities.Users.Social
         /// Gets a value indicating whether is this a Host-Level Relationship (very uncommon).
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsHostList
         {
             get
@@ -63,6 +66,7 @@ namespace DotNetNuke.Entities.Users.Social
         /// Gets a value indicating whether is this a USer-Level Relationship.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsUserList
         {
             get
@@ -117,6 +121,7 @@ namespace DotNetNuke.Entities.Users.Social
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Entities/Users/Social/RelationshipType.cs
+++ b/DNN Platform/Library/Entities/Users/Social/RelationshipType.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Entities.Users
     using System.Xml.Serialization;
 
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -62,6 +63,7 @@ namespace DotNetNuke.Entities.Users
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Entities/Users/Social/UserRelationship.cs
+++ b/DNN Platform/Library/Entities/Users/Social/UserRelationship.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Entities.Users.Social
     using System.Xml.Serialization;
 
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -66,6 +67,7 @@ namespace DotNetNuke.Entities.Users.Social
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Entities/Users/Social/UserRelationshipPreference.cs
+++ b/DNN Platform/Library/Entities/Users/Social/UserRelationshipPreference.cs
@@ -7,6 +7,7 @@ namespace DotNetNuke.Entities.Users.Social
     using System.Data;
     using System.Xml.Serialization;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke

--- a/DNN Platform/Library/Entities/Users/Social/UserRelationshipPreference.cs
+++ b/DNN Platform/Library/Entities/Users/Social/UserRelationshipPreference.cs
@@ -6,7 +6,6 @@ namespace DotNetNuke.Entities.Users.Social
     using System;
     using System.Data;
     using System.Xml.Serialization;
-
     using DotNetNuke.Entities.Modules;
 
     /// -----------------------------------------------------------------------------
@@ -58,6 +57,7 @@ namespace DotNetNuke.Entities.Users.Social
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Security/Permissions/FolderPermissionInfo.cs
+++ b/DNN Platform/Library/Security/Permissions/FolderPermissionInfo.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     [Serializable]
     public class FolderPermissionInfo : PermissionInfoBase, IHydratable
@@ -51,6 +52,7 @@ namespace DotNetNuke.Security.Permissions
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int FolderPermissionID
         {
             get
@@ -65,6 +67,7 @@ namespace DotNetNuke.Security.Permissions
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int FolderID
         {
             get
@@ -79,6 +82,7 @@ namespace DotNetNuke.Security.Permissions
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public int PortalID
         {
             get
@@ -113,6 +117,7 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Security/Permissions/ModulePermissionInfo.cs
+++ b/DNN Platform/Library/Security/Permissions/ModulePermissionInfo.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -103,6 +104,7 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Security/Permissions/PermissionInfo.cs
+++ b/DNN Platform/Library/Security/Permissions/PermissionInfo.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -29,6 +30,7 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int ModuleDefID { get; set; }
 
         /// -----------------------------------------------------------------------------
@@ -65,6 +67,7 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>A String.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public string PermissionName { get; set; }
 
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Security/Permissions/TabPermissionInfo.cs
+++ b/DNN Platform/Library/Security/Permissions/TabPermissionInfo.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -104,6 +105,7 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Security/Roles/RoleInfo.cs
+++ b/DNN Platform/Library/Security/Roles/RoleInfo.cs
@@ -20,16 +20,17 @@ namespace DotNetNuke.Security.Roles
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Tokens;
+using Newtonsoft.Json;
 
-    /// -----------------------------------------------------------------------------
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.Security.Roles
-    /// Class:      RoleInfo
-    /// -----------------------------------------------------------------------------
-    /// <summary>
-    /// The RoleInfo class provides the Entity Layer Role object.
-    /// </summary>
-    /// -----------------------------------------------------------------------------
+/// -----------------------------------------------------------------------------
+/// Project:    DotNetNuke
+/// Namespace:  DotNetNuke.Security.Roles
+/// Class:      RoleInfo
+/// -----------------------------------------------------------------------------
+/// <summary>
+/// The RoleInfo class provides the Entity Layer Role object.
+/// </summary>
+/// -----------------------------------------------------------------------------
     [Serializable]
     public class RoleInfo : BaseEntityInfo, IHydratable, IXmlSerializable, IPropertyAccess
     {
@@ -74,6 +75,7 @@ namespace DotNetNuke.Security.Roles
         /// </summary>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<string, string> Settings
         {
             get
@@ -184,6 +186,7 @@ namespace DotNetNuke.Security.Roles
         /// <value>An Integer representing the Id of the Portal.</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int PortalID { get; set; }
 
         /// -----------------------------------------------------------------------------
@@ -193,6 +196,7 @@ namespace DotNetNuke.Security.Roles
         /// <value>An Integer representing the Id of the Role.</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int RoleID { get; set; }
 
         /// -----------------------------------------------------------------------------
@@ -202,6 +206,7 @@ namespace DotNetNuke.Security.Roles
         /// <value>An Integer representing the Id of the RoleGroup.</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int RoleGroupID { get; set; }
 
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Services/Exceptions/BasePortalException.cs
+++ b/DNN Platform/Library/Services/Exceptions/BasePortalException.cs
@@ -14,6 +14,7 @@ namespace DotNetNuke.Services.Exceptions
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Framework.Providers;
     using DotNetNuke.Instrumentation;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Base Portal Exception.
@@ -90,6 +91,7 @@ namespace DotNetNuke.Services.Exceptions
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public new MethodBase TargetSite
         {
             get

--- a/DNN Platform/Library/Services/FileSystem/FileInfo.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileInfo.cs
@@ -16,6 +16,7 @@ namespace DotNetNuke.Services.FileSystem
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Instrumentation;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -307,6 +308,7 @@ namespace DotNetNuke.Services.FileSystem
 
         /// <inheritdoc/>
         [XmlIgnore]
+        [JsonIgnore]
         public int PortalId { get; set; }
 
         /// <inheritdoc/>
@@ -461,6 +463,7 @@ namespace DotNetNuke.Services.FileSystem
         /// Gets a value indicating whether gets a flag which says whether the file has ever been published.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public bool HasBeenPublished { get; private set; }
 
         /// <summary>
@@ -470,6 +473,7 @@ namespace DotNetNuke.Services.FileSystem
 
         /// <inheritdoc/>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/FileSystem/FolderInfo.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderInfo.cs
@@ -15,6 +15,7 @@ namespace DotNetNuke.Services.FileSystem
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Security.Permissions;
+    using Newtonsoft.Json;
 
     [XmlRoot("folder", IsNullable = false)]
     [Serializable]
@@ -275,6 +276,7 @@ namespace DotNetNuke.Services.FileSystem
 
         /// <inheritdoc/>
         [XmlIgnore]
+        [JsonIgnore]
         public DateTime LastUpdated { get; set; }
 
 
@@ -318,6 +320,7 @@ namespace DotNetNuke.Services.FileSystem
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Installer/Packages/PackageInfo.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageInfo.cs
@@ -10,13 +10,12 @@ namespace DotNetNuke.Services.Installer.Packages
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Services.Installer.Log;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// <summary>
     /// The PackageInfo class represents a single Installer Package.
     /// </summary>
-    /// <remarks>
-    /// </remarks>
     /// -----------------------------------------------------------------------------
     [Serializable]
     public class PackageInfo : BaseEntityInfo
@@ -52,6 +51,7 @@ namespace DotNetNuke.Services.Installer.Packages
 
         /// <summary>Gets the direct dependencies of this package.</summary>
         [XmlIgnore]
+        [JsonIgnore]
         public IList<PackageDependencyInfo> Dependencies
         {
             get
@@ -69,6 +69,7 @@ namespace DotNetNuke.Services.Installer.Packages
         /// <value>A Dictionary(Of String, InstallFile).</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<string, InstallFile> Files
         {
             get
@@ -98,6 +99,7 @@ namespace DotNetNuke.Services.Installer.Packages
         /// <value>An Logger object.</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public Logger Log
         {
             get
@@ -169,6 +171,7 @@ namespace DotNetNuke.Services.Installer.Packages
         /// <value>An InstallerInfo object.</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public InstallerInfo InstallerInfo { get; private set; }
 
         /// -----------------------------------------------------------------------------
@@ -186,6 +189,7 @@ namespace DotNetNuke.Services.Installer.Packages
         /// <value>A Boolean value.</value>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public bool IsValid { get; private set; }
 
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Services/Journal/JournalItem.cs
+++ b/DNN Platform/Library/Services/Journal/JournalItem.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Services.Journal
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Services.Tokens;
+    using Newtonsoft.Json;
 
     public class JournalItem : IHydratable, IPropertyAccess
     {
@@ -85,6 +86,7 @@ namespace DotNetNuke.Services.Journal
         /// If you derive class has its own key id, please override this property and set the value to your own key id.
         /// </remarks>
         [XmlIgnore]
+        [JsonIgnore]
         public virtual int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Mobile/PreviewProfile.cs
+++ b/DNN Platform/Library/Services/Mobile/PreviewProfile.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Services.Mobile
     using System.Xml.Serialization;
 
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     [Serializable]
     public class PreviewProfile : IPreviewProfile, IHydratable
@@ -79,6 +80,7 @@ namespace DotNetNuke.Services.Mobile
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Mobile/Redirection.cs
+++ b/DNN Platform/Library/Services/Mobile/Redirection.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Services.Mobile
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     [Serializable]
     public class Redirection : IRedirection, IHydratable
@@ -18,6 +19,7 @@ namespace DotNetNuke.Services.Mobile
         private int _id = -1;
 
         [XmlIgnore]
+        [JsonIgnore]
         private IList<IMatchRule> _matchRules;
 
         /// <summary>
@@ -73,6 +75,7 @@ namespace DotNetNuke.Services.Mobile
         /// Gets or sets when redirection type is RedirectionType.Other, should use this collection to match the request by capability info.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public IList<IMatchRule> MatchRules
         {
             get
@@ -132,6 +135,7 @@ namespace DotNetNuke.Services.Mobile
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Social/Messaging/Message.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/Message.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Services.Social.Messaging
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -119,6 +120,7 @@ namespace DotNetNuke.Services.Social.Messaging
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Social/Messaging/MessageAttachment.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/MessageAttachment.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Services.Social.Messaging
 
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -57,6 +58,7 @@ namespace DotNetNuke.Services.Social.Messaging
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Social/Messaging/MessageRecipient.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/MessageRecipient.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Services.Social.Messaging
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -70,6 +71,7 @@ namespace DotNetNuke.Services.Social.Messaging
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Social/Notifications/Notification.cs
+++ b/DNN Platform/Library/Services/Social/Notifications/Notification.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Services.Social.Notifications
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -122,6 +123,7 @@ namespace DotNetNuke.Services.Social.Notifications
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/DNN Platform/Library/Services/Social/Notifications/NotificationType.cs
+++ b/DNN Platform/Library/Services/Social/Notifications/NotificationType.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Services.Social.Notifications
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -99,6 +100,7 @@ namespace DotNetNuke.Services.Social.Notifications
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get { return this.NotificationTypeId; }

--- a/DNN Platform/Library/Services/Social/Notifications/NotificationTypeAction.cs
+++ b/DNN Platform/Library/Services/Social/Notifications/NotificationTypeAction.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Services.Social.Notifications
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project:    DotNetNuke
@@ -83,6 +84,7 @@ namespace DotNetNuke.Services.Social.Notifications
         /// Gets or sets iHydratable.KeyID.
         /// </summary>
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get { return this.NotificationTypeActionId; }

--- a/DNN Platform/Library/UI/Skins/SkinPackageInfo.cs
+++ b/DNN Platform/Library/UI/Skins/SkinPackageInfo.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.UI.Skins
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -86,6 +87,7 @@ namespace DotNetNuke.UI.Skins
         }
 
         [XmlIgnore]
+        [JsonIgnore]
         public Dictionary<int, string> Skins
         {
             get

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Model/MenuPermissionInfo.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Model/MenuPermissionInfo.cs
@@ -10,6 +10,7 @@ namespace Dnn.PersonaBar.Library.Model
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Security.Permissions;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -107,6 +108,7 @@ namespace Dnn.PersonaBar.Library.Model
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Model/PermissionInfo.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Model/PermissionInfo.cs
@@ -10,6 +10,7 @@ namespace Dnn.PersonaBar.Library.Model
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Modules;
+    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
@@ -42,6 +43,7 @@ namespace Dnn.PersonaBar.Library.Model
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
+        [JsonIgnore]
         public int KeyID
         {
             get


### PR DESCRIPTION
Fixes #5005 

## Summary
Anywhere there was an ```XmlIgnore``` attribute we have added a ```JsonIgnore``` attribute from the Newtonsoft.Json library. This will help to ensure serializing to Json is mirroring the XML serialization objects.
