### PR TITLE
Fixed an issue where WebFormsMvp initial version mismatched with the config

### DIFF
--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -40,7 +40,8 @@
     "/bin/System.Web.WebPages.Razor.dll",
     "/bin/WebMatrix.Data.dll",
     "/bin/WebMatrix.WebData.dll",
-    "/Install/Module/DNNCE_Website.Deprecated_*_Install.zip"
+    "/Install/Module/DNNCE_Website.Deprecated_*_Install.zip",
+    "/bin/WebFormsMvp.dll"
   ],
   "installInclude": ["/Install/InstallWizard.aspx.cs"],
   "upgradeExclude": [

--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -52,7 +52,8 @@
     "/bin/Providers/DotNetNuke.Providers.AspNetClientCapabilityProvider.dll",
     "/bin/Newtonsoft.Json.dll",
     "/Config/DotNetNuke.config",
-    "/Install/InstallWizard.aspx"
+    "/Install/InstallWizard.aspx",
+    "/bin/WebFormsMvp.dll"
   ],
   "symbolsInclude": [
     "/bin/*.pdb",

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Data.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Data.SqlDataProvider
@@ -6447,7 +6447,7 @@ INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [Package
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (19, NULL, N'System.Web.WebPages.Deployment.dll', N'2.0.20710')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (20, NULL, N'System.Web.WebPages.dll', N'2.0.20710')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (21, NULL, N'System.Web.WebPages.Razor.dll', N'2.0.20126')
-INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (22, NULL, N'WebFormsMvp.dll', N'1.4.1')
+INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (22, NULL, N'WebFormsMvp.dll', N'1.4.5')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (23, NULL, N'WebMatrix.Data.dll', N'2.0.20126')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (24, NULL, N'WebMatrix.WebData.dll', N'2.0.20126')
 SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Assemblies] OFF

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Data.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Data.SqlDataProvider
@@ -6447,7 +6447,6 @@ INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [Package
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (19, NULL, N'System.Web.WebPages.Deployment.dll', N'2.0.20710')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (20, NULL, N'System.Web.WebPages.dll', N'2.0.20710')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (21, NULL, N'System.Web.WebPages.Razor.dll', N'2.0.20126')
-INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (22, NULL, N'WebFormsMvp.dll', N'1.4.5')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (23, NULL, N'WebMatrix.Data.dll', N'2.0.20126')
 INSERT INTO {databaseOwner}[{objectQualifier}Assemblies] ([AssemblyID], [PackageID], [AssemblyName], [Version]) VALUES (24, NULL, N'WebMatrix.WebData.dll', N'2.0.20126')
 SET IDENTITY_INSERT {databaseOwner}[{objectQualifier}Assemblies] OFF

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -261,10 +261,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebFormsMvp" publicKeyToken="537f18701145dff0" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.999.999" newVersion="1.4.5.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -262,7 +262,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebFormsMvp" publicKeyToken="537f18701145dff0" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.999.999" newVersion="1.4.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.999.999" newVersion="1.4.5.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />


### PR DESCRIPTION
A clean install would fail due the the mismatched version in the web.config vs the file in the bin folder.

Upon upgrade the DLL file in the bin folder is not included and the package should take care of upgrading the one that is there.