### PR TITLE
Reapply "Top level pages" on release/9.11.0

### DIFF
--- a/DNN Platform/Library/Common/Utilities/DataCache.cs
+++ b/DNN Platform/Library/Common/Utilities/DataCache.cs
@@ -74,6 +74,10 @@ namespace DotNetNuke.Common.Utilities
         public const CacheItemPriority PortalGroupsCachePriority = CacheItemPriority.High;
         public const int PortalGroupsCacheTimeOut = 20;
 
+        public const string PortalPermissionCacheKey = "PortalPermission{0}";
+        public const CacheItemPriority PortalPermissionCachePriority = CacheItemPriority.High;
+        public const int PortalPermissionCacheTimeOut = 20;
+
         // Tab cache keys
         public const string TabCacheKey = "Tab_Tabs{0}";
         public const string TabSettingsCacheKey = "TabSettings{0}";
@@ -432,6 +436,11 @@ namespace DotNetNuke.Common.Utilities
         public static void ClearTabPermissionsCache(int PortalId)
         {
             RemoveCache(string.Format(TabPermissionCacheKey, PortalId));
+        }
+
+        public static void ClearPortalPermissionsCache(int PortalId)
+        {
+            RemoveCache(string.Format(PortalPermissionCacheKey, PortalId));
         }
 
         public static void ClearUserCache(int PortalId, string username)

--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -1845,6 +1845,38 @@ namespace DotNetNuke.Data
                 createdByUserID);
         }
 
+        public virtual IDataReader GetPortalPermissionsByPortal(int portalId)
+        {
+            return this.ExecuteReader("GetPortalPermissionsByPortal", this.GetNull(portalId));
+        }
+
+        public virtual int AddPortalPermission(int portalId, int permissionId, int roleId, bool allowAccess, int userId, int createdByUserId)
+        {
+            return this.ExecuteScalar<int>(
+                "SaveTabPermission",
+                portalId,
+                permissionId,
+                this.GetRoleNull(roleId),
+                allowAccess,
+                this.GetNull(userId),
+                createdByUserId);
+        }
+
+        public virtual void DeletePortalPermission(int portalPermissionId)
+        {
+            this.ExecuteNonQuery("DeletePortalPermission", portalPermissionId);
+        }
+
+        public virtual void DeletePortalPermissionsByPortalID(int portalId)
+        {
+            this.ExecuteNonQuery("DeletePortalPermissionsByPortalID", portalId);
+        }
+
+        public virtual void DeletePortalPermissionsByUserID(int portalId, int userId)
+        {
+            this.ExecuteNonQuery("DeletePortalPermissionsByUserID", portalId, userId);
+        }
+
         public virtual void DeleteFolderPermission(int folderPermissionId)
         {
             this.ExecuteNonQuery("DeleteFolderPermission", folderPermissionId);

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -687,8 +687,12 @@
     <Compile Include="Security\Cookies\PurgeAuthCookiesTask.cs" />
     <Compile Include="Security\FIPSCompliant.cs" />
     <Compile Include="Security\Membership\AspNetMembershipProvider.cs" />
+    <Compile Include="Security\Permissions\ComparePortalPermissions.cs" />
     <Compile Include="Security\Permissions\CorePermissionProvider.cs" />
     <Compile Include="Security\Permissions\IFolderPermissionController.cs" />
+    <Compile Include="Security\Permissions\PortalPermissionController.cs" />
+    <Compile Include="Security\Permissions\PortalPermissionInfo.cs" />
+    <Compile Include="Security\Permissions\PortalPermissionCollection.cs" />
     <Compile Include="Security\Profile\DNNProfileProvider.cs" />
     <Compile Include="Security\RegistrationSettings.cs" />
     <Compile Include="Security\Roles\DNNRoleProvider.cs" />

--- a/DNN Platform/Library/Entities/Portals/PortalInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalInfo.cs
@@ -14,6 +14,7 @@ namespace DotNetNuke.Entities.Portals
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Security.Permissions;
     using DotNetNuke.Security.Roles;
     using Newtonsoft.Json;
 
@@ -56,6 +57,7 @@ namespace DotNetNuke.Entities.Portals
         private string _administratorRoleName;
         private int _pages = Null.NullInteger;
         private string _registeredRoleName;
+        private PortalPermissionCollection permissions;
 
         private int _users;
 
@@ -228,6 +230,17 @@ namespace DotNetNuke.Entities.Portals
         {
             get => this.ThisAsInterface.PortalId;
             set => this.ThisAsInterface.PortalId = value;
+        }
+
+        /// <summary>Gets the permissions collection for the portal.</summary>
+        [XmlArray("portalpermissions")]
+        [XmlArrayItem("permission")]
+        public PortalPermissionCollection PortalPermissions
+        {
+            get
+            {
+                return this.permissions ?? (this.permissions = new PortalPermissionCollection(PortalPermissionController.GetPortalPermissions(this.ThisAsInterface.PortalId)));
+            }
         }
 
         /// <inheritdoc />

--- a/DNN Platform/Library/Obsolete/EventLogController.cs
+++ b/DNN Platform/Library/Obsolete/EventLogController.cs
@@ -182,6 +182,9 @@ namespace DotNetNuke.Services.Log.EventLog
             WEBSERVER_ENABLED = 151,
             WEBSERVER_PINGFAILED = 152,
             FOLDER_MOVED = 153,
+            PORTALPERMISSION_DELETED = 154,
+            PORTALPERMISSION_CREATED = 155,
+            PORTALPERMISSION_UPDATED = 156,
         }
 
         [Obsolete("Deprecated in 9.8.0. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.Logging.IEventLogger' instead. Scheduled for removal in v11.0.0.")]

--- a/DNN Platform/Library/Security/Permissions/ComparePortalPermissions.cs
+++ b/DNN Platform/Library/Security/Permissions/ComparePortalPermissions.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Security.Permissions
+{
+    using System.Collections;
+
+    /// -----------------------------------------------------------------------------
+    /// Project  : DotNetNuke
+    /// Namespace: DotNetNuke.Security.Permissions
+    /// Class    : ComparePortalPermissions
+    /// -----------------------------------------------------------------------------
+    /// <summary>
+    /// ComparePortalPermissions provides the a custom IComparer implementation for
+    /// PortalPermissionInfo objects.
+    /// </summary>
+    /// -----------------------------------------------------------------------------
+    internal class ComparePortalPermissions : IComparer
+    {
+        /// <inheritdoc/>
+        public int Compare(object x, object y)
+        {
+            return ((PortalPermissionInfo)x).PortalPermissionID.CompareTo(((PortalPermissionInfo)y).PortalPermissionID);
+        }
+    }
+}

