### PR TITLE
Use windows-2019 image for CI build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2019'
 
 variables:
   - name: "Build.ArtifactStagingDirectory"


### PR DESCRIPTION
The 2022 image is currently causing issues, presumably we need to upgrade to Cake 2.x

See https://github.com/dnnsoftware/Dnn.Platform/pull/5004#issuecomment-1030281326 for details