### PR TITLE
Added support for a Notes field in IP Filters

### DIFF
--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -3694,9 +3694,32 @@ namespace DotNetNuke.Data
             return this.ExecuteReader("GetIPFilters");
         }
 
+        /// <summary>
+        /// Adds a new IP filter.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="subnetMask">The subnet mask if the filter is for a range.</param>
+        /// <param name="ruleType">The type of rule (1 for Allow, 2 for Deny).</param>
+        /// <param name="createdByUserId">The ID of the acting user.</param>
+        /// <returns>The ID of the newly created IP Filter.</returns>
+        [Obsolete("Deprecated in v9.11.1. Use the overload that takes a notes string. Scheduled removal in v11.0.0.")]
         public virtual int AddIPFilter(string ipAddress, string subnetMask, int ruleType, int createdByUserId)
         {
-            return this.ExecuteScalar<int>("AddIPFilter", ipAddress, subnetMask, ruleType, createdByUserId);
+            return this.AddIPFilter(ipAddress, subnetMask, ruleType, createdByUserId, null);
+        }
+
+        /// <summary>
+        /// Adds a new IP filter.
+        /// </summary>
+        /// <param name="ipAddress">The IP address.</param>
+        /// <param name="subnetMask">The subnet mask if the filter is for a range.</param>
+        /// <param name="ruleType">The type of rule (1 for Allow, 2 for Deny).</param>
+        /// <param name="createdByUserId">The ID of the acting user.</param>
+        /// <param name="notes">Notes about this filter.</param>
+        /// <returns>The ID of the newly created IP Filter.</returns>
+        public virtual int AddIPFilter(string ipAddress, string subnetMask, int ruleType, int createdByUserId, string notes)
+        {
+            return this.ExecuteScalar<int>("AddIPFilter", ipAddress, subnetMask, ruleType, createdByUserId, notes);
         }
 
         public virtual void DeleteIPFilter(int ipFilterid)
@@ -3704,9 +3727,32 @@ namespace DotNetNuke.Data
             this.ExecuteNonQuery("DeleteIPFilter", ipFilterid);
         }
 
+        /// <summary>
+        /// Updates an existing IP filter.
+        /// </summary>
+        /// <param name="ipFilterid">The ID of the IP Filter to update.</param>
+        /// <param name="ipAddress">The IP address for the filter.</param>
+        /// <param name="subnetMask">The IP mask to use for an IP range.</param>
+        /// <param name="ruleType">The type of filter (1 to allow, 2 to deny).</param>
+        /// <param name="lastModifiedByUserId">The ID of the acting user.</param>
+        [Obsolete("Deprecated in v9.11.1. Use the overload that takes a notes string. Scheduled removal in v11.0.0.")]
         public virtual void UpdateIPFilter(int ipFilterid, string ipAddress, string subnetMask, int ruleType, int lastModifiedByUserId)
         {
-            this.ExecuteNonQuery("UpdateIPFilter", ipFilterid, ipAddress, subnetMask, ruleType, lastModifiedByUserId);
+            this.UpdateIPFilter(ipFilterid, ipAddress, subnetMask, ruleType, lastModifiedByUserId, null);
+        }
+
+        /// <summary>
+        /// Updates an existing IP filter.
+        /// </summary>
+        /// <param name="ipFilterid">The ID of the IP Filter to update.</param>
+        /// <param name="ipAddress">The IP address for the filter.</param>
+        /// <param name="subnetMask">The IP mask to use for an IP range.</param>
+        /// <param name="ruleType">The type of filter (1 to allow, 2 to deny).</param>
+        /// <param name="lastModifiedByUserId">The ID of the acting user.</param>
+        /// <param name="notes">Notes about the filter.</param>
+        public virtual void UpdateIPFilter(int ipFilterid, string ipAddress, string subnetMask, int ruleType, int lastModifiedByUserId, string notes)
+        {
+            this.ExecuteNonQuery("UpdateIPFilter", ipFilterid, ipAddress, subnetMask, ruleType, lastModifiedByUserId, notes);
         }
 
         public virtual IDataReader GetIPFilter(int ipf)

