### PR TITLE
Update to Cake.Issues.MsBuild 2.0 Beta 1

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Cake.Frosting" Version="2.2.0" />
     <PackageReference Include="Cake.Git" Version="2.0.0" />
     <PackageReference Include="Cake.Issues" Version="2.0.0-beta0001" />
-    <PackageReference Include="Cake.Issues.MsBuild" Version="1.0.0" />
+    <PackageReference Include="Cake.Issues.MsBuild" Version="2.0.0-beta0001" />
     <PackageReference Include="Cake.Json" Version="7.0.1" />
     <PackageReference Include="Cake.XdtTransform" Version="2.0.0" />
     <PackageReference Include="Dnn.CakeUtils" Version="2.0.2" />

--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -32,7 +32,6 @@ namespace DotNetNuke.Build
                 .InstallTool(new Uri("nuget:?package=Microsoft.TestPlatform&version=" + MicrosoftTestPlatformVersion))
                 .InstallTool(new Uri("nuget:?package=NUnit3TestAdapter&version=" + NUnit3TestAdapterVersion))
                 .InstallTool(new Uri("nuget:?package=NuGet.CommandLine&version=5.10.0"))
-                .InstallTool(new Uri("nuget:?package=Cake.Issues.MsBuild&version=1.0.0"))
                 .Run(args);
         }
     }

--- a/Build/Tasks/Build.cs
+++ b/Build/Tasks/Build.cs
@@ -24,8 +24,6 @@ namespace DotNetNuke.Build.Tasks
         /// <inheritdoc/>
         public override void Run(Context context)
         {
-            // TODO: when Cake.Issues.MsBuild is updated to support Binary Log version 9, can use .EnableBinaryLogger() instead of .WithLogger(…)
-            // TODO: also can remove the .InstallTool(…) call for Cake.Issues.MsBuild in Program.cs at that point
             var cleanLog = context.ArtifactsDir.Path.CombineWithFilePath("clean.binlog");
             var buildLog = context.ArtifactsDir.Path.CombineWithFilePath("rebuild.binlog");
             try
@@ -71,7 +69,7 @@ namespace DotNetNuke.Build.Tasks
         {
             return new MSBuildSettings().SetConfiguration(context.BuildConfiguration)
                 .SetMaxCpuCount(0)
-                .WithLogger(context.Tools.Resolve("Cake.Issues.MsBuild*/**/StructuredLogger.dll").FullPath, "BinaryLogger", binLogPath.FullPath)
+                .EnableBinaryLogger(binLogPath.FullPath)
                 .SetNoConsoleLogger(context.IsRunningInCI);
         }
     }


### PR DESCRIPTION
## Summary

Updates build to Cake.Issues.MsBuild 2.0 Beta 1 which comes with support for binary log version 9. This allows to remove certain workarounds which are currently required in the build.

