### PR TITLE
Fix 'Add Missing Languages' when parent page only has some languages enabled

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/ITabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/ITabController.cs
@@ -22,7 +22,8 @@ namespace DotNetNuke.Entities.Tabs
         /// </summary>
         /// <param name="portalId"></param>
         /// <param name="tabId"></param>
-        void AddMissingLanguages(int portalId, int tabId);
+        /// <returns>Whether all missing languages were added</returns>
+        bool AddMissingLanguages(int portalId, int tabId);
 
         /// <summary>
         /// Adds a tab.

--- a/DNN Platform/Library/Entities/Tabs/ITabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/ITabController.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Entities.Tabs
         /// </summary>
         /// <param name="portalId"></param>
         /// <param name="tabId"></param>
-        /// <returns>Whether all missing languages were added</returns>
+        /// <returns>Whether all missing languages were added.</returns>
         bool AddMissingLanguages(int portalId, int tabId);
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Tabs/ITabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/ITabController.cs
@@ -22,8 +22,15 @@ namespace DotNetNuke.Entities.Tabs
         /// </summary>
         /// <param name="portalId"></param>
         /// <param name="tabId"></param>
+        void AddMissingLanguages(int portalId, int tabId);
+
+        /// <summary>
+        /// Adds localized copies of the page in all missing languages.
+        /// </summary>
+        /// <param name="portalId"></param>
+        /// <param name="tabId"></param>
         /// <returns>Whether all missing languages were added.</returns>
-        bool AddMissingLanguages(int portalId, int tabId);
+        bool AddMissingLanguagesWithWarnings(int portalId, int tabId);
 
         /// <summary>
         /// Adds a tab.

--- a/DNN Platform/Library/Entities/Tabs/ITabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/ITabController.cs
@@ -4,6 +4,7 @@
 
 namespace DotNetNuke.Entities.Tabs
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
 
@@ -22,6 +23,7 @@ namespace DotNetNuke.Entities.Tabs
         /// </summary>
         /// <param name="portalId"></param>
         /// <param name="tabId"></param>
+        [Obsolete("This has been deprecated in favor of AddMissingLanguagesWithWarnings. Scheduled for removal in v11.0.0")]
         void AddMissingLanguages(int portalId, int tabId);
 
         /// <summary>

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -11,7 +11,6 @@ namespace DotNetNuke.Entities.Tabs
     using System.Linq;
     using System.Text.RegularExpressions;
     using System.Web;
-    using System.Web.UI.WebControls;
     using System.Xml;
 
     using DotNetNuke.Common;

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -2408,8 +2408,6 @@ namespace DotNetNuke.Entities.Tabs
             objTabUrl.PortalAliasUsage = PortalAliasUsageType.Default;
         }
 
-
-
         private static int GetIndexOfTab(TabInfo objTab, IEnumerable<TabInfo> tabs)
         {
             return Null.NullInteger + tabs.TakeWhile(tab => tab.TabID != objTab.TabID).Count();

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -1035,8 +1035,19 @@ namespace DotNetNuke.Entities.Tabs
         /// </summary>
         /// <param name="portalId"></param>
         /// <param name="tabId"></param>
+        [Obsolete("This has been deprecated in favor of AddMissingLanguagesWithWarnings. Scheduled for removal in v11.0.0")]
+        public void AddMissingLanguages(int portalId, int tabId)
+        {
+            this.AddMissingLanguagesWithWarnings(portalId, tabId);
+        }
+
+        /// <summary>
+        /// Adds localized copies of the page in all missing languages.
+        /// </summary>
+        /// <param name="portalId"></param>
+        /// <param name="tabId"></param>
         /// <returns>Whether all missing languages were added.</returns>
-        public bool AddMissingLanguages(int portalId, int tabId)
+        public bool AddMissingLanguagesWithWarnings(int portalId, int tabId)
         {
             var addedAllMissingLanguages = true;
             var currentTab = this.GetTab(tabId, portalId, false);

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Entities.Tabs
     using System.Linq;
     using System.Text.RegularExpressions;
     using System.Web;
+    using System.Web.UI.WebControls;
     using System.Xml;
 
     using DotNetNuke.Common;
@@ -1063,14 +1064,39 @@ namespace DotNetNuke.Entities.Tabs
                         {
                             missing = false;
                         }
-
-                        if (missing)
+                        bool isRootOrLocalizedParentExists = this.isRootPageOrLocalizedParentExists(workingTab, locale);
+                        if (missing && isRootOrLocalizedParentExists)
                         {
                             this.CreateLocalizedCopyInternal(workingTab, locale, false, true, insertAfterOriginal: true);
+                        }
+                        if (missing && !isRootOrLocalizedParentExists)
+                        {
+                            addedAllMissingLanguages = false;
                         }
                     }
                 }
             }