--- a/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
@@ -8,7 +8,8 @@ namespace DotNetNuke.Entities.Host
     using System.Collections.Generic;
 
     /// <summary>
-    /// Controller to manage IP Filters.
+    /// Do not implement.  This interface is meant for reference and unit test purposes only.
+    /// There is no guarantee that this interface will not change.
     /// </summary>
     public interface IIPFilterController
     {

--- a/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
@@ -8,8 +8,7 @@ namespace DotNetNuke.Entities.Host
     using System.Collections.Generic;
 
     /// <summary>
-    /// Do not implement.  This interface is meant for reference and unit test purposes only.
-    /// There is no guarantee that this interface will not change.
+    /// Controller to manage IP Filters.
     /// </summary>
     public interface IIPFilterController
     {

--- a/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IIPFilterController.cs
@@ -13,23 +13,66 @@ namespace DotNetNuke.Entities.Host
     /// </summary>
     public interface IIPFilterController
     {
+        /// <summary>
+        /// Adds an IP filter.
+        /// </summary>
+        /// <param name="ipFilter">The informations about the IP filter to add.</param>
+        /// <returns>The ID of the newly created integer.</returns>
         int AddIPFilter(IPFilterInfo ipFilter);
 
+        /// <summary>
+        /// Updates an existing IP filter.
+        /// </summary>
+        /// <param name="ipFilter">The informations about the IP filter to update.</param>
         void UpdateIPFilter(IPFilterInfo ipFilter);
 
+        /// <summary>
+        /// Deletes an IP filter.
+        /// </summary>
+        /// <param name="ipFilter">The informations about the IP filter to delete.</param>
         void DeleteIPFilter(IPFilterInfo ipFilter);
 
+        /// <summary>
+        /// Gets a single IP filter.
+        /// </summary>
+        /// <param name="ipFilter">The ID of the IP filter to get.</param>
+        /// <returns><see cref="IPFilterInfo"/>.</returns>
         IPFilterInfo GetIPFilter(int ipFilter);
 
+        /// <summary>
+        /// Gets all the IP filters.
+        /// </summary>
+        /// <returns>A collection of <see cref="IPFilterInfo"/>.</returns>
         IList<IPFilterInfo> GetIPFilters();
 
+        /// <summary>
+        /// Gets a value indicating whether a given IP address is banned.
+        /// </summary>
+        /// <param name="ipAddress">A string representation of an IP address.</param>
         [Obsolete("deprecated with 7.1.0 - please use IsIPBanned instead. Scheduled removal in v10.0.0.")]
         void IsIPAddressBanned(string ipAddress);
 
+        /// <summary>
+        /// Gets a value indicating whether a given IP address is banned.
+        /// </summary>
+        /// <param name="ipAddress">A string representation of an IP address.</param>
+        /// <returns>A value indicating wheter the provided IP address is banned.</returns>
         bool IsIPBanned(string ipAddress);
 
+        /// <summary>
+        /// Gets a value indicating whether an IP address can be denied.
+        /// </summary>
+        /// <param name="ipAddress">The IP address to check.</param>
+        /// <param name="ipFilter">The IP filter against which to check.</param>
+        /// <returns>A value indicating whether the IP address can be denied.</returns>
         bool IsAllowableDeny(string ipAddress, IPFilterInfo ipFilter);
 
+        /// <summary>
+        /// Gets a value indicating whether an IP address has access.
+        /// </summary>
+        /// <param name="myip">The IP address to check.</param>
+        /// <param name="filterList">A list of filters to check against.</param>
+        /// <returns>A value indicating whether the IP is authorized.</returns>
         bool CanIPStillAccess(string myip, IList<IPFilterInfo> filterList);
     }
 }

--- a/DNN Platform/Library/Entities/IPFilter/IPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IPFilterController.cs
@@ -19,10 +19,12 @@ namespace DotNetNuke.Entities.Host
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Log.EventLog;
 
+    /// <summary>
+    /// Do not implement.  This interface is meant for reference and unit test purposes only.
+    /// There is no guarantee that this interface will not change.
+    /// </summary>
     public class IPFilterController : ComponentBase<IIPFilterController, IPFilterController>, IIPFilterController
     {
-        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(IPFilterController));
-
         /// <summary>
         /// Initializes a new instance of the <see cref="IPFilterController"/> class.
         /// </summary>
@@ -36,30 +38,34 @@ namespace DotNetNuke.Entities.Host
             Deny = 2,
         }
 
