### PR TITLE
Fixed an issue where Telerik analysis would fail

### DIFF
--- a/DNN Platform/DotNetNuke.Maintenance/Telerik/TelerikUtils.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Telerik/TelerikUtils.cs
@@ -95,8 +95,16 @@ namespace DotNetNuke.Maintenance.Telerik
 
         private bool AssemblyDependsOnTelerik(string path, AppDomain domain)
         {
-            return this.GetReferencedAssemblyNames(path, domain)
-                .Any(assemblyName => assemblyName.StartsWith("Telerik", StringComparison.OrdinalIgnoreCase));
+            try
+            {
+                return this.GetReferencedAssemblyNames(path, domain)
+                    .Any(assemblyName => assemblyName.StartsWith("Telerik", StringComparison.OrdinalIgnoreCase));
+            }
+            catch (Exception)
+            {
+                // If we can't get the referenced assemblies, then it can't depend on Telerik.
+                return false;
+            }
         }
 
         private string[] DirectoryGetFiles(string path, string searchPattern, SearchOption searchOption) =>

--- a/DNN Platform/DotNetNuke.Maintenance/Telerik/TelerikUtils.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Telerik/TelerikUtils.cs
@@ -10,6 +10,7 @@ namespace DotNetNuke.Maintenance.Telerik
     using System.Linq;
 
     using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Instrumentation;
 
     /// <inheritdoc />
     public class TelerikUtils : ITelerikUtils
@@ -34,17 +35,20 @@ namespace DotNetNuke.Maintenance.Telerik
         };
 
         private readonly IApplicationStatusInfo applicationStatusInfo;
+        private readonly ILog log;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TelerikUtils"/> class.
         /// </summary>
-        /// <param name="applicationStatusInfo">
-        /// An instance of <see cref="IApplicationStatusInfo"/>.
-        /// </param>
-        public TelerikUtils(IApplicationStatusInfo applicationStatusInfo)
+        /// <param name="applicationStatusInfo">An instance of <see cref="IApplicationStatusInfo"/>.</param>
+        /// <param name="loggerSource">An instance of <see cref="ILoggerSource"/>.</param>
+        public TelerikUtils(
+            IApplicationStatusInfo applicationStatusInfo,
+            ILoggerSource loggerSource)
         {
             this.applicationStatusInfo = applicationStatusInfo
                 ?? throw new ArgumentNullException(nameof(applicationStatusInfo));
+            this.log = loggerSource.GetLogger(nameof(TelerikUtils));
         }
 
         /// <inheritdoc />
@@ -100,9 +104,10 @@ namespace DotNetNuke.Maintenance.Telerik
                 return this.GetReferencedAssemblyNames(path, domain)
                     .Any(assemblyName => assemblyName.StartsWith("Telerik", StringComparison.OrdinalIgnoreCase));
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // If we can't get the referenced assemblies, then it can't depend on Telerik.
+                this.log.Warn("Could not determine Telerik dependencies on some assemblies.", ex);
                 return false;
             }
         }


### PR DESCRIPTION
Closes #5260

Some dlls may be native code and fail when attemping to check if they have dependencies on Telerik.

This PR basically skips those files, if we can't detect if they depend on Telerik, then they can't possibly depend on Telerik.