### PR TITLE
Fix issue with undefined isProduction in Yarn scripts

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/webpack.config.js
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/webpack.config.js
@@ -1,130 +1,132 @@
 const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const settings = require("../../../../settings.local.json");
 
-module.exports = {
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
     entry: "./app/main.jsx",
     optimization: {
-        minimize: isProduction
+      minimize: isProduction,
     },
     output: {
-        path:
-      isProduction || settings.WebsitePath == ""
-          ? path.resolve(
-              __dirname,
-              "../scripts/"
-          )
-          : path.join(settings.WebsitePath, "\\DesktopModules\\ResourceManager\\scripts"),
-        publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-        filename: "resourceManager-bundle.js"
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(__dirname, "../scripts/")
+          : path.join(
+              settings.WebsitePath,
+              "\\DesktopModules\\ResourceManager\\scripts"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "resourceManager-bundle.js",
     },
     devServer: {
-        disableHostCheck: !isProduction
+      disableHostCheck: !isProduction,
     },
     resolve: {
-        extensions: ["*", ".js", ".json", ".jsx"],
-        modules: [
-            path.resolve("./src"), // Look in src first
-            path.resolve("./node_modules"), // Try local node_modules
-            path.resolve("../../../../node_modules") // Last fallback to workspaces node_modules
-        ]
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
     },
     module: {
-        rules: [
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          loader: "eslint-loader",
+          options: {
+            fix: true,
+          },
+        },
+        {
+          test: /\.less$/,
+          use: [
             {
-                test: /\.(js|jsx)$/,
-                exclude: /node_modules/,
-                enforce: "pre",
-                loader: "eslint-loader",
-                options: {
-                    fix: true
-                }
+              loader: "style-loader", // creates style nodes from JS strings
             },
             {
-                test: /\.less$/,
-                use: [
-                    {
-                        loader: "style-loader" // creates style nodes from JS strings
-                    },
-                    {
-                        loader: "css-loader", // translates CSS into CommonJS
-                        options: { modules: "global" }
-                    },
-                    {
-                        loader: "less-loader" // compiles Less to CSS
-                    }
-                ]
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
             },
             {
-                test: /\.css$/,
-                use: [
-                    {
-                        loader: "style-loader"
-                    },
-                    {
-                        loader: "css-loader",
-                        options: { modules: "global" }
-                    }
-                ]
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.css$/,
+          use: [
+            {
+              loader: "style-loader",
             },
             {
-                test: /\.(js|jsx)$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: "babel-loader",
-                    options: {
-                        presets: ["@babel/preset-env", "@babel/preset-react"]
-                    }
-                }
+              loader: "css-loader",
+              options: { modules: "global" },
             },
-            {
-                test: /\.(ttf|woff)$/,
-                use: {
-                    loader: "url-loader?limit=8192"
-                }
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
             },
-            {
-                test: /\.(gif|png)$/,
-                use: {
-                    loader: "url-loader?mimetype=image/png"
-                }
-            },
-            {
-                test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-                use: {
-                    loader: "url-loader?mimetype=application/font-woff"
-                }
-            },
-            {
-                test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/,
-                use: {
-                    loader: "file-loader?name=[name].[ext]"
-                }
-            },
-            {
-                test: /\.(svg)/,
-                use: {
-                    loader: "raw-loader"
-                }
-            }
-        ]
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+        {
+          test: /\.(gif|png)$/,
+          use: {
+            loader: "url-loader?mimetype=image/png",
+          },
+        },
+        {
+          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+          use: {
+            loader: "url-loader?mimetype=application/font-woff",
+          },
+        },
+        {
+          test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/,
+          use: {
+            loader: "file-loader?name=[name].[ext]",
+          },
+        },
+        {
+          test: /\.(svg)/,
+          use: {
+            loader: "raw-loader",
+          },
+        },
+      ],
     },
 
     plugins: isProduction
-        ? [
-            new webpack.DefinePlugin({
-                VERSION: JSON.stringify(packageJson.version),
-                "process.env": {
-                    NODE_ENV: JSON.stringify("production")
-                }
-            })
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
         ]
-        : [
-            new webpack.DefinePlugin({
-                VERSION: JSON.stringify(packageJson.version)
-            })
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
         ],
-    devtool: "source-map"
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/webpack.config.js
@@ -1,9 +1,8 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const path = require("path");
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -13,67 +12,80 @@ const languages = {
 };
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path: isProduction || settings.WebsitePath == ""
-      ? path.resolve("../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.AdminLogs/scripts/bundles/")
-      : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.AdminLogs\\scripts\\bundles\\"),
-    filename: "adminLogs-bundle.js",
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: /node_modules/,
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      { test: /\.(js|jsx)$/, exclude: /node_modules/, loader: "babel-loader" },
-      {
-        test: /\.(less|css)$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader", options: { modules: "global" } },
-          { loader: "less-loader" }
-        ]
-      },
-      { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" }
-    ]
-  },
-
-  resolve: {
-    extensions: [".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.AdminLogs/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.AdminLogs\\scripts\\bundles\\"
+            ),
+      filename: "adminLogs-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loader: "babel-loader",
+        },
+        {
+          test: /\.(less|css)$/,
+          use: [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: { modules: "global" } },
+            { loader: "less-loader" },
+          ],
+        },
+        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
       ],
