### PR TITLE
Add option to set SSL during the installation process

### DIFF
--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -4123,6 +4123,16 @@ namespace DotNetNuke.Data
             this.ExecuteNonQuery("AuthCookies_DeleteOld", FixDate(utcExpiredBefore));
         }
 
+        /// <summary>
+        /// Sets all tabs of the portal to the specified secure value.
+        /// </summary>
+        /// <param name="portalId">The portal to update</param>
+        /// <param name="secure">True to set all pages to secure, false to set them all to non secure.</param>
+        public virtual void SetAllPortalTabsSecure(int portalId, bool secure)
+        {
+            Instance().ExecuteNonQuery("SetAllPortalTabsSecure", portalId, secure);
+        }
+
         public virtual DataSet ExecuteDataSet(string procedureName, params object[] commandParameters)
         {
             return Globals.ConvertDataReaderToDataSet(this.ExecuteReader(procedureName, commandParameters));

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1525,6 +1525,7 @@
     <Compile Include="Services\Tokens\TokenReplace.cs" />
     <Compile Include="Services\Upgrade\Internals\Steps\AddFcnModeStep.cs" />
     <Compile Include="Services\Upgrade\Internals\Steps\BaseInstallationStep.cs" />
+    <Compile Include="Services\Upgrade\Internals\Steps\InstallSslStep.cs" />
     <Compile Include="Services\Upgrade\Internals\Steps\InstallVersionStep.cs" />
     <Compile Include="Services\Upgrade\Internals\Steps\IISVerificationStep.cs" />
     <Compile Include="Services\Upgrade\Internals\Steps\ActivateLicenseStep.cs" />

--- a/DNN Platform/Library/Services/Upgrade/Internals/InstallConfiguration/PortalConfig.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/InstallConfiguration/PortalConfig.cs
@@ -43,5 +43,7 @@ namespace DotNetNuke.Services.Upgrade.Internals.InstallConfiguration
         public string HomeDirectory { get; set; }
 
         public IList<string> PortAliases { get; set; }
+
+        public bool IsSsl { get; set; }
     }
 }

--- a/DNN Platform/Library/Services/Upgrade/Internals/InstallControllerImpl.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/InstallControllerImpl.cs
@@ -183,6 +183,7 @@ namespace DotNetNuke.Services.Upgrade.Internals
                     XmlNode administratorNode = AppendNewXmlNode(ref installTemplate, ref portalNode, "administrator", null);
                     XmlNode portalAliasesNode = AppendNewXmlNode(ref installTemplate, ref portalNode, "portalaliases", null);
                     AppendNewXmlNode(ref installTemplate, ref portalNode, "portalname", portalConfig.PortalName);
+                    AppendNewXmlNode(ref installTemplate, ref portalNode, "isssl", portalConfig.IsSsl.ToString());
                     AppendNewXmlNode(ref installTemplate, ref administratorNode, "firstname", portalConfig.AdminFirstName);
                     AppendNewXmlNode(ref installTemplate, ref administratorNode, "lastname", portalConfig.AdminLastName);
                     AppendNewXmlNode(ref installTemplate, ref administratorNode, "username", portalConfig.AdminUserName);
