### PR TITLE
Fix MonacoEditor not loading for child aliases

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.ConfigConsole/scripts/ConfigConsole.js
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.ConfigConsole/scripts/ConfigConsole.js
@@ -229,11 +229,15 @@ define(['jquery',
     }
 
     var initConfigConsole = function () {
-      let siteRoot = dnn.getVar("sf_siteRoot");
-      if (!siteRoot) siteRoot = '/';
+      const personaBarSettings = window.parent['personaBarSettings'];
+      const debugMode = personaBarSettings['debugMode'] === true;
+      const cdv = personaBarSettings['buildNumber'];
+      const version = (cdv ? '?cdv=' + cdv : '') + (debugMode ? '&t=' + Math.random(): '');
+      let siteRoot = personaBarSettings.applicationPath ?? '/';
+      if (!siteRoot.endsWith('/')) siteRoot += '/';
       var monacoEditorLoaderScript = document.createElement('script');
       monacoEditorLoaderScript.type = 'text/javascript';
-      monacoEditorLoaderScript.src = siteRoot + 'Resources/Shared/components/MonacoEditor/loader.js';
+      monacoEditorLoaderScript.src = siteRoot + 'Resources/Shared/components/MonacoEditor/loader.js' + version;
       document.body.appendChild(monacoEditorLoaderScript);
 
       require.config({ paths: { 'vs': siteRoot + 'Resources/Shared/components/MonacoEditor' } });

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SqlConsole/scripts/SqlConsole.js
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SqlConsole/scripts/SqlConsole.js
@@ -740,11 +740,15 @@ define(['jquery',
     };
 
     var initSqlConsole = function () {
-      let siteRoot = dnn ? dnn.getVar("sf_siteRoot") : '/';
-      if (!siteRoot) siteRoot = '/';
+      const personaBarSettings = window.parent['personaBarSettings'];
+      const debugMode = personaBarSettings['debugMode'] === true;
+      const cdv = personaBarSettings['buildNumber'];
+      const version = (cdv ? '?cdv=' + cdv : '') + (debugMode ? '&t=' + Math.random(): '');
+      let siteRoot = personaBarSettings.applicationPath ?? '/';
+      if (!siteRoot.endsWith('/')) siteRoot += '/';
       var monacoEditorLoaderScript = document.createElement('script');
       monacoEditorLoaderScript.type = 'text/javascript';
-      monacoEditorLoaderScript.src = siteRoot + 'Resources/Shared/components/MonacoEditor/loader.js';
+      monacoEditorLoaderScript.src = siteRoot + 'Resources/Shared/components/MonacoEditor/loader.js' + version;
       document.body.appendChild(monacoEditorLoaderScript);
 
       require.config({ paths: { 'vs': siteRoot + 'Resources/Shared/components/MonacoEditor' } });


### PR DESCRIPTION
Fixes #5322

## Summary
This PR updates the SQL Console and Config Manager to load the Monaco editor script using `personaBarSettings.applicationPath` instead of `dnn.getVar("sf_siteRoot")`.

This still needs to be tested on a site hosted in a virtual directory.