-  devtool: "source-map"
+    },
+
+    resolve: {
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
+    },
+
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/webpack.config.js
@@ -3,52 +3,81 @@
 const webpack = require("webpack");
 const path = require("path");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const settings = require("../../../settings.local.json");
 
-module.exports = {
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
     entry: "./src/main.jsx",
     optimization: {
-        minimize: isProduction
+      minimize: isProduction,
     },
     output: {
-        path: isProduction || settings.WebsitePath == ""
-            ? path.resolve("../../Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/exports/")
-            : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\scripts\\exports\\"),
-        filename: "export-bundle.js",
-        publicPath: isProduction ? "" : "http://localhost:8070/dist/"
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/exports/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\scripts\\exports\\"
+            ),
+      filename: "export-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8070/dist/",
     },
     devServer: {
-        disableHostCheck: !isProduction
+      disableHostCheck: !isProduction,
     },
     module: {
-        rules:[
-            { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },
-            { test: /\.(js|jsx)$/ , exclude: /node_modules/, loader: "babel-loader" },
-            { test: /\.(less|css)$/, loader: "style-loader!css-loader!less-loader" },
-            { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, loader: "url-loader?mimetype=application/font-woff" },
-            { test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/, loader: "file-loader?name=[name].[ext]" },
-            { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" }
-        ]
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loader: "babel-loader",
+        },
+        {
+          test: /\.(less|css)$/,
+          loader: "style-loader!css-loader!less-loader",
+        },
+        {
+          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "url-loader?mimetype=application/font-woff",
+        },
+        {
+          test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "file-loader?name=[name].[ext]",
+        },
+        { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+      ],
     },
     resolve: {
-        extensions: [".js", ".json", ".jsx"],
-        modules: [
-            path.resolve("./node_modules"), // Try local node_modules
-            path.resolve("../../../node_modules"),
-            path.resolve(__dirname, "src")
-        ]
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"),
+        path.resolve(__dirname, "src"),
+      ],
     },
