### PR TITLE
Feature/5101 ck editor resize images on upload

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/App_LocalResources/Options.aspx.resx
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/App_LocalResources/Options.aspx.resx
@@ -263,6 +263,12 @@
   <data name="lblResizeWidth.Text" xml:space="preserve">
     <value>Default Image Resize Width:</value>
   </data>
+  <data name="lblResizeHeightUpload.Text" xml:space="preserve">
+    <value>Image Resize Height On Upload:</value>
+  </data>
+  <data name="lblResizeWidthUpload.Text" xml:space="preserve">
+    <value>Image Resize Width On Upload:</value>
+  </data>
   <data name="lnkExport.Text" xml:space="preserve">
     <value>Export</value>
   </data>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -2507,68 +2507,69 @@ namespace DNNConnect.CKEditorProvider.Browser
                 if (maxWidth > 0 || maxHeight > 0)
                 {
                     // check if the size of the image is within boundaries
-                    var fileStream = FileManager.Instance.GetFileContent(uploadedFile);
-                    var uplImage = Image.FromStream(fileStream);
-                    fileStream.Close();
-
-                    if (uplImage.Width > maxWidth || uplImage.Height > maxHeight)
+                    using (var fileStream = FileManager.Instance.GetFileContent(uploadedFile))
                     {
-                        // it's too big: we need to resize
-                        int newWidth, newHeight;
-
-                        // which determines the max: height or width?
-                        double ratioWidth = (double)maxWidth / (double)uplImage.Width;
-                        double ratioHeight = (double)maxHeight / (double)uplImage.Height;
-                        if (ratioWidth < ratioHeight)
+                        using (var uplImage = Image.FromStream(fileStream))
                         {
-                            // max width needs to be used
-                            newWidth = maxWidth;
-                            newHeight = (int)Math.Round(uplImage.Height * ratioWidth);
-                        }
-                        else
-                        {
-                            // max height needs to be used
-                            newHeight = maxHeight;
-                            newWidth = (int)Math.Round(uplImage.Width * ratioHeight);
-                        }
-
-                        // Add Compression to Jpeg Images
-                        if (uplImage.RawFormat.Equals(ImageFormat.Jpeg))
-                        {
-                            ImageCodecInfo jpgEncoder = GetEncoder(uplImage.RawFormat);
-
-                            Encoder myEncoder = Encoder.Quality;
-                            EncoderParameters encodeParams = new EncoderParameters(1);
-                            EncoderParameter encodeParam = new EncoderParameter(myEncoder, 80L);
-                            encodeParams.Param[0] = encodeParam;
-
-                            using (Bitmap dst = new Bitmap(newWidth, newHeight))
+                            if (uplImage.Width > maxWidth || uplImage.Height > maxHeight)
                             {
-                                using (Graphics g = Graphics.FromImage(dst))
+                                // it's too big: we need to resize
+                                int newWidth, newHeight;
+
+                                // which determines the max: height or width?
+                                double ratioWidth = (double)maxWidth / (double)uplImage.Width;
+                                double ratioHeight = (double)maxHeight / (double)uplImage.Height;
+                                if (ratioWidth < ratioHeight)
                                 {
-                                    g.SmoothingMode = SmoothingMode.AntiAlias;
-                                    g.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                                    g.DrawImage(uplImage, 0, 0, dst.Width, dst.Height);
+                                    // max width needs to be used
+                                    newWidth = maxWidth;
+                                    newHeight = (int)Math.Round(uplImage.Height * ratioWidth);
+                                }
+                                else
+                                {
+                                    // max height needs to be used
+                                    newHeight = maxHeight;
+                                    newWidth = (int)Math.Round(uplImage.Width * ratioHeight);
                                 }
 
-                                using (var stream = new MemoryStream())
+                                // Add Compression to Jpeg Images
+                                if (uplImage.RawFormat.Equals(ImageFormat.Jpeg))
                                 {
-                                    dst.Save(stream, jpgEncoder, encodeParams);
-                                    FileManager.Instance.AddFile(currentFolderInfo, fileName, stream);
+                                    ImageCodecInfo jpgEncoder = GetEncoder(uplImage.RawFormat);
+
+                                    Encoder myEncoder = Encoder.Quality;
+                                    EncoderParameters encodeParams = new EncoderParameters(1);
+                                    EncoderParameter encodeParam = new EncoderParameter(myEncoder, 80L);
+                                    encodeParams.Param[0] = encodeParam;
+
+                                    using (Bitmap dst = new Bitmap(newWidth, newHeight))
+                                    {
+                                        using (Graphics g = Graphics.FromImage(dst))
+                                        {
+                                            g.SmoothingMode = SmoothingMode.AntiAlias;
+                                            g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                                            g.DrawImage(uplImage, 0, 0, dst.Width, dst.Height);
+                                        }
+
+                                        using (var stream = new MemoryStream())
+                                        {
+                                            dst.Save(stream, jpgEncoder, encodeParams);
+                                            FileManager.Instance.AddFile(currentFolderInfo, fileName, stream);
+                                        }
+                                    }
                                 }
-                            }
-                        }
-                        else
-                        {
-                            // Finally Create a new Resized Image
-                            using (Image newImage = uplImage.GetThumbnailImage(newWidth, newHeight, null, IntPtr.Zero))
-                            {
-                                var imageFormat = uplImage.RawFormat;
-                                uplImage.Dispose();
-                                using (var stream = new MemoryStream())
+                                else
                                 {
-                                    newImage.Save(stream, imageFormat);
-                                    FileManager.Instance.AddFile(currentFolderInfo, fileName, stream);
+                                    // Finally Create a new Resized Image
+                                    using (Image newImage = uplImage.GetThumbnailImage(newWidth, newHeight, null, IntPtr.Zero))
+                                    {
+                                        var imageFormat = uplImage.RawFormat;
+                                        using (var stream = new MemoryStream())
+                                        {
+                                            newImage.Save(stream, imageFormat);
+                                            FileManager.Instance.AddFile(currentFolderInfo, fileName, stream);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx
@@ -183,6 +183,14 @@
                             </asp:TemplateField>
                         </Columns>
                     </asp:GridView>
+                    <div class="dnnFormItem">
+                        <asp:label id="lblResizeWidthUpload" runat="server" CssClass="dnnLabel">Image Resize Width On Upload:</asp:label>
+                        <asp:TextBox ID="txtResizeWidthUpload" runat="server" CssClass="settingValueInputNumeric" />px
+                    </div>
+                    <div class="dnnFormItem">
+                        <asp:label id="lblResizeHeightUpload" runat="server" CssClass="dnnLabel">Image Resize Height On Upload:</asp:label>
+                        <asp:TextBox ID="txtResizeHeightUpload" runat="server" CssClass="settingValueInputNumeric" />px
+                    </div>
                 </fieldset>
 			    <h2 id="Panel-FileBrowserDefaults" class="dnnFormSectionHead"><a href="" class="dnnSectionExpanded"><%=LocalizeString("FileBrowserDefaults.SeectionName")%>Default Settings</a></h2>
 			    <fieldset>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.cs
@@ -866,7 +866,11 @@ namespace DNNConnect.CKEditorProvider
                     break;
             }
 
-            this.txtResizeHeight.Text = importedSettings.ResizeWidth.ToString();
+            this.txtResizeWidthUpload.Text = importedSettings.ResizeWidthUpload.ToString();
+
+            this.txtResizeHeightUpload.Text = importedSettings.ResizeHeightUpload.ToString();
+
+            this.txtResizeWidth.Text = importedSettings.ResizeWidth.ToString();
 
             this.txtResizeHeight.Text = importedSettings.ResizeHeight.ToString();
 
@@ -1021,6 +1025,8 @@ namespace DNNConnect.CKEditorProvider
             moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.CUSTOMJSFILE}");
             moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.CONFIG}");
             moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.ROLES}");
+            moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.RESIZEHEIGHTUPLOAD}");
+            moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.RESIZEWIDTHUPLOAD}");
             moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.RESIZEHEIGHT}");
             moduleController.DeleteModuleSetting(this.ModuleId, $"{moduleKey}{SettingConstants.RESIZEWIDTH}");
 