@@ -403,6 +404,7 @@ namespace DotNetNuke.Services.Upgrade.Internals
                     {
                         var portalConfig = new PortalConfig();
                         portalConfig.PortalName = XmlUtils.GetNodeValue(portalNode.CreateNavigator(), "portalname");
+                        portalConfig.IsSsl = bool.Parse(XmlUtils.GetNodeValue(portalNode.CreateNavigator(), "isssl", "false"));
 
                         XmlNode adminNode = portalNode.SelectSingleNode("administrator");
                         if (adminNode != null)

--- a/DNN Platform/Library/Services/Upgrade/Internals/Steps/InstallSslStep.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/Steps/InstallSslStep.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Services.Upgrade.Internals.Steps
+{
+    using System.Linq;
+
+    using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Data;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Services.Upgrade.Internals;
+
+    using Localization = DotNetNuke.Services.Localization.Localization;
+
+    /// -----------------------------------------------------------------------------
+    /// <summary>
+    /// InstallSslStep - Step that checks and sets SSL where needed.
+    /// </summary>
+    /// -----------------------------------------------------------------------------
+    public class InstallSslStep : BaseInstallationStep
+    {
+        /// <summary>
+        /// Main method to execute the step.
+        /// </summary>
+        public override void Execute()
+        {
+            this.Percentage = 0;
+            this.Status = StepStatus.Running;
+
+            var installConfig = InstallController.Instance.GetInstallConfig();
+
+            var counter = 0;
+            var totalSteps = installConfig.Portals.Count;
+            var percentForEachStep = 100 / totalSteps;
+
+            var portals = PortalController.Instance.GetPortals().Cast<PortalInfo>();
+
+            foreach (var portalConfig in installConfig.Portals)
+            {
+                var portal = (IPortalInfo)portals.FirstOrDefault(p => p.PortalName == portalConfig.PortalName);
+                var description = Localization.GetString("InstallingSslStep", this.LocalInstallResourceFile);
+                this.Details = string.Format(description, portalConfig.PortalName);
+                if (portal != null)
+                {
+                    PortalController.UpdatePortalSetting(portal.PortalId, "SSLSetup", portalConfig.IsSsl ? "1" : "0", false);
+                    DataProvider.Instance().SetAllPortalTabsSecure(portal.PortalId, portalConfig.IsSsl);
+                }
+                else
+                {
+                    this.Errors.Add(string.Format(Localization.GetString("InstallingSslStepSiteNotFound", this.LocalInstallResourceFile), portalConfig.PortalName));
+                }
+
+                counter++;
+                this.Percentage = counter * percentForEachStep;
+            }
+
+            this.Status = this.Errors.Count > 0 ? StepStatus.Retry : StepStatus.Done;
+        }
+    }
+}

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -3185,6 +3185,8 @@
     <Content Include="Licenses\SolPartMenu %28Ms-PL%29.txt.resources" />
     <Content Include="Licenses\Telerik RadControls for ASP.NET AJAX %28Custom%29.pdf.resources" />
     <None Include="Portals\_default\admin.template" />
+    <Content Include="Portals\_default\Blank Website.template" />
+    <Content Include="Portals\_default\Default Website.template" />
     <None Include="Portals\_default\EventQueue\EventQueue.config" />
     <None Include="Portals\_default\Logs\LogConfig\LogConfig.xsd">
       <SubType>Designer</SubType>
@@ -3451,6 +3453,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Licenses\NUnit3TestAdapter %28MIT%29.txt.resources" />
+    <EmbeddedResource Include="Portals\_default\Blank Website.template.en-US.resx" />
+    <EmbeddedResource Include="Portals\_default\Default Website.template.en-US.resx" />
+    <EmbeddedResource Include="Portals\_default\Default Website.template.resources" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
@@ -59,8 +59,8 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -530,5 +530,11 @@ Using Windows Explorer, browse to the folders of your website ( {0} ). Right-cli
   </data>
   <data name="DotNetVersion472Required.Text" xml:space="preserve">
     <value>.Net Framework 4.7.2 is required. Check for Windows updates before proceeding.</value>
+  </data>
+  <data name="WebsiteSsl.Help" xml:space="preserve">
+    <value>Website will be configured to run on SSL</value>
+  </data>
+  <data name="WebsiteSsl.Text" xml:space="preserve">
+    <value>SSL</value>
   </data>
 </root>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
@@ -537,4 +537,10 @@ Using Windows Explorer, browse to the folders of your website ( {0} ). Right-cli
   <data name="WebsiteSsl.Text" xml:space="preserve">
     <value>SSL</value>
   </data>
+  <data name="InstallingSslStep.Text" xml:space="preserve">
+    <value>Checking SSL for site {0}</value>
+  </data>
+  <data name="InstallingSslStepSiteNotFound.Text" xml:space="preserve">
+    <value>Could not find site {0} to set SSL</value>
+  </data>
 </root>

--- a/DNN Platform/Website/Install/InstallWizard.aspx
+++ b/DNN Platform/Website/Install/InstallWizard.aspx
@@ -124,6 +124,10 @@
                             <asp:RequiredFieldValidator ID="valWebsiteName" CssClass="dnnFormMessage dnnFormError dnnRequired" runat="server" resourcekey="WebsiteName.Required" Display="Dynamic" ControlToValidate="txtWebsiteName"  />
                         </div>
                         <div class="dnnFormItem">
+                            <dnn:Label ID="lblWebsiteSsl" runat="server" ControlName="chkWebsiteSsl" ResourceKey="WebsiteSsl" />
+                            <asp:CheckBox ID="chkWebsiteSsl" runat="server" />
+                        </div>
+                        <div class="dnnFormItem">
                             <dnn:Label ID="lblTemplate" runat="server" ControlName="templateList" ResourceKey="WebsiteTemplate" />
                             <dnn:DnnComboBox id="templateList"  runat="server" CausesValidation="False" />
                         </div>

--- a/DNN Platform/Website/Install/InstallWizard.aspx
+++ b/DNN Platform/Website/Install/InstallWizard.aspx
@@ -656,6 +656,7 @@
                             confirmPassword: $('#<%= txtConfirmPassword.ClientID %>')[0].value,
                             email: $('#<%= txtEmail.ClientID %>')[0].value,
                             websiteName: $('#<%= txtWebsiteName.ClientID %>')[0].value,
+                            websiteSsl: $('#<%= chkWebsiteSsl.ClientID %>')[0].checked.toString(),
                             template: $('#<%= templateList.ClientID %>').val(),
                             language: $('#<%= languageList.ClientID %>').val(),
                             databaseSetup: $('#<%= databaseSetupType.ClientID %> input:checked').val(),

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -753,6 +753,8 @@ namespace DotNetNuke.Services.Install
                     }
 
                     this.valEmailValid.ValidationExpression = Globals.glbEmailRegEx;
