### PR TITLE
Smooth out potential issues using ResetDevSite

### DIFF
--- a/Build/Tasks/CopyWebConfigToDevSite.cs
+++ b/Build/Tasks/CopyWebConfigToDevSite.cs
@@ -17,6 +17,11 @@ namespace DotNetNuke.Build.Tasks
         /// <inheritdoc/>
         public override void Run(Context context)
         {
+            if (string.IsNullOrWhiteSpace(context.Settings.DnnConnectionString))
+            {
+                throw new InvalidOperationException("DnnConnectionString was blank and must have a value when the CopyWebConfigToDevSite task is run");
+            }
+
             var conf = context.FileReadText("./Website/web.config");
             var transFile = "./Build/Tasks/webconfig-transform.local.xsl";
             if (!context.FileExists(transFile))

--- a/Build/Tasks/ResetDatabase.cs
+++ b/Build/Tasks/ResetDatabase.cs
@@ -5,6 +5,7 @@ namespace DotNetNuke.Build.Tasks
 {
     using System;
     using System.Data.SqlClient;
+    using System.IO;
     using System.Linq;
 
     using Cake.Common.Diagnostics;
@@ -46,8 +47,12 @@ namespace DotNetNuke.Build.Tasks
 
         private static string ReplaceScriptVariables(Context context, string script)
         {
+            var dbPath = context.FileSystem.GetDirectory(context.Settings.DatabasePath);
+            dbPath.Create();
+            var fullDbPath = Path.GetFullPath(dbPath.Path.FullPath);
+
             return script.Replace("{DBName}", context.Settings.DnnDatabaseName)
-                .Replace("{DBPath}", context.Settings.DatabasePath)
+                .Replace("{DBPath}", fullDbPath)
                 .Replace("{DBLogin}", context.Settings.DnnSqlUsername);
         }
 


### PR DESCRIPTION
## Summary
This PR resolves two issues we ran into while using ResetDevSite to setup a new DNN dev site (plus a third issue that I thought about while in the code).

### DatabasePath Normalization
The first issue is that you get an obscure SQL error if the `DatabasePath` in your local settings uses `/` instead of `\` (or, really `\\` since it's a JSON file). 
>     ========================================
>     ResetDatabase
>     ========================================
>     System.Data.SqlClient.SqlException (0x80131904): A file activation error occurred. The physical file name 'C:/dbs/dnn.local\dnn.local.mdf' may be incorrect. Diagnose and correct additional errors, and retry the operation.
>     CREATE DATABASE failed. Some file names listed could not be created. Check related errors.

### DatabasePath Creation
The extra issue is that if `DatabasePath` doesn't already exist you get the following error:
>     ========================================
>     ResetDatabase
>     ========================================
>     System.Data.SqlClient.SqlException (0x80131904): Directory lookup for the file "C:\dbs\dnn.local\dnn.local.mdf" failed with the operating system error 3(The system cannot find the path specified.).
>     CREATE DATABASE failed. Some file names listed could not be created. Check related errors.

### Blank DnnConnectionString
The final issue we ran into was leaving `DnnConnectionString` blank and then getting a Yellow Screen of Death when the `web.config` was updated with the blank value. I added a check and throw an error if you're trying to set the `web.config` with a blank connection string.