### PR TITLE
Fix PersonaBar project referencing wrong version of Newtonsoft.Json

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -712,7 +712,7 @@
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -745,6 +745,7 @@
     <EmbeddedResource Include="Components\ConfigConsole\Schemas\DotNetConfig.xsd">
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <Content Include="web.config" />
     <Content Include="SqlDataProvider\09.11.00.SqlDataProvider" />

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/app.config
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/packages.config
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.9" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
   <package id="SharpZipLib" version="1.3.3" targetFramework="net472" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
   <package id="Yarn.MSBuild" version="1.22.19" targetFramework="net472" />


### PR DESCRIPTION
## Summary
All references to Newtonsoft.Json are for version 13.0.2 except Dnn.PersonaBar.Extensions which references 13.0.1. This PR resolves the issue