### PR TITLE
Allow the underlying FileInstaller to delete the file if needed.

### DIFF
--- a/DNN Platform/Library/Services/Installer/Installers/AssemblyInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/AssemblyInstaller.cs
@@ -136,7 +136,16 @@ namespace DotNetNuke.Services.Installer.Installers
             bool bSuccess = true;
             if (file.Action == "UnRegister")
             {
-                this.DeleteFile(file);
+                var prevDeleteFiles = this.DeleteFiles;
+                try
+                {
+                    this.DeleteFiles = true;
+                    this.DeleteFile(file);
+                }
+                finally
+                {
+                    this.DeleteFiles = prevDeleteFiles;
+                }
             }
             else
             {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #5025.

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Ensures that the `FileInstaller.DeleteFiles` flag is set to `true` when UnRegister-ing an Assembly file in the AssemblyInstaller.