### PR TITLE
Upgrade Cake to 2.x

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net4.8</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <!-- Make sure start same folder .NET Core CLI and Visual Studio -->
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
@@ -14,20 +14,20 @@
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.BuildSystems.Module" Version="3.0.3" />
-    <PackageReference Include="Cake.FileHelpers" Version="4.0.1" />
-    <PackageReference Include="Cake.Frosting" Version="1.2.0" />
-    <PackageReference Include="Cake.Git" Version="1.1.0" />
-    <PackageReference Include="Cake.Issues" Version="1.0.0" />
+    <PackageReference Include="Cake.BuildSystems.Module" Version="4.1.0" />
+    <PackageReference Include="Cake.FileHelpers" Version="5.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
+    <PackageReference Include="Cake.Git" Version="2.0.0" />
+    <PackageReference Include="Cake.Issues" Version="2.0.0-beta0001" />
     <PackageReference Include="Cake.Issues.MsBuild" Version="1.0.0" />
-    <PackageReference Include="Cake.Json" Version="6.0.1" />
-    <PackageReference Include="Cake.XdtTransform" Version="1.0.0" />
+    <PackageReference Include="Cake.Json" Version="7.0.1" />
+    <PackageReference Include="Cake.XdtTransform" Version="2.0.0" />
     <PackageReference Include="Dnn.CakeUtils" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 </Project>

--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Cake.BuildSystems.Module" Version="3.0.3" />
     <PackageReference Include="Cake.FileHelpers" Version="4.0.1" />
     <PackageReference Include="Cake.Frosting" Version="1.2.0" />
-    <PackageReference Include="Cake.Frosting.Issues.Recipe" Version="1.3.1" />
     <PackageReference Include="Cake.Git" Version="1.1.0" />
     <PackageReference Include="Cake.Issues" Version="1.0.0" />
     <PackageReference Include="Cake.Issues.MsBuild" Version="1.0.0" />

--- a/Build/Context.cs
+++ b/Build/Context.cs
@@ -12,16 +12,16 @@ namespace DotNetNuke.Build
     using Cake.Common.IO.Paths;
     using Cake.Common.Tools.GitVersion;
     using Cake.Core;
-    using Cake.Frosting.Issues.Recipe;
+    using Cake.Frosting;
     using Cake.Json;
 
     /// <inheritdoc/>
