### PR TITLE
Feature/5142 implement resize on upload for browser and easyimage

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx
@@ -384,7 +384,7 @@
             function setupFileUpload(overrideFile) {
                 var overrideFile = overrideFile;
                 var maxFileSize = <%= this.MaxUploadSize %>;
-                var fileUploaderURL = "FileUploader.ashx?portalid=<%= HttpContext.Current.Request.QueryString["PortalID"] %>";
+                var fileUploaderURL = "FileUploader.ashx?mode=<%= HttpContext.Current.Request.QueryString["mode"] %>&portalid=<%= HttpContext.Current.Request.QueryString["PortalID"] %>&tabid=<%= HttpContext.Current.Request.QueryString["tabid"] %>&mid=<%= HttpContext.Current.Request.QueryString["mid"] %>&ckId=<%= HttpContext.Current.Request.QueryString["CKEditor"] %>";
 
                 $('#fileupload').fileupload({
                     url: fileUploaderURL,


### PR DESCRIPTION
Closes #5142
Fixes #5143

This PR addresses 2 issues, because I ran into the second while fixing the first. #5143 looked critical, although I didn't get that one before.

## Summary
The fix for #5143 is done by improving the ccode: before we would save the uploaded file, and when needed we'd resize it and save it again. Since the second save gave a "file in use" exception, I changed the code around so we're now first checking to see wether or not the file needs resizing. In any case we're only saving it once.

The fix for #5142 is done by implementing the logic for resizing on upload in FileUploader.ashx. In order to get that done, I needed the current editor settings there, and for that, I needed to add extra querystring parameters to the url for FileUploader.ashx.

I based this PR on the release/9.11.0 branch, hoping that's ok.