### PR TITLE
Remove react-test-utils

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -36,7 +36,6 @@
     "react-scrollbar": "^0.5.4",
     "react-slider": "0.11.2",
     "react-tabs": "3.0.0",
-    "react-test-utils": "0.0.1",
     "react-tooltip": "^4.2.21",
     "react-widgets": "^4.4.4",
     "redux-undo": "^1.0.0-beta9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,7 +1834,6 @@ __metadata:
     react-slider: 0.11.2
     react-tabs: 3.0.0
     react-test-renderer: ^17.0.2
-    react-test-utils: 0.0.1
     react-tooltip: ^4.2.21
     react-widgets: ^4.4.4
     redux-undo: ^1.0.0-beta9
@@ -10522,18 +10521,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envify@npm:~0.2.0":
-  version: 0.2.0
-  resolution: "envify@npm:0.2.0"
-  dependencies:
-    falafel: ~0.2.1
-    through: ~2.3.4
-  bin:
-    envify: bin/envify
-  checksum: 8c1319d64dd4e8bcffc2786e973ceaef1f1c5785d4c65b1631feedb3d33984a6c366383633ef7fc6a94e027818b735a0a5b25ffa6359c47f9e935210ae2d17a3
-  languageName: node
-  linkType: hard
-
 "envinfo@npm:^7.7.4":
   version: 7.8.1
   resolution: "envinfo@npm:7.8.1"
@@ -11073,16 +11060,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@substack/esprima#is-keyword":
-  version: 1.1.0-dev
-  resolution: "esprima@https://github.com/substack/esprima.git#commit=0a7f8489a11b44b019ce168506f535f22d0be290"
-  bin:
-    esparse: ./bin/esparse.js
-    esvalidate: ./bin/esvalidate.js
-  checksum: a74ad68004d500fe41d56ea1bc52d7d86f95c3fbc695913b7ecd283792161bf6f6254c73c58b5c35d75be76d674be308226579828aebb4c4b8eb1ea1edc0ac44
-  languageName: node
-  linkType: hard
-
 "esquery@npm:^1.4.0":
   version: 1.4.0
   resolution: "esquery@npm:1.4.0"
@@ -11515,15 +11492,6 @@ __metadata:
   peerDependencies:
     webpack: ^3.1.0
   checksum: b3a39b58d8827ea09507c2cf3aec4c154bd0ce54d708f9ec4d0d26d3fa0238cc1c62d023bba48ed5df179cebe029fb8ef50dbbb44cc818023f8db3781b65fce7
-  languageName: node
-  linkType: hard
-
-"falafel@npm:~0.2.1":
-  version: 0.2.1
-  resolution: "falafel@npm:0.2.1"
-  dependencies:
-    esprima: "substack/esprima#is-keyword"
-  checksum: 38d02c330fb6524139fae165fcb7bea7476b404cdc1d4f6ebc4c1c39525d9748276165b46d06f3ce3f28ad53dc9d5ed1704fcd5356a511ae6d904e3f77ca4375
   languageName: node
   linkType: hard
 
@@ -20560,16 +20528,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-test-utils@npm:0.0.1":
-  version: 0.0.1
-  resolution: "react-test-utils@npm:0.0.1"
-  dependencies:
-    envify: ~0.2.0
-    react: ~0.8.0
-  checksum: a11a66ef788771470a46ed10bedca2397a74d2f9ab2990a8e398813895f985f33149d66ecd7a6e997878edff10c6ebba79456e5fbff35e67e747229c2d9837d5
-  languageName: node
-  linkType: hard
-
 "react-textarea-autosize@npm:^7.0.4":
   version: 7.1.0
   resolution: "react-textarea-autosize@npm:7.1.0"
@@ -20708,15 +20666,6 @@ fsevents@^1.2.7:
     prop-types: ^15.6.2
     scheduler: ^0.13.6
   checksum: 8dfdbec9af6999c2cfb33a9389995c6401daba732e1ee7e0a4920d28fd2e8e6b0fde99dfe4b8e2f81efc4a962c92656e3e79e221323449e55850232163f15ff4
-  languageName: node
-  linkType: hard
-
-"react@npm:~0.8.0":
-  version: 0.8.0
-  resolution: "react@npm:0.8.0"
-  peerDependencies:
-    envify: ~0.2.0
-  checksum: 87afdb69147a49f00deffa5c41ead84c7721cfc4eed36788a214647ae2546d48a723ab8bc4cdcf1e2538f0526ad403db5128c152cd4dde20a240964b51fd7a9c
   languageName: node
   linkType: hard
 
@@ -23806,7 +23755,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:~2.3.4":
+"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd


### PR DESCRIPTION
## Summary
This PR removes the unused and unmaintained package `react-test-utils` from the project. This package has a dependency on a GitHub repo that has been removed, so if you don't have that package cached (e.g. run `yarn cache clean --all` in the repo) you will get a build failure.