-    public class Context : IssuesContext
+    public class Context : FrostingContext
     {
         /// <summary>Initializes a new instance of the <see cref="Context"/> class.</summary>
         /// <param name="context">The base context.</param>
         public Context(ICakeContext context)
-            : base(context, RepositoryInfoProviderType.CakeGit)
+            : base(context)
         {
             try
             {

--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -8,7 +8,6 @@ namespace DotNetNuke.Build
 
     using Cake.AzurePipelines.Module;
     using Cake.Frosting;
-    using Cake.Frosting.Issues.Recipe;
 
     /// <summary>Runs the build process.</summary>
     public class Program
@@ -34,7 +33,6 @@ namespace DotNetNuke.Build
                 .InstallTool(new Uri("nuget:?package=NUnit3TestAdapter&version=" + NUnit3TestAdapterVersion))
                 .InstallTool(new Uri("nuget:?package=NuGet.CommandLine&version=5.10.0"))
                 .InstallTool(new Uri("nuget:?package=Cake.Issues.MsBuild&version=1.0.0"))
-                .AddAssembly(Assembly.GetAssembly(typeof(IssuesTask)))
                 .Run(args);
         }
     }

--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -17,8 +17,8 @@ namespace DotNetNuke.Build.Tasks
     using DotNetNuke.Build;
 
     /// <summary>A cake task to compile the platform.</summary>
-    [Dependency(typeof(CleanWebsite))]
-    [Dependency(typeof(RestoreNuGetPackages))]
+    [IsDependentOn(typeof(CleanWebsite))]
+    [IsDependentOn(typeof(RestoreNuGetPackages))]
     public sealed class Build : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/BuildAll.cs
+++ b/Build/Tasks/BuildAll.cs
@@ -4,7 +4,6 @@
 namespace DotNetNuke.Build.Tasks
 {
     using Cake.Frosting;
-    using Cake.Frosting.Issues.Recipe;
 
     /// <summary>A cake task to compile the platform and create all of the packages.</summary>
     /// <remarks>This is the task run during CI.</remarks>
@@ -18,7 +17,6 @@ namespace DotNetNuke.Build.Tasks
     [Dependency(typeof(CreateSymbols))]
     [Dependency(typeof(CreateNugetPackages))]
     [Dependency(typeof(GeneratePackagesChecksums))]
-    [IsDependentOn(typeof(IssuesTask))]
     public sealed class BuildAll : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/BuildAll.cs
+++ b/Build/Tasks/BuildAll.cs
@@ -7,16 +7,16 @@ namespace DotNetNuke.Build.Tasks
 
     /// <summary>A cake task to compile the platform and create all of the packages.</summary>
     /// <remarks>This is the task run during CI.</remarks>
-    [Dependency(typeof(CleanArtifacts))]
-    [Dependency(typeof(UpdateDnnManifests))]
-    [Dependency(typeof(GenerateSecurityAnalyzerChecksums))]
-    [Dependency(typeof(SetPackageVersions))]
-    [Dependency(typeof(CreateInstall))]
-    [Dependency(typeof(CreateUpgrade))]
-    [Dependency(typeof(CreateDeploy))]
-    [Dependency(typeof(CreateSymbols))]
-    [Dependency(typeof(CreateNugetPackages))]
-    [Dependency(typeof(GeneratePackagesChecksums))]
+    [IsDependentOn(typeof(CleanArtifacts))]
+    [IsDependentOn(typeof(UpdateDnnManifests))]
+    [IsDependentOn(typeof(GenerateSecurityAnalyzerChecksums))]
+    [IsDependentOn(typeof(SetPackageVersions))]
+    [IsDependentOn(typeof(CreateInstall))]
+    [IsDependentOn(typeof(CreateUpgrade))]
+    [IsDependentOn(typeof(CreateDeploy))]
+    [IsDependentOn(typeof(CreateSymbols))]
+    [IsDependentOn(typeof(CreateNugetPackages))]
+    [IsDependentOn(typeof(GeneratePackagesChecksums))]
     public sealed class BuildAll : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/BuildServerSetVersion.cs
+++ b/Build/Tasks/BuildServerSetVersion.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to update the build number in CI.</summary>
-    [Dependency(typeof(SetVersion))]
+    [IsDependentOn(typeof(SetVersion))]
     public sealed class BuildServerSetVersion : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/BuildToTempFolder.cs
+++ b/Build/Tasks/BuildToTempFolder.cs
@@ -9,11 +9,11 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to build the platform.</summary>
-    [Dependency(typeof(SetVersion))]
-    [Dependency(typeof(UpdateDnnManifests))]
-    [Dependency(typeof(ResetDatabase))]
-    [Dependency(typeof(PreparePackaging))]
-    [Dependency(typeof(OtherPackages))]
+    [IsDependentOn(typeof(SetVersion))]
+    [IsDependentOn(typeof(UpdateDnnManifests))]
+    [IsDependentOn(typeof(ResetDatabase))]
+    [IsDependentOn(typeof(PreparePackaging))]
+    [IsDependentOn(typeof(OtherPackages))]
     public sealed class BuildToTempFolder : FrostingTask<Context>
     {
     }

--- a/Build/Tasks/BuildWithDatabase.cs
+++ b/Build/Tasks/BuildWithDatabase.cs
@@ -9,13 +9,13 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to compile the platform and create a localdb database.</summary>
-    [Dependency(typeof(CleanArtifacts))]
-    [Dependency(typeof(UpdateDnnManifests))]
-    [Dependency(typeof(CreateInstall))]
-    [Dependency(typeof(CreateUpgrade))]
-    [Dependency(typeof(CreateDeploy))]
-    [Dependency(typeof(CreateSymbols))]
-    [Dependency(typeof(CreateDatabase))]
+    [IsDependentOn(typeof(CleanArtifacts))]
+    [IsDependentOn(typeof(UpdateDnnManifests))]
+    [IsDependentOn(typeof(CreateInstall))]
+    [IsDependentOn(typeof(CreateUpgrade))]
+    [IsDependentOn(typeof(CreateDeploy))]
+    [IsDependentOn(typeof(CreateSymbols))]
+    [IsDependentOn(typeof(CreateDatabase))]
     public sealed class BuildWithDatabase : FrostingTask<Context>
     {
     }

--- a/Build/Tasks/CopyWebsite.cs
+++ b/Build/Tasks/CopyWebsite.cs
@@ -10,8 +10,8 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to copy the built website folder.</summary>
-    [Dependency(typeof(CleanWebsite))]
-    [Dependency(typeof(GenerateSqlDataProvider))]
+    [IsDependentOn(typeof(CleanWebsite))]
+    [IsDependentOn(typeof(GenerateSqlDataProvider))]
     public sealed class CopyWebsite : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/CreateDeploy.cs
+++ b/Build/Tasks/CreateDeploy.cs
@@ -13,8 +13,8 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to crete the Deploy package.</summary>
-    [Dependency(typeof(PreparePackaging))]
-    [Dependency(typeof(OtherPackages))]
+    [IsDependentOn(typeof(PreparePackaging))]
+    [IsDependentOn(typeof(OtherPackages))]
     public sealed class CreateDeploy : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/CreateInstall.cs
+++ b/Build/Tasks/CreateInstall.cs
@@ -13,8 +13,8 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to create the Install package.</summary>
-    [Dependency(typeof(PreparePackaging))]
-    [Dependency(typeof(OtherPackages))]
+    [IsDependentOn(typeof(PreparePackaging))]
+    [IsDependentOn(typeof(OtherPackages))]
     public sealed class CreateInstall : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/CreateNugetPackages.cs
+++ b/Build/Tasks/CreateNugetPackages.cs
@@ -16,7 +16,7 @@ namespace DotNetNuke.Build.Tasks
     using DotNetNuke.Build;
 
     /// <summary>A cake task to create the platform's NuGet packages.</summary>
-    [Dependency(typeof(PreparePackaging))]
+    [IsDependentOn(typeof(PreparePackaging))]
     public sealed class CreateNugetPackages : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/CreateSymbols.cs
+++ b/Build/Tasks/CreateSymbols.cs
@@ -12,8 +12,8 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to create the Symbols package.</summary>
-    [Dependency(typeof(PreparePackaging))]
-    [Dependency(typeof(OtherPackages))]
+    [IsDependentOn(typeof(PreparePackaging))]
+    [IsDependentOn(typeof(OtherPackages))]
     public sealed class CreateSymbols : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/CreateUpgrade.cs
+++ b/Build/Tasks/CreateUpgrade.cs
@@ -14,11 +14,11 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to create the Upgrade package.</summary>
-    [Dependency(typeof(PreparePackaging))]
-    [Dependency(typeof(OtherPackages))]
-    [Dependency(typeof(CreateInstall))] // This is to ensure CreateUpgrade runs last and not in parallel, can be removed when we get to v10 where the telerik workaround is no longer needed
-    [Dependency(typeof(CreateSymbols))] // This is to ensure CreateUpgrade runs last and not in parallel, can be removed when we get to v10 where the telerik workaround is no longer needed
-    [Dependency(typeof(CreateDeploy))] // This is to ensure CreateUpgrade runs last and not in parallel, can be removed when we get to v10 where the telerik workaround is no longer needed
+    [IsDependentOn(typeof(PreparePackaging))]
+    [IsDependentOn(typeof(OtherPackages))]
+    [IsDependentOn(typeof(CreateInstall))] // This is to ensure CreateUpgrade runs last and not in parallel, can be removed when we get to v10 where the telerik workaround is no longer needed
+    [IsDependentOn(typeof(CreateSymbols))] // This is to ensure CreateUpgrade runs last and not in parallel, can be removed when we get to v10 where the telerik workaround is no longer needed
+    [IsDependentOn(typeof(CreateDeploy))] // This is to ensure CreateUpgrade runs last and not in parallel, can be removed when we get to v10 where the telerik workaround is no longer needed
     public sealed class CreateUpgrade : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/Default.cs
+++ b/Build/Tasks/Default.cs
@@ -10,12 +10,12 @@ namespace DotNetNuke.Build.Tasks
 
     /// <summary>A cake task to build the platform and create packages.</summary>
     /// <remarks>This is the default Cake target if no target is supplied.</remarks>
-    [Dependency(typeof(CleanArtifacts))]
-    [Dependency(typeof(UpdateDnnManifests))]
-    [Dependency(typeof(CreateInstall))]
-    [Dependency(typeof(CreateUpgrade))]
-    [Dependency(typeof(CreateDeploy))]
-    [Dependency(typeof(CreateSymbols))]
+    [IsDependentOn(typeof(CleanArtifacts))]
+    [IsDependentOn(typeof(UpdateDnnManifests))]
+    [IsDependentOn(typeof(CreateInstall))]
+    [IsDependentOn(typeof(CreateUpgrade))]
+    [IsDependentOn(typeof(CreateDeploy))]
+    [IsDependentOn(typeof(CreateSymbols))]
     public sealed class Default : FrostingTask<Context>
     {
     }

--- a/Build/Tasks/GeneratePackagesChecksums.cs
+++ b/Build/Tasks/GeneratePackagesChecksums.cs
@@ -15,12 +15,12 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to generate a <c>checksums.md</c> file with the artifact checksums.</summary>
-    [Dependency(typeof(CleanArtifacts))]
-    [Dependency(typeof(UpdateDnnManifests))]
-    [Dependency(typeof(CreateInstall))]
-    [Dependency(typeof(CreateUpgrade))]
-    [Dependency(typeof(CreateDeploy))]
-    [Dependency(typeof(CreateSymbols))]
+    [IsDependentOn(typeof(CleanArtifacts))]
+    [IsDependentOn(typeof(UpdateDnnManifests))]
+    [IsDependentOn(typeof(CreateInstall))]
+    [IsDependentOn(typeof(CreateUpgrade))]
+    [IsDependentOn(typeof(CreateDeploy))]
+    [IsDependentOn(typeof(CreateSymbols))]
     public sealed class GeneratePackagesChecksums : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/GenerateSecurityAnalyzerChecksums.cs
+++ b/Build/Tasks/GenerateSecurityAnalyzerChecksums.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to generate the <c>Default.aspx</c> checksum for the Security Analyzer.</summary>
-    [Dependency(typeof(SetVersion))]
+    [IsDependentOn(typeof(SetVersion))]
     public sealed class GenerateSecurityAnalyzerChecksums : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/GenerateSqlDataProvider.cs
+++ b/Build/Tasks/GenerateSqlDataProvider.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to generate a SQL Data Provider script if it doesn't exist.</summary>
-    [Dependency(typeof(SetVersion))]
+    [IsDependentOn(typeof(SetVersion))]
     public sealed class GenerateSqlDataProvider : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/OtherPackages.cs
+++ b/Build/Tasks/OtherPackages.cs
@@ -16,12 +16,12 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to include other 3rd party packages.</summary>
-    [Dependency(typeof(PackageNewtonsoft))]
-    [Dependency(typeof(PackageMailKit))]
-    [Dependency(typeof(PackageAspNetWebApi))]
-    [Dependency(typeof(PackageAspNetWebPages))]
-    [Dependency(typeof(PackageAspNetMvc))]
-    [Dependency(typeof(PackageMicrosoftGlobbing))]
+    [IsDependentOn(typeof(PackageNewtonsoft))]
+    [IsDependentOn(typeof(PackageMailKit))]
+    [IsDependentOn(typeof(PackageAspNetWebApi))]
+    [IsDependentOn(typeof(PackageAspNetWebPages))]
+    [IsDependentOn(typeof(PackageAspNetMvc))]
+    [IsDependentOn(typeof(PackageMicrosoftGlobbing))]
     public sealed class OtherPackages : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/PreparePackaging.cs
+++ b/Build/Tasks/PreparePackaging.cs
@@ -11,10 +11,10 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Json;
 
     /// <summary>A cake task to prepare for packaging (by building the platform and copying files).</summary>
-    [Dependency(typeof(CopyWebsite))]
-    [Dependency(typeof(Build))]
-    [Dependency(typeof(CopyWebConfig))]
-    [Dependency(typeof(CopyWebsiteBinFolder))]
+    [IsDependentOn(typeof(CopyWebsite))]
+    [IsDependentOn(typeof(Build))]
+    [IsDependentOn(typeof(CopyWebConfig))]
+    [IsDependentOn(typeof(CopyWebsiteBinFolder))]
     public sealed class PreparePackaging : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/ResetDevSite.cs
+++ b/Build/Tasks/ResetDevSite.cs
@@ -9,9 +9,9 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to reset a local dev site.</summary>
-    [Dependency(typeof(BuildToTempFolder))]
-    [Dependency(typeof(CopyToDevSite))]
-    [Dependency(typeof(CopyWebConfigToDevSite))]
+    [IsDependentOn(typeof(BuildToTempFolder))]
+    [IsDependentOn(typeof(CopyToDevSite))]
+    [IsDependentOn(typeof(CopyWebConfigToDevSite))]
     public sealed class ResetDevSite : FrostingTask<Context>
     {
     }

--- a/Build/Tasks/RunUnitTests.cs
+++ b/Build/Tasks/RunUnitTests.cs
@@ -11,7 +11,7 @@ namespace DotNetNuke.Build.Tasks
 
     /// <summary>A cake task to run NUnit 3 tests.</summary>
     /// <remarks>This task is not used (NUnit 3 is not used by DNN), you probably want <see cref="UnitTests"/>.</remarks>
-    [Dependency(typeof(Build))]
+    [IsDependentOn(typeof(Build))]
     public sealed class RunUnitTests : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/SetPackageVersions.cs
+++ b/Build/Tasks/SetPackageVersions.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
 
     /// <summary>A cake task to set the version of client-side packages.</summary>
-    [Dependency(typeof(SetVersion))]
+    [IsDependentOn(typeof(SetVersion))]
     public sealed class SetPackageVersions : FrostingTask<Context>
     {
         /// <inheritdoc/>

--- a/Build/Tasks/UpdateDnnManifests.cs
+++ b/Build/Tasks/UpdateDnnManifests.cs
@@ -16,8 +16,8 @@ namespace DotNetNuke.Build.Tasks
     using Dnn.CakeUtils;
 
     /// <summary>A cake task to set the <c>version</c> attribute in all of the <c>.dnn</c> manifest files.</summary>
-    [Dependency(typeof(SetVersion))]
-    [Dependency(typeof(SetPackageVersions))]
+    [IsDependentOn(typeof(SetVersion))]
+    [IsDependentOn(typeof(SetPackageVersions))]
     public sealed class UpdateDnnManifests : FrostingTask<Context>
     {
         /// <summary>Gets the version from the context and formats it as a string.</summary>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,11 @@ steps:
     key: 'yarn | "$(Agent.OS)" | yarn.lock'
     restoreKeys: 'yarn | "$(Agent.OS)"'
     path: $(YARN_CACHE_FOLDER)
+    
+- task: UseDotNet@2
+  displayName: 'Use .NET Core 3.1 SDK'
+  inputs:
+    version: 3.1.x
 
 - task: PowerShell@2
   displayName: 'Run DNN Update Versions'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-latest'
 
 variables:
   - name: "Build.ArtifactStagingDirectory"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,16 @@ steps:
   inputs:
     version: 3.1.x
 
+- task: UseDotNet@2
+  displayName: 'Use .NET 5.x SDK'
+  inputs:
+    version: 5.x
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 6.x SDK'
+  inputs:
+    version: 6.x
+
 - task: PowerShell@2
   displayName: 'Run DNN Update Versions'
   inputs:


### PR DESCRIPTION
## Summary
This PR upgrades the Build project to Cake 2.0.0. In order to do this upgrade, Cake.Frosting.Issues.Recipe was replaced, since [it's not yet upgraded to support Cake 2](https://github.com/cake-contrib/Cake.Issues.Recipe/issues/253). The basic behavior of the recipe (read issues from MSBuild and report them to Azure DevOps) has been put in place.