### PR TITLE
Fix issues that can cause duplicate rows to show in page->advanced->SEO

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/Table.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/Table.jsx
@@ -5,19 +5,25 @@ import Localization from "../../../localization";
 import UrlRow from "./UrlRow";
 import EditUrl from "./EditUrl";
 import styles from "./style.less";
+import uniqBy from "lodash/uniqBy";
 
 class Table extends Component {
+    generateUrlKey(url) {
+        return `url_${url.id}_${url.path}_${url.statusCode.Key}`;
+    }
 
     getUrlRows(pageUrls) {
         if (!pageUrls || pageUrls.length === 0) {
             return null;
         }
 
+        const deduplicatedUrls = uniqBy(pageUrls, url => this.generateUrlKey(url));
+
         const { siteAliases, primaryAliasId, onSave, onCancel, onDelete, onChange, editedUrl,
             pageHasParent, editingUrl, onOpenEditForm } = this.props;
-        return pageUrls.map((url, index) => {
+        return deduplicatedUrls.map((url) => {
             return <UrlRow 
-                key={url.id === -1 ? -1 - index : url.id}
+                key={this.generateUrlKey(url)}
                 url={url}
                 editedUrl={editedUrl}
                 onOpenEditForm={onOpenEditForm}


### PR DESCRIPTION
## Summary

Fix issues that can cause duplicate rows to show in page->advanced->SEO.

The 'extra duplicate rows appearing after adding new SEO URL' issue is fixed by keying by: `url_${url.id}_${url.path}_${url.statusCode.Key}`. This will be unique for non-automatic URLs because of the {url.id}, and is unique for automatic URLs because of the path and statusCode. It means that the human generated ones will be detected as new rows if the path is edited, but I don't think that's a big deal and this keeps the code simple.

The 'duplicated looking rows show in SEO dialog with multiple languages' issues is fixed by only including unique rows in the dialog. I could have changed it to show the language that's causing the duplicate row in the dialog, but I the extra rows aren't particularly relevant anyway so it makes sense to just strip them out.


Fixes https://github.com/dnnsoftware/Dnn.Platform/issues/5401