@@ -2475,6 +2481,16 @@ namespace DNNConnect.CKEditorProvider
                 moduleController.UpdateModuleSetting(this.ModuleId, $"{key}{SettingConstants.FILELISTPAGESIZE}", this.FileListPageSize.Text);
             }
 
+            if (Utility.IsNumeric(this.txtResizeWidthUpload.Text))
+            {
+                moduleController.UpdateModuleSetting(this.ModuleId, $"{key}{SettingConstants.RESIZEWIDTHUPLOAD}", this.txtResizeWidthUpload.Text);
+            }
+
+            if (Utility.IsNumeric(this.txtResizeHeightUpload.Text))
+            {
+                moduleController.UpdateModuleSetting(this.ModuleId, $"{key}{SettingConstants.RESIZEHEIGHTUPLOAD}", this.txtResizeHeightUpload.Text);
+            }
+
             if (Utility.IsNumeric(this.txtResizeWidth.Text))
             {
                 moduleController.UpdateModuleSetting(this.ModuleId, $"{key}{SettingConstants.RESIZEWIDTH}", this.txtResizeWidth.Text);
@@ -2731,6 +2747,16 @@ namespace DNNConnect.CKEditorProvider
                 EditorController.AddOrUpdateEditorHostSetting($"{key}{SettingConstants.FILELISTPAGESIZE}", this.FileListPageSize.Text);
             }
 