-    plugins: isProduction ? [
-        new webpack.DefinePlugin({
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
             VERSION: JSON.stringify(packageJson.version),
             "process.env": {
-                "NODE_ENV": JSON.stringify("production")
-            }
-        })
-    ] : [
-        new webpack.DefinePlugin({
-            VERSION: JSON.stringify(packageJson.version)
-        })
-    ]
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Extensions.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Extensions.Web/webpack.config.js
@@ -1,126 +1,128 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Extensions/scripts/bundles/"
-          )
-        : path.join(
-            settings.WebsitePath,
-            "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Extensions\\scripts\\bundles\\"
-          ),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "extensions-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: "style-loader"
-          },
-          {
-            loader: "css-loader",
-            options: { modules: "global" }
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      },
-      {
-        test: /\.(gif|png)$/,
-        use: {
-          loader: "url-loader?mimetype=image/png"
-        }
-      },
-      {
-        test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-        use: {
-          loader: "url-loader?mimetype=application/font-woff"
-        }
-      },
-      {
-        test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-        use: {
-          loader: "file-loader?name=[name].[ext]"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Extensions/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Extensions\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "extensions-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.css$/,
+          use: [
+            {
+              loader: "style-loader",
+            },
+            {
+              loader: "css-loader",
+              options: { modules: "global" },
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+        {
+          test: /\.(gif|png)$/,
+          use: {
+            loader: "url-loader?mimetype=image/png",
+          },
+        },
+        {
+          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+          use: {
+            loader: "url-loader?mimetype=application/font-woff",
+          },
+        },
+        {
+          test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+          use: {
+            loader: "file-loader?name=[name].[ext]",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Licensing.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Licensing.Web/webpack.config.js
@@ -1,9 +1,8 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const path = require("path");
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -15,92 +14,95 @@ const settings = require("../../../settings.local.json");
 
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Licensing/scripts/bundles/"
-          )
-        : path.join(
-            settings.WebsitePath,
-            "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Licensing\\scripts\\bundles\\"
-          ),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "licensing-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Licensing/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Licensing\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "licensing-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/webpack.config.js
@@ -1,104 +1,106 @@
-﻿const isProduction = process.env.NODE_ENV === "production";
-const packageJson = require("./package.json");
+﻿const packageJson = require("./package.json");
 const path = require("path");
 const webpack = require("webpack");
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/scripts/bundles/"
-          )
-        : path.join(
-            settings.WebsitePath,
-            "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Pages\\scripts\\bundles\\"
-          ),
-    filename: "pages-bundle.js",
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: { loader: "eslint-loader", options: { fix: true } },
-        enforce: "pre"
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader"
-        }
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader"
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Pages\\scripts\\bundles\\"
+            ),
+      filename: "pages-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: { loader: "eslint-loader", options: { fix: true } },
+          enforce: "pre",
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
           },
-          {
-            loader: "css-loader",
-            options: { modules: "global" }
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader",
+            },
+            {
+              loader: "css-loader",
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader",
+            },
+          ],
+        },
+        {
+          test: /\.css$/,
+          use: [
+            {
+              loader: "style-loader",
+            },
+            {
+              loader: "css-loader",
+              options: { modules: "global" },
+            },
+          ],
+        },
+        {
+          test: /\.(ttf|woff|gif|png)$/,
+          use: {
+            loader: "url-loader?limit=8192",
           },
-          {
-            loader: "less-loader"
-          }
-        ]
-      },
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: "style-loader"
-          },
-          {
-            loader: "css-loader",
-            options: { modules: "global" }
-          }
-        ]
-      },
-      {
-        test: /\.(ttf|woff|gif|png)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  externals: webpackExternals,
-  optimization: {
-    minimize: isProduction
-  },
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+        },
       ],
-  devtool: "source-map"
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
+    },
+    externals: webpackExternals,
+    optimization: {
+      minimize: isProduction,
+    },
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/webpack.config.js
@@ -1,103 +1,105 @@
 const webpack = require("webpack");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const isAnalyze = process.env.NODE_ENV === "analyze";
 const path = require("path");
 const extractTextPlugin = require("extract-text-webpack-plugin");
 const optimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
-  .BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin =
+  require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  context: path.resolve(__dirname, "."),
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Prompt/scripts/bundles/"
-          )
-        : path.join(
-            settings.WebsitePath,
-            "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Prompt\\scripts\\bundles\\"
-          ),
-    publicPath: isProduction ? "" : "http://localhost:8100/dist/",
-    filename: "prompt-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  devtool: "#source-map",
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    context: path.resolve(__dirname, "."),
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Prompt/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Prompt\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8100/dist/",
+      filename: "prompt-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    devtool: "#source-map",
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };
 
 if (isAnalyze) {

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/webpack.config.js
@@ -2,79 +2,90 @@
 const I18nPlugin = require("i18n-webpack-plugin");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve("../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Roles/scripts/bundles/")
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Roles\\scripts\\bundles\\"),
-    filename: "roles-bundle.js",
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: /node_modules/,
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      { test: /\.(js|jsx)$/, exclude: /node_modules/, loader: "babel-loader" },
-      {
-        test: /\.(less|css)$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader", options: { modules: "global" } },
-          { loader: "less-loader" }
-        ]
-      },
-      { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-      { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
-      {
-        test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-        loader: "url-loader?mimetype=application/font-woff"
-      },
-      {
-        test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-        loader: "file-loader?name=[name].[ext]"
-      }
-    ]
-  },
-  resolve: {
-    extensions: [".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Roles/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Roles\\scripts\\bundles\\"
+            ),
+      filename: "roles-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loader: "babel-loader",
+        },
+        {
+          test: /\.(less|css)$/,
+          use: [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: { modules: "global" } },
+            { loader: "less-loader" },
+          ],
+        },
+        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
+        { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+        {
+          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "url-loader?mimetype=application/font-woff",
+        },
+        {
+          test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "file-loader?name=[name].[ext]",
+        },
       ],
