### PR TITLE
Save IsSecure property of Portal Setting 

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -2346,13 +2346,13 @@ namespace DotNetNuke.Entities.Portals
         {
             string currentSetting = GetPortalSetting(settingName, portalID, string.Empty, cultureCode);
 
+            if (isSecure && !string.IsNullOrEmpty(settingName) && !string.IsNullOrEmpty(settingValue))
+            {
+                settingValue = Security.FIPSCompliant.EncryptAES(settingValue, Config.GetDecryptionkey(), Host.Host.GUID);
+            }
+
             if (currentSetting != settingValue)
             {
-                if (isSecure && !string.IsNullOrEmpty(settingName) && !string.IsNullOrEmpty(settingValue))
-                {
-                    settingValue = Security.FIPSCompliant.EncryptAES(settingValue, Config.GetDecryptionkey(), Host.Host.GUID);
-                }
-
                 DataProvider.Instance().UpdatePortalSetting(portalID, settingName, settingValue, UserController.Instance.GetCurrentUserInfo().UserID, cultureCode, isSecure);
                 EventLogController.Instance.AddLog(settingName + ((cultureCode == Null.NullString) ? string.Empty : " (" + cultureCode + ")"), settingValue, GetCurrentPortalSettingsInternal(), UserController.Instance.GetCurrentUserInfo().UserID, EventLogController.EventLogType.PORTAL_SETTING_UPDATED);
                 if (clearCache)

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.01.SqlDataProvider
@@ -1,0 +1,94 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/
+
+/****************************************************************
+ * SPROC: UpdatePortalSetting 
+ ****************************************************************/
+IF (OBJECT_ID(N'{databaseOwner}[{objectQualifier}UpdatePortalSetting]') IS NOT NULL)
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}UpdatePortalSetting]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}UpdatePortalSetting]
+	@PortalID       int,
+	@SettingName    nvarchar(50),
+	@SettingValue   nvarchar(max),
+	@UserID			int,
+	@CultureCode    nvarchar(10),
+	@IsSecure       bit = 0
+AS
+BEGIN
+	-- Define parameter null
+	SELECT	 @PortalID = IsNull(@PortalID, -1)
+			,@SettingName = IsNull(@SettingName, N'')
+			,@SettingValue = IsNull(@SettingValue, N'')
+			,@UserID = IsNull(@UserID, -1)
+			,@CultureCode = IsNull(@CultureCode, N'')
+
+	-- Remove setting when value is null
+	IF @SettingValue = N'' AND @SettingName != N''
+		DELETE FROM {databaseOwner}[{objectQualifier}PortalSettings]
+			WHERE IsNull(PortalID, -1) = @PortalID
+			AND (CultureCode = @CultureCode OR @CultureCode = N'')
+		 	AND SettingName = @SettingName;
+	ELSE IF @SettingName != N'' AND @PortalID != -1  
+	BEGIN
+		MERGE INTO {databaseOwner}[{objectQualifier}PortalSettings] settings
+		 USING (SELECT 
+			@PortalID PortalID, 
+			@CultureCode CultureCode, 
+			@SettingName SettingName, 
+			@SettingValue SettingValue, 
+			@IsSecure IsSecure) input
+		 ON (settings.PortalID = input.PortalID 
+			AND IsNull(settings.CultureCode, N'') = input.CultureCode
+			AND settings.SettingName = input.SettingName)
+		 WHEN MATCHED 
+			AND IsNull(settings.SettingValue, N'') != input.SettingValue THEN 
+			-- Update if SettingValue has been modified
+			UPDATE SET 
+				 [SettingValue] = input.SettingValue
+				,[LastModifiedByUserID] = @UserID
+				,[LastModifiedOnDate] = GetDate()
+				,[IsSecure] = input.IsSecure
+		 WHEN NOT MATCHED THEN
+			-- Add new portal setting
+		    INSERT 
+				(PortalID
+				,SettingName
+				,SettingValue
+				,CultureCode
+				,CreatedByUserID
+				,CreatedOnDate
+				,LastModifiedByUserID
+				,LastModifiedOnDate
+				,IsSecure)
+			VALUES 
+				(@PortalID
+				,@SettingName
+				,@SettingValue
+				,NullIf(@CultureCode, N'')
+				,@UserID
+				,GetDate()
+				,@UserID
+				,GetDate()
+				,@IsSecure);
+		-- Saving a neutral setting overwrites all localized settings with same name
+		IF @CultureCode = N''
+			DELETE FROM {databaseOwner}[{objectQualifier}PortalSettings]
+			 WHERE PortalID = @PortalID 
+				AND SettingName = @SettingName 
+				AND CultureCode IS NOT null;
+	END; --ELSE IF
+END; --PROCEDURE
+GO
+
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/************************************************************/


### PR DESCRIPTION
Fixes #2874

## Summary
Checks IsSecure. If true, encrypt the value before checking if it has changed.  Update stored procedure UpdatePortalSetting to properly save IsSecure in PortalSettings.

### Note 
I'm the developer that was @yog-it which is now my organization account.  