+            if (Utility.IsNumeric(this.txtResizeWidthUpload.Text))
+            {
+                EditorController.AddOrUpdateEditorHostSetting($"{key}{SettingConstants.RESIZEWIDTHUPLOAD}", this.txtResizeWidthUpload.Text);
+            }
+
+            if (Utility.IsNumeric(this.txtResizeHeightUpload.Text))
+            {
+                EditorController.AddOrUpdateEditorHostSetting($"{key}{SettingConstants.RESIZEHEIGHTUPLOAD}", this.txtResizeHeightUpload.Text);
+            }
+
             if (Utility.IsNumeric(this.txtResizeWidth.Text))
             {
                 EditorController.AddOrUpdateEditorHostSetting($"{key}{SettingConstants.RESIZEWIDTH}", this.txtResizeWidth.Text);
@@ -2903,6 +2929,8 @@ namespace DNNConnect.CKEditorProvider
             this.lblToolbarList.Text = Localization.GetString("lblToolbarList.Text", this.ResXFile, this.LangCode);
             this.lblToolbName.Text = Localization.GetString("lblToolbName.Text", this.ResXFile, this.LangCode);
             this.lblToolbSet.Text = Localization.GetString("lblToolbSet.Text", this.ResXFile, this.LangCode);
+            this.lblResizeWidthUpload.Text = Localization.GetString("lblResizeWidthUpload.Text", this.ResXFile, this.LangCode);
+            this.lblResizeHeightUpload.Text = Localization.GetString("lblResizeHeightUpload.Text", this.ResXFile, this.LangCode);
             this.lblResizeWidth.Text = Localization.GetString("lblResizeWidth.Text", this.ResXFile, this.LangCode);
             this.lblResizeHeight.Text = Localization.GetString("lblResizeHeight.Text", this.ResXFile, this.LangCode);
             this.lblImport.Text = Localization.GetString("lnkImport.Text", this.ResXFile, this.LangCode);
@@ -3367,6 +3395,16 @@ namespace DNNConnect.CKEditorProvider
             if (Utility.IsNumeric(this.FileListPageSize.Text))
             {
                 exportSettings.FileListPageSize = int.Parse(this.FileListPageSize.Text);
+            }
+
+            if (Utility.IsNumeric(this.txtResizeWidthUpload.Text))
+            {
+                exportSettings.ResizeWidthUpload = int.Parse(this.txtResizeWidthUpload.Text);
+            }
+
+            if (Utility.IsNumeric(this.txtResizeHeightUpload.Text))
+            {
+                exportSettings.ResizeHeightUpload = int.Parse(this.txtResizeHeightUpload.Text);
             }
 
             if (Utility.IsNumeric(this.txtResizeWidth.Text))

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.designer.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.designer.cs
@@ -501,6 +501,42 @@ namespace DNNConnect.CKEditorProvider
         protected global::System.Web.UI.WebControls.GridView UploadFileLimits;
 
         /// <summary>
+        /// lblResizeWidthUpload control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblResizeWidthUpload;
+
+        /// <summary>
+        /// txtResizeWidthUpload control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtResizeWidthUpload;
+
+        /// <summary>
+        /// lblResizeHeightUpload control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblResizeHeightUpload;
+
+        /// <summary>
+        /// txtResizeHeightUpload control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtResizeHeightUpload;
+
+        /// <summary>
         /// lblResizeWidth control.
         /// </summary>
         /// <remarks>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Constants/SettingConstants.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Constants/SettingConstants.cs
@@ -175,5 +175,15 @@ namespace DNNConnect.CKEditorProvider.Constants
         /// The resize height setting name.
         /// </summary>
         public const string RESIZEHEIGHT = "resizeheight";
+
+        /// <summary>
+        /// The Resize Upload width setting name.
+        /// </summary>
+        public const string RESIZEWIDTHUPLOAD = "resizewidthupload";
+
+        /// <summary>
+        /// The resize Upload height setting name.
+        /// </summary>
+        public const string RESIZEHEIGHTUPLOAD = "resizeheightupload";
     }
 }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Install/Dnn.CKEditorDefaultSettings.xml
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Install/Dnn.CKEditorDefaultSettings.xml
@@ -11,6 +11,8 @@
   <BrowserRootDirForImgId>-1</BrowserRootDirForImgId>
   <UploadDirId>-1</UploadDirId>
   <UploadDirForImgId>-1</UploadDirForImgId>