-  devtool: "source-map"
+    },
+    resolve: {
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
+    },
+
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Security.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/webpack.config.js
@@ -1,9 +1,8 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -15,92 +14,98 @@ const settings = require("../../../settings.local.json");
 
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Security\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "security-settings-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        loader: "eslint-loader",
-        options: {
-          fix: true
-        }
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Security\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "security-settings-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          loader: "eslint-loader",
+          options: {
+            fix: true,
+          },
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/webpack.config.js
@@ -1,93 +1,98 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Seo/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Seo\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "seo-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Seo/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Seo\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "seo-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/webpack.config.js
@@ -1,92 +1,97 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Servers/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Servers\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "servers-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Servers/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Servers\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "servers-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/SiteGroups.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/SiteGroups.Web/webpack.config.js
@@ -1,10 +1,9 @@
 ﻿const webpack = require("webpack");
 const path = require("path");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -15,77 +14,85 @@ const languages = {
 const settings = require("../../../settings.local.json");
 const moduleName = "site-groups";
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve("../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteGroups/scripts/bundles/")
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.SiteGroups\\scripts\\bundles\\"),
-    filename: moduleName + "-bundle.js",
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: /node_modules/,
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        loaders: "babel-loader",
-        options: {
-          presets: ["@babel/preset-env", "@babel/preset-react"],
-          plugins: [
-            "@babel/plugin-transform-react-jsx",
-            "@babel/plugin-proposal-object-rest-spread"
-          ]
-        }
-      },
-      {
-        test: /\.(less|css)$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader", options: { modules: "global" } },
-          { loader: "less-loader" }
-        ]
-      },
-      { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" }
-    ]
-  },
-  resolve: {
-    extensions: [".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./exportables"), // Look in exportables after
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  externals: webpackExternals,
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteGroups/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.SiteGroups\\scripts\\bundles\\"
+            ),
+      filename: moduleName + "-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loaders: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env", "@babel/preset-react"],
+            plugins: [
+              "@babel/plugin-transform-react-jsx",
+              "@babel/plugin-proposal-object-rest-spread",
+            ],
+          },
+        },
+        {
+          test: /\.(less|css)$/,
+          use: [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: { modules: "global" } },
+            { loader: "less-loader" },
+          ],
+        },
+        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
       ],
-  devtool: "source-map"
+    },
+    resolve: {
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./exportables"), // Look in exportables after
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
+    },
+    externals: webpackExternals,
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/webpack.config.js
@@ -1,9 +1,8 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -13,104 +12,110 @@ const languages = {
 };
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteImportExport/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.SiteImportExport\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "siteimportexport-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      //{ test: /\.(js|jsx)$/, exclude: /node_modules/, loader: "eslint-loader" }
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: [
-          {
-            loader: "babel-loader"
-          },
-          {
-            loader: "eslint-loader"
-          }
-        ]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      },
-      {
-        test: /\.svg$/,
-        use: {
-          loader: "svg-url-loader"
-        }
-      }
-    ]
-  },
-
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteImportExport/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.SiteImportExport\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "siteimportexport-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        //{ test: /\.(js|jsx)$/, exclude: /node_modules/, loader: "eslint-loader" }
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: [
+            {
+              loader: "babel-loader",
+            },
+            {
+              loader: "eslint-loader",
+            },
+          ],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+        {
+          test: /\.svg$/,
+          use: {
+            loader: "svg-url-loader",
+          },
+        },
+      ],
+    },
+
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/webpack.config.js
@@ -1,109 +1,114 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteSettings/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.SiteSettings\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8085/dist/",
-    filename: "site-settings-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        loader: "eslint-loader",
-        options: {
-          fix: true
-        }
-      },
-      {
-        test: /\.js$/,
-        enforce: "pre",
-        use: ["source-map-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"],
-            plugins: [
-              "@babel/plugin-transform-react-jsx",
-              "@babel/plugin-proposal-object-rest-spread"
-            ]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      },
-      {
-        test: /\.(svg)$/,
-        exclude: /node_modules/,
-        use: ["raw-loader"]
-      }
-    ]
-  },
-  externals: webpackExternals,
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteSettings/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.SiteSettings\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8085/dist/",
+      filename: "site-settings-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          loader: "eslint-loader",
+          options: {
+            fix: true,
+          },
+        },
+        {
+          test: /\.js$/,
+          enforce: "pre",
+          use: ["source-map-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+              plugins: [
+                "@babel/plugin-transform-react-jsx",
+                "@babel/plugin-proposal-object-rest-spread",
+              ],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+        {
+          test: /\.(svg)$/,
+          exclude: /node_modules/,
+          use: ["raw-loader"],
+        },
+      ],
+    },
+    externals: webpackExternals,
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/webpack.config.js
@@ -1,58 +1,66 @@
 const path = require("path");
 const settings = require("../../../../../settings.local.json");
