### PR TITLE
Fix renamed public/protected properties and fields

### DIFF
--- a/DNN Platform/Library/Security/Permissions/Controls/FolderPermissionsGrid.cs
+++ b/DNN Platform/Library/Security/Permissions/Controls/FolderPermissionsGrid.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke.Security.Permissions.Controls
 
     public class FolderPermissionsGrid : PermissionsGrid
     {
-        protected FolderPermissionCollection folderPermissions;
+        protected FolderPermissionCollection FolderPermissions;
         private string folderPath = string.Empty;
         private List<PermissionInfoBase> permissionsList;
         private bool refreshGrid;
@@ -39,7 +39,7 @@ namespace DotNetNuke.Security.Permissions.Controls
                 this.UpdatePermissions();
 
                 // Return the FolderPermissions
-                return this.folderPermissions;
+                return this.FolderPermissions;
             }
         }
 
@@ -68,9 +68,9 @@ namespace DotNetNuke.Security.Permissions.Controls
         {
             get
             {
-                if (this.permissionsList == null && this.folderPermissions != null)
+                if (this.permissionsList == null && this.FolderPermissions != null)
                 {
-                    this.permissionsList = this.folderPermissions.ToList();
+                    this.permissionsList = this.FolderPermissions.ToList();
                 }
 
                 return this.permissionsList;
@@ -102,7 +102,7 @@ namespace DotNetNuke.Security.Permissions.Controls
         /// -----------------------------------------------------------------------------
         protected virtual void GetFolderPermissions()
         {
-            this.folderPermissions = new FolderPermissionCollection(FolderPermissionController.GetFolderPermissionsCollectionByFolder(this.PortalId, this.FolderPath));
+            this.FolderPermissions = new FolderPermissionCollection(FolderPermissionController.GetFolderPermissionsCollectionByFolder(this.PortalId, this.FolderPath));
             this.permissionsList = null;
         }
 
@@ -125,7 +125,7 @@ namespace DotNetNuke.Security.Permissions.Controls
                 UserID = userId,
                 DisplayName = displayName,
             };
-            this.folderPermissions.Add(objPermission, true);
+            this.FolderPermissions.Add(objPermission, true);
 
             // Clear Permission List
             this.permissionsList = null;
@@ -141,7 +141,7 @@ namespace DotNetNuke.Security.Permissions.Controls
         protected override void AddPermission(ArrayList permissions, UserInfo user)
         {
             bool isMatch = false;
-            foreach (FolderPermissionInfo objFolderPermission in this.folderPermissions)
+            foreach (FolderPermissionInfo objFolderPermission in this.FolderPermissions)
             {
                 if (objFolderPermission.UserID == user.UserID)
                 {
@@ -173,7 +173,7 @@ namespace DotNetNuke.Security.Permissions.Controls
         protected override void AddPermission(ArrayList permissions, RoleInfo role)
         {
             // Search TabPermission Collection for the user
-            if (this.folderPermissions.Cast<FolderPermissionInfo>().Any(p => p.RoleID == role.RoleID))
+            if (this.FolderPermissions.Cast<FolderPermissionInfo>().Any(p => p.RoleID == role.RoleID))
             {
                 return;
             }
@@ -281,7 +281,7 @@ namespace DotNetNuke.Security.Permissions.Controls
                 // Load FolderPermissions
                 if (myState[2] != null)
                 {
-                    this.folderPermissions = new FolderPermissionCollection();
+                    this.FolderPermissions = new FolderPermissionCollection();
                     string state = Convert.ToString(myState[2]);
                     if (!string.IsNullOrEmpty(state))
                     {
@@ -290,7 +290,7 @@ namespace DotNetNuke.Security.Permissions.Controls
                         foreach (string key in permissionKeys)
                         {
                             string[] settings = key.Split('|');
-                            this.folderPermissions.Add(this.ParseKeys(settings));
+                            this.FolderPermissions.Add(this.ParseKeys(settings));
                         }
                     }
                 }
@@ -300,7 +300,7 @@ namespace DotNetNuke.Security.Permissions.Controls
         /// <inheritdoc/>
         protected override void RemovePermission(int permissionID, int roleID, int userID)
         {
-            this.folderPermissions.Remove(permissionID, roleID, userID);
+            this.FolderPermissions.Remove(permissionID, roleID, userID);
 
             // Clear Permission List
             this.permissionsList = null;
@@ -324,10 +324,10 @@ namespace DotNetNuke.Security.Permissions.Controls
 
             // Persist the TabPermisisons
             var sb = new StringBuilder();
-            if (this.folderPermissions != null)
+            if (this.FolderPermissions != null)
             {
                 bool addDelimiter = false;
-                foreach (FolderPermissionInfo objFolderPermission in this.folderPermissions)
+                foreach (FolderPermissionInfo objFolderPermission in this.FolderPermissions)
                 {
                     if (addDelimiter)
                     {

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthSettingsBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthSettingsBase.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
 
     public class OAuthSettingsBase : AuthenticationSettingsBase
     {
-        protected PropertyEditorControl settingsEditor;
+        protected PropertyEditorControl SettingsEditor;
 
         protected virtual string AuthSystemApplicationName
         {
@@ -20,9 +20,9 @@ namespace DotNetNuke.Services.Authentication.OAuth
         /// <inheritdoc/>
         public override void UpdateSettings()
         {
-            if (this.settingsEditor.IsValid && this.settingsEditor.IsDirty)
+            if (this.SettingsEditor.IsValid && this.SettingsEditor.IsDirty)
             {
-                var config = (OAuthConfigBase)this.settingsEditor.DataSource;
+                var config = (OAuthConfigBase)this.SettingsEditor.DataSource;
                 OAuthConfigBase.UpdateConfig(config);
             }
         }
@@ -33,8 +33,8 @@ namespace DotNetNuke.Services.Authentication.OAuth
             base.OnLoad(e);
 
             OAuthConfigBase config = OAuthConfigBase.GetConfig(this.AuthSystemApplicationName, this.PortalId);
-            this.settingsEditor.DataSource = config;
-            this.settingsEditor.DataBind();
+            this.SettingsEditor.DataSource = config;
+            this.SettingsEditor.DataBind();
         }
     }
 }

--- a/DNN Platform/Library/Services/Journal/JournalTypeInfo.cs
+++ b/DNN Platform/Library/Services/Journal/JournalTypeInfo.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.Services.Journal
 
         public string JournalType { get; set; }
 
-        public string Icon { get; set; }
+        public string icon { get; set; }
 
         public bool AppliesToProfile { get; set; }
 
@@ -54,7 +54,7 @@ namespace DotNetNuke.Services.Journal
             this.JournalTypeId = Null.SetNullInteger(dr["JournalTypeId"]);
             this.PortalId = Null.SetNullInteger(dr["PortalId"]);
             this.JournalType = Null.SetNullString(dr["JournalType"]);
-            this.Icon = Null.SetNullString(dr["icon"]);
+            this.icon = Null.SetNullString(dr["icon"]);
             this.AppliesToProfile = Null.SetNullBoolean(dr["AppliesToProfile"]);
             this.AppliesToGroup = Null.SetNullBoolean(dr["AppliesToGroup"]);
             this.AppliesToStream = Null.SetNullBoolean(dr["AppliesToStream"]);

--- a/DNN Platform/Library/Services/OutputCache/Providers/MemoryProvider.cs
+++ b/DNN Platform/Library/Services/OutputCache/Providers/MemoryProvider.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.Services.OutputCache.Providers
     /// </summary>
     public class MemoryProvider : OutputCachingProvider
     {
-        protected const string CachePrefixValue = "DNN_OUTPUT:";
+        protected const string cachePrefix = "DNN_OUTPUT:";
         private static System.Web.Caching.Cache runtimeCache;
 
         internal static System.Web.Caching.Cache Cache
@@ -39,7 +39,7 @@ namespace DotNetNuke.Services.OutputCache.Providers
         {
             get
             {
-                return CachePrefixValue;
+                return cachePrefix;
             }
         }
 
@@ -123,7 +123,7 @@ namespace DotNetNuke.Services.OutputCache.Providers
             IDictionaryEnumerator cacheEnum = Cache.GetEnumerator();
             while (cacheEnum.MoveNext())
             {
-                if (cacheEnum.Key.ToString().StartsWith(string.Concat(CachePrefixValue)))
+                if (cacheEnum.Key.ToString().StartsWith(string.Concat(cachePrefix)))
                 {
                     keys.Add(cacheEnum.Key.ToString());
                 }
@@ -138,7 +138,7 @@ namespace DotNetNuke.Services.OutputCache.Providers
             IDictionaryEnumerator cacheEnum = Cache.GetEnumerator();
             while (cacheEnum.MoveNext())
             {
-                if (cacheEnum.Key.ToString().StartsWith(string.Concat(CachePrefixValue, tabId.ToString(), "_")))
+                if (cacheEnum.Key.ToString().StartsWith(string.Concat(cachePrefix, tabId.ToString(), "_")))
                 {
                     keys.Add(cacheEnum.Key.ToString());
                 }
@@ -154,7 +154,7 @@ namespace DotNetNuke.Services.OutputCache.Providers
                 throw new ArgumentException("Argument cannot be null or an empty string", "CacheKey");
             }
 
-            return string.Concat(CachePrefixValue, cacheKey);
+            return string.Concat(cachePrefix, cacheKey);
         }
     }
 }

--- a/DNN Platform/Library/UI/Skins/Controls/LanguageTokenReplace.cs
+++ b/DNN Platform/Library/UI/Skins/Controls/LanguageTokenReplace.cs
@@ -42,7 +42,7 @@ namespace DotNetNuke.UI.Skins.Controls
     {
         private const string FlagIconPhysicalLocation = @"~\images\Flags";
         private const string NonExistingFlagIconFileName = "none.gif";
-        public LanguageTokenReplace ObjParent;
+        public LanguageTokenReplace objParent;
         private readonly PortalSettings objPortal;
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace DotNetNuke.UI.Skins.Controls
         public LanguagePropertyAccess(LanguageTokenReplace parent, PortalSettings settings)
         {
             this.objPortal = settings;
-            this.ObjParent = parent;
+            this.objParent = parent;
         }
 
         /// <inheritdoc/>
@@ -71,14 +71,14 @@ namespace DotNetNuke.UI.Skins.Controls
             switch (propertyName.ToLowerInvariant())
             {
                 case "url":
-                    return this.NewUrl(this.ObjParent.Language);
+                    return this.NewUrl(this.objParent.Language);
                 case "flagsrc":
-                    var mappedGifFile = PathUtils.Instance.MapPath($@"{FlagIconPhysicalLocation}\{this.ObjParent.Language}.gif");
-                    return File.Exists(mappedGifFile) ? $"/{this.ObjParent.Language}.gif" : $@"/{NonExistingFlagIconFileName}";
+                    var mappedGifFile = PathUtils.Instance.MapPath($@"{FlagIconPhysicalLocation}\{this.objParent.Language}.gif");
+                    return File.Exists(mappedGifFile) ? $"/{this.objParent.Language}.gif" : $@"/{NonExistingFlagIconFileName}";
                 case "selected":
-                    return (this.ObjParent.Language == CultureInfo.CurrentCulture.Name).ToString();
+                    return (this.objParent.Language == CultureInfo.CurrentCulture.Name).ToString();
                 case "label":
-                    return Localization.GetString("Label", this.ObjParent.resourceFile);
+                    return Localization.GetString("Label", this.objParent.resourceFile);
                 case "i":
                     return Globals.ResolveUrl("~/images/Flags");
                 case "p":

--- a/DNN Platform/Library/UI/Skins/SkinControl.cs
+++ b/DNN Platform/Library/UI/Skins/SkinControl.cs
@@ -118,9 +118,9 @@ namespace DotNetNuke.UI.Skins
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            this.optHost.CheckedChanged += this.OptHost_CheckedChanged;
-            this.optSite.CheckedChanged += this.OptSite_CheckedChanged;
-            this.cmdPreview.Click += this.CmdPreview_Click;
+            this.optHost.CheckedChanged += this.optHost_CheckedChanged;
+            this.optSite.CheckedChanged += this.optSite_CheckedChanged;
+            this.cmdPreview.Click += this.cmdPreview_Click;
             try
             {
                 if (this.Request.QueryString["pid"] != null && (Globals.IsHostTab(this.PortalSettings.ActiveTab.TabID) || UserController.Instance.GetCurrentUserInfo().IsSuperUser))
@@ -180,17 +180,17 @@ namespace DotNetNuke.UI.Skins
             }
         }
 
-        protected void OptHost_CheckedChanged(object sender, EventArgs e)
+        protected void optHost_CheckedChanged(object sender, EventArgs e)
         {
             this.LoadSkins();
         }
 
-        protected void OptSite_CheckedChanged(object sender, EventArgs e)
+        protected void optSite_CheckedChanged(object sender, EventArgs e)
         {
             this.LoadSkins();
         }
 
-        protected void CmdPreview_Click(object sender, EventArgs e)
+        protected void cmdPreview_Click(object sender, EventArgs e)
         {
             if (!string.IsNullOrEmpty(this.SkinSrc))
             {

--- a/DNN Platform/Library/UI/Skins/SkinThumbNailControl.cs
+++ b/DNN Platform/Library/UI/Skins/SkinThumbNailControl.cs
@@ -25,8 +25,8 @@ namespace DotNetNuke.UI.Skins
     /// -----------------------------------------------------------------------------
     public abstract class SkinThumbNailControl : UserControlBase
     {
-        protected HtmlGenericControl controlContainer;
-        protected RadioButtonList optSkin;
+        protected HtmlGenericControl ControlContainer;
+        protected RadioButtonList OptSkin;
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(SkinThumbNailControl));
 
         public string Border
@@ -41,10 +41,10 @@ namespace DotNetNuke.UI.Skins
                 this.ViewState["SkinControlBorder"] = value;
                 if (!string.IsNullOrEmpty(value))
                 {
-                    this.controlContainer.Style.Add("border-top", value);
-                    this.controlContainer.Style.Add("border-bottom", value);
-                    this.controlContainer.Style.Add("border-left", value);
-                    this.controlContainer.Style.Add("border-right", value);
+                    this.ControlContainer.Style.Add("border-top", value);
+                    this.ControlContainer.Style.Add("border-bottom", value);
+                    this.ControlContainer.Style.Add("border-left", value);
+                    this.ControlContainer.Style.Add("border-right", value);
                 }
             }
         }
@@ -61,7 +61,7 @@ namespace DotNetNuke.UI.Skins
                 this.ViewState["SkinControlColumns"] = value;
                 if (value > 0)
                 {
-                    this.optSkin.RepeatColumns = value;
+                    this.OptSkin.RepeatColumns = value;
                 }
             }
         }
@@ -78,7 +78,7 @@ namespace DotNetNuke.UI.Skins
                 this.ViewState["SkinControlHeight"] = value;
                 if (!string.IsNullOrEmpty(value))
                 {
-                    this.controlContainer.Style.Add("height", value);
+                    this.ControlContainer.Style.Add("height", value);
                 }
             }
         }
@@ -100,18 +100,18 @@ namespace DotNetNuke.UI.Skins
         {
             get
             {
-                return this.optSkin.SelectedItem != null ? this.optSkin.SelectedItem.Value : string.Empty;
+                return this.OptSkin.SelectedItem != null ? this.OptSkin.SelectedItem.Value : string.Empty;
             }
 
             set
             {
                 // select current skin
                 int intIndex;
-                for (intIndex = 0; intIndex <= this.optSkin.Items.Count - 1; intIndex++)
+                for (intIndex = 0; intIndex <= this.OptSkin.Items.Count - 1; intIndex++)
                 {
-                    if (this.optSkin.Items[intIndex].Value == value)
+                    if (this.OptSkin.Items[intIndex].Value == value)
                     {
-                        this.optSkin.Items[intIndex].Selected = true;
+                        this.OptSkin.Items[intIndex].Selected = true;
                         break;
                     }
                 }
@@ -130,7 +130,7 @@ namespace DotNetNuke.UI.Skins
                 this.ViewState["SkinControlWidth"] = value;
                 if (!string.IsNullOrEmpty(value))
                 {
-                    this.controlContainer.Style.Add("width", value);
+                    this.ControlContainer.Style.Add("width", value);
                 }
             }
         }
@@ -144,7 +144,7 @@ namespace DotNetNuke.UI.Skins
         /// -----------------------------------------------------------------------------
         public void Clear()
         {
-            this.optSkin.Items.Clear();
+            this.OptSkin.Items.Clear();
         }
 
         /// -----------------------------------------------------------------------------
@@ -379,7 +379,7 @@ namespace DotNetNuke.UI.Skins
         {
             var strDefault = Localization.GetString("Not_Specified") + "<br />";
             strDefault += "<img src=\"" + Globals.ApplicationPath.Replace("\\", "/") + "/images/spacer.gif\" width=\"140\" height=\"135\" border=\"0\">";
-            this.optSkin.Items.Insert(0, new ListItem(strDefault, string.Empty));
+            this.OptSkin.Items.Insert(0, new ListItem(strDefault, string.Empty));
         }
 
         /// -----------------------------------------------------------------------------
@@ -405,7 +405,7 @@ namespace DotNetNuke.UI.Skins
                 strImage += "<img src=\"" + Globals.ApplicationPath.Replace("\\", "/") + "/images/thumbnail.jpg\" border=\"1\">";
             }
 
-            this.optSkin.Items.Add(new ListItem(FormatSkinName(strFolder, Path.GetFileNameWithoutExtension(strFile)) + "<br />" + strImage, root + "/" + strFolder + "/" + Path.GetFileName(strFile)));
+            this.OptSkin.Items.Add(new ListItem(FormatSkinName(strFolder, Path.GetFileNameWithoutExtension(strFile)) + "<br />" + strImage, root + "/" + strFolder + "/" + Path.GetFileName(strFile)));
         }
     }
 }

