### PR TITLE
Report build errors as errors to Azure DevOps

### DIFF
--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Build.Tasks
 {
+    using System;
     using System.Collections.Generic;
 
     using Cake.Common.Build;
@@ -13,7 +14,6 @@ namespace DotNetNuke.Build.Tasks
     using Cake.Frosting;
     using Cake.Issues;
     using Cake.Issues.MsBuild;
-
     using DotNetNuke.Build;
 
     /// <summary>A cake task to compile the platform.</summary>
@@ -55,13 +55,20 @@ namespace DotNetNuke.Build.Tasks
 
                 foreach (var issue in issues)
                 {
-                    context.AzurePipelines()
-                           .Commands.WriteWarning(
-                               issue.MessageText,
-                               new AzurePipelinesMessageData
-                               {
-                                   SourcePath = issue.AffectedFileRelativePath?.FullPath, LineNumber = issue.Line,
-                               });
+                    var messageData = new AzurePipelinesMessageData
+                    {
+                        SourcePath = issue.AffectedFileRelativePath?.FullPath,
+                        LineNumber = issue.Line,
+                    };
+
+                    if (string.Equals(issue.PriorityName, "Error", StringComparison.Ordinal))
+                    {
+                        context.AzurePipelines().Commands.WriteError(issue.MessageText, messageData);
+                    }
+                    else
+                    {
+                        context.AzurePipelines().Commands.WriteWarning(issue.MessageText, messageData);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Currently the CI build reports all "issues" as warnings to Azure DevOps, so the errors that caused a build to fail aren't easy to find. Previously we had been using Cake.Frosting.Issues.Recipe to automatically report these issues, which [does not distinguish between errors and warnings](https://github.com/cake-contrib/Cake.Issues.Recipe/blob/b3bca0f7ba02ba478b315365b04e2df8abed77d0/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/AzureDevOpsBuildServer.cs#L64-L79), and that logic was copied when we recently removed the Cake.Frosting.Issues.Recipe package reference during the upgrade to Cake 2.0. This PR adjusts that logic to report errors as errors and everything else as warnings.