### PR TITLE
Added webp support for images

### DIFF
--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/basicSettings/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/src/components/basicSettings/index.jsx
@@ -255,7 +255,7 @@ class BasicSettingsPanelBody extends Component {
                         folderName={state.basicSettings.LogoFile ? state.basicSettings.LogoFile.FolderName : null}
                         validationCode={state.basicSettings.ValidationCode}
                         onSelectFile={this.onSettingChange.bind(this, "LogoFile") }
-                        fileFormats={["image/png", "image/jpg", "image/jpeg", "image/bmp", "image/gif", "image/jpeg", "image/svg+xml"]}
+                        fileFormats={["image/png", "image/jpg", "image/jpeg", "image/bmp", "image/gif", "image/jpeg", "image/svg+xml", "image/webp"]}
                         browseButtonText={resx.get("BrowseButton")}
                         uploadButtonText={resx.get("UploadButton")}
                         linkButtonText={resx.get("LinkButton")}


### PR DESCRIPTION
Fixes #5360
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary

The WebP format was added to the list of allowed files for uploading the logo in the site settings, which was mentioned in post 
I just added the image/webp format to the list of allowed files for logo upload in the site settings