--- a/DNN Platform/Library/Security/Permissions/PermissionProvider.cs
+++ b/DNN Platform/Library/Security/Permissions/PermissionProvider.cs
@@ -377,7 +377,7 @@ namespace DotNetNuke.Security.Permissions
         {
             return (PortalSecurity.IsInRoles(tab.TabPermissions.ToString(permissionKey))
                     || PortalSecurity.IsInRoles(tab.TabPermissions.ToString(AdminPagePermissionKey)))
-                   && !PortalSecurity.IsDenied(tab.TabPermissions.ToString(permissionKey));
+                    && !PortalSecurity.IsDenied(tab.TabPermissions.ToString(permissionKey));
 
             // Deny on Edit permission on page shouldn't take away any other explicitly Allowed
             // &&!PortalSecurity.IsDenied(tab.TabPermissions.ToString(AdminPagePermissionKey));

--- a/DNN Platform/Library/Security/Permissions/PortalPermissionCollection.cs
+++ b/DNN Platform/Library/Security/Permissions/PortalPermissionCollection.cs
@@ -1,0 +1,217 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Security.Permissions
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Serialization;
+
+    using DotNetNuke.Common.Utilities;
+
+    /// -----------------------------------------------------------------------------
+    /// Project  : DotNetNuke
+    /// Namespace: DotNetNuke.Security.Permissions
+    /// Class    : PortalPermissionCollection
+    /// -----------------------------------------------------------------------------
+    /// <summary>
+    /// PortalPermissionCollection provides the a custom collection for PortalPermissionInfo
+    /// objects.
+    /// </summary>
+    /// -----------------------------------------------------------------------------
+    [Serializable]
+    [XmlRoot("portalpermissions")]
+    public class PortalPermissionCollection : CollectionBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.
+        /// </summary>
+        public PortalPermissionCollection()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.
+        /// </summary>
+        /// <param name="portalPermissions"></param>
+        public PortalPermissionCollection(ArrayList portalPermissions)
+        {
+            this.AddRange(portalPermissions);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.
+        /// </summary>
+        /// <param name="portalPermissions"></param>
+        public PortalPermissionCollection(PortalPermissionCollection portalPermissions)
+        {
+            this.AddRange(portalPermissions);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.
+        /// </summary>
+        /// <param name="portalPermissions"></param>
+        /// <param name="PortalId"></param>
+        public PortalPermissionCollection(ArrayList portalPermissions, int PortalId)
+        {
+            foreach (PortalPermissionInfo permission in portalPermissions)
+            {
+                if (permission.PortalID == PortalId)
+                {
+                    this.Add(permission);
+                }
+            }
+        }
+
+        public PortalPermissionInfo this[int index]
+        {
+            get
+            {
+                return (PortalPermissionInfo)this.List[index];
+            }
+
+            set
+            {
+                this.List[index] = value;
+            }
+        }
+
+        public int Add(PortalPermissionInfo value)
+        {
+            return this.List.Add(value);
+        }
+
+        public int Add(PortalPermissionInfo value, bool checkForDuplicates)
+        {
+            int id = Null.NullInteger;
+
+            if (!checkForDuplicates)
+            {
+                id = this.Add(value);
+            }
+            else
+            {
+                bool isMatch = false;
+                foreach (PermissionInfoBase permission in this.List)
+                {
+                    if (permission.PermissionID == value.PermissionID && permission.UserID == value.UserID && permission.RoleID == value.RoleID)
+                    {
+                        isMatch = true;
+                        break;
+                    }
+                }
+
+                if (!isMatch)
+                {
+                    id = this.Add(value);
+                }
+            }
+
+            return id;
+        }
+
+        public void AddRange(ArrayList portalPermissions)
+        {
+            foreach (PortalPermissionInfo permission in portalPermissions)
+            {
+                this.Add(permission);
+            }
+        }
+
+        public void AddRange(IEnumerable<PortalPermissionInfo> portalPermissions)
+        {
+            foreach (PortalPermissionInfo permission in portalPermissions)
+            {
+                this.Add(permission);
+            }
+        }
+
+        public void AddRange(PortalPermissionCollection portalPermissions)
+        {
+            foreach (PortalPermissionInfo permission in portalPermissions)
+            {
+                this.Add(permission);
+            }
+        }
+
+        public bool CompareTo(PortalPermissionCollection objPortalPermissionCollection)
+        {
+            if (objPortalPermissionCollection.Count != this.Count)
+            {
+                return false;
+            }
+
+            this.InnerList.Sort(new ComparePortalPermissions());
+            objPortalPermissionCollection.InnerList.Sort(new ComparePortalPermissions());
+            for (int i = 0; i <= this.Count - 1; i++)
+            {
+                if (objPortalPermissionCollection[i].PortalPermissionID != this[i].PortalPermissionID
+                        || objPortalPermissionCollection[i].PermissionID != this[i].PermissionID
+                        || objPortalPermissionCollection[i].RoleID != this[i].RoleID
+                        || objPortalPermissionCollection[i].UserID != this[i].UserID
+                        || objPortalPermissionCollection[i].AllowAccess != this[i].AllowAccess)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool Contains(PortalPermissionInfo value)
+        {
+            return this.List.Contains(value);
+        }
+
+        public int IndexOf(PortalPermissionInfo value)
+        {
+            return this.List.IndexOf(value);
+        }
+
+        public void Insert(int index, PortalPermissionInfo value)
+        {
+            this.List.Insert(index, value);
+        }
+
+        public void Remove(PortalPermissionInfo value)
+        {
+            this.List.Remove(value);
+        }
+
+        public void Remove(int permissionID, int roleID, int userID)
+        {
+            foreach (PermissionInfoBase permission in this.List)
+            {
+                if (permission.PermissionID == permissionID && permission.UserID == userID && permission.RoleID == roleID)
+                {
+                    this.List.Remove(permission);
+                    break;
+                }
+            }
+        }
+
+        public List<PermissionInfoBase> ToList()
+        {
+            var list = new List<PermissionInfoBase>();
+            foreach (PermissionInfoBase permission in this.List)
+            {
+                list.Add(permission);
+            }
+
+            return list;
+        }
+
+        public string ToString(string key)
+        {
+            return PermissionController.BuildPermissions(this.List, key);
+        }
+
+        public IEnumerable<PortalPermissionInfo> Where(Func<PortalPermissionInfo, bool> predicate)
+        {
+            return this.Cast<PortalPermissionInfo>().Where(predicate);
+        }
+    }
+}

--- a/DNN Platform/Library/Security/Permissions/PortalPermissionController.cs
+++ b/DNN Platform/Library/Security/Permissions/PortalPermissionController.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace DotNetNuke.Security.Permissions
+{
+    using System.Collections.Generic;
+
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Users;
+    using DotNetNuke.Security.Roles;
+    using DotNetNuke.Services.Log.EventLog;
+
+    /// -----------------------------------------------------------------------------
+    /// Project  : DotNetNuke
+    /// Namespace: DotNetNuke.Security.Permissions
+    /// Class    : PortalPermissionController
+    /// -----------------------------------------------------------------------------
+    /// <summary>
+    /// PortalPermissionController provides the Business Layer for Portal Permissions.
+    /// </summary>
+    /// -----------------------------------------------------------------------------
+    public class PortalPermissionController
+    {
+        private static readonly PermissionProvider _provider = PermissionProvider.Instance();
+
+        /// <summary>
+        /// Returns a list with all roles with implicit permissions on Portals.
+        /// </summary>
+        /// <param name="portalId">The Portal Id where the Roles are.</param>
+        /// <returns>A List with the implicit roles.</returns>
+        public static IEnumerable<RoleInfo> ImplicitRoles(int portalId)
+        {
+            return _provider.ImplicitRolesForPages(portalId);
+        }
+
+        /// <summary>
+        /// Returns a flag indicating whether the current user can add top level pages.
+        /// </summary>
+        /// <returns>A flag indicating whether the user has permission.</returns>
+        public static bool CanAddTopLevel()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns a flag indicating whether the current user is a page admin.
+        /// </summary>
+        /// <returns>A flag indicating whether the user has permission.</returns>
+        public static bool CanAdminPages()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// DeletePortalPermissionsByUser deletes a user's Portal Permissions in the Database.
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// -----------------------------------------------------------------------------
+        public static void DeletePortalPermissionsByUser(UserInfo user)
+        {
+            _provider.DeletePortalPermissionsByUser(user);
+            EventLogController.Instance.AddLog(user, PortalController.Instance.GetCurrentPortalSettings(), UserController.Instance.GetCurrentUserInfo().UserID, string.Empty, EventLogController.EventLogType.PORTALPERMISSION_DELETED);
+            DataCache.ClearPortalPermissionsCache(user.PortalID);
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// GetPortalPermissions gets a PortalPermissionCollection.
+        /// </summary>
+        /// <param name="portalId">The ID of the portal.</param>
+        /// <returns></returns>
+        /// -----------------------------------------------------------------------------
+        public static PortalPermissionCollection GetPortalPermissions(int portalId)
+        {
+            return _provider.GetPortalPermissions(portalId);
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// HasPortalPermission checks whether the current user has a specific Portal Permission.
+        /// </summary>
+        /// <remarks>If you pass in a comma delimited list of permissions (eg "ADD,DELETE", this will return
+        /// true if the user has any one of the permissions.</remarks>
+        /// <param name="permissionKey">The Permission to check.</param>
+        /// <returns></returns>
+        /// -----------------------------------------------------------------------------
+        public static bool HasPortalPermission(string permissionKey)
+        {
+            return HasPortalPermission(PortalController.Instance.GetPortal(PortalController.Instance.GetCurrentSettings().PortalId).PortalPermissions, permissionKey);
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// HasPortalPermission checks whether the current user has a specific Portal Permission.
+        /// </summary>
+        /// <remarks>If you pass in a comma delimited list of permissions (eg "ADD,DELETE", this will return
+        /// true if the user has any one of the permissions.</remarks>
+        /// <param name="portalPermissions">The Permissions for the Portal.</param>
+        /// <param name="permissionKey">The Permission(s) to check.</param>
+        /// <returns></returns>
+        /// -----------------------------------------------------------------------------
+        public static bool HasPortalPermission(PortalPermissionCollection portalPermissions, string permissionKey)
+        {
+            return _provider.HasPortalPermission(portalPermissions, permissionKey);
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        /// SavePortalPermissions saves a Portal's permissions.
+        /// </summary>
+        /// <param name="portal">The Portal to update.</param>
+        /// -----------------------------------------------------------------------------
+        public static void SavePortalPermissions(PortalInfo portal)
+        {
+            _provider.SavePortalPermissions(portal);
+            EventLogController.Instance.AddLog(portal, PortalController.Instance.GetCurrentPortalSettings(), UserController.Instance.GetCurrentUserInfo().UserID, string.Empty, EventLogController.EventLogType.PORTALPERMISSION_UPDATED);
+            DataCache.ClearPortalPermissionsCache(portal.PortalID);
+        }
+
+        private static void ClearPermissionCache(int portalId)
+        {
+            var objPortal = PortalController.Instance.GetPortal(portalId);
+            DataCache.ClearPortalPermissionsCache(objPortal.PortalID);
+        }
+    }
+}

--- a/DNN Platform/Library/Security/Permissions/PortalPermissionController.cs
+++ b/DNN Platform/Library/Security/Permissions/PortalPermissionController.cs
@@ -28,31 +28,41 @@ namespace DotNetNuke.Security.Permissions
         private static readonly PermissionProvider _provider = PermissionProvider.Instance();
 
         /// <summary>
-        /// Returns a list with all roles with implicit permissions on Portals.
-        /// </summary>
-        /// <param name="portalId">The Portal Id where the Roles are.</param>
-        /// <returns>A List with the implicit roles.</returns>
-        public static IEnumerable<RoleInfo> ImplicitRoles(int portalId)
-        {
-            return _provider.ImplicitRolesForPages(portalId);
-        }
-
-        /// <summary>
-        /// Returns a flag indicating whether the current user can add top level pages.
+        /// Returns a flag indicating whether the current user can add top level pages on the current portal.
         /// </summary>
         /// <returns>A flag indicating whether the user has permission.</returns>
         public static bool CanAddTopLevel()
         {
-            throw new NotImplementedException();
+            return CanAddTopLevel(PortalController.Instance.GetCurrentSettings().PortalId);
         }
 
         /// <summary>
-        /// Returns a flag indicating whether the current user is a page admin.
+        /// Returns a flag indicating whether the current user can add top level pages on a portal.
+        /// </summary>
+        /// <param name="portalId">The portal id.</param>
+        /// <returns>A flag indicating whether the user has permission.</returns>
+        public static bool CanAddTopLevel(int portalId)
+        {
+            return _provider.CanAddTopLevel(portalId);
+        }
+
+        /// <summary>
+        /// Returns a flag indicating whether the current user is a page admin for the current portal.
         /// </summary>
         /// <returns>A flag indicating whether the user has permission.</returns>
         public static bool CanAdminPages()
         {
-            throw new NotImplementedException();
+            return CanAdminPages(PortalController.Instance.GetCurrentSettings().PortalId);
+        }
+
+        /// <summary>
+        /// Returns a flag indicating whether the current user is a page admin for a portal.
+        /// </summary>
+        /// <param name="portalId">The portal id.</param>
+        /// <returns>A flag indicating whether the user has permission.</returns>
+        public static bool CanAdminPages(int portalId)
+        {
+            return _provider.IsPageAdmin(portalId);
         }
 
         /// -----------------------------------------------------------------------------

--- a/DNN Platform/Library/Security/Permissions/PortalPermissionInfo.cs
+++ b/DNN Platform/Library/Security/Permissions/PortalPermissionInfo.cs
@@ -9,46 +9,45 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
-    using Newtonsoft.Json;
 
     /// -----------------------------------------------------------------------------
     /// Project  : DotNetNuke
     /// Namespace: DotNetNuke.Security.Permissions
-    /// Class    : TabPermissionInfo
+    /// Class    : PortalPermissionInfo
     /// -----------------------------------------------------------------------------
     /// <summary>
-    /// TabPermissionInfo provides the Entity Layer for Tab Permissions.
+    /// PortalPermissionInfo provides the Entity Layer for Portal Permissions.
     /// </summary>
     /// -----------------------------------------------------------------------------
     [Serializable]
     [XmlRoot("permission")]
-    public class TabPermissionInfo : PermissionInfoBase, IHydratable
+    public class PortalPermissionInfo : PermissionInfoBase, IHydratable
     {
-        private int _TabID;
+        private int _PortalID;
 
         // local property declarations
-        private int _TabPermissionID;
+        private int _PortalPermissionID;
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Initializes a new instance of the <see cref="TabPermissionInfo"/> class.
-        /// Constructs a new TabPermissionInfo.
+        /// Initializes a new instance of the <see cref="PortalPermissionInfo"/> class.
+        /// Constructs a new PortalPermissionInfo.
         /// </summary>
         /// -----------------------------------------------------------------------------
-        public TabPermissionInfo()
+        public PortalPermissionInfo()
         {
-            this._TabPermissionID = Null.NullInteger;
-            this._TabID = Null.NullInteger;
+            this._PortalPermissionID = Null.NullInteger;
+            this._PortalID = Null.NullInteger;
         }
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Initializes a new instance of the <see cref="TabPermissionInfo"/> class.
-        /// Constructs a new TabPermissionInfo.
+        /// Initializes a new instance of the <see cref="PortalPermissionInfo"/> class.
+        /// Constructs a new PortalPermissionInfo.
         /// </summary>
         /// <param name="permission">A PermissionInfo object.</param>
         /// -----------------------------------------------------------------------------
-        public TabPermissionInfo(PermissionInfo permission)
+        public PortalPermissionInfo(PermissionInfo permission)
             : this()
         {
             this.ModuleDefID = permission.ModuleDefID;
@@ -60,68 +59,67 @@ namespace DotNetNuke.Security.Permissions
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Gets or sets and sets the Tab Permission ID.
+        /// Gets or sets and sets the Portal Permission ID.
         /// </summary>
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
-        [XmlElement("tabpermissionid")]
-        public int TabPermissionID
+        [XmlElement("portalpermissionid")]
+        public int PortalPermissionID
         {
             get
             {
-                return this._TabPermissionID;
+                return this._PortalPermissionID;
             }
 
             set
             {
-                this._TabPermissionID = value;
+                this._PortalPermissionID = value;
             }
         }
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Gets or sets and sets the Tab ID.
+        /// Gets or sets the Portal ID.
         /// </summary>
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
-        [XmlElement("tabid")]
-        public int TabID
+        [XmlElement("portalid")]
+        public int PortalID
         {
             get
             {
-                return this._TabID;
+                return this._PortalID;
             }
 
             set
             {
-                this._TabID = value;
+                this._PortalID = value;
             }
         }
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Gets or sets and sets the Key ID.
+        /// Gets or sets the Key ID.
         /// </summary>
         /// <returns>An Integer.</returns>
         /// -----------------------------------------------------------------------------
         [XmlIgnore]
-        [JsonIgnore]
         public int KeyID
         {
             get
             {
-                return this.TabPermissionID;
+                return this.PortalPermissionID;
             }
 
             set
             {
-                this.TabPermissionID = value;
+                this.PortalPermissionID = value;
             }
         }
 
         /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Fills a TabPermissionInfo from a Data Reader.
+        /// Fills a PortalPermissionInfo from a Data Reader.
         /// </summary>
         /// <param name="dr">The Data Reader to use.</param>
         /// -----------------------------------------------------------------------------
@@ -129,8 +127,8 @@ namespace DotNetNuke.Security.Permissions
         {
             // Call the base classes fill method to populate base class properties
             this.FillInternal(dr);
-            this.TabPermissionID = Null.SetNullInteger(dr["TabPermissionID"]);
-            this.TabID = Null.SetNullInteger(dr["TabID"]);
+            this.PortalPermissionID = Null.SetNullInteger(dr["PortalPermissionID"]);
+            this.PortalID = Null.SetNullInteger(dr["PortalID"]);
         }
     }
 }

--- a/DNN Platform/Library/Security/Permissions/TabPermissionController.cs
+++ b/DNN Platform/Library/Security/Permissions/TabPermissionController.cs
@@ -70,7 +70,18 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>A flag indicating whether the user has permission.</returns>
         public static bool CanAddPage(TabInfo tab)
         {
-            return _provider.CanAddPage(tab);
+            if (_provider.CanAddPage(tab))
+            {
+                return true;
+            }
+
+            if (tab.TabID == Null.NullInteger)
+            {
+                var portalSettings = PortalController.Instance.GetCurrentSettings();
+                return _provider.CanAddPage(TabController.Instance.GetTab(portalSettings.HomeTabId, portalSettings.PortalId));
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/DNN Platform/Library/Security/Permissions/TabPermissionController.cs
+++ b/DNN Platform/Library/Security/Permissions/TabPermissionController.cs
@@ -70,18 +70,7 @@ namespace DotNetNuke.Security.Permissions
         /// <returns>A flag indicating whether the user has permission.</returns>
         public static bool CanAddPage(TabInfo tab)
         {
-            if (_provider.CanAddPage(tab))
-            {
-                return true;
-            }
-
-            if (tab.TabID == Null.NullInteger)
-            {
-                var portalSettings = PortalController.Instance.GetCurrentSettings();
-                return _provider.CanAddPage(TabController.Instance.GetTab(portalSettings.HomeTabId, portalSettings.PortalId));
-            }
-
-            return false;
+            return _provider.CanAddPage(tab);
         }
 
         /// <summary>

--- a/DNN Platform/Library/Security/PortalSecurity.cs
+++ b/DNN Platform/Library/Security/PortalSecurity.cs
@@ -819,7 +819,9 @@ namespace DotNetNuke.Security
                         }
                     }
                 }
-                else // Grant permission
+
+                // Grant permission
+                else
                 {
                     if (roleName == Globals.glbRoleAllUsersName || user.IsInRole(roleName))
                     {

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
@@ -67,6 +67,104 @@ SET IsSecure=@Secure
 WHERE PortalId=@PortalId
 GO
 
+/*    Add PortalPermissions table and procedures            */
+/************************************************************/
+
+IF NOT EXISTS (SELECT * FROM dbo.sysobjects WHERE id = object_id(N'{databaseOwner}{objectQualifier}PortalPermission') AND OBJECTPROPERTY(id, N'IsTable') = 1)
+BEGIN
+    CREATE TABLE {databaseOwner}[{objectQualifier}PortalPermission](
+	    	[PermissionId] [INT] IDENTITY(1,1) NOT NULL,
+			[PortalId] [INT] NOT NULL,
+	        [PermissionKey] [VARCHAR](50) NOT NULL,
+	        [PermissionName] [VARCHAR](50) NOT NULL,
+			[ViewOrder] [INT] NOT NULL DEFAULT ((9999)),
+	        [CreatedByUserID] [INT] NULL,
+	        [CreatedOnDate] [DATETIME] NULL,
+	        [LastModifiedByUserID] [INT] NULL,
+	        [LastModifiedOnDate] [DATETIME] NULL,
+        CONSTRAINT [PK_{objectQualifier}PortalPermission] PRIMARY KEY CLUSTERED ([PermissionId] ASC),
+        CONSTRAINT [FK_{objectQualifier}PortalPermission_MenuId] FOREIGN KEY([PortalId]) REFERENCES {databaseOwner}[{objectQualifier}Portals] ([PortalId]),
+        CONSTRAINT [IX_{objectQualifier}PortalPermissionScope] UNIQUE NONCLUSTERED ([PortalId] ASC, [PermissionKey] ASC)
+    )
+END
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Portal_GetPortalPermissions') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}Portal_GetPortalPermissions
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}Portal_GetPortalPermissions]
+AS
+	SELECT 
+        [PermissionId],
+	    [PortalId],
+	    [PermissionKey],
+	    [PermissionName],
+	    [ViewOrder],
+	    [CreatedByUserID],
+	    [CreatedOnDate],
+	    [LastModifiedByUserID],
+	    [LastModifiedOnDate]
+    FROM {databaseOwner}[{objectQualifier}PortalPermission] ORDER BY ViewOrder ASC
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Portal_SavePortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}Portal_SavePortalPermission
+GO
+
+CREATE PROCEDURE {databaseOwner}{objectQualifier}Portal_SavePortalPermission
+	@PortalId		    INT,
+	@PermissionKey		VARCHAR(50),
+	@PermissionName		VARCHAR(50),
+	@CurrentUserId	    INT
+AS
+    IF EXISTS(SELECT PermissionId FROM {databaseOwner}[{objectQualifier}PortalPermission]
+                WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey)
+    BEGIN
+        UPDATE {databaseOwner}[{objectQualifier}PortalPermission]  SET
+	        [PortalId] = @PortalId,
+	        [PermissionName] = @PermissionName,
+	        [LastModifiedByUserID] = @CurrentUserId,
+	        [LastModifiedOnDate] = GETDATE()
+        WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey
+
+        SELECT PermissionId FROM {databaseOwner}[{objectQualifier}PortalPermission]
+                WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey
+    END
+    ELSE
+    BEGIN
+        INSERT INTO {databaseOwner}[{objectQualifier}PortalPermission] (
+	        [PortalId],
+	        [PermissionKey],
+	        [PermissionName],
+	        [CreatedByUserID],
+	        [CreatedOnDate],
+	        [LastModifiedByUserID],
+	        [LastModifiedOnDate]
+        ) VALUES (
+	        @PortalId,
+	        @PermissionKey,
+	        @PermissionName,
+	        @CurrentUserId,
+	        GETDATE(),
+	        @CurrentUserId,
+	        GETDATE()
+        )
+
+        SELECT SCOPE_IDENTITY()
+    END
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Portal_DeletePortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}Portal_DeletePortalPermission
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}Portal_DeletePortalPermission]
+    @PermissionId           INT
+AS
+    DELETE FROM {databaseOwner}[{objectQualifier}PortalPermission] 
+        WHERE PermissionId = @PermissionId
+GO
 
 
 /************************************************************/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
@@ -257,8 +257,8 @@ AS
         WHERE PortalId = @PortalId AND UserId = @UserId
 GO
 
-INSERT INTO {databaseOwner}[{objectQualifier}Permission] ([PermissionCode], [ModuleDefID], [PermissionKey], [PermissionName], [ViewOrder], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES ('SYSTEM_TAB', -1, 'ADDTOPLEVELPAGE', 'Add Top Level Page', 9999, -1, GETDATE(), -1, GETDATE())
-INSERT INTO {databaseOwner}[{objectQualifier}Permission] ([PermissionCode], [ModuleDefID], [PermissionKey], [PermissionName], [ViewOrder], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES ('SYSTEM_TAB', -1, 'PAGEADMIN', 'Page Admin', 9999, -1, GETDATE(), -1, GETDATE())
+INSERT INTO {databaseOwner}[{objectQualifier}Permission] ([PermissionCode], [ModuleDefID], [PermissionKey], [PermissionName], [ViewOrder], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES ('SYSTEM_PORTAL', -1, 'ADDTOPLEVELPAGE', 'Add Top Level Page', 9999, -1, GETDATE(), -1, GETDATE())
+INSERT INTO {databaseOwner}[{objectQualifier}Permission] ([PermissionCode], [ModuleDefID], [PermissionKey], [PermissionName], [ViewOrder], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES ('SYSTEM_PORTAL', -1, 'PAGEADMIN', 'Page Admin', 9999, -1, GETDATE(), -1, GETDATE())
 
 GO
 

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.00.SqlDataProvider
@@ -73,99 +73,194 @@ GO
 IF NOT EXISTS (SELECT * FROM dbo.sysobjects WHERE id = object_id(N'{databaseOwner}{objectQualifier}PortalPermission') AND OBJECTPROPERTY(id, N'IsTable') = 1)
 BEGIN
     CREATE TABLE {databaseOwner}[{objectQualifier}PortalPermission](
-	    	[PermissionId] [INT] IDENTITY(1,1) NOT NULL,
-			[PortalId] [INT] NOT NULL,
-	        [PermissionKey] [VARCHAR](50) NOT NULL,
-	        [PermissionName] [VARCHAR](50) NOT NULL,
-			[ViewOrder] [INT] NOT NULL DEFAULT ((9999)),
+	    	[PortalPermissionId] [INT] IDENTITY(1,1) NOT NULL,
+			[PortalId] [INT] NULL,
+	        [PermissionId] [INT] NOT NULL,
+            [AllowAccess] [BIT] NOT NULL,
+            [RoleID] [INT] NULL,
+            [UserID] [INT] NULL,
 	        [CreatedByUserID] [INT] NULL,
 	        [CreatedOnDate] [DATETIME] NULL,
 	        [LastModifiedByUserID] [INT] NULL,
 	        [LastModifiedOnDate] [DATETIME] NULL,
-        CONSTRAINT [PK_{objectQualifier}PortalPermission] PRIMARY KEY CLUSTERED ([PermissionId] ASC),
-        CONSTRAINT [FK_{objectQualifier}PortalPermission_MenuId] FOREIGN KEY([PortalId]) REFERENCES {databaseOwner}[{objectQualifier}Portals] ([PortalId]),
-        CONSTRAINT [IX_{objectQualifier}PortalPermissionScope] UNIQUE NONCLUSTERED ([PortalId] ASC, [PermissionKey] ASC)
+        CONSTRAINT [PK_{objectQualifier}PortalPermission] PRIMARY KEY CLUSTERED ([PortalPermissionId] ASC),
+        CONSTRAINT [FK_{objectQualifier}PortalPermission_PortalId] FOREIGN KEY([PortalId]) REFERENCES {databaseOwner}[{objectQualifier}Portals] ([PortalId]),
+        CONSTRAINT [FK_{objectQualifier}PortalPermission_PermissionId] FOREIGN KEY([PermissionId]) REFERENCES {databaseOwner}[{objectQualifier}Permission] ([PermissionId]),
+        CONSTRAINT [FK_{objectQualifier}PortalPermission_RoleId] FOREIGN KEY([RoleId]) REFERENCES {databaseOwner}[{objectQualifier}Roles] ([RoleId]),
+        CONSTRAINT [FK_{objectQualifier}PortalPermission_UserId] FOREIGN KEY([UserId]) REFERENCES {databaseOwner}[{objectQualifier}Users] ([UserId])
     )
 END
 GO
 
-IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Portal_GetPortalPermissions') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
-    DROP PROCEDURE {databaseOwner}{objectQualifier}Portal_GetPortalPermissions
+CREATE UNIQUE NONCLUSTERED INDEX [IX_{objectQualifier}PortalPermission_Roles] ON {databaseOwner}[{objectQualifier}PortalPermission] ([RoleID] ASC,[PortalID] ASC,[PermissionID] ASC) INCLUDE([AllowAccess]) WHERE ([RoleID] IS NOT NULL)
+CREATE UNIQUE NONCLUSTERED INDEX [IX_{objectQualifier}PortalPermission_Users] ON {databaseOwner}[{objectQualifier}PortalPermission] ([UserID] ASC,[PortalID] ASC,[PermissionID] ASC) INCLUDE([AllowAccess]) WHERE ([UserID] IS NOT NULL)
+CREATE UNIQUE NONCLUSTERED INDEX [IX_{objectQualifier}PortalPermission_Portals] ON {databaseOwner}[{objectQualifier}PortalPermission] ([PortalID] ASC,[PermissionID] ASC, [RoleID] ASC, [UserID] ASC) INCLUDE([AllowAccess])
+CREATE NONCLUSTERED INDEX [IX_{objectQualifier}PortalPermission_Permission] ON {databaseOwner}[{objectQualifier}PortalPermission] ([PermissionID] ASC)
+
 GO
 
-CREATE PROCEDURE {databaseOwner}[{objectQualifier}Portal_GetPortalPermissions]
+CREATE VIEW [dbo].[vw_PortalPermissions]
 AS
-	SELECT 
-        [PermissionId],
-	    [PortalId],
-	    [PermissionKey],
-	    [PermissionName],
-	    [ViewOrder],
-	    [CreatedByUserID],
-	    [CreatedOnDate],
-	    [LastModifiedByUserID],
-	    [LastModifiedOnDate]
-    FROM {databaseOwner}[{objectQualifier}PortalPermission] ORDER BY ViewOrder ASC
+SELECT  PP.PortalPermissionID,
+        PP.PortalId,
+        P.PermissionID,
+        PP.RoleID,
+        R.RoleName,
+        PP.AllowAccess,
+        PP.UserID,
+        U.Username,
+        U.DisplayName,
+        P.PermissionCode,
+        P.ModuleDefID,
+        P.PermissionKey,
+        P.PermissionName,
+        PP.CreatedByUserID,
+        PP.CreatedOnDate,
+        PP.LastModifiedByUserID,
+        PP.LastModifiedOnDate
+FROM        dbo.[PortalPermission]    AS PP
+ INNER JOIN dbo.[Permission]       AS P  ON PP.PermissionID = P.PermissionID
+ LEFT  JOIN dbo.[Roles]            AS R  ON PP.RoleID       = R.RoleID
+ LEFT  JOIN dbo.[Users]            AS U  ON PP.UserID       = U.UserID
 GO
 
-IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Portal_SavePortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
-    DROP PROCEDURE {databaseOwner}{objectQualifier}Portal_SavePortalPermission
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}GetPortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}GetPortalPermission
 GO
 
-CREATE PROCEDURE {databaseOwner}{objectQualifier}Portal_SavePortalPermission
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}GetPortalPermission]
+
+	@PortalPermissionId INT
+
+AS
+SELECT *
+FROM {databaseOwner}{objectQualifier}vw_PortalPermissions
+WHERE PortalPermissionId = @PortalPermissionId
+
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects WHERE id = object_id(N'{databaseOwner}[{objectQualifier}GetPortalPermissionsByPortal]') AND OBJECTPROPERTY(id, N'IsPROCEDURE') = 1)
+  DROP PROCEDURE {databaseOwner}{objectQualifier}GetPortalPermissionsByPortal
+GO
+
+CREATE procedure {databaseOwner}{objectQualifier}GetPortalPermissionsByPortal
+	
+	@PortalID int
+
+AS
+
+	IF @PortalID is not null
+		BEGIN 
+			SELECT *
+				FROM {databaseOwner}{objectQualifier}vw_PortalPermissions
+				WHERE PortalID = @PortalID
+		END
+	ELSE
+		BEGIN
+			SELECT *
+				FROM {databaseOwner}{objectQualifier}vw_PortalPermissions
+				WHERE PortalID IS NULL 
+		END
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}SavePortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}SavePortalPermission
+GO
+
+CREATE PROCEDURE {databaseOwner}{objectQualifier}SavePortalPermission
 	@PortalId		    INT,
 	@PermissionKey		VARCHAR(50),
