### PR TITLE
Fixed an issue where resource manager menus would show under icons

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/dnn-rm-actions-bar.scss
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/dnn-rm-actions-bar.scss
@@ -57,3 +57,6 @@ dnn-vertical-overflow-menu{
   flex-grow: 1;
   margin-left:24px;
 }
+dnn-collapsible{
+  z-index: 1;
+}


### PR DESCRIPTION
Closes #5284
In gridview some dropdowns would display under the file/folder icons making them unusable.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
