### PR TITLE
Fix casing issue on SelectedItemTemplate property

### DIFF
--- a/DNN Platform/Website/admin/Skins/Language.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Language.ascx.cs
@@ -151,17 +151,17 @@ namespace DotNetNuke.UI.Skins.Controls
         {
             get
             {
-                if (string.IsNullOrEmpty(this.SelectedItemTemplate))
+                if (string.IsNullOrEmpty(this.selectedItemTemplate))
                 {
-                    this.SelectedItemTemplate = Localization.GetString("SelectedItemTemplate.Default", this.LocalResourceFile, this.TemplateCulture);
+                    this.selectedItemTemplate = Localization.GetString("SelectedItemTemplate.Default", this.LocalResourceFile, this.TemplateCulture);
                 }
 
-                return this.SelectedItemTemplate;
+                return this.selectedItemTemplate;
             }
 
             set
             {
-                this.SelectedItemTemplate = value;
+                this.selectedItemTemplate = value;
             }
         }
 


### PR DESCRIPTION
In a previous PR the backing field has been changed and inadvertently the code in this property was set to the property name which creates an infinite loop.