### PR TITLE
5406 Fix uploading documents through link popup

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -2419,7 +2419,11 @@ namespace DNNConnect.CKEditorProvider.Browser
                     fileName = string.Format("{0}_{1}{2}", sFileNameNoExt, iCounter, Path.GetExtension(file.FileName));
                 }
 
-                if (bIsImage)
+                if (!bIsImage)
+                {
+                    FileManager.Instance.AddFile(currentFolderInfo, fileName, file.InputStream);
+                }
+                else
                 {
                     int maxWidth = this.currentSettings.ResizeWidthUpload;
                     int maxHeight = this.currentSettings.ResizeHeightUpload;


### PR DESCRIPTION
Fixes #5406 

## Summary
In Browser.FileUpload in CKEditorProvider, there is a check for images, that handles the uploading of images, but the branch for non-images is missing.