### PR TITLE
Resolve HTML module bug with invalid HTML

### DIFF
--- a/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
+++ b/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
@@ -125,13 +125,14 @@ namespace DotNetNuke.Modules.Html
                     R = strHTML.IndexOf("\"", S);
 
                     // end of URL
-                    if (R >= 0)
+                    if (R >= 0 && R < strHTML.Length - 2)
                     {
                         strURL = strHTML.Substring(S, R - S).ToLowerInvariant();
                     }
                     else
                     {
-                        strURL = strHTML.Substring(S).ToLowerInvariant();
+                        P = -1;
+                        continue;
                     }
 
                     if (strHTML.Substring(P + tLen, 10).Equals("data:image", StringComparison.InvariantCultureIgnoreCase))

--- a/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
+++ b/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
@@ -98,83 +98,88 @@ namespace DotNetNuke.Modules.Html
             return content;
         }
 
-        public static string ManageRelativePaths(string strHTML, string strUploadDirectory, string strToken, int intPortalID)
+        [Obsolete("Deprecated in Platform 9.11.0. Use overload without int. Scheduled removal in v11.0.0.")]
+        public static string ManageRelativePaths(string htmlContent, string strUploadDirectory, string strToken, int intPortalID)
         {
-            int P = 0;
-            int R = 0;
-            int S = 0;
-            int tLen = 0;
-            string strURL = null;
+            return ManageRelativePaths(htmlContent, strUploadDirectory, strToken);
+        }
+
+        public static string ManageRelativePaths(string htmlContent, string uploadDirectory, string token)
+        {
+            var htmlContentIndex = 0;
             var sbBuff = new StringBuilder(string.Empty);
 
-            if (!string.IsNullOrEmpty(strHTML))
+            if (string.IsNullOrEmpty(htmlContent))
             {
-                tLen = strToken.Length + 2;
-                string uploadDirectory = strUploadDirectory.ToLowerInvariant();
+                return string.Empty;
+            }
 
-                // find position of first occurrance:
-                P = strHTML.IndexOf(strToken + "=\"", StringComparison.InvariantCultureIgnoreCase);
-                while (P != -1)
+            token = token + "=\"";
+            var tokenLength = token.Length;
+            uploadDirectory = uploadDirectory.ToLowerInvariant();
+
+            // find position of first occurrence:
+            var tokenIndex = htmlContent.IndexOf(token, StringComparison.InvariantCultureIgnoreCase);
+            while (tokenIndex != -1)
+            {
+                sbBuff.Append(htmlContent.Substring(htmlContentIndex, tokenIndex - htmlContentIndex + tokenLength));
+
+                // keep characters left of URL
+                htmlContentIndex = tokenIndex + tokenLength;
+
+                // save start position of URL
+                var urlEndIndex = htmlContent.IndexOf('\"', htmlContentIndex);
+
+                // end of URL
+                string strURL;
+                if (urlEndIndex >= 0 && urlEndIndex < htmlContent.Length - 2)
                 {
-                    sbBuff.Append(strHTML.Substring(S, P - S + tLen));
-
-                    // keep charactes left of URL
-                    S = P + tLen;
-
-                    // save startpos of URL
-                    R = strHTML.IndexOf("\"", S);
-
-                    // end of URL
-                    if (R >= 0 && R < strHTML.Length - 2)
-                    {
-                        strURL = strHTML.Substring(S, R - S).ToLowerInvariant();
-                    }
-                    else
-                    {
-                        P = -1;
-                        continue;
-                    }
-
-                    if (strHTML.Substring(P + tLen, 10).Equals("data:image", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        P = strHTML.IndexOf(strToken + "=\"", S + strURL.Length + 2, StringComparison.InvariantCultureIgnoreCase);
-                        continue;
-                    }
-
-                    // if we are linking internally
-                    if (!strURL.Contains("://"))
-                    {
-                        // remove the leading portion of the path if the URL contains the upload directory structure
-                        string strDirectory = uploadDirectory;
-                        if (!strDirectory.EndsWith("/"))
-                        {
-                            strDirectory += "/";
-                        }
-
-                        if (strURL.IndexOf(strDirectory) != -1)
-                        {
-                            S = S + strURL.IndexOf(strDirectory) + strDirectory.Length;
-                            strURL = strURL.Substring(strURL.IndexOf(strDirectory) + strDirectory.Length);
-                        }
-
-                        // add upload directory
-                        if (!strURL.StartsWith("/")
-                            && !string.IsNullOrEmpty(strURL.Trim())) // We don't write the UploadDirectory if the token/attribute has not value. Therefore we will avoid an unnecessary request
-                        {
-                            sbBuff.Append(uploadDirectory);
-                        }
-                    }
-
-                    // find position of next occurrance
-                    P = strHTML.IndexOf(strToken + "=\"", S + strURL.Length + 2, StringComparison.InvariantCultureIgnoreCase);
+                    strURL = htmlContent.Substring(htmlContentIndex, urlEndIndex - htmlContentIndex).ToLowerInvariant();
+                }
+                else
+                {
+                    tokenIndex = -1;
+                    continue;
                 }
 
-                if (S > -1)
+                if (htmlContent.Substring(tokenIndex + tokenLength, 10).Equals("data:image", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    sbBuff.Append(strHTML.Substring(S));
+                    tokenIndex = htmlContent.IndexOf(token, htmlContentIndex + strURL.Length + 2, StringComparison.InvariantCultureIgnoreCase);
+                    continue;
                 }
 
-                // append characters of last URL and behind
+                // if we are linking internally
+                if (!strURL.Contains("://"))
+                {
+                    // remove the leading portion of the path if the URL contains the upload directory structure
+                    var strDirectory = uploadDirectory;
+                    if (!strDirectory.EndsWith("/", StringComparison.Ordinal))
+                    {
+                        strDirectory += "/";
+                    }
+
+                    if (strURL.IndexOf(strDirectory, StringComparison.InvariantCultureIgnoreCase) != -1)
+                    {
+                        htmlContentIndex = htmlContentIndex + strURL.IndexOf(strDirectory, StringComparison.InvariantCultureIgnoreCase) + strDirectory.Length;
+                        strURL = strURL.Substring(strURL.IndexOf(strDirectory, StringComparison.InvariantCultureIgnoreCase) + strDirectory.Length);
+                    }
+
+                    // add upload directory
+                    // We don't write the UploadDirectory if the token/attribute has not value. Therefore we will avoid an unnecessary request
+                    if (!strURL.StartsWith("/", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(strURL))
+                    {
+                        sbBuff.Append(uploadDirectory);
+                    }
+                }
+
+                // find position of next occurrence
+                tokenIndex = htmlContent.IndexOf(token, htmlContentIndex + strURL.Length + 2, StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            // append characters of last URL and behind
+            if (htmlContentIndex > -1)
+            {
+                sbBuff.Append(htmlContent.Substring(htmlContentIndex));
             }
 
             return sbBuff.ToString();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/AssemblyInfo.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DotNetNuke.Library.Tests.Modules")]
+[assembly: AssemblyDescription("Open Source Web Application Framework - Test Project")]
+
+[assembly: AssemblyCompany(".NET Foundation")]
+[assembly: AssemblyProduct("https://dnncommunity.org")]
+[assembly: AssemblyCopyright("DNN Platform is copyright 2002-2022 by .NET Foundation. All Rights Reserved.")]
+[assembly: AssemblyTrademark("DNN")]
+
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/DotNetNuke.Tests.Modules.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/DotNetNuke.Tests.Modules.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\NUnit3TestAdapter.4.2.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\..\packages\NUnit3TestAdapter.4.2.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\..\packages\NUnit.3.13.2\build\NUnit.props" Condition="Exists('..\..\..\packages\NUnit.3.13.2\build\NUnit.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DotNetNuke.Tests.Modules</RootNamespace>
+    <AssemblyName>DotNetNuke.Tests.Modules</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <RestorePackages>true</RestorePackages>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>1591, 0618,SA0001</NoWarn>
+    <LangVersion>7</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>1591, 0618,SA0001</NoWarn>
+    <LangVersion>7</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Moq">
+      <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.13.2.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.13.2\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Html\HtmlTextControllerTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Library\DotNetNuke.Library.csproj">
+      <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
+      <Name>DotNetNuke.Library</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Modules\HTML\DotNetNuke.Modules.Html.csproj">
+      <Project>{cd8732d8-b4dd-435d-bf21-a90c2964aba4}</Project>
+      <Name>DotNetNuke.Modules.Html</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\..\stylecop.json">
+      <Link>stylecop.json</Link>
+    </AdditionalFiles>
+    <None Include="..\App.config">
+      <Link>App.config</Link>
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\NUnit.3.13.2\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit.3.13.2\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\NUnit3TestAdapter.4.2.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit3TestAdapter.4.2.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
@@ -65,6 +65,28 @@ namespace DotNetNuke.Tests.Modules.Html
         }
 
         [Test]
+        public void ManageRelativePaths_DoesNotAdjustContentEndingInImgSrc()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "src=\"image.jpg\"",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("src=\"image.jpg\"", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_DoesNotAdjustContentEndingInUnclosedImgSrc()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "src=\"image.jpg",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("src=\"image.jpg", actual);
+        }
+
+        [Test]
         public void ManageRelativePaths_DoesAdjustImgSrcWithRelativeUrlInContent()
         {
             // TODO: should we attempt to avoid making this change?
@@ -85,6 +107,38 @@ namespace DotNetNuke.Tests.Modules.Html
                 "src",
                 0);
             Assert.AreEqual("<img src=\"data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7\"/>", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_AdjustsNonRootedRelativePathsAndDoesNotAdjustOtherPaths()
+        {
+            const string HtmlContent = @"
+<img alt=""a data URI"" src=""data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7""/>
+<img alt=""a non-rooted relative path"" src=""images/image.png"" />
+<img alt=""a rooted relative path"" src=""/image.png"" />
+<img alt=""an absolute path"" src=""https://dnncommunity.org/Portals/0/DNN_White_Logo_lg.png"" />
+<img alt=""another data URI"" src=""data:image/gif;base64,R0lGODlhDgAOAOYAAOBxJvGKIfOEIu5+ItlaIt1XD/zu5uNzNvSJItxXD99cFumEIe2/lOGfb/nNoN9/Huy+lNxgIuqHHeOAH/PQsNZ+SfvRpN+NNficPu2DLt1WDfueOvCfV+WldviSLfHJoeGYR9+AH+l3It1hHvbfxu/MqeSLT+OcUedxIuFwIfaQMeate+qTNeWkfuGib/fcwvufPvjn1uuCKNxbFe2QTOOLNvKHGfmdOt95F9uGRuSjdeiHH+KMQ999H/ubOei0jO6LKuFoIvjZuuFuMeSZSt58P+CFNvCZSPfDivjIm9NgIN5rJfOLLttaH/KNIPKvavSMIfeMJdZUDu+MMvvz6uV4KeR2J+qUXtlTDPLXv+l9KvSMG+y7jPrTqPaWNu2EHdlWD/CELPufPOOJWvfl0tlkI91lIvuaMuadcOONSuqTSeOQU95XD+aIM+SBGu2sivCFHfucOdp5F+etc91cF92CRvHLotxyKPzu5+SLQviSL/rQpN9dF+NvMdxNAP///yH5BAAAAAAALAAAAAAOAA4AAAe7gHgHIzN0fIeHCgp9BgdmSi1oJlZaYUwqeh59CWUVf59/FEdePhtnfhpLdTodP1mfDjdicX4FAHdreW01czF/XTA+tQA5ny9PLCBkfxhRtVU8ECWfSDsnf0kCfmwZU0ALRCR/HCEMfwN+CTJfNlsSF39CPSt/NH5gOB9/Fk4P00Yu/lzxI0UOlU9QJnD5k6bBnzd+sLix82cPggVqOKQoMoaAnyFwAgRAIGCACBRBIhBowqiPn5cwYzIKBAA7"">
+<img alt=""another non-rooted relative path"" src=""images2/image2.png"" />
+<img alt=""another rooted relative path"" src=""/images/image2.png"" />
+<img alt=""another absolute path"" src=""https://dnncommunity.org/DesktopModules/ActiveForums/images/feedicon.gif"" />
+";
+            var actual = HtmlTextController.ManageRelativePaths(
+                HtmlContent,
+                "/portals/0/",
+                "src",
+                0);
+
+            const string Expected = @"
+<img alt=""a data URI"" src=""data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7""/>
+<img alt=""a non-rooted relative path"" src=""/portals/0/images/image.png"" />
+<img alt=""a rooted relative path"" src=""/image.png"" />
+<img alt=""an absolute path"" src=""https://dnncommunity.org/Portals/0/DNN_White_Logo_lg.png"" />
+<img alt=""another data URI"" src=""data:image/gif;base64,R0lGODlhDgAOAOYAAOBxJvGKIfOEIu5+ItlaIt1XD/zu5uNzNvSJItxXD99cFumEIe2/lOGfb/nNoN9/Huy+lNxgIuqHHeOAH/PQsNZ+SfvRpN+NNficPu2DLt1WDfueOvCfV+WldviSLfHJoeGYR9+AH+l3It1hHvbfxu/MqeSLT+OcUedxIuFwIfaQMeate+qTNeWkfuGib/fcwvufPvjn1uuCKNxbFe2QTOOLNvKHGfmdOt95F9uGRuSjdeiHH+KMQ999H/ubOei0jO6LKuFoIvjZuuFuMeSZSt58P+CFNvCZSPfDivjIm9NgIN5rJfOLLttaH/KNIPKvavSMIfeMJdZUDu+MMvvz6uV4KeR2J+qUXtlTDPLXv+l9KvSMG+y7jPrTqPaWNu2EHdlWD/CELPufPOOJWvfl0tlkI91lIvuaMuadcOONSuqTSeOQU95XD+aIM+SBGu2sivCFHfucOdp5F+etc91cF92CRvHLotxyKPzu5+SLQviSL/rQpN9dF+NvMdxNAP///yH5BAAAAAAALAAAAAAOAA4AAAe7gHgHIzN0fIeHCgp9BgdmSi1oJlZaYUwqeh59CWUVf59/FEdePhtnfhpLdTodP1mfDjdicX4FAHdreW01czF/XTA+tQA5ny9PLCBkfxhRtVU8ECWfSDsnf0kCfmwZU0ALRCR/HCEMfwN+CTJfNlsSF39CPSt/NH5gOB9/Fk4P00Yu/lzxI0UOlU9QJnD5k6bBnzd+sLix82cPggVqOKQoMoaAnyFwAgRAIGCACBRBIhBowqiPn5cwYzIKBAA7"">
+<img alt=""another non-rooted relative path"" src=""/portals/0/images2/image2.png"" />
+<img alt=""another rooted relative path"" src=""/images/image2.png"" />
+<img alt=""another absolute path"" src=""https://dnncommunity.org/DesktopModules/ActiveForums/images/feedicon.gif"" />
+";
+            Assert.AreEqual(Expected, actual);
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Modules.Html
+{
+    using DotNetNuke.Modules.Html;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class HtmlTextControllerTests
+    {
+        [Test]
+        public void ManageRelativePaths_DoesNotChangePlainHtml()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "<p>Hello</p>",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("<p>Hello</p>", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_AdjustsRelativeImgSrc()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "<img src=\"image.jpg\"/>",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("<img src=\"/portals/0/image.jpg\"/>", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_DoesNotAdjustImgSrcWithCorrectPathCaseInsensitive()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "<img src=\"/Portals/0/image.jpg\"/>",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("<img src=\"/portals/0/image.jpg\"/>", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_DoesNotAdjustImgSrcWithAbsoluteUrl()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "<img src=\"https://example.com/image.jpg\"/>",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("<img src=\"https://example.com/image.jpg\"/>", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_DoesNotAdjustImgSrcWithAbsoluteUrlInContent()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "src=\"https://example.com/image.jpg\" is how you indicate a URL",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("src=\"https://example.com/image.jpg\" is how you indicate a URL", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_DoesAdjustImgSrcWithRelativeUrlInContent()
+        {
+            // TODO: should we attempt to avoid making this change?
+            var actual = HtmlTextController.ManageRelativePaths(
+                "src=\"image.jpg\" is how you indicate a URL",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("src=\"/portals/0/image.jpg\" is how you indicate a URL", actual);
+        }
+
+        [Test]
+        public void ManageRelativePaths_DoesNotAdjustImgSrcWithDataUrl()
+        {
+            var actual = HtmlTextController.ManageRelativePaths(
+                "<img src=\"data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7\"/>",
+                "/portals/0/",
+                "src",
+                0);
+            Assert.AreEqual("<img src=\"data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7\"/>", actual);
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/TestSetup.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/TestSetup.cs
@@ -1,0 +1,25 @@
+﻿// 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// 
+using DotNetNuke.Tests.Utilities.Mocks;
+
+using NUnit.Framework;
+
+namespace DotNetNuke.Tests.Core
+{
+    [SetUpFixture]
+    internal class TestSetup
+    {
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            MockComponentProvider.ResetContainer();
+        }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="NUnit" version="3.13.2" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="4.2.0" targetFramework="net472" />
+  <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
+</packages>

--- a/DNN_Platform.sln
+++ b/DNN_Platform.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Projects", "Support Projects", "{1DFA65CE-5978-49F9-83BA-CFBD0C7A1814}"
 EndProject
@@ -117,8 +117,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.ps1 = build.ps1
 		CONTRIBUTING.md = CONTRIBUTING.md
 		Directory.Build.props = Directory.Build.props
-		DNN_Platform.build = DNN_Platform.build
 		dnnplatform.png = dnnplatform.png
+		DNN_Platform.build = DNN_Platform.build
 		gitversion.yml = gitversion.yml
 		LICENSE = LICENSE
 		NOTICE.md = NOTICE.md
@@ -569,6 +569,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.Extensions.FileSy
 		DNN Platform\Components\Microsoft.Extensions.FileSystemGlobbing\License.txt = DNN Platform\Components\Microsoft.Extensions.FileSystemGlobbing\License.txt
 		DNN Platform\Components\Microsoft.Extensions.FileSystemGlobbing\Microsoft.Extensions.FileSystemGlobbing.dnn = DNN Platform\Components\Microsoft.Extensions.FileSystemGlobbing\Microsoft.Extensions.FileSystemGlobbing.dnn
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Tests.Modules", "DNN Platform\Tests\DotNetNuke.Tests.Modules\DotNetNuke.Tests.Modules.csproj", "{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2082,6 +2084,30 @@ Global
 		{12583A7E-7BEF-4F79-9CEA-3736D28C3241}.Release-Net45|Any CPU.Build.0 = Release|Any CPU
 		{12583A7E-7BEF-4F79-9CEA-3736D28C3241}.Release-Net45|x86.ActiveCfg = Release|Any CPU
 		{12583A7E-7BEF-4F79-9CEA-3736D28C3241}.Release-Net45|x86.Build.0 = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Debug|x86.Build.0 = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Release|Any CPU.Build.0 = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Release|x86.ActiveCfg = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Cloud_Release|x86.Build.0 = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug|x86.Build.0 = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug-Net45|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug-Net45|Any CPU.Build.0 = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug-Net45|x86.ActiveCfg = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Debug-Net45|x86.Build.0 = Debug|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release|x86.ActiveCfg = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release|x86.Build.0 = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release-Net45|Any CPU.ActiveCfg = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release-Net45|Any CPU.Build.0 = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release-Net45|x86.ActiveCfg = Release|Any CPU
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43}.Release-Net45|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2202,6 +2228,7 @@ Global
 		{CBBA26D2-68FF-4FDB-BD9E-17D4C2CE717F} = {A193D0F9-C722-44BD-B209-2AA2F25C9816}
 		{6395573E-D778-4DBE-BD22-A39273DBF0C9} = {A193D0F9-C722-44BD-B209-2AA2F25C9816}
 		{890623E0-F6C8-4011-9FAF-00939601EBE8} = {A193D0F9-C722-44BD-B209-2AA2F25C9816}
+		{EEFFEA77-4FA5-4498-9A9C-1BDBD6436E43} = {88E649D7-1379-430F-B794-1F3B9B442C80}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46B6A641-57EB-4B19-B199-23E6FC2AB40B}


### PR DESCRIPTION
Fixes #5187

This PR adds a new DotNetNuke.Tests.Modules project with tests for `HtmlTextController.ManageRelativePaths`. It resolves the linked issue and also refactors that function to clean up and clarify its implementation.