### PR TITLE
Include SharpZipLib package

### DIFF
--- a/Build/Tasks/OtherPackages.cs
+++ b/Build/Tasks/OtherPackages.cs
@@ -23,6 +23,7 @@ namespace DotNetNuke.Build.Tasks
     [IsDependentOn(typeof(PackageAspNetMvc))]
     [IsDependentOn(typeof(PackageMicrosoftGlobbing))]
     [IsDependentOn(typeof(PackageWebFormsMvp))]
+    [IsDependentOn(typeof(PackageSharpZipLib))]
     public sealed class OtherPackages : FrostingTask<Context>
     {
         /// <inheritdoc/>


### PR DESCRIPTION
Resolves issue mentioned at https://github.com/dnnsoftware/Dnn.Platform/pull/5185#issuecomment-1254967053

## Summary
In #5185 SharpZipLib was removed as a dependency of DNN (except where required by deprecated APIs). A library package was introduced to manage upgrading the dependency, but that package was mistakenly left out of the distribution. This PR resolves that oversight.