### PR TITLE
Remove now-unused Yarn.MsBuild package

### DIFF
--- a/Build/Tasks/BuildNpmPackages.cs
+++ b/Build/Tasks/BuildNpmPackages.cs
@@ -4,29 +4,20 @@
 namespace DotNetNuke.Build.Tasks
 {
     using Cake.Common.IO;
-    using Cake.Core;
-    using Cake.Core.IO;
     using Cake.Core.Tooling;
     using Cake.Frosting;
     using Cake.Yarn;
 
-    /// <summary>
-    /// Builds the npm packages for the entire solution.
-    /// </summary>
+    /// <summary>Builds the npm packages for the entire solution.</summary>
     public sealed class BuildNpmPackages : FrostingTask<Context>
     {
         /// <inheritdoc/>
         public override void Run(Context context)
         {
-            var yarn = new YarnRunner(
-                context.FileSystem,
-                context.Environment,
-                context.ProcessRunner,
-                context.Tools);
-            yarn.Install(c => c
+            context.Yarn().Install(c => c
                 .WithArgument("--no-immutable")
                 .WithWorkingDirectory(context.Directory("./")));
-            yarn.RunScript("build");
+            context.Yarn().RunScript("build");
         }
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.props" Condition="Exists('..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -765,22 +764,6 @@
   </ItemGroup>
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <ProjectExtensions>
-    <VisualStudio>
-      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
-        <WebProjectProperties>
-          <SaveServerSettingsInUserFile>True</SaveServerSettingsInUserFile>
-        </WebProjectProperties>
-      </FlavorProperties>
-    </VisualStudio>
-  </ProjectExtensions>
+  <ProjectExtensions />
   <Import Project="Module.build" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.props'))" />
-    <Error Condition="!Exists('..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.targets" Condition="Exists('..\..\packages\Yarn.MSBuild.1.22.19\build\Yarn.MSBuild.targets')" />
 </Project>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/packages.config
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/packages.config
@@ -8,5 +8,4 @@
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
   <package id="SharpZipLib" version="1.3.3" targetFramework="net472" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-  <package id="Yarn.MSBuild" version="1.22.19" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Summary
As a follow-up to #5433, this PR removes the Yarn.MsBuild package that is no longer used.