-	@PermissionName		VARCHAR(50),
+    @RoleId             INT,
+    @UserId             INT,
+    @AllowAccess        BIT,
 	@CurrentUserId	    INT
 AS
-    IF EXISTS(SELECT PermissionId FROM {databaseOwner}[{objectQualifier}PortalPermission]
-                WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey)
+    DECLARE @PortalPermissionId INT;
+    SELECT @PortalPermissionId = PortalPermissionId FROM {databaseOwner}[{objectQualifier}vw_PortalPermissions]
+        WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey AND ((@RoleId IS NULL AND RoleId IS NULL) OR RoleId = @RoleId) AND ((@UserId IS NULL AND UserId IS NULL) OR UserId = @UserId)
+    IF (@PortalPermissionId IS NOT NULL)
     BEGIN
-        UPDATE {databaseOwner}[{objectQualifier}PortalPermission]  SET
-	        [PortalId] = @PortalId,
-	        [PermissionName] = @PermissionName,
+        UPDATE {databaseOwner}[{objectQualifier}PortalPermission] SET
+	        [AllowAccess] = @AllowAccess,
 	        [LastModifiedByUserID] = @CurrentUserId,
 	        [LastModifiedOnDate] = GETDATE()
-        WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey
+        WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PortalPermissionId = @PortalPermissionId AND ((@RoleId IS NULL AND RoleId IS NULL) OR RoleId = @RoleId) AND ((@UserId IS NULL AND UserId IS NULL) OR UserId = @UserId)
 
