### PR TITLE
Improve HTML attribute support in client resource manager

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -182,7 +182,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
         /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
-        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>script</c> tag. The key being the attribute name and the value its value.</param>
         public static void RegisterScript(Page page, string filePath, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, FileOrder.Js.DefaultPriority, htmlAttributes);
@@ -201,7 +201,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
-        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>script</c> tag. The key being the attribute name and the value its value.</param>
         public static void RegisterScript(Page page, string filePath, int priority, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, priority, DefaultJsProvider, htmlAttributes);
@@ -220,7 +220,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
-        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>script</c> tag. The key being the attribute name and the value its value.</param>
         public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, (int)priority, DefaultJsProvider, htmlAttributes);
@@ -241,7 +241,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
-        /// /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
+        /// /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>script</c> tag. The key being the attribute name and the value its value.</param>
         public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, string provider, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, (int)priority, provider, htmlAttributes);
@@ -262,7 +262,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
-        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>script</c> tag. The key being the attribute name and the value its value.</param>
         public static void RegisterScript(Page page, string filePath, int priority, string provider, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, priority, provider, string.Empty, string.Empty, htmlAttributes);
@@ -287,7 +287,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
         /// <param name="name">Name of framework like Bootstrap, Angular, etc.</param>
         /// <param name="version">Version number of framework.</param>
-        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>script</c> tag. The key being the attribute name and the value its value.</param>
         public static void RegisterScript(
             Page page,
             string filePath,
@@ -314,7 +314,16 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="filePath">The relative file path to the CSS resource.</param>
         public static void RegisterStyleSheet(Page page, string filePath)
         {
-            RegisterStyleSheet(page, filePath, Constants.DefaultPriority, DefaultCssProvider);
+            RegisterStyleSheet(page, filePath, Constants.DefaultPriority, DefaultCssProvider, htmlAttributes: null);
+        }
+
+        /// <summary>Requests that a CSS file be registered on the client browser.</summary>
+        /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
+        /// <param name="filePath">The relative file path to the CSS resource.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>link</c> tag. The key being the attribute name and the value its value.</param>
+        public static void RegisterStyleSheet(Page page, string filePath, IDictionary<string, string> htmlAttributes)
+        {
+            RegisterStyleSheet(page, filePath, Constants.DefaultPriority, DefaultCssProvider, htmlAttributes);
         }
 
         /// <summary>Requests that a CSS file be registered on the client browser. Defaults to rendering in the page header.</summary>
@@ -323,7 +332,17 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         public static void RegisterStyleSheet(Page page, string filePath, int priority)
         {
-            RegisterStyleSheet(page, filePath, priority, DefaultCssProvider);
+            RegisterStyleSheet(page, filePath, priority, DefaultCssProvider, htmlAttributes: null);
+        }
+
+        /// <summary>Requests that a CSS file be registered on the client browser. Defaults to rendering in the page header.</summary>
+        /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
+        /// <param name="filePath">The relative file path to the CSS resource.</param>
+        /// <param name="priority">The relative priority in which the file should be loaded.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>link</c> tag. The key being the attribute name and the value its value.</param>
+        public static void RegisterStyleSheet(Page page, string filePath, int priority, IDictionary<string, string> htmlAttributes)
+        {
+            RegisterStyleSheet(page, filePath, priority, DefaultCssProvider, htmlAttributes);
         }
 
         /// <summary>Requests that a CSS file be registered on the client browser. Defaults to rendering in the page header.</summary>
@@ -332,7 +351,17 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         public static void RegisterStyleSheet(Page page, string filePath, FileOrder.Css priority)
         {
-            RegisterStyleSheet(page, filePath, (int)priority, DefaultCssProvider);
+            RegisterStyleSheet(page, filePath, (int)priority, DefaultCssProvider, htmlAttributes: null);
+        }
+
+        /// <summary>Requests that a CSS file be registered on the client browser. Defaults to rendering in the page header.</summary>
+        /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
+        /// <param name="filePath">The relative file path to the CSS resource.</param>
+        /// <param name="priority">The relative priority in which the file should be loaded.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>link</c> tag. The key being the attribute name and the value its value.</param>
+        public static void RegisterStyleSheet(Page page, string filePath, FileOrder.Css priority, IDictionary<string, string> htmlAttributes)
+        {
+            RegisterStyleSheet(page, filePath, (int)priority, DefaultCssProvider, htmlAttributes);
         }
 
         /// <summary>Requests that a CSS file be registered on the client browser. Allows for overriding the default provider.</summary>
@@ -342,7 +371,18 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="provider">The provider name to be used to render the css file on the page.</param>
         public static void RegisterStyleSheet(Page page, string filePath, int priority, string provider)
         {
-            RegisterStyleSheet(page, filePath, priority, provider, string.Empty, string.Empty);
+            RegisterStyleSheet(page, filePath, priority, provider, string.Empty, string.Empty, htmlAttributes: null);
+        }
+
+        /// <summary>Requests that a CSS file be registered on the client browser. Allows for overriding the default provider.</summary>
+        /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
+        /// <param name="filePath">The relative file path to the CSS resource.</param>
+        /// <param name="priority">The relative priority in which the file should be loaded.</param>
+        /// <param name="provider">The provider name to be used to render the css file on the page.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>link</c> tag. The key being the attribute name and the value its value.</param>
+        public static void RegisterStyleSheet(Page page, string filePath, int priority, string provider, IDictionary<string, string> htmlAttributes)
+        {
+            RegisterStyleSheet(page, filePath, priority, provider, string.Empty, string.Empty, htmlAttributes);
         }
 
         /// <summary>Requests that a CSS file be registered on the client browser. Allows for overriding the default provider.</summary>
@@ -353,6 +393,19 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="name">Name of framework like Bootstrap, Angular, etc.</param>
         /// <param name="version">Version number of framework.</param>
         public static void RegisterStyleSheet(Page page, string filePath, int priority, string provider, string name, string version)
+        {
+            RegisterStyleSheet(page, filePath, priority, provider, name, version, htmlAttributes: null);
+        }
+
+        /// <summary>Requests that a CSS file be registered on the client browser. Allows for overriding the default provider.</summary>
+        /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
+        /// <param name="filePath">The relative file path to the CSS resource.</param>
+        /// <param name="priority">The relative priority in which the file should be loaded.</param>
+        /// <param name="provider">The provider name to be used to render the css file on the page.</param>
+        /// <param name="name">Name of framework like Bootstrap, Angular, etc.</param>
+        /// <param name="version">Version number of framework.</param>
+        /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the <c>link</c> tag. The key being the attribute name and the value its value.</param>
+        public static void RegisterStyleSheet(Page page, string filePath, int priority, string provider, string name, string version, IDictionary<string, string> htmlAttributes)
         {
             var fileExists = false;
 
@@ -379,6 +432,13 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
             }
 
             var include = new DnnCssInclude { ForceProvider = provider, Priority = priority, FilePath = filePath, Name = name, Version = version };
+            if (htmlAttributes != null)
+            {
+                foreach (var attribute in htmlAttributes)
+                {
+                    include.HtmlAttributes[attribute.Key] = attribute.Value;
+                }
+            }
 
             page.FindControl("ClientResourceIncludes")?.Controls.Add(include);
         }

