### PR TITLE
Keep track of whether in global assets mode

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/dnn-rm-queued-file.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-queued-file/dnn-rm-queued-file.tsx
@@ -10,7 +10,7 @@ import { UploadFromLocalResponse } from './UploadFromLocalResponse';
     shadow: true,
 })
 export class DnnRmQueuedFile {
-    
+
     /** The file to upload. */
     @Prop() file!: File;
 
@@ -94,7 +94,7 @@ export class DnnRmQueuedFile {
             }
 
             if (this.file.size > this.maxUploadFileSize) {
-                const message = `${this.file.name} ${state.localization.FileSizeErrorMessage} ${getFileSize(this.maxUploadFileSize)}`; 
+                const message = `${this.file.name} ${state.localization.FileSizeErrorMessage} ${getFileSize(this.maxUploadFileSize)}`;
                 this.fileUploadResults = {
                     alreadyExists: false,
                     message: message,
@@ -106,16 +106,16 @@ export class DnnRmQueuedFile {
                 reject(message);
                 return;
             }
-            
+
             const headers = this.servicesFramework.getModuleHeaders();
-    
+
             const formData = new FormData();
             formData.append("folder", state.currentItems.folder.folderPath);
             formData.append("filter", this.filter);
             formData.append("extract", this.extract ? "true" : "false");
             formData.append("overwrite", this.overwrite ? "true" : "false");
             formData.append("validationCode", this.validationCode);
-            formData.append("isHostPortal", "false");
+            formData.append("isHostPortal", state.settings.IsHostPortal ? "true" : "false");
             formData.append("postfile", this.file);
             this.xhr.onload = () => {
                 if (this.xhr.status === 200) {
@@ -124,7 +124,7 @@ export class DnnRmQueuedFile {
                     reject(this.xhr.statusText);
                 }
             }
-            
+
             this.xhr.upload.onprogress = e => {
                 if (e.lengthComputable) {
                     const percent = Math.round((e.loaded / e.total) * 100);
@@ -135,7 +135,7 @@ export class DnnRmQueuedFile {
             this.xhr.onabort = () => {
                 this.dismiss();
             };
-            
+
             const url = this.servicesFramework.getServiceRoot('InternalServices') + 'FileUpload/UploadFromLocal';
             this.xhr.open("POST", url);
             headers.forEach((value, key) => {

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -48,7 +48,7 @@ export class ItemsClient{
      * @param startIndex Which item to start at in the paging mechanism.
      * @param numItems How many items to return.
      * @param sorting How to sort the items returned.
-     * @returns 
+     * @returns
      */
     public getFolderContent(
         folderId: number,
@@ -119,7 +119,7 @@ export class ItemsClient{
      * @param numItems The number of items.
      * @param sorting The sorting.
      * @param recursive If true sync recursively.
-     * @returns 
+     * @returns
      */
      public syncFolderContent(
         folderId: number,
@@ -151,7 +151,7 @@ export class ItemsClient{
     /**
      * Downloads a file.
      * @param fileId The id of the file to download.
-     * @param forceDownload A value indicating whether to force the download. 
+     * @param forceDownload A value indicating whether to force the download.
      *                      When true, will download the file as an attachment and ensures the browser won't just render the file if supported.
      *                      When false, the browser may render the file instead of downloading it for some formats like pdf or images.
      * @returns The actual requested file.
@@ -189,7 +189,7 @@ export class ItemsClient{
             .catch(error => reject(error));
         });
     }
-    
+
     public search(
         folderId: number,
         search: string,
@@ -534,7 +534,7 @@ export class ItemsClient{
             result = parts[groupIdIndex + 1];
             return result;
         }
-        
+
         const searchParams = new URLSearchParams(window.location.search);
         const groupId = searchParams.get("groupid");
         if (groupId){
@@ -549,12 +549,15 @@ export class ItemsClient{
 export interface GetSettingsResponse{
         /** The name of the root folder (could be an actual folder name or "Site Assets" or "Global Assets") */
         HomeFolderName: string;
-        
+
         /** The ID of the home folder configures in the settings */
         HomeFolderId: number;
-    
+
         /** The current module mode configured in the settings */
         Mode: ModuleMode;
+
+        /** Whether folder is global or for current portal */
+        IsHostPortal: boolean;
 }
 
 export enum ModuleMode{


### PR DESCRIPTION
## Summary
I haven't had a chance to test this, but I believe this should pass through to the API whether the module is in Global Assets mode or for the current portal.