### PR TITLE
Add new Security Analyzer check for permissions on "Activity Feed" and "User Profile" pages

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/AuditChecks.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/AuditChecks.cs
@@ -36,6 +36,7 @@ namespace Dnn.PersonaBar.Security.Components
                 new CheckAllowableFileExtensions(),
                 new CheckHiddenSystemFiles(),
                 new CheckTelerikPresence(applicationStatusInfo),
+                new CheckUserProfilePage(),
             };
 
             if (Globals.NETFrameworkVersion <= new Version(4, 5, 1))

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/BaseCheck.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/BaseCheck.cs
@@ -1,0 +1,81 @@
+﻿namespace Dnn.PersonaBar.Security.Components.Checks
+{
+    using System;
+
+    using DotNetNuke.Instrumentation;
+    using DotNetNuke.Services.Localization;
+
+    /// <summary>
+    /// Base class for security checks.
+    /// </summary>
+    public abstract class BaseCheck : IAuditCheck
+    {
+        private readonly Lazy<ILog> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseCheck"/> class.
+        /// </summary>
+        public BaseCheck()
+        {
+            this.logger = new Lazy<ILog>(() => LoggerSource.Instance.GetLogger(this.GetType()));
+        }
+
+        /// <inheritdoc cref="IAuditCheck.Id" />
+        public virtual string Id => this.GetType().Name;
+
+        /// <inheritdoc cref="IAuditCheck.LazyLoad" />
+        public virtual bool LazyLoad => false;
+
+        /// <summary>
+        /// Gets the path to the resources file (.resx).
+        /// </summary>
+        protected virtual string LocalResourceFile =>
+            "~/DesktopModules/admin/Dnn.PersonaBar/Modules/Dnn.Security/App_LocalResources/Security.resx";
+
+        /// <summary>
+        /// Gets a typed instance of the <see cref="ILog"/> interface.
+        /// </summary>
+        protected virtual ILog Logger => this.logger.Value;
+
+        /// <inheritdoc cref="IAuditCheck.Execute" />
+        public virtual CheckResult Execute()
+        {
+            try
+            {
+                return this.ExecuteInternal();
+            }
+            catch (Exception ex)
+            {
+                this.Logger.Error($"{this.Id} failed.", ex);
+                return this.Unverified("An internal error occurred. See logs for details.");
+            }
+        }
+
+        /// <summary>
+        /// Performs the actual security check.
+        /// </summary>
+        /// <returns>A <see cref="CheckResult"/> with the outcome of the security check.</returns>
+        protected abstract CheckResult ExecuteInternal();
+
+        /// <inheritdoc cref="Localization.GetString(string, string)" />
+        protected virtual string GetLocalizedString(string key)
+        {
+            return Localization.GetString(this.Id + key, this.LocalResourceFile);
+        }
+
+        /// <summary>
+        /// Returns an "unverified" result.
+        /// </summary>
+        /// <param name="reason">The reason why we are returning an unverified result.
+        /// This text will be displayed in the Notes column.</param>
+        /// <returns>A <see cref="CheckResult"/> with a <see cref="CheckResult.Severity"/>
+        /// of <see cref="SeverityEnum.Unverified"/>.</returns>
+        protected virtual CheckResult Unverified(string reason)
+        {
+            return new CheckResult(SeverityEnum.Unverified, this.Id)
+            {
+                Notes = { reason },
+            };
+        }
+    }
+}

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/CheckUserProfilePage.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/CheckUserProfilePage.cs
@@ -1,0 +1,148 @@
+﻿namespace Dnn.PersonaBar.Security.Components.Checks
+{
+    using System;
+    using System.Linq;
+
+    using Dnn.PersonaBar.Pages.Components;
+    using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Common;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Tabs;
+
+    /// <summary>
+    /// A security check for permissions on the User Profile page
+    /// (by detault the "Activity Feed" page and the companion "My Profile" page).
+    /// If User Registration = None or Private and either of these pages are visible to all users,
+    /// it issues a warning that user profile information is displayed publicly.
+    /// For all other user registration values, shows an informational message if user profiles are public.
+    /// </summary>
+    public class CheckUserProfilePage : BaseCheck
+    {
+        /// <summary>
+        /// The default "Activity Feed" tab path.
+        /// </summary>
+        public const string ActivityFeedTabPath = "//ActivityFeed";
+
+        /// <summary>
+        /// The default "My Profile" tab path.
+        /// </summary>
+        public const string MyProfileTabPath = "//ActivityFeed//MyProfile";
+
+        /// <summary>
+        /// Name of the "View Tab" permission.
+        /// </summary>
+        public const string ViewTab = "View Tab";
+
+        private readonly ITabController tabController;
+        private readonly IPagesController pagesController;
+        private readonly Lazy<IPortalSettings> portalSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CheckUserProfilePage"/> class.
+        /// </summary>
+        public CheckUserProfilePage()
+            : this(PortalController.Instance, TabController.Instance, PagesController.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CheckUserProfilePage"/> class.
+        /// </summary>
+        /// <param name="portalController">An instance of the <see cref="IPortalController"/> interface.</param>
+        /// <param name="tabController">An instance of the <see cref="ITabController"/> interface.</param>
+        /// <param name="pagesController">An instance of the <see cref="IPagesController"/> interface.</param>
+        internal CheckUserProfilePage(
+            IPortalController portalController,
+            ITabController tabController,
+            IPagesController pagesController)
+            : base()
+        {
+            this.tabController = tabController
+                ?? throw new ArgumentNullException(nameof(tabController));
+
+            this.pagesController = pagesController
+                ?? throw new ArgumentNullException(nameof(pagesController));
+
+            if (portalController == null)
+            {
+                throw new ArgumentNullException(nameof(portalController));
+            }
+
+            this.portalSettings = new Lazy<IPortalSettings>(() => portalController.GetCurrentSettings());
+        }
+
+        private int PortalId => this.portalSettings.Value.PortalId;
+
+        private int UserTabId => this.portalSettings.Value.UserTabId;
+
+        /// <inheritdoc />
+        protected override CheckResult ExecuteInternal()
+        {
+            return this.UserProfilePageIsPublic() ? this.Public() : this.NotPublic();
+        }
+
+        private bool UserProfilePageIsPublic()
+        {
+            var userProfilePage = this.tabController.GetTab(this.UserTabId, this.PortalId);
+
+            if (userProfilePage == null || userProfilePage.IsDeleted)
+            {
+                return false; // invalid UserTabId in portal settings somehow
+            }
+
+            if (this.PageIsPublic(userProfilePage))
+            {
+                return true;
+            }
+
+            var userProfilePageIsActivityFeed = string.Equals(
+                ActivityFeedTabPath,
+                userProfilePage.TabPath,
+                StringComparison.OrdinalIgnoreCase);
+
+            if (!userProfilePageIsActivityFeed)
+            {
+                return false; // neither public nor activity feed, so no need to check "My Profile" page.
+            }
+
+            var myProfilePage = this.FindTabByPath(MyProfileTabPath, this.PortalId);
+
+            if (myProfilePage == null)
+            {
+                return false; // "My Profile" page not found, so not public.
+            }
+
+            return this.PageIsPublic(myProfilePage);
+        }
+
+        private CheckResult Public()
+        {
+            return new CheckResult(SeverityEnum.Warning, this.Id);
+        }
+
+        private CheckResult NotPublic()
+        {
+            return new CheckResult(SeverityEnum.Pass, this.Id);
+        }
+
+        private TabInfo FindTabByPath(string tabPath, int portalId)
+        {
+            return this.tabController.GetTabsByPortal(portalId)
+                .Select(kvp => kvp.Value)
+                .Where(tab => !tab.IsDeleted)
+                .Where(tab => string.Equals(tab.TabPath, tabPath, StringComparison.OrdinalIgnoreCase))
+                .SingleOrDefault();
+        }
+
+        private bool PageIsPublic(TabInfo tabInfo)
+        {
+            var allUsersRoleId = int.Parse(Globals.glbRoleAllUsers);
+
+            var permissions = this.pagesController.GetPermissionsData(tabInfo.TabID);
+
+            return permissions.RolePermissions
+                .Any(rp => rp.RoleId == allUsersRoleId &&
+                    rp.Permissions.Any(p => p.PermissionName == ViewTab && p.AllowAccess));
+        }
+    }
+}

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Components\Security\Checks\CheckHiddenSystemFiles.cs" />
     <Compile Include="Components\Security\Checks\CheckModuleHeaderAndFooter.cs" />
     <Compile Include="Components\Security\Checks\CheckPasswordFormat.cs" />
+    <Compile Include="Components\Security\Checks\CheckUserProfilePage.cs" />
     <Compile Include="Components\Security\Checks\CheckRarelyUsedSuperuser.cs" />
     <Compile Include="Components\Security\Checks\CheckSiteRegistration.cs" />
     <Compile Include="Components\Security\Checks\CheckSqlRisk.cs" />

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Components\Security\Attributes\UserRegistrationOptionAttribute.cs" />
     <Compile Include="Components\Security\AuditChecks.cs" />
     <Compile Include="Components\Security\CheckResult.cs" />
+    <Compile Include="Components\Security\Checks\BaseCheck.cs" />
     <Compile Include="Components\Security\Checks\CheckAllowableFileExtensions.cs" />
     <Compile Include="Components\Security\Checks\CheckBiography.cs" />
     <Compile Include="Components\Security\Checks\CheckDebug.cs" />

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -1120,6 +1120,18 @@
   <data name="CheckTelerikPresenceInstalledAndUsed.Text" xml:space="preserve">
     <value>Dependencies on Telerik were discovered in assemblies that will NOT be addressed by un-installing per the instructions with 9.8.0. The list below includes all:</value>
   </data>
+  <data name="CheckUserProfilePageFailure.Text" xml:space="preserve">
+    <value>The User Profile page is public.</value>
+  </data>
+  <data name="CheckUserProfilePageName.Text" xml:space="preserve">
+    <value>Check access to the User Profile page</value>
+  </data>
+  <data name="CheckUserProfilePageReason.Text" xml:space="preserve">
+    <value>The User Profile page might be visible to all users unintentionally.</value>
+  </data>
+  <data name="CheckUserProfilePageSuccess.Text" xml:space="preserve">
+    <value>The User Profile page is not public.</value>
+  </data>
   <data name="UserNotMemberOfRole.Text" xml:space="preserve">
     <value>User not member of {0} role.</value>
   </data>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Checks/CheckUserProfilePageTests.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Checks/CheckUserProfilePageTests.cs
@@ -1,0 +1,369 @@
+﻿namespace Dnn.PersonaBar.Security.Tests.Checks
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Dnn.PersonaBar.Library.DTO;
+    using Dnn.PersonaBar.Pages.Components;
+    using Dnn.PersonaBar.Pages.Services.Dto;
+    using Dnn.PersonaBar.Security.Components;
+    using Dnn.PersonaBar.Security.Components.Checks;
+    using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Common;
+    using DotNetNuke.ComponentModel;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Security.Permissions;
+    using DotNetNuke.Security.Roles;
+    using Moq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CheckUserProfilePageTests
+    {
+        private const string CustomUserProfilePageTabPath = "//MyCustomUserProfilePage";
+        private const int PortalId = 1;
+
+        [Test]
+        [TestCase("portalController")]
+        [TestCase("tabController")]
+        [TestCase("pagesController")]
+        public void Constructor_WhenArgumentIsNull_ThrowsArgumentNullException(string nullParamName)
+        {
+            // arrange
+            var argumentNullException = default(ArgumentNullException);
+            var unexpectedException = default(Exception);
+
+            // act
+            try
+            {
+                new CheckUserProfilePage(
+                    nullParamName == "portalController" ? null : new Mock<IPortalController>().Object,
+                    nullParamName == "tabController" ? null : new Mock<ITabController>().Object,
+                    nullParamName == "pagesController" ? null : new Mock<IPagesController>().Object);
+            }
+            catch (ArgumentNullException ex)
+            {
+                argumentNullException = ex;
+            }
+            catch (Exception ex)
+            {
+                unexpectedException = ex;
+            }
+
+            // assert
+            Assert.IsNull(unexpectedException);
+            Assert.IsNotNull(argumentNullException);
+            Assert.AreEqual(nullParamName, argumentNullException.ParamName);
+        }
+
+        [Test]
+        public void Execute_WhenNotFound_ReturnsPass()
+        {
+            // arrange
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+            var tabControllerMock = SetupTabControllerMock();
+            var pagesControllerMock = new Mock<IPagesController>();
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(SeverityEnum.Pass, result.Severity);
+        }
+
+        [Test]
+        public void Execute_WhenDeleted_ReturnsPass()
+        {
+            // arrange
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+
+            var tabControllerMock = SetupTabControllerMock(profilePage: new TabInfo { IsDeleted = true });
+
+            var pagesControllerMock = new Mock<IPagesController>();
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(SeverityEnum.Pass, result.Severity);
+        }
+
+        [Test]
+        public void Execute_WhenPublic_ReturnsWarning()
+        {
+            // arrange
+            RegisterTestablePermissionProvider();
+
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+            var activityFeedPage = BuildActivityFeedTabInfo();
+            var tabControllerMock = SetupTabControllerMock(activityFeedPage);
+            var pagesControllerMock = SetupPagesControllerMock(userProfilePageIsPublic: true);
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(SeverityEnum.Warning, result.Severity);
+        }
+
+        [Test]
+        public void Execute_WhenNeitherPublicNorActivityFeed_ReturnsPass()
+        {
+            // arrange
+            RegisterTestablePermissionProvider();
+
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+            var customProfilePage = BuildCustomProfileTabInfo();
+            var tabControllerMock = SetupTabControllerMock(customProfilePage);
+            var pagesControllerMock = SetupPagesControllerMock(userProfilePageIsPublic: false);
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(SeverityEnum.Pass, result.Severity);
+        }
+
+        [Test]
+        public void Execute_WhenNotPublicAndActivityFeedAndMyProfileNotFound_ReturnsPass()
+        {
+            // arrange
+            RegisterTestablePermissionProvider();
+
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+            var activityFeedPage = BuildActivityFeedTabInfo();
+            var tabControllerMock = SetupTabControllerMock(activityFeedPage, myProfilePage: null);
+            var pagesControllerMock = SetupPagesControllerMock(userProfilePageIsPublic: false);
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(SeverityEnum.Pass, result.Severity);
+        }
+
+        [Test]
+        public void Execute_WhenNotPublicAndActivityFeedAndMyProfileDeleted_ReturnsPass()
+        {
+            // arrange
+            RegisterTestablePermissionProvider();
+
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+
+            var activityFeedPage = BuildActivityFeedTabInfo();
+
+            var myProfilePage = new TabInfo
+            {
+                TabID = 2,
+                IsDeleted = true,
+                PortalID = PortalId,
+            };
+
+            var tabControllerMock = SetupTabControllerMock(activityFeedPage, myProfilePage);
+
+            var pagesControllerMock = SetupPagesControllerMock(userProfilePageIsPublic: false);
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(SeverityEnum.Pass, result.Severity);
+        }
+
+        [Test]
+        [TestCase(true, SeverityEnum.Warning)]
+        [TestCase(false, SeverityEnum.Pass)]
+        public void Execute_WhenNotPublicAndActivityFeedAndMyProfileValid_ReturnsCorrectSeverity(
+            bool myProfilePageIsPublic, SeverityEnum expectedSeverity)
+        {
+            // arrange
+            RegisterTestablePermissionProvider();
+
+            var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
+            var activityFeedPage = BuildActivityFeedTabInfo();
+            var myProfilePage = BuildMyProfileTabInfo();
+            var tabControllerMock = SetupTabControllerMock(activityFeedPage, myProfilePage);
+            var pagesControllerMock = SetupPagesControllerMock(false, myProfilePageIsPublic);
+
+            var sut = new CheckUserProfilePage(
+                portalControllerMock.Object,
+                tabControllerMock.Object,
+                pagesControllerMock.Object);
+
+            // act
+            var result = sut.Execute();
+
+            // assert
+            Assert.AreEqual(expectedSeverity, result.Severity);
+        }
+
+        private static TabInfo BuildActivityFeedTabInfo(bool deleted = false) => new TabInfo
+        {
+            TabID = 1,
+            IsDeleted = deleted,
+            TabPath = CheckUserProfilePage.ActivityFeedTabPath,
+            PortalID = PortalId,
+        };
+
+        private static TabInfo BuildCustomProfileTabInfo(bool deleted = false) => new TabInfo
+        {
+            TabID = 1,
+            IsDeleted = deleted,
+            TabPath = CustomUserProfilePageTabPath,
+            PortalID = PortalId,
+        };
+
+        private static TabInfo BuildMyProfileTabInfo(bool deleted = false) => new TabInfo
+        {
+            TabID = 2,
+            IsDeleted = deleted,
+            TabPath = CheckUserProfilePage.MyProfileTabPath,
+            PortalID = PortalId,
+        };
+
+        private static void RegisterTestablePermissionProvider()
+        {
+            var mock = new Mock<PermissionProvider>();
+
+            mock.Setup(x => x.ImplicitRolesForPages(It.IsAny<int>()))
+                .Returns(new List<RoleInfo>());
+
+            ComponentFactory.RegisterComponentInstance<PermissionProvider>(mock.Object);
+        }
+
+        private static Mock<IPagesController> SetupPagesControllerMock(
+            bool userProfilePageIsPublic, bool myProfilePageIsPublic = false)
+        {
+            var mock = new Mock<IPagesController>();
+
+            mock.Setup(x => x.GetPermissionsData(It.IsAny<int>()))
+                .Returns((int pageId) =>
+                {
+                    switch (pageId)
+                    {
+                        case 1: return BuildPermissionsData(userProfilePageIsPublic);
+                        case 2: return BuildPermissionsData(myProfilePageIsPublic);
+                        default: throw new ArgumentOutOfRangeException(nameof(pageId));
+                    }
+                });
+
+            return mock;
+        }
+
+        private static PagePermissions BuildPermissionsData(bool allUsersCanView)
+        {
+            var permissionsData = new PagePermissions(false);
+            if (allUsersCanView)
+            {
+                permissionsData.RolePermissions = new List<RolePermission>
+                {
+                    new RolePermission
+                    {
+                        RoleId = int.Parse(Globals.glbRoleAllUsers),
+                        Permissions = new List<Permission>
+                        {
+                            new Permission
+                            {
+                                PermissionName = CheckUserProfilePage.ViewTab,
+                                AllowAccess = true,
+                            },
+                        },
+                    },
+                };
+            }
+
+            return permissionsData;
+        }
+
+        private static Mock<IPortalSettings> SetupPortalSettingsMock(int portalId, int userTabId)
+        {
+            var mock = new Mock<IPortalSettings>();
+            mock.SetupGet(x => x.PortalId).Returns(portalId);
+            mock.SetupGet(x => x.UserTabId).Returns(userTabId);
+            return mock;
+        }
+
+        private static Mock<IPortalController> SetupPortalControllerMock(int portalId, int userTabId)
+        {
+            var settingsMock = SetupPortalSettingsMock(portalId, userTabId);
+
+            var settingsDictionary = new Dictionary<string, string>
+            {
+                {
+                    nameof(settingsMock.Object.ContentLocalizationEnabled),
+                    settingsMock.Object.ContentLocalizationEnabled.ToString()
+                },
+            };
+
+            var portalSettings = new PortalSettings
+            {
+                PortalId = settingsMock.Object.PortalId,
+            };
+
+            var mock = new Mock<IPortalController>();
+
+            mock.Setup(x => x.GetCurrentSettings()).Returns(settingsMock.Object);
+            mock.Setup(x => x.GetPortalSettings(It.IsAny<int>())).Returns(settingsDictionary);
+            mock.Setup(x => x.GetCurrentPortalSettings()).Returns(portalSettings);
+
+            PortalController.SetTestableInstance(mock.Object);
+
+            return mock;
+        }
+
+        private static Mock<ITabController> SetupTabControllerMock(
+            TabInfo profilePage = null, TabInfo myProfilePage = null)
+        {
+            var mock = new Mock<ITabController>();
+
+            mock.Setup(x => x.GetTab(It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(profilePage);
+
+            mock.Setup(x => x.GetTabsByPortal(It.IsAny<int>()))
+                .Returns((int portalId) =>
+                {
+                    var tabCollection = new TabCollection();
+
+                    if (myProfilePage != null)
+                    {
+                        tabCollection.Add(myProfilePage);
+                    }
+
+                    return tabCollection;
+                });
+
+            return mock;
+        }
+    }
+}

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
@@ -63,6 +63,7 @@
       <Link>SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="Checks\CheckTelerikPresenceTests.cs" />
+    <Compile Include="Checks\CheckUserProfilePageTests.cs" />
     <Compile Include="Services\SecurityControllerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Closes #4948

## Summary
This pull request adds this new `CheckUserProfilePage` class to check the visibility of the user profile page defined in Site Settings > Site Behavior > Default Pages > User Profile Page, according to the following criteria:

### Case 1: the selected user profile page is "Activity Feed"
* If the Activity Feed page cannot be found, or is deleted, it returns PASS.
* Otherwise, if the Activity Feed page is public, it returns ALERT.
* Otherwise, if My Profile cannot be found or is deleted, it returns PASS.
* Otherwise, if My Profile is public, it returns ALERT.
* Otherwise, it returns PASS.

### Case 2: the selected user profile page is not "Activity Feed"
* If the selected user profile page cannot be found, or is deleted, it returns PASS.
* Otherwise, if the selected user profile page is public, it returns ALERT.
* Otherwise, it returns PASS.

![image](https://user-images.githubusercontent.com/30123437/162604988-9d0e724b-b268-45c6-96ca-b5a4ab2cd627.png)

Also, a new base class for audit checks is introduced, and some refactoring to the existing `CheckTelerikPresence` class is done in order to avoid redundancy.