### PR TITLE
Possibly fixed intermittent build issues

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -8,7 +8,6 @@
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{9CCA271F-CFAA-42A3-B577-7D5CBB38C646}</ProjectGuid>
-    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Extensions</RootNamespace>


### PR DESCRIPTION
I was consistently experiencing locally the build issues we sometimes (well oftentimes) get on azure (can't resolved Dnn.Platform\Dnn.AdminExperience\Dnn.PersonaBar.Extensions\Dnn.PersonaBar.Extensions.csproj)...

So I was trying to pinpoint the possible cause of that issues and when I removed the Project GUIDS from this project file, the build started working. Many of the other .csproj files don't have any ProjectType defined at all and they work fine.

I have confirmed that the install files are still being produced.

One of the GUIDs defines this as an MVC project but it is clearly not, the other defines it as a C# project but the .csproj extension already defines that.

Is anyone is opposed to remove both, then I can bring back the one starting with FAE04....

I am absolutelly not sure this will fix the intermittent build issues, because of them beeing intermittent but if it works, we may have fixed it...