-const isProduction = process.env.NODE_ENV === "production";
 
-module.exports = {
-  entry: "./index",
-  optimization: {
-    minimize: true
-  },
-  node: {
-    fs: "empty"
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Sites/scripts/exportables/Sites"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Sites\\scripts\\exportables\\Sites\\"),
-    filename: "SitesListView.js",
-    publicPath: isProduction ? "" : "http://localhost:8050/dist/"
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: /node_modules/,
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        loaders: "babel-loader",
-        options: {
-          presets: ["@babel/preset-env", "@babel/preset-react"],
-          plugins: [
-            "@babel/plugin-transform-react-jsx",
-            "@babel/plugin-proposal-object-rest-spread"
-          ]
-        }
-      },
-      { test: /\.(less|css)$/, loader: "style-loader!css-loader!less-loader" }
-    ]
-  },
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-  resolve: {
-    extensions: [".js", ".json", ".jsx"],
-    modules: [
-      path.resolve(__dirname, "./src"),
-      path.resolve(__dirname, "../"),
-      path.resolve(__dirname, "node_modules"),
-      path.resolve(__dirname, "../../node_modules"),
-      path.resolve(__dirname, "../../../../../node_modules")
-    ]
-  }
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./index",
+    optimization: {
+      minimize: true,
+    },
+    node: {
+      fs: "empty",
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Sites/scripts/exportables/Sites"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Sites\\scripts\\exportables\\Sites\\"
+            ),
+      filename: "SitesListView.js",
+      publicPath: isProduction ? "" : "http://localhost:8050/dist/",
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loaders: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env", "@babel/preset-react"],
+            plugins: [
+              "@babel/plugin-transform-react-jsx",
+              "@babel/plugin-proposal-object-rest-spread",
+            ],
+          },
+        },
+        {
+          test: /\.(less|css)$/,
+          loader: "style-loader!css-loader!less-loader",
+        },
+      ],
+    },
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+    resolve: {
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve(__dirname, "./src"),
+        path.resolve(__dirname, "../"),
+        path.resolve(__dirname, "node_modules"),
+        path.resolve(__dirname, "../../node_modules"),
+        path.resolve(__dirname, "../../../../../node_modules"),
+      ],
+    },
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/webpack.config.js
@@ -1,10 +1,9 @@
 ﻿const webpack = require("webpack");
 const path = require("path");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -15,82 +14,90 @@ const languages = {
 const settings = require("../../../settings.local.json");
 const moduleName = "sites";
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve("../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Sites/scripts/bundles/")
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Sites\\scripts\\bundles\\"),
-    filename: moduleName + "-bundle.js",
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: /node_modules/,
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        loaders: "babel-loader",
-        options: {
-          presets: ["@babel/preset-env", "@babel/preset-react"],
-          plugins: [
-            "@babel/plugin-transform-react-jsx",
-            "@babel/plugin-proposal-object-rest-spread"
-          ]
-        }
-      },
-      {
-        test: /\.(less|css)$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader", options: { modules: "global" } },
-          { loader: "less-loader" }
-        ]
-      },
-      { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" }
-    ]
-  },
-  resolve: {
-    extensions: [".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./exportables"), // Look in exportables after
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  externals: Object.assign(webpackExternals, {
-    "dnn-sites-common-action-types": "window.dnn.Sites.CommonActionTypes",
-    "dnn-sites-common-components": "window.dnn.Sites.CommonComponents",
-    "dnn-sites-common-reducers": "window.dnn.Sites.CommonReducers",
-    "dnn-sites-common-actions": "window.dnn.Sites.CommonActions"
-  }),
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Sites/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Sites\\scripts\\bundles\\"
+            ),
+      filename: moduleName + "-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loaders: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env", "@babel/preset-react"],
+            plugins: [
+              "@babel/plugin-transform-react-jsx",
+              "@babel/plugin-proposal-object-rest-spread",
+            ],
+          },
+        },
+        {
+          test: /\.(less|css)$/,
+          use: [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: { modules: "global" } },
+            { loader: "less-loader" },
+          ],
+        },
+        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
       ],