+            return addedAllMissingLanguages;
+        }
+
+        /// <summary>
+        /// Checks if the page is root or has a localized parent.
+        /// If neither is true, then we cannot create localized version of the page for the given locale
+        /// </summary>
+        /// <param name="tab">The tab to be checked.</param>
+        /// <param name="locale">The locale to be checked.</param>
+        /// <returns></returns>
+        private bool isRootPageOrLocalizedParentExists(TabInfo tab, Locale locale)
+        {
+            // If root page, return true
+            if (Null.IsNull(tab.ParentId))
+            {
+                return true;
+            }
+            // Otherwise return true if localized parent is found
+            TabInfo parent = this.GetTab(tab.ParentId, tab.PortalID, false);
+            TabInfo localizedParent = this.GetTabByCulture(parent.TabID, parent.PortalID, locale);
+            return localizedParent != null;
         }
 
         /// <summary>

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageLocalization/PageLocalization.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageLocalization/PageLocalization.jsx
@@ -116,7 +116,10 @@ class PageLocalization extends Component {
     onAddMissingLanguages() {
         const {props} = this;
         const {tabId} = props.page;
-        props.dispatch(LanguagesActions.addMissingLanguages(tabId, () => {
+        props.dispatch(LanguagesActions.addMissingLanguages(tabId, (data) => {
+            if (data && data.Success && !data.AllLanguagesAdded) {
+                utils.notify('Success, but not all languages were added, because the parent page does not have them all.', 3000);
+            }
             this.getLanguages();
         }));
     }

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageLocalization/PageLocalization.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PageLocalization/PageLocalization.jsx
@@ -118,7 +118,9 @@ class PageLocalization extends Component {
         const {tabId} = props.page;
         props.dispatch(LanguagesActions.addMissingLanguages(tabId, (data) => {
             if (data && data.Success && !data.AllLanguagesAdded) {
-                utils.notify('Success, but not all languages were added, because the parent page does not have them all.', 3000);
+                utils.notify(Localization.get("OnlyAddedSomeMissingLanguagesWarning"), { clickToClose: true });
+            } else if (!data || !data.Success) {
+                utils.notifyError(Localization.get("AnErrorOccurred"));
             }
             this.getLanguages();
         }));

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
@@ -713,7 +713,7 @@ namespace Dnn.PersonaBar.Pages.Services
 
                 var defaultLocale = this.localeController.GetDefaultLocale(this.PortalId);
                 this.tabController.LocalizeTab(currentTab, defaultLocale, true);
-                this.tabController.AddMissingLanguages(this.PortalId, pageId);
+                this.tabController.AddMissingLanguagesWithWarnings(this.PortalId, pageId);
                 this.tabController.ClearCache(this.PortalId);
                 return this.Request.CreateResponse(HttpStatusCode.OK, new { Success = true });
             }
@@ -743,7 +743,7 @@ namespace Dnn.PersonaBar.Pages.Services
                     return this.GetForbiddenResponse();
                 }
 
-                bool allLanguagesAdded = this.tabController.AddMissingLanguages(this.PortalId, pageId);
+                bool allLanguagesAdded = this.tabController.AddMissingLanguagesWithWarnings(this.PortalId, pageId);
                 this.tabController.ClearCache(this.PortalId);
                 return this.Request.CreateResponse(HttpStatusCode.OK, new { Success = true, AllLanguagesAdded = allLanguagesAdded });
             }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/PagesController.cs
@@ -743,9 +743,9 @@ namespace Dnn.PersonaBar.Pages.Services
                     return this.GetForbiddenResponse();
                 }
 
-                this.tabController.AddMissingLanguages(this.PortalId, pageId);
+                bool allLanguagesAdded = this.tabController.AddMissingLanguages(this.PortalId, pageId);
                 this.tabController.ClearCache(this.PortalId);
-                return this.Request.CreateResponse(HttpStatusCode.OK, new { Success = true });
+                return this.Request.CreateResponse(HttpStatusCode.OK, new { Success = true, AllLanguagesAdded = allLanguagesAdded });
             }
             catch (Exception ex)
             {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -156,6 +156,9 @@
   <data name="Continue.Text" xml:space="preserve">
     <value>Continue</value>
   </data>
+  <data name="OnlyAddedSomeMissingLanguagesWarning.Text" xml:space="preserve">
+    <value>Done adding missing languages. Only languages belonging to the parent page were added.</value>
+  </data>
   <data name="UpdateLocalizationWarning.Text" xml:space="preserve">
     <value>Updating localization might take a few minutes depending on the number of modules. Please wait until the process finishes completely.</value>
   </data>


### PR DESCRIPTION
## Summary
The previous code was throwing a null ref exception in CreateLocalizedCopyInternal when trying to copy languages that didn't exist in the parent page.  Instead we should skip them.

Also added a warning to the UI to make it clear to users why all their languages weren't added for partially localized parent pages.

Fixes https://github.com/dnnsoftware/Dnn.Platform/issues/5403
