### PR TITLE
Disable PR merge for 10.0.0 branch

### DIFF
--- a/.github/workflows/open-merged-pr-to-future.yml
+++ b/.github/workflows/open-merged-pr-to-future.yml
@@ -1,10 +1,10 @@
 name: Open Merged PR to release/10.0.0 Branch
 
-on:
-  pull_request:
-    types: [closed]
-    branches:
-      - develop
+on: workflow_dispatch
+#  pull_request:
+#    types: [closed]
+#    branches:
+#      - develop
 
 jobs:
   open-merged-pr-to-release-branch:


### PR DESCRIPTION
Until we have a `release/10.0.0` this will fail every time