-  devtool: "source-map"
+    },
+    resolve: {
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./exportables"), // Look in exportables after
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
+    },
+    externals: Object.assign(webpackExternals, {
+      "dnn-sites-common-action-types": "window.dnn.Sites.CommonActionTypes",
+      "dnn-sites-common-components": "window.dnn.Sites.CommonComponents",
+      "dnn-sites-common-reducers": "window.dnn.Sites.CommonReducers",
+      "dnn-sites-common-actions": "window.dnn.Sites.CommonActions",
+    }),
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/webpack.config.js
@@ -1,93 +1,98 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const path = require("path");
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.TaskScheduler/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.TaskScheduler\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: "task-scheduler-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.TaskScheduler/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.TaskScheduler\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: "task-scheduler-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Themes.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Themes.Web/webpack.config.js
@@ -1,10 +1,9 @@
 ﻿const webpack = require("webpack");
 const packageJson = require("./package.json");
 const path = require("path");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const languages = {
-  en: null
+  en: null,
   // TODO: create locallizaton files per language
   // "de": require("./localizations/de.json"),
   // "es": require("./localizations/es.json"),
@@ -15,90 +14,96 @@ const languages = {
 const settings = require("../../../settings.local.json");
 const moduleName = "themes";
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Themes/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Themes\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: moduleName + "-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./exportables"), // Look in exportables after
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-  externals: webpackExternals,
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Themes/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Themes\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: moduleName + "-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./exportables"), // Look in exportables after
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+    externals: webpackExternals,
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/webpack.config.js
@@ -1,76 +1,81 @@
 const path = require("path");
 const settings = require("../../../../../settings.local.json");
-const isProduction = process.env.NODE_ENV === "production";
 