-        /// <summary>
-        /// add a new IP filter.
-        /// </summary>
-        /// <param name="ipFilter">filter details.</param>
-        /// <returns>filter id.</returns>
+        /// <inheritdoc/>
         public int AddIPFilter(IPFilterInfo ipFilter)
         {
             Requires.NotNull("ipFilter", ipFilter);
             AssertValidIPFilter(ipFilter);
 
-            int id = DataProvider.Instance().AddIPFilter(ipFilter.IPAddress, ipFilter.SubnetMask, ipFilter.RuleType, UserController.Instance.GetCurrentUserInfo().UserID);
+            int id = DataProvider.Instance().AddIPFilter(
+                ipFilter.IPAddress,
+                ipFilter.SubnetMask,
+                ipFilter.RuleType,
+                UserController.Instance.GetCurrentUserInfo().UserID,
+                ipFilter.Notes);
             return id;
         }
 
-        /// <summary>
-        /// update an existing IP filter.
-        /// </summary>
-        /// <param name="ipFilter">filter details.</param>
+        /// <inheritdoc/>
         public void UpdateIPFilter(IPFilterInfo ipFilter)
         {
             Requires.NotNull("ipFilter", ipFilter);
             AssertValidIPFilter(ipFilter);
 
-            DataProvider.Instance().UpdateIPFilter(ipFilter.IPFilterID, ipFilter.IPAddress, ipFilter.SubnetMask, ipFilter.RuleType, UserController.Instance.GetCurrentUserInfo().UserID);
+            DataProvider.Instance().UpdateIPFilter(
+                ipFilter.IPFilterID,
+                ipFilter.IPAddress,
+                ipFilter.SubnetMask,
+                ipFilter.RuleType,
+                UserController.Instance.GetCurrentUserInfo().UserID,
+                ipFilter.Notes);
         }
 
         /// <inheritdoc/>
@@ -69,11 +75,7 @@ namespace DotNetNuke.Entities.Host
             DataProvider.Instance().DeleteIPFilter(ipFilter.IPFilterID);
         }
 
-        /// <summary>
-        /// get an IP filter.
-        /// </summary>
-        /// <param name="ipFilter">filter details.</param>
-        /// <returns>the selected IP filter.</returns>
+        /// <inheritdoc/>
         public IPFilterInfo GetIPFilter(int ipFilter)
         {
             return CBO.FillObject<IPFilterInfo>(DataProvider.Instance().GetIPFilter(ipFilter));
@@ -89,23 +91,13 @@ namespace DotNetNuke.Entities.Host
             }
         }
 
-        /// <summary>
-        /// Check the set of rules to see if an IP address is banned (used on login).
-        /// </summary>
-        /// <param name="ipAddress">IP address.</param>
-        /// <returns>true if banned.</returns>
+        /// <inheritdoc/>
         public bool IsIPBanned(string ipAddress)
         {
             return this.CheckIfBannedIPAddress(ipAddress);
         }
 
-        /// <summary>
-        /// Check if an IP address range can still access based on a set of rules
-        /// note: this set is typically the list of IP filter rules minus a proposed delete.
-        /// </summary>
-        /// <param name="myip">IP address.</param>
-        /// <param name="filterList">list of IP filters.</param>
-        /// <returns>true if IP can access, false otherwise.</returns>
+        /// <inheritdoc/>
         public bool CanIPStillAccess(string myip, IList<IPFilterInfo> filterList)
         {
             var allowAllIPs = false;
@@ -162,12 +154,7 @@ namespace DotNetNuke.Entities.Host
             return false;
         }
 
-        /// <summary>
-        /// Check if a new rule would block the existing IP address.
-        /// </summary>
-        /// <param name="currentIP">current IP address.</param>
-        /// <param name="ipFilter">new propose rule.</param>
-        /// <returns>true if rule would not block current IP, false otherwise.</returns>
+        /// <inheritdoc/>
         public bool IsAllowableDeny(string currentIP, IPFilterInfo ipFilter)
         {
             if (ipFilter.RuleType == (int)FilterType.Allow)
@@ -183,6 +170,12 @@ namespace DotNetNuke.Entities.Host
             return true;
         }
 
