### PR TITLE
Resolve XCOPY error during build

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
+++ b/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
@@ -34,7 +34,7 @@
 
   <Import Project="..\..\DNN_Platform.build" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.Abstractions*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />
+    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.Abstractions*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y /I" />
   </Target>
 
 </Project>

--- a/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
+++ b/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
@@ -40,7 +40,7 @@
 
   <Import Project="..\..\DNN_Platform.build" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.DependencyInjection*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />
+    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.DependencyInjection*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y /I" />
   </Target>
 
 </Project>

--- a/DNN Platform/DotNetNuke.Maintenance/DotNetNuke.Maintenance.csproj
+++ b/DNN Platform/DotNetNuke.Maintenance/DotNetNuke.Maintenance.csproj
@@ -31,7 +31,7 @@
 
   <Import Project="..\..\DNN_Platform.build" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.Maintenance*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />
+    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\netstandard2.0\DotNetNuke.Maintenance*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y /I" />
   </Target>
 
 </Project>

--- a/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
+++ b/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\net472\DotNetNuke.ModulePipeline.*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y" />
+    <Exec Command="XCOPY &quot;$(ProjectDir)bin\$(ConfigurationName)\net472\DotNetNuke.ModulePipeline.*&quot; &quot;$(WebsitePath)\bin&quot; /S /Y /I" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Summary
The last couple of builds have errored with the following error:

```
Does D:\a\1\s\DNN Platform\DotNetNuke.Abstractions\..\..\Website\bin specify a file name
or directory name on the target
(F = file, D = directory)?
```

`D:\a\1\s\DNN Platform\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj(37,5): error MSB3073: The command "XCOPY "D:\a\1\s\DNN Platform\DotNetNuke.Abstractions\bin\Release\netstandard2.0\DotNetNuke.Abstractions*" "D:\a\1\s\DNN Platform\DotNetNuke.Abstractions\..\..\Website\bin" /S /Y" exited with code 2. [D:\a\1\s\DNN Platform\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj]`