### PR TITLE
Fixed an issue where first level folders were auto-expanded.

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
@@ -92,7 +92,6 @@ export class DnnRmFolderList {
             <dnn-rm-folder-list-item
               folder={item}
               parentFolderId={Number.parseInt(state.rootFolders.Tree.data.key)}
-              expanded
               onDnnRmFolderListItemClicked={e => this.handleFolderPicked(e)}
               selectedFolder={this.selectedFolder}
             >


### PR DESCRIPTION
In #5351 a change was implemented to get the root folders according to the settings. Because of this a user is now always on some sort of root folder instead of the root folders not being part of any and having a virtual "root" ListItem. So before that change we were auto-expending that root item but now all direct children are open by default and it does not look right. This PR solves that by not expanding automatically the first level in the tree.

Before:
![image](https://user-images.githubusercontent.com/6371568/197422517-0e242a60-eb60-4ecd-832e-955c2d04d477.png)

After:
![image](https://user-images.githubusercontent.com/6371568/197422528-a5fc5eea-bd1b-4a72-9587-85a669d8699f.png)
