### PR TITLE
Removed two unused utility methods that depended on `momentjs`

### DIFF
--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/scripts/util.js
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/scripts/util.js
@@ -118,18 +118,6 @@ define(['jquery'], function ($) {
                     return trimmed;
                 },
 
-                deserializeCustomDate: function (str) {
-                    if (this.moment) {
-                        return this.moment(str, 'YYYY-MM-DD').toDate();
-                    }
-                },
-                
-                serializeCustomDate: function (dateObj) {
-                    if (this.moment) {
-                        return this.moment(dateObj).format('YYYY-MM-DD');
-                    }
-                },
-
                 getApplicationRootPath: function getApplicationRootPath() {
                     var rootPath = location.protocol + '//' + location.host + (location.port ? (':' + location.port) : '');
                     if (rootPath.substr(rootPath.length - 1, 1) === '/') {


### PR DESCRIPTION
## Summary
These two utility methods are unused and they depended on `momentjs`.  Instead of swapping out for `dayjs` I felt it best to remove the methods instead.  

This PR relates to #3875 