### PR TITLE
(WIP) SharpZipLib removal

### DIFF
--- a/DNN Platform/Library/Common/Utilities/FileSystemExtensions.cs
+++ b/DNN Platform/Library/Common/Utilities/FileSystemExtensions.cs
@@ -1,16 +1,27 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Common.Utilities
 {
     using System;
+    using System.IO.Compression;
 
     public static class FileSystemExtensions
     {
+        [Obsolete("Deprecated in 9.11.0. Scheduled for removal in v11.0.0, use overload taking System.IO.Compression.ZipArchiveEntry.")]
         public static void CheckZipEntry(this ICSharpCode.SharpZipLib.Zip.ZipEntry input)
         {
-            var fullName = input.Name.Replace('\\', '/');
+            CheckZipEntryName(input.Name);
+        }
+
+        public static void CheckZipEntry(this ZipArchiveEntry input)
+        {
+            CheckZipEntryName(input.Name);
+        }
+
+        private static void CheckZipEntryName(string inputName)
+        {
+            var fullName = inputName.Replace('\\', '/');
             if (fullName.StartsWith("..") || fullName.Contains("/../"))
             {
                 throw new Exception("Illegal Zip File");

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -151,6 +151,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Entities.Portals
     using System.Data;
     using System.Globalization;
     using System.IO;
+    using System.IO.Compression;
     using System.Linq;
     using System.Text;
     using System.Web;
@@ -45,7 +46,6 @@ namespace DotNetNuke.Entities.Portals
     // using DotNetNuke.Services.Upgrade.Internals.InstallConfiguration;
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Web.Client;
-    using ICSharpCode.SharpZipLib.Zip;
 
     using FileInfo = DotNetNuke.Services.FileSystem.FileInfo;
     using IAbPortalSettings = DotNetNuke.Abstractions.Portals.IPortalSettings;
@@ -1464,7 +1464,12 @@ namespace DotNetNuke.Entities.Portals
         {
             try
             {
-                FileSystemUtils.UnzipResources(new ZipInputStream(new FileStream(resoureceFile, FileMode.Open, FileAccess.Read)), portalPath);
+                using (var resourceStream = File.OpenRead(resoureceFile))
+                {
+                    FileSystemUtils.UnzipResources(new ZipArchive(resourceStream), portalPath);
+                }
+
+                ////new ZipInputStream(new FileStream(resoureceFile, FileMode.Open, FileAccess.Read)), portalPath);
             }
             catch (Exception exc)
             {

--- a/DNN Platform/Library/Services/FileSystem/FileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileManager.cs
@@ -34,7 +34,6 @@ namespace DotNetNuke.Services.FileSystem
     using DotNetNuke.Services.FileSystem.EventArgs;
     using DotNetNuke.Services.FileSystem.Internal;
     using DotNetNuke.Services.Log.EventLog;
-    using ICSharpCode.SharpZipLib.Zip;
 
     using Localization = DotNetNuke.Services.Localization.Localization;
 

--- a/DNN Platform/Library/Services/Installer/InstallFile.cs
+++ b/DNN Platform/Library/Services/Installer/InstallFile.cs
@@ -8,8 +8,6 @@ namespace DotNetNuke.Services.Installer
     using System.IO;
     using System.Text.RegularExpressions;
 
-    using ICSharpCode.SharpZipLib.Zip;
-
     /// -----------------------------------------------------------------------------
     /// <summary>
     /// The InstallFile class represents a single file in an Installer Package.

--- a/DNN Platform/Library/Services/Installer/InstallerInfo.cs
+++ b/DNN Platform/Library/Services/Installer/InstallerInfo.cs
@@ -13,7 +13,6 @@ namespace DotNetNuke.Services.Installer
     using DotNetNuke.Security;
     using DotNetNuke.Services.Installer.Log;
     using DotNetNuke.Services.Installer.Packages;
-    using ICSharpCode.SharpZipLib.Zip;
 
     /// -----------------------------------------------------------------------------
     /// <summary>

--- a/DNN Platform/Library/Services/Installer/Installers/ResourceFileInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/ResourceFileInstaller.cs
@@ -10,7 +10,6 @@ namespace DotNetNuke.Services.Installer.Installers
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Instrumentation;
-    using ICSharpCode.SharpZipLib.Zip;
 
     /// -----------------------------------------------------------------------------
     /// <summary>

--- a/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
@@ -22,7 +22,6 @@ namespace DotNetNuke.Services.Installer.Packages
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.UI.Skins;
-    using ICSharpCode.SharpZipLib.Zip;
 
     /// -----------------------------------------------------------------------------
     /// <summary>

--- a/DNN Platform/Library/Services/Installer/Writers/PackageWriterBase.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/PackageWriterBase.cs
@@ -6,6 +6,7 @@ namespace DotNetNuke.Services.Installer.Writers
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.IO.Compression;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Xml;
@@ -15,7 +16,6 @@ namespace DotNetNuke.Services.Installer.Writers
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Services.Installer.Log;
     using DotNetNuke.Services.Installer.Packages;
-    using ICSharpCode.SharpZipLib.Zip;
 
     /// -----------------------------------------------------------------------------
     /// <summary>
@@ -625,7 +625,7 @@ namespace DotNetNuke.Services.Installer.Writers
         {
         }
 
-        private void AddFilesToZip(ZipOutputStream stream, IDictionary<string, InstallFile> files, string basePath)
+        private void AddFilesToZip(ZipArchive zipArchive, IDictionary<string, InstallFile> files, string basePath)
         {
             foreach (InstallFile packageFile in files.Values)
             {
@@ -647,7 +647,7 @@ namespace DotNetNuke.Services.Installer.Writers
                         packageFilePath = packageFilePath.Replace(basePath + "\\", string.Empty);
                     }
 
-                    FileSystemUtils.AddToZip(ref stream, filepath, packageFile.Name, packageFilePath);
+                    FileSystemUtils.AddToZip(zipArchive, filepath, packageFile.Name, packageFilePath);
                     this.Log.AddInfo(string.Format(Util.WRITER_SavedFile, packageFile.FullName));
                 }
             }

--- a/DNN Platform/Library/UI/Skins/SkinController.cs
+++ b/DNN Platform/Library/UI/Skins/SkinController.cs
@@ -19,7 +19,6 @@ namespace DotNetNuke.UI.Skins
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Log.EventLog;
-    using ICSharpCode.SharpZipLib.Zip;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -106,6 +106,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
@@ -1,22 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core
 {
     using System;
     using System.IO;
-    using System.Linq;
-    using System.Reflection;
+    using System.IO.Compression;
 
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.ComponentModel;
-    using DotNetNuke.Entities.Tabs;
-    using DotNetNuke.Tests.Utilities.Mocks;
-    using ICSharpCode.SharpZipLib.Zip;
     using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using NUnit.Framework;
@@ -78,17 +72,14 @@ namespace DotNetNuke.Tests.Core
             var files = Directory.GetFiles(Globals.ApplicationMapPath, "*.*", SearchOption.TopDirectoryOnly);
             using (var stream = File.Create(zipFilePath))
             {
-                var zipStream = new ZipOutputStream(stream);
-                zipStream.SetLevel(9);
-
-                foreach (var file in files)
+                using (var zipArchive = new ZipArchive(stream, ZipArchiveMode.Update))
                 {
-                    var fileName = Path.GetFileName(file);
-                    FileSystemUtils.AddToZip(ref zipStream, file, fileName, string.Empty);
+                    foreach (var file in files)
+                    {
+                        var fileName = Path.GetFileName(file);
+                        FileSystemUtils.AddToZip(zipArchive, file, fileName, string.Empty);
+                    }
                 }
-
-                zipStream.Finish();
-                zipStream.Close();
             }
 
             // Assert

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/InstallController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/InstallController.cs
@@ -20,7 +20,6 @@ namespace Dnn.PersonaBar.Extensions.Components
     using DotNetNuke.Framework;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Installer;
-    using ICSharpCode.SharpZipLib;
 
     public class InstallController : ServiceLocator<IInstallController, InstallController>, IInstallController
     {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -716,6 +716,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>


### PR DESCRIPTION
Fixes #2735

## Summary
This PR marks the APIs that expose `SharpZipLib` types as deprecated, introduces new overloads of those APIs which take types from `System.IO.Compression`, and starts the process of removing usages of the `SharpZipLib` overloads from the platform.