+        /// <inheritdoc/>
+        IList<IPFilterInfo> IIPFilterController.GetIPFilters()
+        {
+            return CBO.FillCollection<IPFilterInfo>(DataProvider.Instance().GetIPFilters());
+        }
+
         private static void AssertValidIPFilter(IPFilterInfo ipFilter)
         {
             IPAddress parsed;
@@ -196,15 +189,6 @@ namespace DotNetNuke.Entities.Host
             {
                 throw new ArgumentException(Localization.GetExceptionMessage("SubnetMaskIncorrect", "Subnet mask is not in correct format"));
             }
-        }
-
-        /// <summary>
-        /// get the list of IP filters.
-        /// </summary>
-        /// <returns>list of IP filters.</returns>
-        IList<IPFilterInfo> IIPFilterController.GetIPFilters()
-        {
-            return CBO.FillCollection<IPFilterInfo>(DataProvider.Instance().GetIPFilters());
         }
 
         private bool CheckIfBannedIPAddress(string ipAddress)
@@ -241,7 +225,7 @@ namespace DotNetNuke.Entities.Host
         {
             var log = new LogInfo
             {
-                LogTypeKey = EventLogController.EventLogType.IP_LOGIN_BANNED.ToString(),
+                LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.IP_LOGIN_BANNED.ToString(),
             };
             log.LogProperties.Add(new LogDetailInfo("HostAddress", ipAddress));
             LogController.Instance.AddLog(log);

--- a/DNN Platform/Library/Entities/IPFilter/IPFilterController.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IPFilterController.cs
@@ -15,13 +15,11 @@ namespace DotNetNuke.Entities.Host
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Users;
-    using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Log.EventLog;
 
     /// <summary>
-    /// Do not implement.  This interface is meant for reference and unit test purposes only.
-    /// There is no guarantee that this interface will not change.
+    /// Controller to manage IP Filters.
     /// </summary>
     public class IPFilterController : ComponentBase<IIPFilterController, IPFilterController>, IIPFilterController
     {

--- a/DNN Platform/Library/Entities/IPFilter/IPFilterInfo.cs
+++ b/DNN Platform/Library/Entities/IPFilter/IPFilterInfo.cs
@@ -9,6 +9,9 @@ namespace DotNetNuke.Entities.Host
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
 
+    /// <summary>
+    /// Represents information about an IP Filter.
+    /// </summary>
     [Serializable]
     public class IPFilterInfo : BaseEntityInfo, IHydratable
     {
@@ -16,8 +19,9 @@ namespace DotNetNuke.Entities.Host
         /// Initializes a new instance of the <see cref="IPFilterInfo"/> class.
         /// Create new IPFilterInfo instance.
         /// </summary>
-        /// <remarks>
-        /// </remarks>
+        /// <param name="ipAddress">The IP Address.</param>
+        /// <param name="subnetMask">The Subnet Mask.</param>
+        /// <param name="ruleType">The Rule Type, 1 to allow, 2 to deny.</param>
         public IPFilterInfo(string ipAddress, string subnetMask, int ruleType)
         {
             this.IPAddress = ipAddress;
@@ -35,19 +39,31 @@ namespace DotNetNuke.Entities.Host
             this.RuleType = -1;
         }
 
+        /// <summary>
+        /// Gets or sets the IP of the IP filter.
+        /// </summary>
         public int IPFilterID { get; set; }
 
+        /// <summary>
+        /// Gets or sets the IP Adress for this filter.
+        /// </summary>
         public string IPAddress { get; set; }
 
+        /// <summary>
+        /// Gets or sets the subnet mask if this filter is for a range.
+        /// </summary>
         public string SubnetMask { get; set; }
 
+        /// <summary>
+        /// Gets or sets the type of filter (1 to allow, 2 to deny).
+        /// </summary>
         public int RuleType { get; set; }
 
         /// <summary>
         /// Gets or sets and sets the Key ID.
         /// </summary>
         /// <returns>KeyId of the IHydratable.Key.</returns>
-        /// <remarks><seealso cref="Fill"></seealso></remarks>
+        /// <remarks><seealso cref="Fill"></seealso>.</remarks>
         public int KeyID
         {
             get
@@ -60,6 +76,11 @@ namespace DotNetNuke.Entities.Host
                 this.IPFilterID = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets some notes about this IP filter.
+        /// </summary>
+        public string Notes { get; set; }
 
         /// <summary>
         /// Fills an IPFilterInfo from a Data Reader.
@@ -83,6 +104,7 @@ namespace DotNetNuke.Entities.Host
             this.IPAddress = Null.SetNullString(dr["IPAddress"]);
             this.SubnetMask = Null.SetNullString(dr["SubnetMask"]);
             this.RuleType = Null.SetNullInteger(dr["RuleType"]);
+            this.Notes = Null.SetNullString(dr["Notes"]);
 
             this.FillInternal(dr);
         }

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/index.jsx
@@ -30,6 +30,7 @@ class IpFiltersPanelBody extends Component {
         tableFields = [];
         tableFields.push({ "name": resx.get("FilterType.Header"), "id": "RuleType" });
         tableFields.push({ "name": resx.get("IpAddress.Header"), "id": "IPAddress" });
+        tableFields.push({ "name": resx.get("Notes.Header"), "id": "Notes" });
     }
 
     renderHeader() {
@@ -95,6 +96,7 @@ class IpFiltersPanelBody extends Component {
                     ipFilterId={item.IPFilterID}
                     ruleType={item.RuleType}
                     ipFilter={item.IPFilter}
+                    notes={item.Notes}
                     index={index}
                     key={"ipFilter-" + index}
                     closeOnClick={true}

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/ipFilterEditor/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/ipFilterEditor/index.jsx
@@ -2,7 +2,7 @@ import React, {Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import "./style.less";
-import { SingleLineInputWithError, GridSystem, Label, InputGroup, Button, RadioButtons, Dropdown } from "@dnnsoftware/dnn-react-common";
+import { SingleLineInputWithError, GridSystem, Label, InputGroup, Button, RadioButtons, Dropdown, MultiLineInput } from "@dnnsoftware/dnn-react-common";
 import { security as SecurityActions } from "../../../actions";
 import resx from "../../../resources";
 
@@ -169,6 +169,16 @@ class IpFilterEditor extends Component {
                         onChange={this.onSettingChange.bind(this, "SubnetMask") } />
                 </InputGroup>
             }
+            <InputGroup>
+                <Label
+                    tooltipMessage={resx.get("plNotes.Help") }
+                    label={resx.get("plNotes") } />
+                <MultiLineInput
+                    inputStyle={{ margin: "0" }}
+                    withLabel={false}
+                    value={this.state.ipFilter.Notes}
+                    onChange={this.onSettingChange.bind(this, "Notes") } />
+            </InputGroup>
         </div>;
 
         let children = [];

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/ipFilterRow/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/ipFilterRow/index.jsx
@@ -72,6 +72,9 @@ class IpFilterRow extends Component {
                             <div className="ip-filter-item item-row-ipAddress">
                                 {props.ipFilter}
                             </div>
+                            <div className="ip-filter-item item-row-notes">
+                                {props.notes}
+                            </div>
                             {props.id !== "add" && !props.readOnly &&
                                 <div className="ip-filter-item item-row-editButton">
                                     <div className={opened ? "delete-icon-hidden" : "delete-icon"} dangerouslySetInnerHTML={{ __html: deleteIcon }} onClick={this.props.onDelete.bind(this) }></div>
@@ -91,6 +94,7 @@ class IpFilterRow extends Component {
 IpFilterRow.propTypes = {
     ipFilterId: PropTypes.number,
     ipFilter: PropTypes.string,
+    notes: PropTypes.string,
     ruleType: PropTypes.number,
     OpenCollapse: PropTypes.func,
     Collapse: PropTypes.func,

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/ipFilterRow/style.less
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/ipFilterRow/style.less
@@ -43,7 +43,12 @@
                 }
             }
             .item-row-ipAddress {
-                width: 65%;
+                width: 25%;
+                float: left;
+                padding-top: 3px;
+            }
+            .item-row-notes {
+                width: 40%;
                 float: left;
                 padding-top: 3px;
             }

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/style.less
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/ipFilters/style.less
@@ -24,7 +24,12 @@
         padding-left: 15px;
     }
     .header-IPAddress {
-        width: 65%;
+        width: 25%;
+        float: left;
+        font-weight: bolder;
+    }
+    .header-Notes {
+        width: 40%;
         float: left;
         font-weight: bolder;
     }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -748,6 +748,7 @@
     <None Include="packages.config" />
     <Content Include="web.config" />
     <Content Include="SqlDataProvider\09.11.00.SqlDataProvider" />
+    <Content Include="SqlDataProvider\09.11.01.SqlDataProvider" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/DTO/UpdateIpFilterRequest.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/DTO/UpdateIpFilterRequest.cs
@@ -3,23 +3,35 @@
 // See the LICENSE file in the project root for more information
 namespace Dnn.PersonaBar.Security.Services.Dto
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.Runtime.Serialization;
-
-    using DotNetNuke.ComponentModel.DataAnnotations;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
-
+    /// <summary>
+    /// Data-transfer object to save an IP filter.
+    /// </summary>
     public class UpdateIpFilterRequest
     {
+        /// <summary>
+        /// Gets or sets the IP Address for the filter.
+        /// </summary>
         public string IPAddress { get; set; }
 
+        /// <summary>
+        /// Gets or sets the subnet mask for an IP range.
+        /// </summary>
         public string SubnetMask { get; set; }
 
+        /// <summary>
+        /// Gets or sets the type of rule.
+        /// Allow = 1, Deny = 2.
+        /// </summary>
         public int RuleType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the ID of the filter.
+        /// </summary>
         public int IPFilterID { get; set; }
+
+        /// <summary>
+        /// Gets or sets notes about this filter.
+        /// </summary>
+        public string Notes { get; set; }
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
@@ -179,7 +179,6 @@ namespace Dnn.PersonaBar.Security.Services
         /// <summary>
         /// Gets list of IP filters.
         /// </summary>
-        /// <param></param>
         /// <returns>List of IP filters.</returns>
         [HttpGet]
         [RequireHost]
@@ -193,6 +192,7 @@ namespace Dnn.PersonaBar.Security.Services
                     v.IPFilterID,
                     IPFilter = NetworkUtils.FormatAsCidr(v.IPAddress, v.SubnetMask),
                     v.RuleType,
+                    v.Notes,
                 }).ToList();
                 var response = new
                 {
@@ -200,7 +200,7 @@ namespace Dnn.PersonaBar.Security.Services
                     Results = new
                     {
                         Filters = filters,
-                        EnableIPChecking = Host.EnableIPChecking,
+                        Host.EnableIPChecking,
                     },
                 };
 
@@ -217,7 +217,7 @@ namespace Dnn.PersonaBar.Security.Services
         /// <summary>
         /// Gets an IP filter.
         /// </summary>
-        /// <param name="filterId"></param>
+        /// <param name="filterId">The ID of the IP filter to get.</param>
         /// <returns>IP filter.</returns>
         [HttpGet]
         [RequireHost]
@@ -235,6 +235,7 @@ namespace Dnn.PersonaBar.Security.Services
                         filter.IPFilterID,
                         filter.RuleType,
                         filter.SubnetMask,
+                        filter.Notes,
                     },
                 };
 
@@ -251,8 +252,8 @@ namespace Dnn.PersonaBar.Security.Services
         /// <summary>
         /// Updates an IP filter.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
+        /// <param name="request"><see cref="UpdateIpFilterRequest"/>.</param>
+        /// <returns>Ok or BadRequest or InternalServerError.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         [RequireHost]
@@ -264,6 +265,7 @@ namespace Dnn.PersonaBar.Security.Services
                 ipf.IPAddress = request.IPAddress;
                 ipf.SubnetMask = request.SubnetMask;
                 ipf.RuleType = request.RuleType;
+                ipf.Notes = request.Notes;
 
                 if ((ipf.IPAddress == "127.0.0.1" || ipf.IPAddress == "localhost" || ipf.IPAddress == "::1" || ipf.IPAddress == "*") && ipf.RuleType == 2)
                 {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/SqlDataProvider/09.11.01.SqlDataProvider
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/SqlDataProvider/09.11.01.SqlDataProvider
@@ -1,0 +1,89 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/
+
+/*********************/
+/** ADD NOTES FIELD **/
+/*********************/
+IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.Columns WHERE TABLE_NAME='{objectQualifier}IPFilter' AND COLUMN_NAME='Notes')
+	BEGIN
+		ALTER TABLE {databaseOwner}{objectQualifier}IPFilter
+			ADD Notes nvarchar(255) NULL
+	END
+GO
+
+/**************************/
+/** UpdateIPFilter SPROC **/
+/**************************/
+
+DROP PROCEDURE IF EXISTS {databaseOwner}[{objectQualifier}UpdateIPFilter]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}UpdateIPFilter]
+	@IPFilterID		int,
+	@IPAddress		nvarchar(50),
+	@SubnetMask		nvarchar(50),
+	@RuleType		tinyint,
+	@LastModifiedByUserID int,
+    @Notes          nvarchar(255)
+AS 
+	BEGIN
+		UPDATE {databaseOwner}{objectQualifier}IPFilter 
+			SET 
+				IPAddress = @IPAddress,
+				SubnetMask = @SubnetMask,
+				RuleType = @RuleType,
+				LastModifiedByUserID = @LastModifiedByUserID,
+				LastModifiedOnDate = getdate(),
+                Notes = @Notes
+			WHERE IPFilterID = @IPFilterID
+	END
+GO
+
+/**************************/
+/** AddIPFilter SPROC **/
+/**************************/
+
+DROP PROCEDURE IF EXISTS {databaseOwner}[{objectQualifier}AddIPFilter]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}AddIPFilter]
+	@IPAddress nvarchar(50),
+	@SubnetMask nvarchar(50),
+	@RuleType tinyint,
+	@CreatedByUserID int,
+    @Notes nvarchar(255)
+AS 
+	BEGIN
+		INSERT INTO {databaseOwner}{objectQualifier}IPFilter  
+		(
+		[IPAddress]
+           ,[SubnetMask]
+           ,[RuleType]
+           ,[CreatedByUserID]
+           ,[CreatedOnDate]
+           ,[LastModifiedByUserID]
+           ,[LastModifiedOnDate]
+           ,[Notes]
+		)  
+		VALUES  
+		( 
+			@IPAddress , 
+			@SubnetMask , 
+			@RuleType,
+			@CreatedByUserID , 
+			getdate() , 
+			@CreatedByUserID , 
+			getdate() ,
+            @Notes
+		) 
+		 
+		SELECT SCOPE_IDENTITY()
+	END
+GO

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -243,6 +243,9 @@
   <data name="IpAddress.Header" xml:space="preserve">
     <value>IP ADDRESS</value>
   </data>
+  <data name="Notes.Header" xml:space="preserve">
+    <value>Notes</value>
+  </data>
   <data name="DeleteSuccess.Text" xml:space="preserve">
     <value>The IP filter has been deleted.</value>
   </data>
@@ -287,6 +290,12 @@
   </data>
   <data name="plSubnet.Help" xml:space="preserve">
     <value>The subnet mask will be combined with the first IP address to calculate a range of IP addresses for filtering.</value>
+  </data>
+  <data name="plNotes.Help" xml:space="preserve">
+    <value>Optional notes about this rule.</value>
+  </data>
+  <data name="plNotes.Text" xml:space="preserve">
+    <value>Notes</value>
   </data>
   <data name="IpFilterUpdateSuccess.Text" xml:space="preserve">
     <value>The IP filter has been updated.</value>


### PR DESCRIPTION
Closes #4140

Hosts can now set a note with each IP Filter rule to remind them about the purpose of each rule.

![image](https://user-images.githubusercontent.com/6371568/204118185-69b58bb3-a8e5-4321-9bf7-217991304110.png)

