### PR TITLE
Fixed an issue where resource manager modal could not contain long lists

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/package.json
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@dnncommunity/dnn-elements": "^0.15.1",
+    "@dnncommunity/dnn-elements": "^0.15.2",
     "@stencil/sass": "^2.0.0",
     "@stencil/store": "^2.0.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,10 +1774,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dnncommunity/dnn-elements@npm:^0.15.1":
-  version: 0.15.1
-  resolution: "@dnncommunity/dnn-elements@npm:0.15.1"
-  checksum: dfabf0d4df59363e7487dcca2ba62192a42869975f8da8248d8664cdecb650ffbf62ad9c4cc4bfccfd89c6a115a8de6f5c32354efed574da650909be0b066140
+"@dnncommunity/dnn-elements@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@dnncommunity/dnn-elements@npm:0.15.2"
+  checksum: 7e294ca5f235e0cd26b8abdc8cdfab19aefe636d1ed6c9e0d13983aa7d372ceff83438aec1ff48285b12f4fbaa3e9574b175cf8068b0f44fa93e8bbbd3ff0984
   languageName: node
   linkType: hard
 
@@ -9952,7 +9952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dnn-resource-manager@workspace:DNN Platform/Modules/ResourceManager/ResourceManager.Web"
   dependencies:
-    "@dnncommunity/dnn-elements": ^0.15.1
+    "@dnncommunity/dnn-elements": ^0.15.2
     "@stencil/core": ^2.18.0
     "@stencil/sass": ^2.0.0
     "@stencil/store": ^2.0.1


### PR DESCRIPTION
Closes #5349

This was fixed on the dnn-modal itself in https://github.com/DNNCommunity/dnn-elements/pull/633 and this PR simply bumps our dependency on dnn-elements to bring in that fix.
