### PR TITLE
Added support for RelativeAppPath in Request token

### DIFF
--- a/DNN Platform/Library/UI/Modules/Html5/RequestPropertyAccess.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/RequestPropertyAccess.cs
@@ -41,6 +41,11 @@ namespace DotNetNuke.UI.Modules.Html5
                     return this.request.QueryString.ToString();
                 case "applicationpath":
                     return this.request.ApplicationPath;
+                case "relativeapppath":
+                    // RelativeAppPath is like ApplicationPath, but will always end with a forward slash (/)
+                    return this.request.ApplicationPath.EndsWith("/")
+                        ? this.request.ApplicationPath
+                        : $"{this.request.ApplicationPath}/";
             }
 
             propertyNotFound = true;

--- a/DNN Platform/Modules/ResourceManager/View.html
+++ b/DNN Platform/Modules/ResourceManager/View.html
@@ -1,6 +1,6 @@
 ﻿﻿[AntiForgeryToken:True]
-<script type="module" src="[Request:ApplicationPath]/DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.esm.js"></script>
-<script nomodule src="[Request:ApplicationPath]/DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.js"></script>
+<script type="module" src="[Request:RelativeAppPath]DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.esm.js"></script>
+<script nomodule src="[Request:RelativeAppPath]DesktopModules/ResourceManager/Scripts/dnn-resource-manager/dnn-resource-manager.js"></script>
 <style type="text/css">
     :root {
         --dnn-color-primary: #3792ED;


### PR DESCRIPTION
Closes #5265

The .Net Request.ApplicationPath behaves this way:
- For a normal install it returns `/`
- For a virtual directory install it retursn `/dnn` (or whatever virtual directory name)

Notice here that in one case the string ends with a / and in the other case not.

This behaviour makes it diffucult to use it in a multi-purpose token made for relative urls as in:
```
<script src="[Request.ApplicationPath]/DesktopModules" />
```
Would render:
- `/dnn/DesktopModules` for a virtual directory (OK)
- `//DesktopModules` for a normal hosting scenario (NOT OK)

This PR adds `RelativeAppPath` which is a variation of `ApplicationPath` that will always end with `/`.

Usage as follows makes it usable in both scenarios and consumers can expect to always have the ending `/` provided:
```
<script src="[Request.RelativeAppPath]DesktopModules" />
```

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