--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -8,7 +8,6 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Threading;
     using System.Web;
     using System.Web.Hosting;
@@ -298,10 +297,13 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
             string version,
             Dictionary<string, string> htmlAttributes)
         {
-            var include = new DnnJsInclude { ForceProvider = provider, Priority = priority, FilePath = filePath, Name = name, Version = version };
-            if (htmlAttributes != null && htmlAttributes.Any())
+            var include = new DnnJsInclude { ForceProvider = provider, Priority = priority, FilePath = filePath, Name = name, Version = version, };
+            if (htmlAttributes != null)
             {
-                include.HtmlAttributesAsString = string.Join(",", htmlAttributes.Select(h => $"{h.Key}:{h.Value}"));
+                foreach (var attribute in htmlAttributes)
+                {
+                    include.HtmlAttributes[attribute.Key] = attribute.Value;
+                }
             }
 
             page.FindControl("ClientResourceIncludes")?.Controls.Add(include);

--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -176,14 +176,14 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         public static void RegisterScript(Page page, string filePath)
         {
-            RegisterScript(page, filePath, new Dictionary<string, string>());
+            RegisterScript(page, filePath, htmlAttributes: null);
         }
 
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
         /// <param name="page">The current page. Used to get a reference to the client resource loader.</param>
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
-        public static void RegisterScript(Page page, string filePath, Dictionary<string, string> htmlAttributes)
+        public static void RegisterScript(Page page, string filePath, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, FileOrder.Js.DefaultPriority, htmlAttributes);
         }
@@ -194,7 +194,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         public static void RegisterScript(Page page, string filePath, int priority)
         {
-            RegisterScript(page, filePath, priority, new Dictionary<string, string>());
+            RegisterScript(page, filePath, priority, htmlAttributes: null);
         }
 
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
@@ -202,7 +202,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
-        public static void RegisterScript(Page page, string filePath, int priority, Dictionary<string, string> htmlAttributes)
+        public static void RegisterScript(Page page, string filePath, int priority, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, priority, DefaultJsProvider, htmlAttributes);
         }
