### PR TITLE
Fixed an issue where folder provider icons would not show

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-mappings/dnn-rm-folder-mappings.scss
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-mappings/dnn-rm-folder-mappings.scss
@@ -22,3 +22,11 @@ table{
         }
     }
 }
+.controls{
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1em;
+    dnn-button{
+        margin-left: 1em;
+    }
+}

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-mappings/dnn-rm-folder-mappings.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-mappings/dnn-rm-folder-mappings.tsx
@@ -68,18 +68,11 @@ export class DnnRmFolderMappings {
                 }
                 {this.addFolderTypeUrl &&
                     <div class="controls">
-                        <dnn-button
-                            type='primary'
-                            reversed
-                            onClick={() => this.dismiss()}
-                        >
-                            Cancel
+                        <dnn-button reversed onClick={() => this.dismiss()}>
+                            {state.localization?.Cancel}
                         </dnn-button>
-                        <dnn-button
-                            type='primary'
-                            onClick={() => window.location.href = this.addFolderTypeUrl}
-                        >
-                            Add Folder Type
+                        <dnn-button onClick={() => window.location.href = this.addFolderTypeUrl}>
+                            {state.localization?.AddFolderType}
                         </dnn-button>
                     </div>
                 }

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-mappings/dnn-rm-folder-mappings.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-mappings/dnn-rm-folder-mappings.tsx
@@ -1,4 +1,4 @@
-import {Component, Host, h, State} from '@stencil/core';
+import {Component, Element, Host, h, State} from '@stencil/core';
 import { FolderMappingInfo, ItemsClient } from '../../services/ItemsClient';
 import state from "../../store/store";
 
@@ -9,7 +9,11 @@ import state from "../../store/store";
 })
 export class DnnRmFolderMappings {
     private itemsClient: ItemsClient;
+
+    @Element() el: HTMLDnnRmFolderMappingsElement;
+
     @State() folderMappings: FolderMappingInfo[];
+    @State() addFolderTypeUrl: string;
 
     constructor() {
         this.itemsClient = new ItemsClient(state.moduleId);
@@ -21,6 +25,15 @@ export class DnnRmFolderMappings {
                 this.folderMappings = data;
             })
             .catch(reason => console.error(reason));
+        this.itemsClient.getAddFolderTypeUrl()
+            .then(data => {
+                this.addFolderTypeUrl = data;
+            })
+            .catch(reason => console.error(reason));
+    }
+
+    private dismiss(): void {
+        this.el.closest('dnn-modal').hide();
     }
 
     render() {
@@ -52,6 +65,23 @@ export class DnnRmFolderMappings {
                             )}
                         </tbody>
                     </table>
+                }
+                {this.addFolderTypeUrl &&
+                    <div class="controls">
+                        <dnn-button
+                            type='primary'
+                            reversed
+                            onClick={() => this.dismiss()}
+                        >
+                            Cancel
+                        </dnn-button>
+                        <dnn-button
+                            type='primary'
+                            onClick={() => window.location.href = this.addFolderTypeUrl}
+                        >
+                            Add Folder Type
+                        </dnn-button>
+                    </div>
                 }
             </Host>
         );

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -215,6 +215,24 @@ export class ItemsClient{
         });
     }
 
