### PR TITLE
Fixed an issue that prevent upload when using application folder

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/dnn-rm-queued-file.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/dnn-rm-queued-file.tsx
@@ -136,7 +136,8 @@ export class DnnRmQueuedFile {
                 this.dismiss();
             };
             
-            this.xhr.open("POST", "/API/InternalServices/FileUpload/UploadFromLocal");
+            const url = this.servicesFramework.getServiceRoot('InternalServices') + 'FileUpload/UploadFromLocal';
+            this.xhr.open("POST", url);
             headers.forEach((value, key) => {
                 this.xhr.setRequestHeader(key, value);
             });


### PR DESCRIPTION
Closes #5271

The url used to upload files did not support DNN being hosted on non-root folder in IIS hosting.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