@@ -213,7 +213,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         public static void RegisterScript(Page page, string filePath, FileOrder.Js priority)
         {
-            RegisterScript(page, filePath, priority, new Dictionary<string, string>());
+            RegisterScript(page, filePath, priority, htmlAttributes: null);
         }
 
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
@@ -221,7 +221,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="filePath">The relative file path to the JavaScript resource.</param>
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
-        public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, Dictionary<string, string> htmlAttributes)
+        public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, (int)priority, DefaultJsProvider, htmlAttributes);
         }
@@ -233,7 +233,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
         public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, string provider)
         {
-            RegisterScript(page, filePath, priority, provider, new Dictionary<string, string>());
+            RegisterScript(page, filePath, priority, provider, htmlAttributes: null);
         }
 
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
@@ -242,7 +242,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
         /// /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
-        public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, string provider, Dictionary<string, string> htmlAttributes)
+        public static void RegisterScript(Page page, string filePath, FileOrder.Js priority, string provider, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, (int)priority, provider, htmlAttributes);
         }
@@ -254,7 +254,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
         public static void RegisterScript(Page page, string filePath, int priority, string provider)
         {
-            RegisterScript(page, filePath, priority, provider, new Dictionary<string, string>());
+            RegisterScript(page, filePath, priority, provider, htmlAttributes: null);
         }
 
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
@@ -263,7 +263,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="priority">The relative priority in which the file should be loaded.</param>
         /// <param name="provider">The name of the provider responsible for rendering the script output.</param>
         /// <param name="htmlAttributes">A dictionary of HTML attributes to use for the script tag. The key being the attribute name and the value its value.</param>
-        public static void RegisterScript(Page page, string filePath, int priority, string provider, Dictionary<string, string> htmlAttributes)
+        public static void RegisterScript(Page page, string filePath, int priority, string provider, IDictionary<string, string> htmlAttributes)
         {
             RegisterScript(page, filePath, priority, provider, string.Empty, string.Empty, htmlAttributes);
         }
@@ -277,7 +277,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
         /// <param name="version">Version number of framework.</param>
         public static void RegisterScript(Page page, string filePath, int priority, string provider, string name, string version)
         {
-            RegisterScript(page, filePath, priority, provider, name, version, new Dictionary<string, string>());
+            RegisterScript(page, filePath, priority, provider, name, version, htmlAttributes: null);
         }
 
         /// <summary>Requests that a JavaScript file be registered on the client browser.</summary>
@@ -295,7 +295,7 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
             string provider,
             string name,
             string version,
