### PR TITLE
Fixed an issue where comments in manifest would make install fail

### DIFF
--- a/DNN Platform/Library/Services/Installer/Installer.cs
+++ b/DNN Platform/Library/Services/Installer/Installer.cs
@@ -22,17 +22,14 @@ namespace DotNetNuke.Services.Installer
     using DotNetNuke.Services.Installer.Writers;
     using DotNetNuke.Services.Log.EventLog;
 
-    /// -----------------------------------------------------------------------------
     /// <summary>
     /// The Installer class provides a single entrypoint for Package Installation.
     /// </summary>
-    /// -----------------------------------------------------------------------------
     public class Installer
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(Installer));
-        private Stream inputStream;
+        private readonly Stream inputStream;
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Initializes a new instance of the <see cref="Installer"/> class.
         /// This Constructor creates a new Installer instance from a string representing
@@ -43,7 +40,6 @@ namespace DotNetNuke.Services.Installer
         /// <param name="manifest">The manifest filename.</param>
         /// <param name="physicalSitePath">The physical path to the root of the site.</param>
         /// <param name="loadManifest">Flag that determines whether the manifest will be loaded.</param>
-        /// -----------------------------------------------------------------------------
         public Installer(string tempFolder, string manifest, string physicalSitePath, bool loadManifest)
         {
             this.Packages = new SortedList<int, PackageInstaller>();
@@ -57,7 +53,6 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Initializes a new instance of the <see cref="Installer"/> class.
         /// This Constructor creates a new Installer instance from a Stream and a
@@ -66,13 +61,11 @@ namespace DotNetNuke.Services.Installer
         /// <param name="inputStream">The Stream to use to create this InstallerInfo instance.</param>
         /// <param name="physicalSitePath">The physical path to the root of the site.</param>
         /// <param name="loadManifest">Flag that determines whether the manifest will be loaded.</param>
-        /// -----------------------------------------------------------------------------
         public Installer(Stream inputStream, string physicalSitePath, bool loadManifest)
             : this(inputStream, physicalSitePath, loadManifest, true)
         {
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Initializes a new instance of the <see cref="Installer"/> class.
         /// This Constructor creates a new Installer instance from a Stream and a
@@ -82,7 +75,6 @@ namespace DotNetNuke.Services.Installer
         /// <param name="physicalSitePath">The physical path to the root of the site.</param>
         /// <param name="loadManifest">Flag that determines whether the manifest will be loaded.</param>
         /// <param name="deleteTemp">Whether delete the temp folder.</param>
-        /// -----------------------------------------------------------------------------
         public Installer(Stream inputStream, string physicalSitePath, bool loadManifest, bool deleteTemp)
         {
             this.Packages = new SortedList<int, PackageInstaller>();
@@ -99,14 +91,12 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Initializes a new instance of the <see cref="Installer"/> class.
         /// This Constructor creates a new Installer instance from a PackageInfo object.
         /// </summary>
         /// <param name="package">The PackageInfo instance.</param>
         /// <param name="physicalSitePath">The physical path to the root of the site.</param>
-        /// -----------------------------------------------------------------------------
         public Installer(PackageInfo package, string physicalSitePath)
         {
             this.Packages = new SortedList<int, PackageInstaller>();
@@ -118,9 +108,9 @@ namespace DotNetNuke.Services.Installer
         /// <summary>
         /// Initializes a new instance of the <see cref="Installer"/> class.
         /// </summary>
-        /// <param name="manifest"></param>
-        /// <param name="physicalSitePath"></param>
-        /// <param name="loadManifest"></param>
+        /// <param name="manifest">The install package manifest.</param>
+        /// <param name="physicalSitePath">The physical path to the site.</param>
+        /// <param name="loadManifest">A value indicating whether to load the manifest.</param>
         public Installer(string manifest, string physicalSitePath, bool loadManifest)
         {
             this.Packages = new SortedList<int, PackageInstaller>();
@@ -131,12 +121,10 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Gets a value indicating whether gets whether the associated InstallerInfo is valid.
         /// </summary>
         /// <value>True - if valid, False if not.</value>
-        /// -----------------------------------------------------------------------------
         public bool IsValid
         {
             get
@@ -145,12 +133,10 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
-        /// Gets.
+        /// Gets the installation temporary folder path.
         /// </summary>
-        /// <value>A Dictionary(Of String, PackageInstaller).</value>
-        /// -----------------------------------------------------------------------------
+        /// <value>The installation temporory folder path.</value>
         public string TempInstallFolder
         {
             get
@@ -159,22 +145,24 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Gets the associated InstallerInfo object.
         /// </summary>
         /// <value>An InstallerInfo.</value>
-        /// -----------------------------------------------------------------------------
         public InstallerInfo InstallerInfo { get; private set; }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Gets a SortedList of Packages that are included in the Package Zip.
         /// </summary>
         /// <value>A SortedList(Of Integer, PackageInstaller).</value>
-        /// -----------------------------------------------------------------------------
         public SortedList<int, PackageInstaller> Packages { get; private set; }
 
+        /// <summary>
+        /// Converts legacy manifest navigation to support old manifest format.
+        /// </summary>
+        /// <param name="rootNav">The root xml navigation path.</param>
+        /// <param name="info"><see cref="InstallerInfo"/>.</param>
+        /// <returns>A new converted <see cref="XPathNavigator"/> that works with current manifest schema.</returns>
         public static XPathNavigator ConvertLegacyNavigator(XPathNavigator rootNav, InstallerInfo info)
         {
             XPathNavigator nav = null;
@@ -248,6 +236,9 @@ namespace DotNetNuke.Services.Installer
             return nav;
         }
 
+        /// <summary>
+        /// Deletes the package temporary folder.
+        /// </summary>
         public void DeleteTempFolder()
         {
             try
@@ -264,16 +255,14 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// The Install method installs the feature.
         /// </summary>
-        /// <returns></returns>
-        /// -----------------------------------------------------------------------------
+        /// <returns>A value indicating whether the install succeeded.</returns>
         public bool Install()
         {
             this.InstallerInfo.Log.StartJob(Util.INSTALL_Start);
-            bool bStatus = true;
+            bool succeeded = true;
             try
             {
                 bool clearClientCache = false;
@@ -287,7 +276,7 @@ namespace DotNetNuke.Services.Installer
             catch (Exception ex)
             {
                 this.InstallerInfo.Log.AddFailure(ex);
-                bStatus = false;
+                succeeded = false;
             }
             finally
             {
@@ -307,14 +296,14 @@ namespace DotNetNuke.Services.Installer
             else
             {
                 this.InstallerInfo.Log.EndJob(Util.INSTALL_Failed);
-                bStatus = false;
+                succeeded = false;
             }
 
             // log installation event
             this.LogInstallEvent("Package", "Install");
 
             // when the installer initialized by file stream, we need save the file stream into backup folder.
-            if (this.inputStream != null && bStatus && this.Packages.Any())
+            if (this.inputStream != null && succeeded && this.Packages.Any())
             {
                 Task.Run(() =>
                 {
@@ -331,14 +320,13 @@ namespace DotNetNuke.Services.Installer
                 Config.Touch();
             }
 
-            return bStatus;
+            return succeeded;
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// The ReadManifest method reads the manifest file and parses it into packages.
         /// </summary>
-        /// -----------------------------------------------------------------------------
+        /// <param name="deleteTemp">A value indicating whether to delete the temporary folder.</param>
         public void ReadManifest(bool deleteTemp)
         {
             this.InstallerInfo.Log.StartJob(Util.DNN_Reading);
@@ -353,19 +341,15 @@ namespace DotNetNuke.Services.Installer
             }
             else if (deleteTemp)
             {
-                // Delete Temp Folder
                 this.DeleteTempFolder();
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// The UnInstall method uninstalls the feature.
         /// </summary>
-        /// <param name="deleteFiles">A flag that indicates whether the files should be
-        /// deleted.</param>
-        /// <returns></returns>
-        /// -----------------------------------------------------------------------------
+        /// <param name="deleteFiles">A flag that indicates whether the files should be deleted.</param>
+        /// <returns>A value indicating whether the uninstall succeeded.</returns>
         public bool UnInstall(bool deleteFiles)
         {
             this.InstallerInfo.Log.StartJob(Util.UNINSTALL_Start);
@@ -393,19 +377,15 @@ namespace DotNetNuke.Services.Installer
             return true;
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// The InstallPackages method installs the packages.
         /// </summary>
-        /// -----------------------------------------------------------------------------
         private void InstallPackages(ref bool clearClientCache)
         {
-            // Iterate through all the Packages
             for (int index = 0; index <= this.Packages.Count - 1; index++)
             {
                 PackageInstaller installer = this.Packages.Values[index];
 
-                // Check if package is valid
                 if (installer.Package.IsValid)
                 {
                     if (installer.Package.InstallerInfo.PackageID > Null.NullInteger || installer.Package.InstallerInfo.RepairInstall)
@@ -431,13 +411,11 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// Logs the Install event to the Event Log.
         /// </summary>
         /// <param name="package">The name of the package.</param>
         /// <param name="eventType">Event Type.</param>
-        /// -----------------------------------------------------------------------------
         private void LogInstallEvent(string package, string eventType)
         {
             try
@@ -462,11 +440,9 @@ namespace DotNetNuke.Services.Installer
             }
         }
 
-        /// -----------------------------------------------------------------------------
         /// <summary>
         /// The ProcessPackages method processes the packages nodes in the manifest.
         /// </summary>
-        /// -----------------------------------------------------------------------------
         private void ProcessPackages(XPathNavigator rootNav)
         {
             // Parse the package nodes

--- a/DNN Platform/Library/Services/Installer/Installer.cs
+++ b/DNN Platform/Library/Services/Installer/Installer.cs
@@ -491,6 +491,11 @@ namespace DotNetNuke.Services.Installer
             // Read the root node to determine what version the manifest is
             XPathNavigator rootNav = doc.CreateNavigator();
             rootNav.MoveToFirstChild();
+            while (rootNav.NodeType == XPathNodeType.Comment)
+            {
+                rootNav.MoveToNext();
+            }
+
             string packageType = Null.NullString;
 
             if (rootNav.Name == "dotnetnuke")


### PR DESCRIPTION
If a package manifest would have a comment on the level of the first node, the installer would try to parse the comment instead of the real non-comment node.

0f60ce3a8ba7985e8fb835a9570cbd6855cc6b65 Fixes the actual issue and
50bb9e9328fc4af567e4e1125c41140e2d7c6712 just cleans-ups the file a bit and adds some documentation