--- a/DNN Platform/Library/UI/UserControls/DualListControl.cs
+++ b/DNN Platform/Library/UI/UserControls/DualListControl.cs
@@ -13,8 +13,8 @@ namespace DotNetNuke.UI.UserControls
 
     public abstract class DualListControl : UserControlBase
     {
-        protected Label label1;
-        protected Label label2;
+        protected Label Label1;
+        protected Label Label2;
         protected LinkButton cmdAdd;
         protected LinkButton cmdAddAll;
         protected LinkButton cmdRemove;
@@ -131,8 +131,8 @@ namespace DotNetNuke.UI.UserControls
             try
             {
                 // Localization
-                this.label1.Text = Localization.GetString("Available", Localization.GetResourceFile(this, this.myFileName));
-                this.label2.Text = Localization.GetString("Assigned", Localization.GetResourceFile(this, this.myFileName));
+                this.Label1.Text = Localization.GetString("Available", Localization.GetResourceFile(this, this.myFileName));
+                this.Label2.Text = Localization.GetString("Assigned", Localization.GetResourceFile(this, this.myFileName));
                 this.cmdAdd.ToolTip = Localization.GetString("Add", Localization.GetResourceFile(this, this.myFileName));
                 this.cmdAddAll.ToolTip = Localization.GetString("AddAll", Localization.GetResourceFile(this, this.myFileName));
                 this.cmdRemove.ToolTip = Localization.GetString("Remove", Localization.GetResourceFile(this, this.myFileName));

--- a/DNN Platform/Library/UI/UserControls/Help.cs
+++ b/DNN Platform/Library/UI/UserControls/Help.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.UI.UserControls
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            this.cmdCancel.Click += this.CmdCancel_Click;
+            this.cmdCancel.Click += this.cmdCancel_Click;
             int moduleControlId = Null.NullInteger;
 
             if (this.Request.QueryString["ctlid"] != null)
@@ -121,7 +121,7 @@ namespace DotNetNuke.UI.UserControls
         /// </summary>
         /// <remarks>
         /// </remarks>
-        protected void CmdCancel_Click(object sender, EventArgs e)
+        protected void cmdCancel_Click(object sender, EventArgs e)
         {
             try
             {

--- a/DNN Platform/Library/UI/UserControls/HelpButtonControl.cs
+++ b/DNN Platform/Library/UI/UserControls/HelpButtonControl.cs
@@ -122,7 +122,7 @@ namespace DotNetNuke.UI.UserControls
         {
             base.OnLoad(e);
 
-            this.cmdHelp.Click += this.CmdHelp_Click;
+            this.cmdHelp.Click += this.cmdHelp_Click;
 
             try
             {
@@ -145,7 +145,7 @@ namespace DotNetNuke.UI.UserControls
             }
         }
 
-        protected void CmdHelp_Click(object sender, EventArgs e)
+        protected void cmdHelp_Click(object sender, EventArgs e)
         {
             this.pnlHelp.Visible = true;
         }

--- a/DNN Platform/Library/UI/UserControls/SectionHeadControl.cs
+++ b/DNN Platform/Library/UI/UserControls/SectionHeadControl.cs
@@ -263,7 +263,7 @@ namespace DotNetNuke.UI.UserControls
             }
         }
 
-        protected void ImgIcon_Click(object sender, ImageClickEventArgs e)
+        protected void imgIcon_Click(object sender, ImageClickEventArgs e)
         {
             var ctl = (HtmlControl)this.Parent.FindControl(this.Section);
             if (ctl != null)

--- a/DNN Platform/Library/UI/UserControls/TextEditor.cs
+++ b/DNN Platform/Library/UI/UserControls/TextEditor.cs
@@ -30,15 +30,15 @@ namespace DotNetNuke.UI.UserControls
     public class TextEditor : UserControl
     {
         private const string MyFileName = "TextEditor.ascx";
-        protected Panel panelTextEditor;
-        protected RadioButtonList optRender;
-        protected RadioButtonList optView;
-        protected PlaceHolder plcEditor;
-        protected HtmlGenericControl divBasicTextBox;
-        protected HtmlGenericControl divBasicRender;
-        protected HtmlGenericControl divRichTextBox;
-        protected Panel panelView;
-        protected TextBox txtDesktopHTML;
+        protected Panel PanelTextEditor;
+        protected RadioButtonList OptRender;
+        protected RadioButtonList OptView;
+        protected PlaceHolder PlcEditor;
+        protected HtmlGenericControl DivBasicTextBox;
+        protected HtmlGenericControl DivBasicRender;
+        protected HtmlGenericControl DivRichTextBox;
+        protected Panel PanelView;
+        protected TextBox TxtDesktopHTML;
         private HtmlEditorProvider richTextEditor;
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace DotNetNuke.UI.UserControls
         {
             get
             {
-                return this.txtDesktopHTML;
+                return this.TxtDesktopHTML;
             }
         }
 
@@ -81,7 +81,7 @@ namespace DotNetNuke.UI.UserControls
         {
             get
             {
-                return this.optView.ClientID;
+                return this.OptView.ClientID;
             }
         }
 
@@ -196,33 +196,33 @@ namespace DotNetNuke.UI.UserControls
         {
             get
             {
-                switch (this.optView.SelectedItem.Value)
+                switch (this.OptView.SelectedItem.Value)
                 {
                     case "BASIC":
-                        switch (this.optRender.SelectedItem.Value)
+                        switch (this.OptRender.SelectedItem.Value)
                         {
                             case "T":
-                                return this.Encode(HtmlUtils.ConvertToHtml(RemoveBaseTags(this.txtDesktopHTML.Text)));
+                                return this.Encode(HtmlUtils.ConvertToHtml(RemoveBaseTags(this.TxtDesktopHTML.Text)));
 
                             // break;
                             case "R":
-                                return RemoveBaseTags(this.txtDesktopHTML.Text);
+                                return RemoveBaseTags(this.TxtDesktopHTML.Text);
 
                             // break;
                             default:
-                                return this.Encode(RemoveBaseTags(this.txtDesktopHTML.Text));
+                                return this.Encode(RemoveBaseTags(this.TxtDesktopHTML.Text));
 
                                 // break;
                         }
 
                     default:
-                        return this.IsRichEditorAvailable ? this.Encode(RemoveBaseTags(this.richTextEditor.Text)) : this.Encode(RemoveBaseTags(this.txtDesktopHTML.Text));
+                        return this.IsRichEditorAvailable ? this.Encode(RemoveBaseTags(this.richTextEditor.Text)) : this.Encode(RemoveBaseTags(this.TxtDesktopHTML.Text));
                 }
             }
 
             set
             {
-                this.txtDesktopHTML.Text = HtmlUtils.ConvertToText(this.Decode(value));
+                this.TxtDesktopHTML.Text = HtmlUtils.ConvertToText(this.Decode(value));
                 if (this.IsRichEditorAvailable)
                 {
                     this.richTextEditor.Text = this.Decode(value);
@@ -255,14 +255,14 @@ namespace DotNetNuke.UI.UserControls
 
         public void ChangeMode(string mode)
         {
-            this.optView.SelectedItem.Value = mode;
-            this.OptViewSelectedIndexChanged(this.optView, EventArgs.Empty);
+            this.OptView.SelectedItem.Value = mode;
+            this.OptViewSelectedIndexChanged(this.OptView, EventArgs.Empty);
         }
 
         public void ChangeTextRenderMode(string textRenderMode)
         {
-            this.optRender.SelectedItem.Value = textRenderMode;
-            this.OptRenderSelectedIndexChanged(this.optRender, EventArgs.Empty);
+            this.OptRender.SelectedItem.Value = textRenderMode;
+            this.OptRenderSelectedIndexChanged(this.OptRender, EventArgs.Empty);
         }
 
         /// <inheritdoc/>
@@ -290,8 +290,8 @@ namespace DotNetNuke.UI.UserControls
         {
             base.OnLoad(e);
 
-            this.optRender.SelectedIndexChanged += this.OptRenderSelectedIndexChanged;
-            this.optView.SelectedIndexChanged += this.OptViewSelectedIndexChanged;
+            this.OptRender.SelectedIndexChanged += this.OptRenderSelectedIndexChanged;
+            this.OptView.SelectedIndexChanged += this.OptViewSelectedIndexChanged;
 
             try
             {
@@ -308,26 +308,26 @@ namespace DotNetNuke.UI.UserControls
                     this.richTextEditor.Height = this.Height;
                 }
 
-                this.txtDesktopHTML.Height = this.Height;
-                this.txtDesktopHTML.Width = this.Width;
-                this.panelView.Width = this.Width;
-                this.panelTextEditor.Width = this.Width;
+                this.TxtDesktopHTML.Height = this.Height;
+                this.TxtDesktopHTML.Width = this.Width;
+                this.PanelView.Width = this.Width;
+                this.PanelTextEditor.Width = this.Width;
 
                 // Optionally display the radio button lists
                 if (!this.ChooseMode)
                 {
-                    this.panelView.Visible = false;
+                    this.PanelView.Visible = false;
                 }
 
                 if (!this.ChooseRender)
                 {
-                    this.divBasicRender.Visible = false;
+                    this.DivBasicRender.Visible = false;
                 }
 
                 // Load the editor
                 if (this.IsRichEditorAvailable)
                 {
-                    this.plcEditor.Controls.Add(this.richTextEditor.HtmlEditorControl);
+                    this.PlcEditor.Controls.Add(this.richTextEditor.HtmlEditorControl);
                 }
 
                 this.SetPanels();
@@ -347,14 +347,14 @@ namespace DotNetNuke.UI.UserControls
         /// -----------------------------------------------------------------------------
         protected void OptRenderSelectedIndexChanged(object sender, EventArgs e)
         {
-            if (this.optRender.SelectedIndex != -1)
+            if (this.OptRender.SelectedIndex != -1)
             {
-                this.TextRenderMode = this.optRender.SelectedItem.Value;
+                this.TextRenderMode = this.OptRender.SelectedItem.Value;
             }
 
             if (this.Mode == "BASIC")
             {
-                this.txtDesktopHTML.Text = this.TextRenderMode == "H" ? HtmlUtils.ConvertToHtml(this.txtDesktopHTML.Text) : HtmlUtils.ConvertToText(this.txtDesktopHTML.Text);
+                this.TxtDesktopHTML.Text = this.TextRenderMode == "H" ? HtmlUtils.ConvertToHtml(this.TxtDesktopHTML.Text) : HtmlUtils.ConvertToText(this.TxtDesktopHTML.Text);
             }
 
             this.SetPanels();
@@ -369,9 +369,9 @@ namespace DotNetNuke.UI.UserControls
         /// -----------------------------------------------------------------------------
         protected void OptViewSelectedIndexChanged(object sender, EventArgs e)
         {
-            if (this.optView.SelectedIndex != -1)
+            if (this.OptView.SelectedIndex != -1)
             {
-                this.Mode = this.optView.SelectedItem.Value;
+                this.Mode = this.OptView.SelectedItem.Value;
             }
 
             if (this.Mode == "BASIC")
@@ -379,10 +379,10 @@ namespace DotNetNuke.UI.UserControls
                 switch (this.TextRenderMode)
                 {
                     case "T":
-                        this.txtDesktopHTML.Text = HtmlUtils.ConvertToText(this.richTextEditor.Text);
+                        this.TxtDesktopHTML.Text = HtmlUtils.ConvertToText(this.richTextEditor.Text);
                         break;
                     default:
-                        this.txtDesktopHTML.Text = this.richTextEditor.Text;
+                        this.TxtDesktopHTML.Text = this.richTextEditor.Text;
                         break;
                 }
             }
@@ -391,10 +391,10 @@ namespace DotNetNuke.UI.UserControls
                 switch (this.TextRenderMode)
                 {
                     case "T":
-                        this.richTextEditor.Text = HtmlUtils.ConvertToHtml(this.txtDesktopHTML.Text);
+                        this.richTextEditor.Text = HtmlUtils.ConvertToHtml(this.TxtDesktopHTML.Text);
                         break;
                     default:
-                        this.richTextEditor.Text = this.txtDesktopHTML.Text;
+                        this.richTextEditor.Text = this.TxtDesktopHTML.Text;
                         break;
                 }
             }
@@ -444,19 +444,19 @@ namespace DotNetNuke.UI.UserControls
         /// -----------------------------------------------------------------------------
         private void PopulateLists()
         {
-            if (this.optRender.Items.Count == 0)
+            if (this.OptRender.Items.Count == 0)
             {
-                this.optRender.Items.Add(new ListItem(Localization.GetString("Text", Localization.GetResourceFile(this, MyFileName)), "T"));
-                this.optRender.Items.Add(new ListItem(Localization.GetString("Html", Localization.GetResourceFile(this, MyFileName)), "H"));
-                this.optRender.Items.Add(new ListItem(Localization.GetString("Raw", Localization.GetResourceFile(this, MyFileName)), "R"));
+                this.OptRender.Items.Add(new ListItem(Localization.GetString("Text", Localization.GetResourceFile(this, MyFileName)), "T"));
+                this.OptRender.Items.Add(new ListItem(Localization.GetString("Html", Localization.GetResourceFile(this, MyFileName)), "H"));
+                this.OptRender.Items.Add(new ListItem(Localization.GetString("Raw", Localization.GetResourceFile(this, MyFileName)), "R"));
             }
 
-            if (this.optView.Items.Count == 0)
+            if (this.OptView.Items.Count == 0)
             {
-                this.optView.Items.Add(new ListItem(Localization.GetString("BasicTextBox", Localization.GetResourceFile(this, MyFileName)), "BASIC"));
+                this.OptView.Items.Add(new ListItem(Localization.GetString("BasicTextBox", Localization.GetResourceFile(this, MyFileName)), "BASIC"));
                 if (this.IsRichEditorAvailable)
                 {
-                    this.optView.Items.Add(new ListItem(Localization.GetString("RichTextBox", Localization.GetResourceFile(this, MyFileName)), "RICH"));
+                    this.OptView.Items.Add(new ListItem(Localization.GetString("RichTextBox", Localization.GetResourceFile(this, MyFileName)), "RICH"));
                 }
             }
         }
@@ -470,46 +470,46 @@ namespace DotNetNuke.UI.UserControls
         /// -----------------------------------------------------------------------------
         private void SetPanels()
         {
-            if (this.optView.SelectedIndex != -1)
+            if (this.OptView.SelectedIndex != -1)
             {
-                this.Mode = this.optView.SelectedItem.Value;
+                this.Mode = this.OptView.SelectedItem.Value;
             }
 
             if (!string.IsNullOrEmpty(this.Mode))
             {
-                this.optView.Items.FindByValue(this.Mode).Selected = true;
+                this.OptView.Items.FindByValue(this.Mode).Selected = true;
             }
             else
             {
-                this.optView.SelectedIndex = 0;
+                this.OptView.SelectedIndex = 0;
             }
 
             // Set the text render mode for basic mode
-            if (this.optRender.SelectedIndex != -1)
+            if (this.OptRender.SelectedIndex != -1)
             {
-                this.TextRenderMode = this.optRender.SelectedItem.Value;
+                this.TextRenderMode = this.OptRender.SelectedItem.Value;
             }
 
             if (!string.IsNullOrEmpty(this.TextRenderMode))
             {
-                this.optRender.Items.FindByValue(this.TextRenderMode).Selected = true;
+                this.OptRender.Items.FindByValue(this.TextRenderMode).Selected = true;
             }
             else
             {
-                this.optRender.SelectedIndex = 0;
+                this.OptRender.SelectedIndex = 0;
             }
 
-            if (this.optView.SelectedItem.Value == "BASIC")
+            if (this.OptView.SelectedItem.Value == "BASIC")
             {
-                this.divBasicTextBox.Visible = true;
-                this.divRichTextBox.Visible = false;
-                this.panelView.CssClass = "dnnTextPanelView dnnTextPanelView-basic";
+                this.DivBasicTextBox.Visible = true;
+                this.DivRichTextBox.Visible = false;
+                this.PanelView.CssClass = "dnnTextPanelView dnnTextPanelView-basic";
             }
             else
             {
-                this.divBasicTextBox.Visible = false;
-                this.divRichTextBox.Visible = true;
-                this.panelView.CssClass = "dnnTextPanelView";
+                this.DivBasicTextBox.Visible = false;
+                this.DivRichTextBox.Visible = true;
+                this.PanelView.CssClass = "dnnTextPanelView";
             }
         }
     }

--- a/DNN Platform/Library/UI/UserControls/URLControl.cs
+++ b/DNN Platform/Library/UI/UserControls/URLControl.cs
@@ -26,13 +26,13 @@ namespace DotNetNuke.UI.UserControls
 
     public abstract class UrlControl : UserControlBase
     {
-        protected Panel errorRow;
-        protected Panel fileRow;
-        protected Panel imagesRow;
-        protected Panel tabRow;
-        protected Panel typeRow;
-        protected Panel urlRow;
-        protected Panel userRow;
+        protected Panel ErrorRow;
+        protected Panel FileRow;
+        protected Panel ImagesRow;
+        protected Panel TabRow;
+        protected Panel TypeRow;
+        protected Panel URLRow;
+        protected Panel UserRow;
         protected DropDownList cboFiles;
         protected DropDownList cboFolders;
         protected DropDownList cboImages;
@@ -516,7 +516,7 @@ namespace DotNetNuke.UI.UserControls
                             else
                             {
                                 this.lblMessage.Text = Localization.GetString("NoUser", this.LocalResourceFile);
-                                this.errorRow.Visible = true;
+                                this.ErrorRow.Visible = true;
                                 this.txtUser.Text = string.Empty;
                             }
                         }
@@ -602,16 +602,16 @@ namespace DotNetNuke.UI.UserControls
         {
             base.OnLoad(e);
 
-            this.cboFolders.SelectedIndexChanged += this.CboFolders_SelectedIndexChanged;
-            this.optType.SelectedIndexChanged += this.OptType_SelectedIndexChanged;
-            this.cmdAdd.Click += this.CmdAdd_Click;
-            this.cmdCancel.Click += this.CmdCancel_Click;
-            this.cmdDelete.Click += this.CmdDelete_Click;
-            this.cmdSave.Click += this.CmdSave_Click;
-            this.cmdSelect.Click += this.CmdSelect_Click;
-            this.cmdUpload.Click += this.CmdUpload_Click;
+            this.cboFolders.SelectedIndexChanged += this.cboFolders_SelectedIndexChanged;
+            this.optType.SelectedIndexChanged += this.optType_SelectedIndexChanged;
+            this.cmdAdd.Click += this.cmdAdd_Click;
+            this.cmdCancel.Click += this.cmdCancel_Click;
+            this.cmdDelete.Click += this.cmdDelete_Click;
+            this.cmdSave.Click += this.cmdSave_Click;
+            this.cmdSelect.Click += this.cmdSelect_Click;
+            this.cmdUpload.Click += this.cmdUpload_Click;
 
-            this.errorRow.Visible = false;
+            this.ErrorRow.Visible = false;
 
             try
             {
@@ -687,7 +687,7 @@ namespace DotNetNuke.UI.UserControls
             }
         }
 
-        protected void CboFolders_SelectedIndexChanged(object sender, EventArgs e)
+        protected void cboFolders_SelectedIndexChanged(object sender, EventArgs e)
         {
             int portalId = Null.NullInteger;
 
@@ -746,7 +746,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void CmdAdd_Click(object sender, EventArgs e)
+        protected void cmdAdd_Click(object sender, EventArgs e)
         {
             this.cboUrls.Visible = false;
             this.cmdSelect.Visible = true;
@@ -760,7 +760,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void CmdCancel_Click(object sender, EventArgs e)
+        protected void cmdCancel_Click(object sender, EventArgs e)
         {
             this.cboFiles.Visible = true;
             this.cmdUpload.Visible = true;
@@ -774,7 +774,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void CmdDelete_Click(object sender, EventArgs e)
+        protected void cmdDelete_Click(object sender, EventArgs e)
         {
             if (this.cboUrls.SelectedItem != null)
             {
@@ -790,7 +790,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void CmdSave_Click(object sender, EventArgs e)
+        protected void cmdSave_Click(object sender, EventArgs e)
         {
             this.cmdUpload.Visible = false;
 
@@ -817,7 +817,7 @@ namespace DotNetNuke.UI.UserControls
             {
                 // trying to upload a file not allowed for current filter
                 this.lblMessage.Text = string.Format(Localization.GetString("UploadError", this.LocalResourceFile), this.FileFilter, strExtension);
-                this.errorRow.Visible = true;
+                this.ErrorRow.Visible = true;
             }
             else
             {
@@ -831,7 +831,7 @@ namespace DotNetNuke.UI.UserControls
                 var folderPath = Globals.GetSubFolderPath(parentFolderName.Replace("/", "\\") + fileName, portalID);
 
                 var folder = folderManager.GetFolder(portalID, folderPath);
-                this.errorRow.Visible = false;
+                this.ErrorRow.Visible = false;
 
                 try
                 {
@@ -840,22 +840,22 @@ namespace DotNetNuke.UI.UserControls
                 catch (Services.FileSystem.PermissionsNotMetException)
                 {
                     this.lblMessage.Text += "<br />" + string.Format(Localization.GetString("InsufficientFolderPermission"), folder.FolderPath);
-                    this.errorRow.Visible = true;
+                    this.ErrorRow.Visible = true;
                 }
                 catch (NoSpaceAvailableException)
                 {
                     this.lblMessage.Text += "<br />" + string.Format(Localization.GetString("DiskSpaceExceeded"), fileName);
-                    this.errorRow.Visible = true;
+                    this.ErrorRow.Visible = true;
                 }
                 catch (InvalidFileExtensionException)
                 {
                     this.lblMessage.Text += "<br />" + string.Format(Localization.GetString("RestrictedFileType"), fileName, Host.AllowedExtensionWhitelist.ToDisplayString());
-                    this.errorRow.Visible = true;
+                    this.ErrorRow.Visible = true;
                 }
                 catch (Exception)
                 {
                     this.lblMessage.Text += "<br />" + string.Format(Localization.GetString("SaveFileError"), fileName);
-                    this.errorRow.Visible = true;
+                    this.ErrorRow.Visible = true;
                 }
             }
 
@@ -866,7 +866,7 @@ namespace DotNetNuke.UI.UserControls
                 this.txtFile.Visible = false;
                 this.cmdSave.Visible = false;
                 this.cmdCancel.Visible = false;
-                this.errorRow.Visible = false;
+                this.ErrorRow.Visible = false;
 
                 var root = new DirectoryInfo(parentFolderName);
                 this.cboFiles.Items.Clear();
@@ -896,7 +896,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void CmdSelect_Click(object sender, EventArgs e)
+        protected void cmdSelect_Click(object sender, EventArgs e)
         {
             this.cboUrls.Visible = true;
             this.cmdSelect.Visible = false;
@@ -917,7 +917,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void CmdUpload_Click(object sender, EventArgs e)
+        protected void cmdUpload_Click(object sender, EventArgs e)
         {
             string strSaveFolder = this.cboFolders.SelectedValue;
             this.LoadFolders("ADD");
@@ -952,7 +952,7 @@ namespace DotNetNuke.UI.UserControls
                     this.cmdSave.Visible = false;
                     this.cmdCancel.Visible = false;
                     this.lblMessage.Text = Localization.GetString("NoWritePermission", this.LocalResourceFile);
-                    this.errorRow.Visible = true;
+                    this.ErrorRow.Visible = true;
                 }
             }
 
@@ -963,7 +963,7 @@ namespace DotNetNuke.UI.UserControls
             this.doReloadFiles = false;
         }
 
-        protected void OptType_SelectedIndexChanged(object sender, EventArgs e)
+        protected void optType_SelectedIndexChanged(object sender, EventArgs e)
         {
             // Type changed, render the correct control set
             this.ViewState["UrlType"] = this.optType.SelectedItem.Value;
@@ -1270,11 +1270,11 @@ namespace DotNetNuke.UI.UserControls
                     this.doRenderTypeControls = true; // Type changed, re-draw
                 }
 
-                this.typeRow.Visible = this.optType.Items.Count > 1;
+                this.TypeRow.Visible = this.optType.Items.Count > 1;
             }
             else
             {
-                this.typeRow.Visible = false;
+                this.TypeRow.Visible = false;
             }
         }
 
@@ -1318,18 +1318,18 @@ namespace DotNetNuke.UI.UserControls
                 switch (this.optType.SelectedItem.Value)
                 {
                     case "N": // None
-                        this.urlRow.Visible = false;
-                        this.tabRow.Visible = false;
-                        this.fileRow.Visible = false;
-                        this.userRow.Visible = false;
-                        this.imagesRow.Visible = false;
+                        this.URLRow.Visible = false;
+                        this.TabRow.Visible = false;
+                        this.FileRow.Visible = false;
+                        this.UserRow.Visible = false;
+                        this.ImagesRow.Visible = false;
                         break;
                     case "I": // System Image
-                        this.urlRow.Visible = false;
-                        this.tabRow.Visible = false;
-                        this.fileRow.Visible = false;
-                        this.userRow.Visible = false;
-                        this.imagesRow.Visible = true;
+                        this.URLRow.Visible = false;
+                        this.TabRow.Visible = false;
+                        this.FileRow.Visible = false;
+                        this.UserRow.Visible = false;
+                        this.ImagesRow.Visible = true;
 
                         this.cboImages.Items.Clear();
 
@@ -1349,11 +1349,11 @@ namespace DotNetNuke.UI.UserControls
                         break;
 
                     case "U": // Url
-                        this.urlRow.Visible = true;
-                        this.tabRow.Visible = false;
-                        this.fileRow.Visible = false;
-                        this.userRow.Visible = false;
-                        this.imagesRow.Visible = false;
+                        this.URLRow.Visible = true;
+                        this.TabRow.Visible = false;
+                        this.FileRow.Visible = false;
+                        this.UserRow.Visible = false;
+                        this.ImagesRow.Visible = false;
                         if (string.IsNullOrEmpty(this.txtUrl.Text))
                         {
                             this.txtUrl.Text = url;
@@ -1373,11 +1373,11 @@ namespace DotNetNuke.UI.UserControls
                         this.cmdDelete.Visible = false;
                         break;
                     case "T": // tab
-                        this.urlRow.Visible = false;
-                        this.tabRow.Visible = true;
-                        this.fileRow.Visible = false;
-                        this.userRow.Visible = false;
-                        this.imagesRow.Visible = false;
+                        this.URLRow.Visible = false;
+                        this.TabRow.Visible = true;
+                        this.FileRow.Visible = false;
+                        this.UserRow.Visible = false;
+                        this.ImagesRow.Visible = false;
 
                         this.cboTabs.Items.Clear();
 
@@ -1396,11 +1396,11 @@ namespace DotNetNuke.UI.UserControls
 
                         break;
                     case "F": // file
-                        this.urlRow.Visible = false;
-                        this.tabRow.Visible = false;
-                        this.fileRow.Visible = true;
-                        this.userRow.Visible = false;
-                        this.imagesRow.Visible = false;
+                        this.URLRow.Visible = false;
+                        this.TabRow.Visible = false;
+                        this.FileRow.Visible = true;
+                        this.UserRow.Visible = false;
+                        this.ImagesRow.Visible = false;
 
                         if (this.ViewState["FoldersLoaded"] == null || this.doReloadFolders)
                         {
@@ -1411,8 +1411,8 @@ namespace DotNetNuke.UI.UserControls
                         if (this.cboFolders.Items.Count == 0)
                         {
                             this.lblMessage.Text = Localization.GetString("NoPermission", this.LocalResourceFile);
-                            this.errorRow.Visible = true;
-                            this.fileRow.Visible = false;
+                            this.ErrorRow.Visible = true;
+                            this.FileRow.Visible = false;
                             return;
                         }
 
@@ -1525,11 +1525,11 @@ namespace DotNetNuke.UI.UserControls
 
                         break;
                     case "M": // membership users
-                        this.urlRow.Visible = false;
-                        this.tabRow.Visible = false;
-                        this.fileRow.Visible = false;
-                        this.userRow.Visible = true;
-                        this.imagesRow.Visible = false;
+                        this.URLRow.Visible = false;
+                        this.TabRow.Visible = false;
+                        this.FileRow.Visible = false;
+                        this.UserRow.Visible = true;
+                        this.ImagesRow.Visible = false;
                         if (string.IsNullOrEmpty(this.txtUser.Text))
                         {
                             this.txtUser.Text = url;
@@ -1540,11 +1540,11 @@ namespace DotNetNuke.UI.UserControls
             }
             else
             {
-                this.urlRow.Visible = false;
-                this.imagesRow.Visible = false;
-                this.tabRow.Visible = false;
-                this.fileRow.Visible = false;
-                this.userRow.Visible = false;
+                this.URLRow.Visible = false;
+                this.ImagesRow.Visible = false;
+                this.TabRow.Visible = false;
+                this.FileRow.Visible = false;
+                this.UserRow.Visible = false;
             }
         }
     }

--- a/DNN Platform/Library/UI/UserControls/URLTrackingControl.cs
+++ b/DNN Platform/Library/UI/UserControls/URLTrackingControl.cs
@@ -19,13 +19,13 @@ namespace DotNetNuke.UI.UserControls
 
     public abstract class URLTrackingControl : UserControlBase
     {
-        protected Label label1;
-        protected Label label2;
-        protected Label label3;
-        protected Label label4;
-        protected Label label5;
-        protected Label label6;
-        protected Label label7;
+        protected Label Label1;
+        protected Label Label2;
+        protected Label Label3;
+        protected Label Label4;
+        protected Label Label5;
+        protected Label Label6;
+        protected Label Label7;
         protected LinkButton cmdDisplay;
         protected HyperLink cmdEndCalendar;
         protected HyperLink cmdStartCalendar;

--- a/DNN Platform/Library/UI/UserControls/User.cs
+++ b/DNN Platform/Library/UI/UserControls/User.cs
@@ -20,8 +20,8 @@ namespace DotNetNuke.UI.UserControls
     /// -----------------------------------------------------------------------------
     public abstract class User : UserControlBase
     {
-        protected HtmlTableRow confirmPasswordRow;
-        protected HtmlTableRow passwordRow;
+        protected HtmlTableRow ConfirmPasswordRow;
+        protected HtmlTableRow PasswordRow;
         protected Label lblUsername;
         protected Label lblUsernameAsterisk;
         protected LabelControl plConfirm;
@@ -278,8 +278,8 @@ namespace DotNetNuke.UI.UserControls
                         this.valPassword.Enabled = false;
                         this.valConfirm1.Enabled = false;
                         this.valConfirm2.Enabled = false;
-                        this.passwordRow.Visible = false;
-                        this.confirmPasswordRow.Visible = false;
+                        this.PasswordRow.Visible = false;
+                        this.ConfirmPasswordRow.Visible = false;
                         this.txtUsername.Visible = false;
                         this.valUsername.Enabled = false;
                         this.lblUsername.Visible = true;
@@ -294,8 +294,8 @@ namespace DotNetNuke.UI.UserControls
                         this.valPassword.Enabled = true;
                         this.valConfirm1.Enabled = true;
                         this.valConfirm2.Enabled = true;
-                        this.passwordRow.Visible = true;
-                        this.confirmPasswordRow.Visible = true;
+                        this.PasswordRow.Visible = true;
+                        this.ConfirmPasswordRow.Visible = true;
                     }
 
                     this.ViewState["ModuleId"] = Convert.ToString(this.ModuleId);

--- a/DNN Platform/Library/UI/WebControls/PagingControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PagingControl.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.UI.WebControls
     [ToolboxData("<{0}:PagingControl runat=server></{0}:PagingControl>")]
     public class PagingControl : WebControl, IPostBackEventHandler
     {
-        protected Repeater pageNumbers;
+        protected Repeater PageNumbers;
         protected TableCell cellDisplayLinks;
         protected TableCell cellDisplayStatus;
         protected Table tablePageNumbers;
@@ -133,9 +133,9 @@ namespace DotNetNuke.UI.WebControls
             // cellDisplayLinks.CssClass = "Normal";
             this.tablePageNumbers.CssClass = string.IsNullOrEmpty(this.CssClass) ? "PagingTable" : this.CssClass;
             var intRowIndex = this.tablePageNumbers.Rows.Add(new TableRow());
-            this.pageNumbers = new Repeater();
+            this.PageNumbers = new Repeater();
             var i = new PageNumberLinkTemplate(this);
-            this.pageNumbers.ItemTemplate = i;
+            this.PageNumbers.ItemTemplate = i;
             this.BindPageNumbers(this.TotalRecords, this.PageSize);
             this.cellDisplayStatus.HorizontalAlign = HorizontalAlign.Left;
 
@@ -167,7 +167,7 @@ namespace DotNetNuke.UI.WebControls
         /// <inheritdoc/>
         protected override void Render(HtmlTextWriter output)
         {
-            if (this.pageNumbers == null)
+            if (this.PageNumbers == null)
             {
                 this.CreateChildControls();
             }
@@ -176,7 +176,7 @@ namespace DotNetNuke.UI.WebControls
             str.Append(this.GetFirstLink() + "&nbsp;&nbsp;&nbsp;");
             str.Append(this.GetPreviousLink() + "&nbsp;&nbsp;&nbsp;");
             var result = new StringBuilder(1024);
-            this.pageNumbers.RenderControl(new HtmlTextWriter(new StringWriter(result)));
+            this.PageNumbers.RenderControl(new HtmlTextWriter(new StringWriter(result)));
             str.Append(result.ToString());
             str.Append(this.GetNextLink() + "&nbsp;&nbsp;&nbsp;");
             str.Append(this.GetLastLink() + "&nbsp;&nbsp;&nbsp;");
@@ -249,8 +249,8 @@ namespace DotNetNuke.UI.WebControls
                     ht.Rows.Add(tmpRow);
                 }
 
-                this.pageNumbers.DataSource = ht;
-                this.pageNumbers.DataBind();
+                this.PageNumbers.DataSource = ht;
+                this.PageNumbers.DataBind();
             }
         }
 


### PR DESCRIPTION
## Summary
PR #5337 changed the casing of some `public` and `protected` field and property names. These are breaking changes, as pointed out by @skamphuis. This PR resolves these renames.