+
+                    this.chkWebsiteSsl.Checked = this.Request.IsSecureConnection;
                 }
             }
         }

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -74,8 +74,9 @@ namespace DotNetNuke.Services.Install
             { InstallSiteStep, 20 },
             { InstallSuperUserStep, 5 },
             { new AddFcnModeStep(), 1 },
-            { ActivateLicenseStep, 4 },
+            { ActivateLicenseStep, 3 },
             { new InstallVersionStep(), 1 },
+            { new InstallSslStep(), 1 },
         };
 
         private static string localResourceFile = "~/Install/App_LocalResources/InstallWizard.aspx.resx";
@@ -1018,6 +1019,7 @@ namespace DotNetNuke.Services.Install
             var portalConfig = new PortalConfig()
             {
                 PortalName = installInfo["websiteName"],
+                IsSsl = bool.Parse(installInfo["websiteSsl"]),
                 TemplateFileName = installInfo["template"],
                 IsChild = false,
             };

--- a/DNN Platform/Website/Install/InstallWizard.aspx.designer.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.designer.cs
@@ -386,7 +386,16 @@ namespace DotNetNuke.Services.Install {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.RequiredFieldValidator valWebsiteName;
-        
+
+        /// <summary>
+        /// chkWebsiteSsl control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CheckBox chkWebsiteSsl;
+
         /// <summary>
         /// lblTemplate control.
         /// </summary>

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
@@ -51,6 +51,22 @@ BEGIN
 END
 GO
 
+/*    Set IsSecure to true for all tabs of a portal         */
+/************************************************************/
+
+IF EXISTS (SELECT * FROM sys.Procedures WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}SetAllPortalTabsSecure]'))
+    DROP PROCEDURE {databaseOwner}[{objectQualifier}SetAllPortalTabsSecure];
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}SetAllPortalTabsSecure]
+@PortalId INT,
+@Secure BIT
+AS
+UPDATE {databaseOwner}[{objectQualifier}Tabs]
+SET IsSecure=@Secure
+WHERE PortalId=@PortalId
+GO
+
 
 
 /************************************************************/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/UnInstall.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/UnInstall.SqlDataProvider
@@ -1164,6 +1164,8 @@ DROP PROCEDURE {databaseOwner}[{objectQualifier}SetCorePackageVersions]
 GO
 DROP PROCEDURE {databaseOwner}[{objectQualifier}GetPortalSettingsBySetting]
 GO
