### PR TITLE
Fixes #5183 : Crash caused by a web spider providing an invalid referrer uri with the request.

### DIFF
--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -1472,7 +1472,7 @@ namespace DotNetNuke.Entities.Urls
                 // mapped virtual url
                 return false;
             }
-            catch (InvalidUriException)
+            catch (UriFormatException)
             {
                 // catch and handle this exception, caused by an invalid hostname in the referrer
                 return false;


### PR DESCRIPTION
## Summary
Provides an error handler to catch the InvalidUriException thrown when an invalid referrer URI is passed in the web request.

Closes #5183 