+    public getAddFolderTypeUrl(){
+        return new Promise<string>((resolve, reject) => {
+            const url = `${this.requestUrl}GetAddFolderTypeUrl`;
+            fetch(url, {
+                headers: this.sf.getModuleHeaders(),
+            })
+            .then(response => {
+                if (response.status == 200){
+                    response.json().then(data => resolve(data));
+                }
+                else{
+                    response.json().then(error => reject(error.message));
+                }
+            })
+            .catch(error => reject(error));
+        });
+    };
+
     public createNewFolder(request: CreateNewFolderRequest){
         return new Promise<CreateNewFolderResponse>((resolve, reject) => {
             const url = `${this.requestUrl}CreateNewFolder`;

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -12,6 +12,7 @@ namespace Dnn.Modules.ResourceManager.Services
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Web;
+    using System.Web.Hosting;
     using System.Web.Http;
 
     using Dnn.Modules.ResourceManager.Components;
@@ -660,7 +661,7 @@ namespace Dnn.Modules.ResourceManager.Services
 
         private static string GetFileIconUrl(string extension)
         {
-            if (!string.IsNullOrEmpty(extension) && File.Exists(HttpContext.Current.Server.MapPath(IconController.IconURL("Ext" + extension, "32x32", "Standard"))))
+            if (!string.IsNullOrEmpty(extension) && File.Exists(HostingEnvironment.MapPath(IconController.IconURL("Ext" + extension, "32x32", "Standard"))))
             {
                 return IconController.IconURL("Ext" + extension, "32x32", "Standard");
             }
@@ -679,16 +680,14 @@ namespace Dnn.Modules.ResourceManager.Services
             }
 
             var localSvg = string.Format(svgPath, folderMapping.FolderProviderType.Replace("FolderProvider", string.Empty).ToLowerInvariant());
-            if (File.Exists(HttpContext.Current.Server.MapPath($"~/{localSvg}")))
+            if (File.Exists(HostingEnvironment.MapPath($"~/{localSvg}")))
             {
                 return Globals.ApplicationPath + "/" + localSvg;
             }
 
-            if (File.Exists(HttpContext.Current.Server.MapPath(folderMapping.ImageUrl)))
+            if (File.Exists(HostingEnvironment.MapPath(folderMapping.ImageUrl)))
             {
-                var path = folderMapping.ImageUrl.Replace("~", HttpContext.Current.Request.ApplicationPath)
-                    .TrimStart('/');
-                return $"/{path}";
+                return VirtualPathUtility.ToAbsolute(folderMapping.ImageUrl);
             }
 
             return Globals.ApplicationPath + "/" + string.Format(svgPath, "standard");

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -670,14 +670,28 @@ namespace Dnn.Modules.ResourceManager.Services
 
         private static string GetFolderIconUrl(int portalId, int folderMappingId)
         {
-            var url = Globals.ApplicationPath + "/" + Constants.ModulePath + "images/icon-asset-manager-{0}-folder.svg";
-
             var folderMapping = FolderMappingController.Instance.GetFolderMapping(portalId, folderMappingId);
-            var name = folderMapping != null && File.Exists(HttpContext.Current.Server.MapPath(folderMapping.ImageUrl))
-                       ? folderMapping.FolderProviderType.Replace("FolderProvider", string.Empty)
-                       : "standard";
+            var svgPath = Constants.ModulePath + "images/icon-asset-manager-{0}-folder.svg";
 
-            return string.Format(url, name.ToLower());
+            if (folderMapping is null)
+            {
+                return Globals.ApplicationPath + "/" + string.Format(svgPath, "standard");
+            }
+
+            var localSvg = string.Format(svgPath, folderMapping.FolderProviderType.Replace("FolderProvider", string.Empty).ToLowerInvariant());
+            if (File.Exists(HttpContext.Current.Server.MapPath($"~/{localSvg}")))
+            {
+                return Globals.ApplicationPath + "/" + localSvg;
+            }
+
+            if (File.Exists(HttpContext.Current.Server.MapPath(folderMapping.ImageUrl)))
+            {
+                var path = folderMapping.ImageUrl.Replace("~", HttpContext.Current.Request.ApplicationPath)
+                    .TrimStart('/');
+                return $"/{path}";
+            }
+
+            return Globals.ApplicationPath + "/" + string.Format(svgPath, "standard");
         }
 
         private int FindGroupId(HttpRequestMessage request)


### PR DESCRIPTION
Closes #5274

The new logic is as follows:
1. If we don't have any folder mapping info, we show the standard folder svg
2. If we have in the resource manager an svg for the provider, we use that one (usually nicer and we have one for our own Azure profider connector)
3. If the provider has one, we use the one the provider dictates If all else fails, we use the standard svg one.

In addition to this, I also added a button so users can create new folder mappings (totally forgot about that part when implementing the feature).

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