-            Dictionary<string, string> htmlAttributes)
+            IDictionary<string, string> htmlAttributes)
         {
             var include = new DnnJsInclude { ForceProvider = provider, Priority = priority, FilePath = filePath, Name = name, Version = version, };
             if (htmlAttributes != null)

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptDto.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptDto.cs
@@ -5,6 +5,8 @@
 // ReSharper disable once CheckNamespace
 namespace DotNetNuke.Services.Tokens
 {
+    using System.Collections.Generic;
+
     using Newtonsoft.Json;
 
     /// <summary>Data-transfer-object for javascript file registration.</summary>
@@ -35,7 +37,7 @@ namespace DotNetNuke.Services.Tokens
         public string Version { get; set; }
 
         /// <summary>Gets or sets the HTML attributes to include in the script tag.</summary>
-        [JsonProperty("htmlattributesasstring")]
-        public string HtmlAttributesAsString { get; set; }
+        [JsonProperty("htmlAttributes")]
+        public IDictionary<string, string> HtmlAttributes { get; set; }
     }
 }

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptDto.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptDto.cs
@@ -5,59 +5,36 @@
 // ReSharper disable once CheckNamespace
 namespace DotNetNuke.Services.Tokens
 {
-    using System;
-    using System.Web.UI;
-
-    using DotNetNuke.Entities.Users;
-    using DotNetNuke.Framework.JavaScriptLibraries;
-    using DotNetNuke.Web.Client;
-    using DotNetNuke.Web.Client.ClientResourceManagement;
     using Newtonsoft.Json;
 
-    /// <summary>
-    /// Data-transfer-object for javascript file registration.
-    /// </summary>
+    /// <summary>Data-transfer-object for javascript file registration.</summary>
     public class JavaScriptDto
     {
-        /// <summary>
-        /// Gets or sets the name of an installed javascript library.
-        /// </summary>
+        /// <summary>Gets or sets the name of an installed javascript library.</summary>
         [JsonProperty("jsname")]
         public string JsName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the path to the javascript file.
-        /// </summary>
+        /// <summary>Gets or sets the path to the javascript file.</summary>
         [JsonProperty("path")]
         public string Path { get; set; }
 
-        /// <summary>
-        /// Gets or sets the priority of the javascript file.
-        /// </summary>
+        /// <summary>Gets or sets the priority of the javascript file.</summary>
         [JsonProperty("priority")]
         public int Priority { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name of the provider to use. Examples: DnnPageHeaderProvider, DnnBodyProvider, DnnFormBottomProvider.
-        /// </summary>
+        /// <summary>Gets or sets the name of the provider to use. Examples: <c>DnnPageHeaderProvider</c>, <c>DnnBodyProvider</c>, <c>DnnFormBottomProvider</c>.</summary>
         [JsonProperty("provider")]
         public string Provider { get; set; }
 
-        /// <summary>
-        /// Gets or sets the specific version to use. Examples: Latest, LatestMajor, LatestMinor, Exact.
-        /// </summary>
+        /// <summary>Gets or sets the specific version to use. Examples: <c>Latest</c>, <c>LatestMajor</c>, <c>LatestMinor</c>, <c>Exact</c>c>.</summary>
         [JsonProperty("specific")]
         public string Specific { get; set; }
 
-        /// <summary>
-        /// Gets or sets the version number to load.
-        /// </summary>
+        /// <summary>Gets or sets the version number to load.</summary>
         [JsonProperty("version")]
         public string Version { get; set; }
 
-        /// <summary>
-        /// Gets or sets the html attributes to include in the script tag.
-        /// </summary>
+        /// <summary>Gets or sets the HTML attributes to include in the script tag.</summary>
         [JsonProperty("htmlattributesasstring")]
         public string HtmlAttributesAsString { get; set; }
     }

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptPropertyAccess.cs
@@ -39,13 +39,21 @@ namespace DotNetNuke.Services.Tokens
                 model.Priority = (int)FileOrder.Js.DefaultPriority;
             }
 
-            if (!string.IsNullOrEmpty(model.JsName) && string.IsNullOrEmpty(model.Path))
+            if (string.IsNullOrEmpty(model.Path))
             {
                 RegisterInstalledLibrary(model);
-                return string.Empty;
             }
-
-            this.RegisterPath(model);
+            else
+            {
+                ClientResourceManager.RegisterScript(
+                    this.page,
+                    model.Path,
+                    model.Priority,
+                    model.Provider ?? string.Empty,
+                    model.JsName ?? string.Empty,
+                    model.Version ?? string.Empty,
+                    model.HtmlAttributes);
+            }
 
             return string.Empty;
         }
@@ -79,36 +87,6 @@ namespace DotNetNuke.Services.Tokens
             }
 
             JavaScript.RequestRegistration(model.JsName, version, specific);
-        }
-
-        private void RegisterPath(JavaScriptDto model)
-        {
-            var htmlAttributes = new Dictionary<string, string>();
-            try
-            {
-                if (!string.IsNullOrEmpty(model.HtmlAttributesAsString))
-                {
-                    var attributes = model.HtmlAttributesAsString.Split(',');
-                    foreach (var attribute in attributes)
-                    {
-                        var attributeParts = attribute.Split(':');
-                        htmlAttributes.Add(attributeParts[0], attributeParts[1]);
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                throw new ArgumentException("HtmlAttributesAsString is malformed.");
-            }
-
-            ClientResourceManager.RegisterScript(
-                this.page,
-                model.Path,
-                model.Priority,
-                model.Provider ?? string.Empty,
-                model.JsName ?? string.Empty,
-                model.Version ?? string.Empty,
-                htmlAttributes);
         }
     }
 }

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptPropertyAccess.cs
@@ -83,10 +83,6 @@ namespace DotNetNuke.Services.Tokens
 
         private void RegisterPath(JavaScriptDto model)
         {
-            var hasName = !string.IsNullOrEmpty(model.JsName);
-            var hasProvider = !string.IsNullOrEmpty(model.Provider);
-            var hasPath = !string.IsNullOrEmpty(model.Path);
-
             var htmlAttributes = new Dictionary<string, string>();
             try
             {
@@ -105,22 +101,14 @@ namespace DotNetNuke.Services.Tokens
                 throw new ArgumentException("HtmlAttributesAsString is malformed.");
             }
 
-            if (hasName && hasProvider && hasPath)
-            {
-                ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, model.Provider, model.JsName, model.Version, htmlAttributes);
-            }
-            else if (hasName && hasProvider)
-            {
-                ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, string.Empty, model.JsName, model.Version, htmlAttributes);
-            }
-            else if (hasProvider)
-            {
-                ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, model.Provider, htmlAttributes);
-            }
-            else
-            {
-                ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, htmlAttributes);
-            }
+            ClientResourceManager.RegisterScript(
+                this.page,
+                model.Path,
+                model.Priority,
+                model.Provider ?? string.Empty,
+                model.JsName ?? string.Empty,
+                model.Version ?? string.Empty,
+                htmlAttributes);
         }
     }
 }

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/JavaScriptPropertyAccess.cs
@@ -14,16 +14,12 @@ namespace DotNetNuke.Services.Tokens
     using DotNetNuke.Web.Client;
     using DotNetNuke.Web.Client.ClientResourceManagement;
 
