### PR TITLE
Deduplicated some code in audit check unit test

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/CheckUserProfilePage.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/CheckUserProfilePage.cs
@@ -10,11 +10,19 @@
     using DotNetNuke.Entities.Tabs;
 
     /// <summary>
-    /// A security check for permissions on the User Profile page
-    /// (by detault the "Activity Feed" page and the companion "My Profile" page).
-    /// If User Registration = None or Private and either of these pages are visible to all users,
-    /// it issues a warning that user profile information is displayed publicly.
-    /// For all other user registration values, shows an informational message if user profiles are public.
+    /// A security check for permissions on the User Profile page defined in
+    /// Site Settings > Site Behavior > Default Pages > User Profile Page,
+    /// according to the following criteria:
+    /// Case 1: the selected user profile page is "Activity Feed"
+    /// * If the Activity Feed page cannot be found, or is deleted, it returns PASS.
+    /// * Otherwise, if the Activity Feed page is public, it returns ALERT.
+    /// * Otherwise, if My Profile page cannot be found or is deleted, it returns PASS.
+    /// * Otherwise, if My Profile page is public, it returns ALERT.
+    /// * Otherwise, it returns PASS.
+    /// Case 2: the selected user profile page is not "Activity Feed"
+    /// * If the selected user profile page cannot be found, or is deleted, it returns PASS.
+    /// * Otherwise, if the selected user profile page is public, it returns ALERT.
+    /// * Otherwise, it returns PASS.
     /// </summary>
     public class CheckUserProfilePage : BaseCheck
     {

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Checks/CheckUserProfilePageTests.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Checks/CheckUserProfilePageTests.cs
@@ -175,18 +175,9 @@
             RegisterTestablePermissionProvider();
 
             var portalControllerMock = SetupPortalControllerMock(PortalId, userTabId: 1);
-
             var activityFeedPage = BuildActivityFeedTabInfo();
-
-            var myProfilePage = new TabInfo
-            {
-                TabID = 2,
-                IsDeleted = true,
-                PortalID = PortalId,
-            };
-
+            var myProfilePage = BuildMyProfileTabInfo(deleted: true);
             var tabControllerMock = SetupTabControllerMock(activityFeedPage, myProfilePage);
-
             var pagesControllerMock = SetupPagesControllerMock(userProfilePageIsPublic: false);
 
             var sut = new CheckUserProfilePage(


### PR DESCRIPTION
This is a small addendum to #5080.
* The summary of `CheckUserProfilePage` was still referencing the portal registration type.
* There was a small bit of duplicate code in one of the unit tests.