-module.exports = {
-  entry: "./index",
-  optimization: {
-    minimize: isProduction
-  },
-  node: {
-    fs: "empty"
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/exportables/Users"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Users\\scripts\\exportables\\Users\\"),
-    filename: "UsersCommon.js",
-    publicPath: isProduction ? "" : "http://localhost:8050/dist/"
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: /node_modules/,
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        loaders: "babel-loader",
-        options: {
-          presets: ["@babel/preset-env", "@babel/preset-react"],
-          plugins: [
-            "@babel/plugin-transform-react-jsx",
-            "@babel/plugin-proposal-object-rest-spread"
-          ]
-        }
-      },
-      {
-        test: /\.(less|css)$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader", options: { modules: "global" } },
-          { loader: "less-loader" }
-        ]
-      },
-      { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-      { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
-      {
-        test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-        loader: "url-loader?mimetype=application/font-woff"
-      },
-      {
-        test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-        loader: "file-loader?name=[name].[ext]"
-      }
-    ]
-  },
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-  resolve: {
-    extensions: [".js", ".json", ".jsx"],
-    modules: [
-      path.resolve(__dirname, "./src"),
-      path.resolve(__dirname, "../"),
-      path.resolve(__dirname, "node_modules"),
-      path.resolve(__dirname, "../../node_modules"),
-      path.resolve(__dirname, "../../../../../node_modules")
-    ]
-  },
-  devtool: "source-map"
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./index",
+    optimization: {
+      minimize: isProduction,
+    },
+    node: {
+      fs: "empty",
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/exportables/Users"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Users\\scripts\\exportables\\Users\\"
+            ),
+      filename: "UsersCommon.js",
+      publicPath: isProduction ? "" : "http://localhost:8050/dist/",
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: /node_modules/,
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          loaders: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env", "@babel/preset-react"],
+            plugins: [
+              "@babel/plugin-transform-react-jsx",
+              "@babel/plugin-proposal-object-rest-spread",
+            ],
+          },
+        },
+        {
+          test: /\.(less|css)$/,
+          use: [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: { modules: "global" } },
+            { loader: "less-loader" },
+          ],
+        },
+        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
+        { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+        {
+          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "url-loader?mimetype=application/font-woff",
+        },
+        {
+          test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "file-loader?name=[name].[ext]",
+        },
+      ],
+    },
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+    resolve: {
+      extensions: [".js", ".json", ".jsx"],
+      modules: [
+        path.resolve(__dirname, "./src"),
+        path.resolve(__dirname, "../"),
+        path.resolve(__dirname, "node_modules"),
+        path.resolve(__dirname, "../../node_modules"),
+        path.resolve(__dirname, "../../../../../node_modules"),
+      ],
+    },
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Users.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/webpack.config.js
@@ -1,84 +1,91 @@
 ﻿const webpack = require("webpack");
 const path = require("path");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const webpackExternals = require("@dnnsoftware/dnn-react-common/WebpackExternals");
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve("../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/bundles/")
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Users\\scripts\\bundles\\"),
-    filename: "users-bundle.js",
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        enforce: "pre",
-        exclude: [/node_modules/],
-        loader: "eslint-loader",
-        options: { fix: true }
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: [/node_modules/],
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"],
-            plugins: [
-              "@babel/plugin-transform-react-jsx",
-              "@babel/plugin-proposal-object-rest-spread"
-            ]
-          }
-        }
-      },
-      {
-        test: /\.(less|css)$/,
-        use: [
-          { loader: "style-loader" },
-          { loader: "css-loader", options: { modules: "global" } },
-          { loader: "less-loader" }
-        ]
-      },
-      { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-      { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
-      {
-        test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-        loader: "url-loader?mimetype=application/font-woff"
-      },
-      {
-        test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-        loader: "file-loader?name=[name].[ext]"
-      }
-    ]
-  },
-  resolve: {
-    extensions: [".jsx", ".js", ".json"],
-    modules: [
-      path.resolve(__dirname, "./src"),
-      path.resolve(__dirname, "./node_modules"), // Try local node_modules
-      path.resolve(__dirname, "./src/_exportables/src"),
-      path.resolve(__dirname, "./src/_exportables/node_modules"),
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-  externals: Object.assign(webpackExternals, {
-    "dnn-users-common-action-types": "window.dnn.Users.CommonActionTypes",
-    "dnn-users-common-components": "window.dnn.Users.CommonComponents",
-    "dnn-users-common-reducers": "window.dnn.Users.CommonReducers",
-    "dnn-users-common-actions": "window.dnn.Users.CommonActions"
-  }),
-  devtool: "source-map"
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Users\\scripts\\bundles\\"
+            ),
+      filename: "users-bundle.js",
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          enforce: "pre",
+          exclude: [/node_modules/],
+          loader: "eslint-loader",
+          options: { fix: true },
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: [/node_modules/],
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+              plugins: [
+                "@babel/plugin-transform-react-jsx",
+                "@babel/plugin-proposal-object-rest-spread",
+              ],
+            },
+          },
+        },
+        {
+          test: /\.(less|css)$/,
+          use: [
+            { loader: "style-loader" },
+            { loader: "css-loader", options: { modules: "global" } },
+            { loader: "less-loader" },
+          ],
+        },
+        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
+        { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+        {
+          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "url-loader?mimetype=application/font-woff",
+        },
+        {
+          test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+          loader: "file-loader?name=[name].[ext]",
+        },
+      ],
+    },
+    resolve: {
+      extensions: [".jsx", ".js", ".json"],
+      modules: [
+        path.resolve(__dirname, "./src"),
+        path.resolve(__dirname, "./node_modules"), // Try local node_modules
+        path.resolve(__dirname, "./src/_exportables/src"),
+        path.resolve(__dirname, "./src/_exportables/node_modules"),
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
+      ],
+    },
+    externals: Object.assign(webpackExternals, {
+      "dnn-users-common-action-types": "window.dnn.Users.CommonActionTypes",
+      "dnn-users-common-components": "window.dnn.Users.CommonComponents",
+      "dnn-users-common-reducers": "window.dnn.Users.CommonReducers",
+      "dnn-users-common-actions": "window.dnn.Users.CommonActions",
+    }),
+    devtool: "source-map",
+  };
 };