-    /// <summary>
-    /// Property Access implementenation for javascript registration.
-    /// </summary>
+    /// <summary>Property Access implementation for javascript registration.</summary>
     public class JavaScriptPropertyAccess : JsonPropertyAccess<JavaScriptDto>
     {
         private readonly Page page;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JavaScriptPropertyAccess"/> class.
-        /// </summary>
+        /// <summary>Initializes a new instance of the <see cref="JavaScriptPropertyAccess"/> class.</summary>
         /// <param name="page">The current page.</param>
         public JavaScriptPropertyAccess(Page page)
         {
@@ -35,7 +31,7 @@ namespace DotNetNuke.Services.Tokens
         {
             if (string.IsNullOrEmpty(model.JsName) && string.IsNullOrEmpty(model.Path))
             {
-                throw new ArgumentException("If the jsname property is not specified then the JavaScript token must specify a path or property.");
+                throw new ArgumentException("If the jsname property is not specified then the JavaScript token must specify a path.");
             }
 
             if (model.Priority == 0)
@@ -45,7 +41,7 @@ namespace DotNetNuke.Services.Tokens
 
             if (!string.IsNullOrEmpty(model.JsName) && string.IsNullOrEmpty(model.Path))
             {
-                this.RegisterInstalledLibrary(model);
+                RegisterInstalledLibrary(model);
                 return string.Empty;
             }
 
@@ -54,10 +50,10 @@ namespace DotNetNuke.Services.Tokens
             return string.Empty;
         }
 
-        private void RegisterInstalledLibrary(JavaScriptDto model)
+        private static void RegisterInstalledLibrary(JavaScriptDto model)
         {
             Version version = null;
-            SpecificVersion specific = SpecificVersion.Latest;
+            var specific = SpecificVersion.Latest;
             if (!string.IsNullOrEmpty(model.Version))
             {
                 version = new Version(model.Version);
@@ -112,22 +108,19 @@ namespace DotNetNuke.Services.Tokens
             if (hasName && hasProvider && hasPath)
             {
                 ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, model.Provider, model.JsName, model.Version, htmlAttributes);
-                return;
             }
-
-            if (hasName && hasProvider)
+            else if (hasName && hasProvider)
             {
                 ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, string.Empty, model.JsName, model.Version, htmlAttributes);
-                return;
             }
-
-            if (hasProvider)
+            else if (hasProvider)
             {
                 ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, model.Provider, htmlAttributes);
-                return;
             }
-
-            ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, htmlAttributes);
+            else
+            {
+                ClientResourceManager.RegisterScript(this.page, model.Path, model.Priority, htmlAttributes);
+            }
         }
     }
 }

--- a/DNN Platform/Modules/ResourceManager/View.html
+++ b/DNN Platform/Modules/ResourceManager/View.html
@@ -1,6 +1,6 @@
 ﻿﻿[AntiForgeryToken:True]
-[JavaScript:{ path: "~/DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.esm.js", htmlAttributesAsString: "type:module"}]
-[JavaScript:{ path: "~/DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.js", htmlAttributesAsString: "nomodule:nomodule"}]
+[JavaScript:{ path: "~/DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.esm.js", htmlAttributes: { "type":"module" } }]
+[JavaScript:{ path: "~/DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.js", htmlAttributes: { "nomodule":"nomodule" } }]
 <style type="text/css">
     :root {
         --dnn-color-primary: #3792ED;


### PR DESCRIPTION
## Summary
This PR improves on #5242. 

- Use dictionaries of attributes directly instead of requiring them to be serialized and deserialized as strings
- Add HTML attributes overloads for CSS
- Clean up some comments, typos, and other code