+DROP PROCEDURE {databaseOwner}[{objectQualifier}SetAllPortalTabsSecure]
+GO
 
 /** Remove AspNet Data **/
 

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Ssl/SslController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Ssl/SslController.cs
@@ -21,15 +21,6 @@ namespace Dnn.PersonaBar.Extensions.Components.Security.Ssl
             }
         }
 
-        /// <inheritdoc />
-        public void SetAllPortalTabsSecure(int portalId, bool secure)
-        {
-            using (IDataContext context = DataContext.Instance())
-            {
-                context.Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}PersonaBar_SetAllPortalTabsSecure", portalId, secure);
-            }
-        }
-
         protected override Func<ISSlController> GetFactory()
         {
             return () => new SslController();
@@ -44,12 +35,5 @@ namespace Dnn.PersonaBar.Extensions.Components.Security.Ssl
         /// <param name="portalId">Portal id of the portal.</param>
         /// <returns>PortalStats object.</returns>
         PortalStats GetPortalStats(int portalId);
-
-        /// <summary>
-        /// Sets all tabs of the portal to the specified secure value.
-        /// </summary>
-        /// <param name="portalId">The portal to update</param>
-        /// <param name="secure">True to set all pages to secure, false to set them all to non secure.</param>
-        void SetAllPortalTabsSecure(int portalId, bool secure);
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.dnn
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.dnn
@@ -81,10 +81,15 @@
                       <name>09.04.01.SqlDataProvider</name>
                       <version>09.04.01</version>
                     </script>
+                    <script type="Install">
+                      <path>SqlDataProvider</path>
+                      <name>09.11.00.SqlDataProvider</name>
+                      <version>09.11.00</version>
+                    </script>
                     <script type="UnInstall">
                       <path>SqlDataProvider</path>
                       <name>Uninstall.SqlDataProvider</name>
-                      <version>09.04.01</version>
+                      <version>09.11.00</version>
                     </script>
                   </scripts>
                 </component>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
@@ -632,7 +632,7 @@ namespace Dnn.PersonaBar.Security.Services
         {
             try
             {
-                SslController.Instance.SetAllPortalTabsSecure(this.PortalId, true);
+                DotNetNuke.Data.DataProvider.Instance().SetAllPortalTabsSecure(this.PortalId, true);
                 return this.Request.CreateResponse(HttpStatusCode.OK, new { Success = true });
             }
             catch (Exception exc)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/SqlDataProvider/09.11.00.SqlDataProvider
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/SqlDataProvider/09.11.00.SqlDataProvider
@@ -23,17 +23,3 @@ SELECT
 FROM {databaseOwner}[{objectQualifier}Portals] p
 WHERE p.PortalID=@PortalId
 GO
-
-IF EXISTS (SELECT * FROM sys.Procedures WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}PersonaBar_SetAllPortalTabsSecure]'))
-    DROP PROCEDURE {databaseOwner}[{objectQualifier}PersonaBar_SetAllPortalTabsSecure];
-GO
-
-CREATE PROCEDURE {databaseOwner}[{objectQualifier}PersonaBar_SetAllPortalTabsSecure]
-@PortalId INT,
-@Secure BIT
-AS
-UPDATE {databaseOwner}[{objectQualifier}Tabs]
-SET IsSecure=@Secure
-WHERE PortalId=@PortalId
-GO
-

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/SqlDataProvider/Uninstall.SqlDataProvider
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/SqlDataProvider/Uninstall.SqlDataProvider
@@ -40,10 +40,6 @@ IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwne
 	DROP PROCEDURE {databaseOwner}[{objectQualifier}PersonaBar_GetPortalStats]
 GO
 
-IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}PersonaBar_SetAllPortalTabsSecure]') AND type in (N'P', N'PC'))
-	DROP PROCEDURE {databaseOwner}[{objectQualifier}PersonaBar_SetAllPortalTabsSecure]
-GO
-
 /************************************************************/
 /***** Servers SqlDataProvider                          *****/
 /************************************************************/


### PR DESCRIPTION
This PR resolves issue #4945 

During the first installation of DNN, the installwizard shows a checkbox to optionally set the site as SSL during the installation process. This does the same as selecting SSL "on" in the new security tab. It sets all pages to be secure.

The checkbox is set automatically if the installwizard is called using https.