### PR TITLE
Removing some unnecessary values from SMTP entity

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -47,7 +47,7 @@ namespace Dnn.PersonaBar.Servers.Services
                         smtpAuthentication = HostController.Instance.GetString("SMTPAuthentication"),
                         enableSmtpSsl = HostController.Instance.GetBoolean("SMTPEnableSSL", false),
                         smtpUserName = HostController.Instance.GetString("SMTPUsername"),
-                        smtpPassword = GetSmtpPassword(),
+                        smtpPassword = string.Empty,
                         smtpHostEmail = HostController.Instance.GetString("HostEmail"),
                         messageSchedulerBatchSize = Host.MessageSchedulerBatchSize,
                     },
@@ -81,6 +81,11 @@ namespace Dnn.PersonaBar.Servers.Services
             {
                 var portalId = PortalSettings.Current.PortalId;
                 PortalController.UpdatePortalSetting(portalId, "SMTPmode", request.SmtpServerMode, false);
+
+                if (string.IsNullOrWhiteSpace(request.SmtpPassword))
+                {
+                    request.SmtpPassword = GetSmtpPassword();
+                }
 
                 if (request.SmtpServerMode == "h")
                 {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Servers/App_LocalResources/Servers.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Servers/App_LocalResources/Servers.resx
@@ -418,7 +418,7 @@
     <value>SMTP Server Mode:</value>
   </data>
   <data name="plSMTPPassword.Help" xml:space="preserve">
-    <value>Enter the password for the SMTP server.</value>
+    <value>Enter the password for the SMTP server. Leave blank to not to change it.</value>
   </data>
   <data name="plSMTPPassword.Text" xml:space="preserve">
     <value>SMTP Password:</value>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
SMTP entity was returning some values which should not be inside of the response. This change is removing some unnecessary values from SMTP entity. And sending this field as blank from UI page will not change the value. 