+  <ResizeHeightUpload>-1</ResizeHeightUpload>
+  <ResizeWidthUpload>-1</ResizeWidthUpload>
   <ResizeHeight>-1</ResizeHeight>
   <ResizeWidth>-1</ResizeWidth>
   <ToolBarRoles>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Objects/EditorProviderSettings.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Objects/EditorProviderSettings.cs
@@ -31,6 +31,8 @@ namespace DNNConnect.CKEditorProvider.Objects
             this.UploadDirId = -1;
             this.UploadDirForImgId = -1;
             this.ResizeHeight = -1;
+            this.ResizeWidthUpload = -1;
+            this.ResizeHeightUpload = -1;
             this.ResizeWidth = -1;
             this.BrowserRoles = "0;Administrators;";
             this.Browser = "standard";
@@ -138,6 +140,16 @@ namespace DNNConnect.CKEditorProvider.Objects
         /// The custom JS file.
         /// </value>
         public string CustomJsFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the Resize Image Height On Upload.
+        /// </summary>
+        public int ResizeHeightUpload { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the Resize Image Width On Upload.
+        /// </summary>
+        public int ResizeWidthUpload { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether Default Resize Image Height.

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Objects/SettingBase.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Objects/SettingBase.cs
@@ -92,6 +92,16 @@ namespace DNNConnect.CKEditorProvider.Objects
         public int UploadDirForImgId { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating the Resize Image Height On Upload.
+        /// </summary>
+        public int iResizeHeightUpload { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the Resize Image Width On Upload.
+        /// </summary>
+        public int iResizeWidthUpload { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether Default Resize Image Height.
         /// </summary>
         public int iResizeHeight { get; set; }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/SettingsUtil.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/SettingsUtil.cs
@@ -806,6 +806,48 @@ namespace DNNConnect.CKEditorProvider.Utilities
 
             if (
                 filteredSettings.Any(
+                    setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTHUPLOAD))))
+            {
+                var settingValue =
+                    filteredSettings.FirstOrDefault(
+                        s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTHUPLOAD))).Value;
+
+                if (!string.IsNullOrEmpty(settingValue))
+                {
+                    try
+                    {
+                        currentSettings.ResizeWidthUpload = int.Parse(settingValue);
+                    }
+                    catch (Exception)
+                    {
+                        currentSettings.ResizeWidthUpload = -1;
+                    }
+                }
+            }
+
+            if (
+                filteredSettings.Any(
+                    setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEHEIGHTUPLOAD))))
+            {
+                var settingValue =
+                    filteredSettings.FirstOrDefault(
+                        s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEHEIGHTUPLOAD))).Value;
+
+                if (!string.IsNullOrEmpty(settingValue))
+                {
+                    try
+                    {
+                        currentSettings.ResizeHeightUpload = int.Parse(settingValue);
+                    }
+                    catch (Exception)
+                    {
+                        currentSettings.ResizeHeightUpload = -1;
+                    }
+                }
+            }
+
+            if (
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTH))))
             {
                 var settingValue =
@@ -1296,6 +1338,30 @@ namespace DNNConnect.CKEditorProvider.Utilities
                 }
             }
 
