### PR TITLE
5339 Handle upload for image smaller than configured resize dimensions

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -2494,6 +2494,11 @@ namespace DNNConnect.CKEditorProvider.Browser
                                     }
                                 }
                             }
+                            else
+                            {
+                                // fits within configured maximum dimensions
+                                FileManager.Instance.AddFile(currentFolderInfo, fileName, file.InputStream);
+                            }
                         }
                     }
                 }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx.cs
@@ -385,6 +385,11 @@ namespace DNNConnect.CKEditorProvider.Browser
                                     }
                                 }
                             }
+                            else
+                            {
+                                // fits within configured maximum dimensions
+                                FileManager.Instance.AddFile(this.StorageFolder, fileName, file.InputStream);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #5339 

## Summary
The code checked wether resize on upload dimensions are configured, then checked wether the image needs resizing, but fails to actually upload if the image doesn't need resising.
This PR fixes that.