### PR TITLE
Allow removal of rel for Terms and Privacy skin objects

### DIFF
--- a/DNN Platform/Website/admin/Skins/Privacy.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Privacy.ascx.cs
@@ -61,7 +61,10 @@ namespace DotNetNuke.UI.Skins.Controls
 
                 this.hypPrivacy.NavigateUrl = this.PortalSettings.PrivacyTabId == Null.NullInteger ? this._navigationManager.NavigateURL(this.PortalSettings.ActiveTab.TabID, "Privacy") : this._navigationManager.NavigateURL(this.PortalSettings.PrivacyTabId);
                 if (!string.IsNullOrWhiteSpace(this.Rel))
+                {
                     this.hypPrivacy.Attributes["rel"] = this.Rel;
+                }
+
             }
             catch (Exception exc)
             {

--- a/DNN Platform/Website/admin/Skins/Privacy.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Privacy.ascx.cs
@@ -60,7 +60,8 @@ namespace DotNetNuke.UI.Skins.Controls
                 }
 
                 this.hypPrivacy.NavigateUrl = this.PortalSettings.PrivacyTabId == Null.NullInteger ? this._navigationManager.NavigateURL(this.PortalSettings.ActiveTab.TabID, "Privacy") : this._navigationManager.NavigateURL(this.PortalSettings.PrivacyTabId);
-                this.hypPrivacy.Attributes["rel"] = this.Rel;
+                if (!string.IsNullOrWhiteSpace(this.Rel))
+                    this.hypPrivacy.Attributes["rel"] = this.Rel;
             }
             catch (Exception exc)
             {

--- a/DNN Platform/Website/admin/Skins/Terms.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Terms.ascx.cs
@@ -61,7 +61,10 @@ namespace DotNetNuke.UI.Skins.Controls
 
                 this.hypTerms.NavigateUrl = this.PortalSettings.TermsTabId == Null.NullInteger ? this._navigationManager.NavigateURL(this.PortalSettings.ActiveTab.TabID, "Terms") : this._navigationManager.NavigateURL(this.PortalSettings.TermsTabId);
                 if (!string.IsNullOrWhiteSpace(this.Rel))
+                {
                     this.hypTerms.Attributes["rel"] = this.Rel;
+                }
+
             }
             catch (Exception exc)
             {

--- a/DNN Platform/Website/admin/Skins/Terms.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Terms.ascx.cs
@@ -60,7 +60,8 @@ namespace DotNetNuke.UI.Skins.Controls
                 }
 
                 this.hypTerms.NavigateUrl = this.PortalSettings.TermsTabId == Null.NullInteger ? this._navigationManager.NavigateURL(this.PortalSettings.ActiveTab.TabID, "Terms") : this._navigationManager.NavigateURL(this.PortalSettings.TermsTabId);
-                this.hypTerms.Attributes["rel"] = this.Rel;
+                if (!string.IsNullOrWhiteSpace(this.Rel))
+                    this.hypTerms.Attributes["rel"] = this.Rel;
             }
             catch (Exception exc)
             {


### PR DESCRIPTION
Set the rel attribute of the hyperlink only if there is either no value set in the skin or a non blank value defined in the skin. If it is set to rel="" in the skin, the hyperlink will be rendered without a rel attribute.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #5047 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