+            if (!string.IsNullOrEmpty((string)hshModSet[string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTHUPLOAD)]))
+            {
+                try
+                {
+                    currentSettings.ResizeWidthUpload = int.Parse((string)hshModSet[string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTHUPLOAD)]);
+                }
+                catch (Exception)
+                {
+                    currentSettings.ResizeWidthUpload = -1;
+                }
+            }
+
+            if (!string.IsNullOrEmpty((string)hshModSet[string.Format("{0}{1}", key, SettingConstants.RESIZEHEIGHTUPLOAD)]))
+            {
+                try
+                {
+                    currentSettings.ResizeHeightUpload = int.Parse((string)hshModSet[string.Format("{0}{1}", key, SettingConstants.RESIZEHEIGHTUPLOAD)]);
+                }
+                catch (Exception)
+                {
+                    currentSettings.ResizeHeightUpload = -1;
+                }
+            }
+
             if (!string.IsNullOrEmpty((string)hshModSet[string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTH)]))
             {
                 try
@@ -1572,6 +1638,8 @@ namespace DNNConnect.CKEditorProvider.Utilities
                 BrowserRootDirForImgId = oldDefaultSettings.BrowserRootDirForImgId,
                 UploadDirId = oldDefaultSettings.UploadDirId,
                 UploadDirForImgId = oldDefaultSettings.UploadDirForImgId,
+                ResizeHeightUpload = oldDefaultSettings.iResizeHeightUpload,
+                ResizeWidthUpload = oldDefaultSettings.iResizeWidthUpload,
                 ResizeHeight = oldDefaultSettings.iResizeHeight,
                 ResizeWidth = oldDefaultSettings.iResizeWidth,
                 ToolBarRoles = oldDefaultSettings.listToolbRoles,


### PR DESCRIPTION
This PR is a redo of #5123 because of merge/rebase issues. As @valadas advised, I cherry picked the relevant commits, and gave it a quick test based on a fresh 9.11.0 install.

Closes #5101 
This PR is built on PR #5122 which was submitted for #5100, but is not necessarily related.

## Summary
This PR adds settings for:
* Image Resize Width On Upload
* Image Resize Height On Upload
And will resize any uploaded image to fit within these dimension on upload.

Since pictures are becoming larger and larger, it can be important on many portals, to have this automatic resize option, to allow users uncapable of resizing images themselves, to upload reasonably sized images.
![image](https://user-images.githubusercontent.com/4275042/168089867-f5c4e936-05e2-495b-ab26-0098217f2ff2.png)