--- a/Dnn.AdminExperience/ClientSide/Vocabularies.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Vocabularies.Web/webpack.config.js
@@ -1,95 +1,100 @@
 ﻿const webpack = require("webpack");
 const path = require("path");
 const packageJson = require("./package.json");
-const isProduction = process.env.NODE_ENV === "production";
 const moduleName = "vocabulary";
 const settings = require("../../../settings.local.json");
 
-module.exports = {
-  entry: "./src/main.jsx",
-  optimization: {
-    minimize: isProduction
-  },
-  output: {
-    path:
-      isProduction || settings.WebsitePath == ""
-        ? path.resolve(
-            __dirname,
-            "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Vocabularies/scripts/bundles/"
-          )
-        : path.join(settings.WebsitePath, "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Vocabularies\\scripts\\bundles\\"),
-    publicPath: isProduction ? "" : "http://localhost:8080/dist/",
-    filename: moduleName + "-bundle.js"
-  },
-  devServer: {
-    disableHostCheck: !isProduction
-  },
-  resolve: {
-    extensions: ["*", ".js", ".json", ".jsx"],
-    modules: [
-      path.resolve("./src"), // Look in src first
-      path.resolve("./node_modules"), // Try local node_modules
-      path.resolve("../../../node_modules") // Last fallback to workspaces node_modules
-    ]
-  },
-
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["eslint-loader"]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: "style-loader" // creates style nodes from JS strings
-          },
-          {
-            loader: "css-loader", // translates CSS into CommonJS
-            options: { modules: "global" }
-          },
-          {
-            loader: "less-loader" // compiles Less to CSS
-          }
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"]
-          }
-        }
-      },
-      {
-        test: /\.(ttf|woff)$/,
-        use: {
-          loader: "url-loader?limit=8192"
-        }
-      }
-    ]
-  },
-
-  externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-
-  plugins: isProduction
-    ? [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version),
-          "process.env": {
-            NODE_ENV: JSON.stringify("production")
-          }
-        })
-      ]
-    : [
-        new webpack.DefinePlugin({
-          VERSION: JSON.stringify(packageJson.version)
-        })
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === "production";
+  return {
+    entry: "./src/main.jsx",
+    optimization: {
+      minimize: isProduction,
+    },
+    output: {
+      path:
+        isProduction || settings.WebsitePath == ""
+          ? path.resolve(
+              __dirname,
+              "../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Vocabularies/scripts/bundles/"
+            )
+          : path.join(
+              settings.WebsitePath,
+              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Vocabularies\\scripts\\bundles\\"
+            ),
+      publicPath: isProduction ? "" : "http://localhost:8080/dist/",
+      filename: moduleName + "-bundle.js",
+    },
+    devServer: {
+      disableHostCheck: !isProduction,
+    },
+    resolve: {
+      extensions: ["*", ".js", ".json", ".jsx"],
+      modules: [
+        path.resolve("./src"), // Look in src first
+        path.resolve("./node_modules"), // Try local node_modules
+        path.resolve("../../../node_modules"), // Last fallback to workspaces node_modules
       ],
-  devtool: "source-map"
+    },
+
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["eslint-loader"],
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: "style-loader", // creates style nodes from JS strings
+            },
+            {
+              loader: "css-loader", // translates CSS into CommonJS
+              options: { modules: "global" },
+            },
+            {
+              loader: "less-loader", // compiles Less to CSS
+            },
+          ],
+        },
+        {
+          test: /\.(js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-react"],
+            },
+          },
+        },
+        {
+          test: /\.(ttf|woff)$/,
+          use: {
+            loader: "url-loader?limit=8192",
+          },
+        },
+      ],
+    },
+
+    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+
+    plugins: isProduction
+      ? [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+            "process.env": {
+              NODE_ENV: JSON.stringify("production"),
+            },
+          }),
+        ]
+      : [
+          new webpack.DefinePlugin({
+            VERSION: JSON.stringify(packageJson.version),
+          }),
+        ],
+    devtool: "source-map",
+  };
 };


### PR DESCRIPTION
Resolves issue #5120 

What it does is to replace the following:

```
module.exports = {
```

with 

```
module.exports = (env, argv) => {
  const isProduction = argv.mode === "production";
  return {
```

for all the webpack configurations where we use isProduction. The command line p option (i.e. `webpack -p`) will now properly set isProduction in the configuration.