-        SELECT PermissionId FROM {databaseOwner}[{objectQualifier}PortalPermission]
-                WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PermissionKey = @PermissionKey
+        SELECT PortalPermissionId FROM {databaseOwner}[{objectQualifier}PortalPermission]
+            WHERE ((@PortalId IS NULL AND PortalId IS NULL) OR PortalId = @PortalId) AND PortalPermissionId = @PortalPermissionId AND ((@RoleId IS NULL AND RoleId IS NULL) OR RoleId = @RoleId) AND ((@UserId IS NULL AND UserId IS NULL) OR UserId = @UserId)
     END
     ELSE
     BEGIN
-        INSERT INTO {databaseOwner}[{objectQualifier}PortalPermission] (
-	        [PortalId],
-	        [PermissionKey],
-	        [PermissionName],
-	        [CreatedByUserID],
-	        [CreatedOnDate],
-	        [LastModifiedByUserID],
-	        [LastModifiedOnDate]
-        ) VALUES (
-	        @PortalId,
-	        @PermissionKey,
-	        @PermissionName,
-	        @CurrentUserId,
-	        GETDATE(),
-	        @CurrentUserId,
-	        GETDATE()
-        )
+        DECLARE @PermissionId INT;
+        SELECT @PermissionId = PermissionId FROM {databaseOwner}[{objectQualifier}Permission]
+            WHERE PermissionKey = @PermissionKey
+        IF (@PermissionId IS NOT NULL)
+        BEGIN
+	        INSERT INTO {databaseOwner}[{objectQualifier}PortalPermission] (
+		        [PortalId],
+	            [PermissionId],
+	            [AllowAccess],
+                [RoleId],
+                [UserId],
+		        [CreatedByUserID],
+		        [CreatedOnDate],
+		        [LastModifiedByUserID],
+		        [LastModifiedOnDate]
+	        ) VALUES (
+		        @PortalId,
+	            @PermissionId,
+	            @AllowAccess,
+                @RoleId,
+                @UserId,
+		        @CurrentUserId,
+		        GETDATE(),
+		        @CurrentUserId,
+		        GETDATE()
+	        )
 
