### PR TITLE
Ensure Resource Manager script files are included in package

### DIFF
--- a/DNN Platform/Modules/ResourceManager/Module.build
+++ b/DNN Platform/Modules/ResourceManager/Module.build
@@ -15,10 +15,7 @@
     </PropertyGroup>
     <Import Project="$(BuildScriptsPath)\Package.Targets" />
     <Import Project="$(BuildScriptsPath)\Module.Build"/>
-    <ItemGroup>
-        <Scripts Include="$(MSBuildProjectDirectory)\Scripts\**\*.*" />
-    </ItemGroup>
-    <Target Name="UpdateFiles">
+    <Target Name="CopyScripts" BeforeTargets="UpdateFiles">
         <PropertyGroup>
             <ComponentsDestinationFolder>$(MSBuildProjectDirectory)\Scripts\dnn-resource-manager</ComponentsDestinationFolder>
         </PropertyGroup>
@@ -27,7 +24,11 @@
         </ItemGroup>
         <RemoveDir Directories="$(ComponentsDestinationFolder)" />
         <Copy SourceFiles="@(ComponentsSource)" DestinationFolder="$(ComponentsDestinationFolder)" />
+    </Target>
+    <Target Name="UpdateFiles">
         <ItemGroup>
+            <Scripts Include="$(MSBuildProjectDirectory)\Scripts\**\*.*" />
+            <Resources Include="$(MSBuildProjectDirectory)\Scripts\**\*.*" />
             <Resources Remove="web.config" />
             <Resources Remove="web.Debug.config" />
             <Resources Remove="web.Release.config" />


### PR DESCRIPTION
Fixes #5251

## Summary
The MSBuild script copies files from `ResourceManager.Web\dist\dnn-resource-manager` to `Scripts\dnn-resource-manager` and then expects those files to be includes in the resources zip, but the timing of operations means that the files for the resources zip get calculated because the copy.

This PR adjusts the timing of the copying (which I don't think actually does anything, but I don't want to spend more time trying to understand MSBuild). The second change is to explicitly include those new files into the `Resources` variable in MSBuild during the `UpdateFiles` target, so that they get included in the later `Package` target.