### PR TITLE
Fix issue #5371 to correctly handle Request IP Addresses

### DIFF
--- a/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
@@ -31,6 +31,10 @@ namespace DotNetNuke.Services.UserRequest
             {
                 userIPAddress = request.Headers[userRequestIPHeader];
                 userIPAddress = userIPAddress.Split(',')[0];
+                if (userIPAddress.Contains(':'))
+                {
+                    userIPAddress = userIPAddress.Split(':')[0];
+                }
             }
 
             if (string.IsNullOrEmpty(userIPAddress))

--- a/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
@@ -31,6 +31,10 @@ namespace DotNetNuke.Services.UserRequest
             {
                 userIPAddress = request.Headers[userRequestIPHeader];
                 userIPAddress = userIPAddress.Split(',')[0];
+                if (ipFamily == IPAddressFamily.IPv4 && userIPAddress.Contains(':'))
+                {
+                    userIPAddress = userIPAddress.Split(':')[0];
+                }
             }
 
             if (string.IsNullOrEmpty(userIPAddress))
@@ -68,11 +72,6 @@ namespace DotNetNuke.Services.UserRequest
 
         private bool ValidateIP(string ipString, IPAddressFamily ipFamily)
         {
-            if (ipFamily == IPAddressFamily.IPv4 && ipString.Contains(':'))
-            {
-                ipString = ipString.Split(':')[0];
-            }
-
             IPAddress address;
             if (IPAddress.TryParse(ipString, out address))
             {

--- a/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
@@ -31,10 +31,6 @@ namespace DotNetNuke.Services.UserRequest
             {
                 userIPAddress = request.Headers[userRequestIPHeader];
                 userIPAddress = userIPAddress.Split(',')[0];
-                if (userIPAddress.Contains(':'))
-                {
-                    userIPAddress = userIPAddress.Split(':')[0];
-                }
             }
 
             if (string.IsNullOrEmpty(userIPAddress))
@@ -72,6 +68,11 @@ namespace DotNetNuke.Services.UserRequest
 
         private bool ValidateIP(string ipString, IPAddressFamily ipFamily)
         {
+            if (ipFamily == IPAddressFamily.IPv4 && ipString.Contains(':'))
+            {
+                ipString = ipString.Split(':')[0];
+            }
+
             IPAddress address;
             if (IPAddress.TryParse(ipString, out address))
             {

--- a/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/UserRequestIPAddressController.cs
@@ -34,6 +34,10 @@ namespace DotNetNuke.Services.UserRequest
                 if (ipFamily == IPAddressFamily.IPv4 && userIPAddress.Contains(':'))
                 {
                     userIPAddress = userIPAddress.Split(':')[0];
+                } else if (ipFamily == IPAddressFamily.IPv6 
+                    && userIPAddress.StartsWith("[") && userIPAddress.Contains(']'))
+                {
+                    userIPAddress = userIPAddress.Split(']')[0].Substring(1);
                 }
             }
 


### PR DESCRIPTION
Fixes issue #5371.

## Summary
Added code to correctly parse the request IP Address when original IP Address comes in the request header "X-Forwarded-For" (i.e. when using an ARR like in an Azure App Service) by removing the port.