### PR TITLE
Add unique suffix to artifact name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,4 +122,5 @@ steps:
     condition: always()
 
 - publish: 'Artifacts'
+  artifact: 'Artifacts$(System.JobAttempt)'
   condition: always()


### PR DESCRIPTION
This will allow us to rerun a build without getting an error that the artifact was already published 