### PR TITLE
Fixed 2 build issues

### DIFF
--- a/Build/BuildScripts/AEModule.build
+++ b/Build/BuildScripts/AEModule.build
@@ -17,7 +17,7 @@
       <PersonaBar-css Include="admin/personaBar/**/css/**/*" />
       <PersonaBar-resources Include="admin/personaBar/**/App_LocalResources/*.resx" />
       <PersonaBar-controls Include="admin/personaBar/**/UserControls/*.ascx" />
-      <PersonaBar-scripts Include="admin/personaBar/**/scripts/*;admin/personaBar/**/scripts/**/*" />
+      <PersonaBar-scripts Include="admin/personaBar/**/scripts/**/*" />
       <Resources Include="@(PersonaBar-views);@(PersonaBar-images);@(PersonaBar-css);@(PersonaBar-scripts);@(PersonaBar-data);@(PersonaBar-resources);@(PersonaBar-controls)" Exclude="**/node_modules/**/*" />
     </ItemGroup>
   </Target>

--- a/Build/Tasks/unversionedManifests.txt
+++ b/Build/Tasks/unversionedManifests.txt
@@ -1,5 +1,6 @@
 DNN Platform/Components/MailKit/*.dnn
 DNN Platform/Components/Microsoft.*/**/*.dnn
 DNN Platform/Components/Newtonsoft/*.dnn
+DNN Platform/Components/WebFormsMvp/*.dnn
 DNN Platform/JavaScript Libraries/**/*.dnn
 Temp/**/*.dnn


### PR DESCRIPTION
AEModule.build had 2 globs that would return some of the same files and have them duplicated in resources.zip files, which was not a major issue but found it while troubleshooting another issue.

Also, WebFormsMVP had recently been made into a package but it was not added to the list of unversioned manifest and would get automatically versioned by the current DNN version upon build.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