-        SELECT SCOPE_IDENTITY()
+	        SELECT SCOPE_IDENTITY()
+	    END
     END
 GO
 
-IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Portal_DeletePortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
-    DROP PROCEDURE {databaseOwner}{objectQualifier}Portal_DeletePortalPermission
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}DeletePortalPermission') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}DeletePortalPermission
 GO
 
-CREATE PROCEDURE {databaseOwner}[{objectQualifier}Portal_DeletePortalPermission]
-    @PermissionId           INT
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}DeletePortalPermission]
+    @PortalPermissionId           INT
 AS
     DELETE FROM {databaseOwner}[{objectQualifier}PortalPermission] 
-        WHERE PermissionId = @PermissionId
+        WHERE PortalPermissionId = @PortalPermissionId 
 GO
 
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}DeletePortalPermissionsByPortalID') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}DeletePortalPermissionsByPortalID
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}DeletePortalPermissionsByPortalID]
+    @PortalId           INT
+AS
+    DELETE FROM {databaseOwner}[{objectQualifier}PortalPermission] 
+        WHERE PortalId = @PortalId
+GO
+
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}DeletePortalPermissionsByUserID') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+    DROP PROCEDURE {databaseOwner}{objectQualifier}DeletePortalPermissionsByUserID
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}DeletePortalPermissionsByUserID]
+    @PortalId           INT,
+    @UserId             INT
+AS
+    DELETE FROM {databaseOwner}[{objectQualifier}PortalPermission] 
+        WHERE PortalId = @PortalId AND UserId = @UserId
+GO
+
+INSERT INTO {databaseOwner}[{objectQualifier}Permission] ([PermissionCode], [ModuleDefID], [PermissionKey], [PermissionName], [ViewOrder], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES ('SYSTEM_TAB', -1, 'ADDTOPLEVELPAGE', 'Add Top Level Page', 9999, -1, GETDATE(), -1, GETDATE())
+INSERT INTO {databaseOwner}[{objectQualifier}Permission] ([PermissionCode], [ModuleDefID], [PermissionKey], [PermissionName], [ViewOrder], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate]) VALUES ('SYSTEM_TAB', -1, 'PAGEADMIN', 'Page Admin', 9999, -1, GETDATE(), -1, GETDATE())
+
+GO
 
 /************************************************************/
 /*****              SqlDataProvider                     *****/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/UnInstall.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/UnInstall.SqlDataProvider
