### PR TITLE
Fix versions of dependencies in Nuget spec files

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -18,9 +18,9 @@
       <dependency id="DotNetNuke.Web" version="$version$" />
       <dependency id="DotNetNuke.Web.Client" version="$version$" />
       <dependency id="DotNetNuke.WebApi" version="$version$" />
-      <dependency id="Microsoft.AspNet.Mvc" version="5.1.3" />
-      <dependency id="Microsoft.AspNet.Razor" version="3.1.2" />
-      <dependency id="Microsoft.AspNet.WebPages" version="3.1.2" />
+      <dependency id="Microsoft.AspNet.Mvc" version="5.2.7" />
+      <dependency id="Microsoft.AspNet.Razor" version="3.2.7" />
+      <dependency id="Microsoft.AspNet.WebPages" version="3.2.7" />
       <dependency id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
     </dependencies>
   </metadata>

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -15,8 +15,8 @@
     </description>
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>
     <dependencies>
-      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
-      <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
+      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.7" />
+      <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.7" />
       <dependency id="NewtonSoft.Json" version="10.0.3" />
       <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>


### PR DESCRIPTION
Since version 9.10.0 DNN moved up the dependencies on Microsoft's libraries. This should be reflected in the Nuspec file or else your module will not build. This also means that 9.10.0, 9.10.1 and 9.10.2 nuget packages for DNN will not work to build MVC style modules.