### PR TITLE
Fix error getting host tab URL

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
@@ -1405,9 +1405,9 @@ namespace DotNetNuke.Entities.Urls
             var localSettings = new FriendlyUrlSettings(portalId);
 
             // Call GetFriendlyAlias to get the Alias part of the url
-            if (string.IsNullOrEmpty(portalAlias) && portalSettings != null)
+            if (string.IsNullOrEmpty(portalAlias) && portalSettings?.PortalAlias is IPortalAliasInfo portalSettingsAlias)
             {
-                portalAlias = portalSettings.PortalAlias.HTTPAlias;
+                portalAlias = portalSettingsAlias.HttpAlias;
             }
 
             string friendlyPath = GetFriendlyAlias(

--- a/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
@@ -16,6 +16,7 @@ namespace DotNetNuke.Modules.Admin.Modules
 
     using DotNetNuke.Abstractions;
     using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Modules.Definitions;
     using DotNetNuke.Entities.Portals;
@@ -89,7 +90,7 @@ namespace DotNetNuke.Modules.Admin.Modules
             {
                 var index = 0;
                 TabController.Instance.PopulateBreadCrumbs(ref tab);
-                var defaultAlias = PortalAliasController.Instance.GetPortalAliasesByPortalId(tab.PortalID)
+                var defaultAlias = PortalAliasController.Instance.GetPortalAliasesByPortalId(tab.IsSuperTab ? Host.HostPortalID : tab.PortalID)
                                         .OrderByDescending(a => a.IsPrimary)
                                         .FirstOrDefault();
                 var portalSettings = new PortalSettings(tab.PortalID)


### PR DESCRIPTION
Closes #5051

This PR fixes two related issues.

First, in module settings, when getting the alias for a page, use the host portal ID if it's a host tab.

Second, in the advanced friendly URL provider, make sure that `PortalAlias` isn't `null` before trying to read its `HttpAlias`.