@@ -396,6 +396,14 @@ DROP INDEX {databaseOwner}[{objectQualifier}UserRoles].[IX_{objectQualifier}User
 GO
 DROP INDEX {databaseOwner}[{objectQualifier}VendorClassification].[IX_{objectQualifier}VendorClassification_1]
 GO
+DROP PROCEDURE {databaseOwner}[{objectQualifier}GetPortalPermission]
+GO
+DROP PROCEDURE {databaseOwner}[{objectQualifier}SavePortalPermission]
+GO
+DROP PROCEDURE {databaseOwner}[{objectQualifier}DeletePortalPermission]
+GO
+DROP TABLE {databaseOwner}[{objectQualifier}PortalPermission]
+GO
 DROP PROCEDURE {databaseOwner}[{objectQualifier}GetCurrencies]
 GO
 DROP PROCEDURE {databaseOwner}[{objectQualifier}GetPortals]

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/App.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/App.jsx
@@ -1561,7 +1561,7 @@ class App extends Component {
                 { isListPagesAllowed &&
                     <PersonaBarPage fullWidth={true} isOpen={true}>
                         <PersonaBarPageHeader title={Localization.get(inSearch ? "PagesSearchHeader" : "Pages")}>
-                            {securityService.isSuperUser() &&
+                            {securityService.canAddPages() &&
                                 <div>
                                     <Button type="primary" disabled={ this.onEditMode()  || this.state.inSearch} size="large" onClick={this.onAddPage.bind(this)}>{Localization.get("AddPage")}</Button>
                                     <Button type="secondary" disabled={ this.onEditMode() || this.state.inSearch } size="large" onClick={this.onAddMultiplePage.bind(this)}>{Localization.get("AddMultiplePages")}</Button>

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/services/securityService.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/services/securityService.js
@@ -19,6 +19,9 @@ const securityService = {
     },
     canSeePagesList() {
         return utils.canSeePagesList();
-    }
+    },
+    canAddPages() {
+        return utils.canAddPages();
+    },
 };
 export default securityService;

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/utils.js
@@ -150,6 +150,11 @@ function canSeePagesList() {
     return settings.isHost || settings.isAdmin || settings.canSeePagesList;
 }
 
+function canAddPages() {
+    checkInit();
+    return settings.isHost || settings.isAdmin || settings.canAddPages;
+}
+
 function getCurrentPagePermissions() {
     checkInit();
     return settings.currentPagePermissions;
@@ -230,6 +235,7 @@ const utils = {
     getTemplateFolder,
     getIsSuperUser,
     canSeePagesList,
+    canAddPages,
     getCurrentPagePermissions,
     getCurrentParentHasChildren,
     getCurrentPageName,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -865,15 +865,15 @@ namespace Dnn.PersonaBar.Pages.Components
 
         public virtual PageSettings GetDefaultSettings(int pageId = 0)
         {
+            var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
             var pageSettings = new PageSettings
             {
                 Templates = this._templateController.GetTemplates(),
-                Permissions = this.GetPermissionsData(pageId),
+                Permissions = pageId == 0 ? this.GetPermissionsData(portalSettings.HomeTabId) : this.GetPermissionsData(pageId),
             };
 
             pageSettings.TemplateId = this._templateController.GetDefaultTemplateId(pageSettings.Templates);
 
-            var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
             if (portalSettings.SSLSetup == DotNetNuke.Abstractions.Security.SiteSslSetup.On || (portalSettings.SSLEnabled && portalSettings.SSLEnforced))
             {
                 pageSettings.IsSecure = true;

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -911,10 +911,6 @@ namespace Dnn.PersonaBar.Pages.Components
                     permissions.UserPermissions = permissions.UserPermissions.OrderBy(p => p.DisplayName).ToList();
                 }
             }
-            else if (pageId == 0)
-            {
-                return this.GetPermissionsData(PortalController.Instance.GetCurrentSettings().HomeTabId);
-            }
 
             return permissions;
         }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -911,6 +911,10 @@ namespace Dnn.PersonaBar.Pages.Components
                     permissions.UserPermissions = permissions.UserPermissions.OrderBy(p => p.DisplayName).ToList();
                 }
             }
+            else if (pageId == 0)
+            {
+                return this.GetPermissionsData(PortalController.Instance.GetCurrentSettings().HomeTabId);
+            }
 
             return permissions;
         }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/Security/SecurityService.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/Security/SecurityService.cs
@@ -173,7 +173,7 @@ namespace Dnn.PersonaBar.Pages.Components.Security
         private TabInfo GetTabById(int pageId)
         {
             var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
-            return pageId <= 0 ? new TabInfo() : this._tabController.GetTab(pageId, portalSettings.PortalId, false);
+            return pageId <= 0 ? new TabInfo { PortalID = portalSettings.PortalId } : this._tabController.GetTab(pageId, portalSettings.PortalId, false);
         }
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/PagesMenuController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/PagesMenuController.cs
@@ -45,7 +45,7 @@ namespace Dnn.PersonaBar.Pages.MenuControllers
             var settings = new Dictionary<string, object>
             {
                 { "canSeePagesList", this.securityService.CanViewPageList(menuItem.MenuId) },
-                { "canAddPages", this.securityService.CanAddPage(Null.NullInteger) },
+                { "canAddPages", this.securityService.CanAddPage(PortalSettings.Current.PortalId) },
                 { "portalName", PortalSettings.Current.PortalName },
                 { "currentPagePermissions", this.securityService.GetCurrentPagePermissions() },
                 { "currentPageName", PortalSettings.Current?.ActiveTab?.TabName },

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/PagesMenuController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/PagesMenuController.cs
@@ -10,6 +10,7 @@ namespace Dnn.PersonaBar.Pages.MenuControllers
     using Dnn.PersonaBar.Library.Model;
     using Dnn.PersonaBar.Pages.Components.Security;
     using DotNetNuke.Application;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
 
     /// <summary>
@@ -44,6 +45,7 @@ namespace Dnn.PersonaBar.Pages.MenuControllers
             var settings = new Dictionary<string, object>
             {
                 { "canSeePagesList", this.securityService.CanViewPageList(menuItem.MenuId) },
+                { "canAddPages", this.securityService.CanAddPage(Null.NullInteger) },
                 { "portalName", PortalSettings.Current.PortalName },
                 { "currentPagePermissions", this.securityService.GetCurrentPagePermissions() },
                 { "currentPageName", PortalSettings.Current?.ActiveTab?.TabName },

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
@@ -268,7 +268,7 @@ namespace Dnn.PersonaBar.Pages.Services
         /// Gets the pages hierarchy.
         /// </summary>
         /// <param name="pageId">The page (tab) id.</param>
-        /// <returns>The page hyerarchy.</returns>
+        /// <returns>The page hierarchy.</returns>
         [HttpGet]
         [AdvancedPermission(MenuName = "Dnn.Pages", Permission = "Edit")]
         public HttpResponseMessage GetPageHierarchy(int pageId)


### PR DESCRIPTION
Replays #5118 on `release/9.11.0` (it was originally incorrectly merged into `develop`).