### PR TITLE
Pass TabId instead of PortalId

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/PagesMenuController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/PagesMenuController.cs
@@ -45,7 +45,7 @@ namespace Dnn.PersonaBar.Pages.MenuControllers
             var settings = new Dictionary<string, object>
             {
                 { "canSeePagesList", this.securityService.CanViewPageList(menuItem.MenuId) },
-                { "canAddPages", this.securityService.CanAddPage(PortalSettings.Current.PortalId) },
+                { "canAddPages", this.securityService.CanAddPage(PortalSettings.Current?.ActiveTab?.TabID ?? 0) },
                 { "portalName", PortalSettings.Current.PortalName },
                 { "currentPagePermissions", this.securityService.GetCurrentPagePermissions() },
                 { "currentPageName", PortalSettings.Current?.ActiveTab?.TabName },


### PR DESCRIPTION
Fixes #5312 
Pass the TabId of the current page instead of PortalId.