### PR TITLE
Fix not reporting errors or warnings from build

### DIFF
--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -44,7 +44,7 @@ namespace DotNetNuke.Build.Tasks
                 var issueProviders =
                     from logFilePath in new[] { cleanLog, buildLog, }
                     where context.FileExists(logFilePath)
-                    let settings = new MsBuildIssuesSettings(cleanLog, context.MsBuildBinaryLogFileFormat())
+                    let settings = new MsBuildIssuesSettings(logFilePath, context.MsBuildBinaryLogFileFormat())
                     select new MsBuildIssuesProvider(context.Log, settings);
                 var issues = context.ReadIssues(issueProviders, context.Directory("."));
                 foreach (var issue in issues)


### PR DESCRIPTION
## Summary
Due to a bug I introduced in #5034 we stopped reporting any build errors or warnings from the build process (_only_ errors from the clean before the build were reported)