### PR TITLE
Ensure StandardFolderProvider always returns an absolute URL.

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -169,7 +169,7 @@ namespace DotNetNuke.Entities.Portals
         }
 
         /// <inheritdoc/>
-        public string DefaultPortalAlias
+        public virtual string DefaultPortalAlias
         {
             get
             {

--- a/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/Providers/StandardFolderProvider.cs
@@ -219,10 +219,10 @@ namespace DotNetNuke.Services.FileSystem
                     file.LastModificationTime.GetHashCode().ToString(),
                     portalSettings.GUID.ToString());
 
-                return TestableGlobals.Instance.ResolveUrl(fullPath + "?ver=" + cachebusterToken);
+                return this.EnforceAbsoluteUrl(TestableGlobals.Instance.ResolveUrl(fullPath + "?ver=" + cachebusterToken), portalSettings);
             }
 
-            return TestableGlobals.Instance.ResolveUrl(fullPath);
+            return this.EnforceAbsoluteUrl(TestableGlobals.Instance.ResolveUrl(fullPath), portalSettings);
         }
 
         /// <inheritdoc/>
@@ -466,5 +466,18 @@ namespace DotNetNuke.Services.FileSystem
         {
             return PathUtils.Instance.GetRelativePath(folderMapping.PortalID, path);
         }
+
+        private string EnforceAbsoluteUrl(string uri, PortalSettings portalSettings)
+        {
+            var initialUri = new Uri(uri, UriKind.RelativeOrAbsolute);
+            if (!initialUri.IsAbsoluteUri)
+            {
+                var appUrl = new Uri(Globals.AddHTTP(portalSettings.DefaultPortalAlias));
+                return new Uri(appUrl, initialUri).AbsoluteUri;
+            }
+
+            return uri;
+        }
+
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
@@ -779,7 +779,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             portalSettingsMock.Object.PortalId = Constants.CONTENT_ValidPortalId;
             portalSettingsMock.Object.EnableUrlLanguage = false;
             portalSettingsMock.Object.GUID = Guid.NewGuid();
-
+            portalSettingsMock.SetupGet(x => x.DefaultPortalAlias).Returns("example.com");
             return portalSettingsMock.Object;
         }
     }


### PR DESCRIPTION
Fixes #5085 

Includes the fixes suggested in PR #5086.