### PR TITLE
Fixed an issue that prevented sending smtp test emails

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpAdminController.cs
@@ -8,15 +8,14 @@ namespace Dnn.PersonaBar.Servers.Services
     using System.Net;
     using System.Net.Http;
     using System.Text;
-    using System.Text.RegularExpressions;
     using System.Web.Http;
 
     using Dnn.PersonaBar.Library;
     using Dnn.PersonaBar.Library.Attributes;
     using Dnn.PersonaBar.Servers.Services.Dto;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Collections;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework.Providers;
@@ -25,14 +24,31 @@ namespace Dnn.PersonaBar.Servers.Services
     using DotNetNuke.Services.Mail;
     using DotNetNuke.Web.Api;
 
+    /// <summary>
+    /// Provides the APIs for SMTP settings management.
+    /// </summary>
     [MenuPermission(Scope = ServiceScope.Admin)]
     public class ServerSettingsSmtpAdminController : PersonaBarApiController
     {
         private const string ObfuscateString = "*****";
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ServerSettingsSmtpHostController));
+        private readonly IHostSettingsService hostSettingsService;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerSettingsSmtpAdminController"/> class.
+        /// </summary>
+        /// <param name="hostSettingsService">A service to manage host settings.</param>
+        public ServerSettingsSmtpAdminController(
+            IHostSettingsService hostSettingsService)
+        {
+            this.hostSettingsService = hostSettingsService;
+        }
+
+        /// <summary>
+        /// Gets the SMTP settings.
+        /// </summary>
+        /// <returns>An object representing the SMTP settings for the current portal.</returns>
         [HttpGet]
-
         public HttpResponseMessage GetSmtpSettings()
         {
             try
@@ -65,9 +81,13 @@ namespace Dnn.PersonaBar.Servers.Services
             }
         }
 
+        /// <summary>
+        /// Updates the SMTP settings for the current portal.
+        /// </summary>
+        /// <param name="request"><see cref="UpdateSmtpSettingsRequest"/>.</param>
+        /// <returns>A value indicating whether the operation succeeded.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
-
         public HttpResponseMessage UpdateSmtpSettings(UpdateSmtpSettingsRequest request)
         {
             try
@@ -84,10 +104,16 @@ namespace Dnn.PersonaBar.Servers.Services
                 PortalController.UpdatePortalSetting(portalId, "SMTPServer", request.SmtpServer, false);
                 PortalController.UpdatePortalSetting(portalId, "SMTPConnectionLimit", request.SmtpConnectionLimit, false);
                 PortalController.UpdatePortalSetting(portalId, "SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
-                PortalController.UpdatePortalSetting(portalId, "SMTPAuthentication",
-                    request.SmtpAuthentication.ToString(), false);
+                PortalController.UpdatePortalSetting(
+                    portalId,
+                    "SMTPAuthentication",
+                    request.SmtpAuthentication.ToString(),
+                    false);
                 PortalController.UpdatePortalSetting(portalId, "SMTPUsername", request.SmtpUsername, false);
-                PortalController.UpdateEncryptedString(portalId, "SMTPPassword", request.SmtpPassword,
+                PortalController.UpdateEncryptedString(
+                    portalId,
+                    "SMTPPassword",
+                    request.SmtpPassword,
                     Config.GetDecryptionkey());
                 PortalController.UpdatePortalSetting(portalId, "SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
 
@@ -101,12 +127,11 @@ namespace Dnn.PersonaBar.Servers.Services
             }
         }
 
-        /// POST: api/Servers/SendTestEmail
         /// <summary>
-        /// Tests SMTP settings.
+        /// Sends a test email to validate the settings work.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
+        /// <param name="request"><see cref="SendTestEmailRequest"/>.</param>
+        /// <returns>A localized test result message.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
 
@@ -117,6 +142,11 @@ namespace Dnn.PersonaBar.Servers.Services
                 var smtpHostMode = request.SmtpServerMode == "h";
                 var mailFrom = smtpHostMode ? Host.HostEmail : this.PortalSettings.Email;
                 var mailTo = this.UserInfo.Email;
+                var portalId = PortalSettings.Current.PortalId;
+                if (request.SmtpPassword == ObfuscateString)
+                {
+                    request.SmtpPassword = GetSmtpPassword(portalId, false);
+                }
 
                 var errMessage = Mail.SendMail(
                     mailFrom,
@@ -129,11 +159,11 @@ namespace Dnn.PersonaBar.Servers.Services
                     Encoding.UTF8,
                     string.Empty,
                     string.Empty,
-                    smtpHostMode ? HostController.Instance.GetString("SMTPServer") : request.SmtpServer,
-                    smtpHostMode ? HostController.Instance.GetString("SMTPAuthentication") : request.SmtpAuthentication.ToString(),
-                    smtpHostMode ? HostController.Instance.GetString("SMTPUsername") : request.SmtpUsername,
-                    smtpHostMode ? HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey()) : request.SmtpPassword,
-                    smtpHostMode ? HostController.Instance.GetBoolean("SMTPEnableSSL", false) : request.EnableSmtpSsl);
+                    smtpHostMode ? this.hostSettingsService.GetString("SMTPServer") : request.SmtpServer,
+                    smtpHostMode ? this.hostSettingsService.GetString("SMTPAuthentication") : request.SmtpAuthentication.ToString(),
+                    smtpHostMode ? this.hostSettingsService.GetString("SMTPUsername") : request.SmtpUsername,
+                    smtpHostMode ? this.hostSettingsService.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey()) : request.SmtpPassword,
+                    smtpHostMode ? this.hostSettingsService.GetBoolean("SMTPEnableSSL", false) : request.EnableSmtpSsl);
 
                 var success = string.IsNullOrEmpty(errMessage);
                 return this.Request.CreateResponse(success ? HttpStatusCode.OK : HttpStatusCode.BadRequest, new

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ServerSettingsSmtpHostController.cs
@@ -13,9 +13,9 @@ namespace Dnn.PersonaBar.Servers.Services
     using Dnn.PersonaBar.Library;
     using Dnn.PersonaBar.Library.Attributes;
     using Dnn.PersonaBar.Servers.Services.Dto;
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Collections;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework.Providers;
@@ -24,14 +24,31 @@ namespace Dnn.PersonaBar.Servers.Services
     using DotNetNuke.Services.Mail;
     using DotNetNuke.Web.Api;
 
+    /// <summary>
+    /// Provides the APIs for SMTP settings management.
+    /// </summary>
     [MenuPermission(Scope = ServiceScope.Host)]
     public class ServerSettingsSmtpHostController : PersonaBarApiController
     {
         private const string ObfuscateString = "*****";
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ServerSettingsSmtpHostController));
+        private readonly IHostSettingsService hostSettingsService;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServerSettingsSmtpHostController"/> class.
+        /// </summary>
+        /// <param name="hostSettingsService">A service to manage host settings.</param>
+        public ServerSettingsSmtpHostController(
+            IHostSettingsService hostSettingsService)
+        {
+            this.hostSettingsService = hostSettingsService;
+        }
+
+        /// <summary>
+        /// Gets the SMTP settings for the host.
+        /// </summary>
+        /// <returns>An object representing the host smtp settings.</returns>
         [HttpGet]
-
         public HttpResponseMessage GetSmtpSettings()
         {
             try
@@ -43,14 +60,14 @@ namespace Dnn.PersonaBar.Servers.Services
                     smtpServerMode = PortalController.GetPortalSetting("SMTPmode", portalId, "h"),
                     host = new
                     {
-                        smtpServer = HostController.Instance.GetString("SMTPServer"),
-                        smtpConnectionLimit = HostController.Instance.GetInteger("SMTPConnectionLimit", 2),
-                        smtpMaxIdleTime = HostController.Instance.GetInteger("SMTPMaxIdleTime", 100000),
-                        smtpAuthentication = HostController.Instance.GetString("SMTPAuthentication"),
-                        enableSmtpSsl = HostController.Instance.GetBoolean("SMTPEnableSSL", false),
-                        smtpUserName = HostController.Instance.GetString("SMTPUsername"),
+                        smtpServer = this.hostSettingsService.GetString("SMTPServer"),
+                        smtpConnectionLimit = this.hostSettingsService.GetInteger("SMTPConnectionLimit", 2),
+                        smtpMaxIdleTime = this.hostSettingsService.GetInteger("SMTPMaxIdleTime", 100000),
+                        smtpAuthentication = this.hostSettingsService.GetString("SMTPAuthentication"),
+                        enableSmtpSsl = this.hostSettingsService.GetBoolean("SMTPEnableSSL", false),
+                        smtpUserName = this.hostSettingsService.GetString("SMTPUsername"),
                         smtpPassword = GetSmtpPassword(-1, true),
-                        smtpHostEmail = HostController.Instance.GetString("HostEmail"),
+                        smtpHostEmail = this.hostSettingsService.GetString("HostEmail"),
                         messageSchedulerBatchSize = Host.MessageSchedulerBatchSize,
                     },
                     site = new
@@ -75,9 +92,13 @@ namespace Dnn.PersonaBar.Servers.Services
             }
         }
 
+        /// <summary>
+        /// Updates the SMTP settings.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>A value indicating whether the operation succeeded.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
-
         public HttpResponseMessage UpdateSmtpSettings(UpdateSmtpSettingsRequest request)
         {
             try
@@ -89,21 +110,18 @@ namespace Dnn.PersonaBar.Servers.Services
                 {
                     if (request.SmtpPassword == ObfuscateString)
                     {
-                        request.SmtpPassword = GetHostSmtpPassword();
+                        request.SmtpPassword = this.GetHostSmtpPassword();
                     }
 
-                    HostController.Instance.Update("SMTPServer", request.SmtpServer, false);
-                    HostController.Instance.Update("SMTPConnectionLimit", request.SmtpConnectionLimit, false);
-                    HostController.Instance.Update("SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
-                    HostController.Instance.Update("SMTPAuthentication", request.SmtpAuthentication.ToString(), false);
-                    HostController.Instance.Update("SMTPUsername", request.SmtpUsername, false);
-                    HostController.Instance.UpdateEncryptedString("SMTPPassword", request.SmtpPassword,
-                        Config.GetDecryptionkey());
-                    HostController.Instance.Update("HostEmail", request.SmtpHostEmail);
-                    HostController.Instance.Update("SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
-                    HostController.Instance.Update(
-                        "MessageSchedulerBatchSize",
-                        request.MessageSchedulerBatchSize.ToString(), false);
+                    this.hostSettingsService.Update("SMTPServer", request.SmtpServer, false);
+                    this.hostSettingsService.Update("SMTPConnectionLimit", request.SmtpConnectionLimit, false);
+                    this.hostSettingsService.Update("SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
+                    this.hostSettingsService.Update("SMTPAuthentication", request.SmtpAuthentication.ToString(), false);
+                    this.hostSettingsService.Update("SMTPUsername", request.SmtpUsername, false);
+                    this.hostSettingsService.UpdateEncryptedString("SMTPPassword", request.SmtpPassword, Config.GetDecryptionkey());
+                    this.hostSettingsService.Update("HostEmail", request.SmtpHostEmail);
+                    this.hostSettingsService.Update("SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
+                    this.hostSettingsService.Update("MessageSchedulerBatchSize", request.MessageSchedulerBatchSize.ToString(), false);
                 }
                 else
                 {
@@ -115,8 +133,11 @@ namespace Dnn.PersonaBar.Servers.Services
                     PortalController.UpdatePortalSetting(portalId, "SMTPServer", request.SmtpServer, false);
                     PortalController.UpdatePortalSetting(portalId, "SMTPConnectionLimit", request.SmtpConnectionLimit, false);
                     PortalController.UpdatePortalSetting(portalId, "SMTPMaxIdleTime", request.SmtpMaxIdleTime, false);
-                    PortalController.UpdatePortalSetting(portalId, "SMTPAuthentication",
-                        request.SmtpAuthentication.ToString(), false);
+                    PortalController.UpdatePortalSetting(
+                        portalId,
+                        "SMTPAuthentication",
+                        request.SmtpAuthentication.ToString(),
+                        false);
                     PortalController.UpdatePortalSetting(portalId, "SMTPUsername", request.SmtpUsername, false);
                     PortalController.UpdateEncryptedString(portalId, "SMTPPassword", request.SmtpPassword, Config.GetDecryptionkey());
                     PortalController.UpdatePortalSetting(portalId, "SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
@@ -132,21 +153,23 @@ namespace Dnn.PersonaBar.Servers.Services
             }
         }
 
-        /// POST: api/Servers/SendTestEmail
         /// <summary>
-        /// Tests SMTP settings.
+        /// Sends an email to test the SMTP settings.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
+        /// <param name="request"><see cref="SendTestEmailRequest"/>.</param>
+        /// <returns>A localized result message object.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
-
         public HttpResponseMessage SendTestEmail(SendTestEmailRequest request)
         {
             try
             {
                 var mailFrom = request.SmtpServerMode == "h" ? Host.HostEmail : this.PortalSettings.Email;
                 var mailTo = this.UserInfo.Email;
+                if (request.SmtpPassword == ObfuscateString)
+                {
+                    request.SmtpPassword = this.GetHostSmtpPassword();
+                }
 
                 var errMessage = Mail.SendMail(
                     mailFrom,
@@ -188,12 +211,12 @@ namespace Dnn.PersonaBar.Servers.Services
             }
         }
 
-        private static string GetSmtpPassword(int portalId, bool obfuscate)
+        private string GetSmtpPassword(int portalId, bool obfuscate)
         {
             var pwd = string.Empty;
             if (portalId == -1)
             {
-                pwd = GetHostSmtpPassword();
+                pwd = this.GetHostSmtpPassword();
             }
             else
             {
@@ -208,20 +231,20 @@ namespace Dnn.PersonaBar.Servers.Services
             return pwd;
         }
 
-        private static string GetHostSmtpPassword()
+        private string GetHostSmtpPassword()
         {
             string decryptedText;
             try
             {
-                decryptedText = HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey());
+                decryptedText = this.hostSettingsService.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey());
             }
             catch (Exception)
             {
                 // fixes case where smtppassword failed to encrypt due to failing upgrade
-                var current = HostController.Instance.GetString("SMTPPassword");
+                var current = this.hostSettingsService.GetString("SMTPPassword");
                 if (!string.IsNullOrEmpty(current))
                 {
-                    HostController.Instance.UpdateEncryptedString("SMTPPassword", current, Config.GetDecryptionkey());
+                    this.hostSettingsService.UpdateEncryptedString("SMTPPassword", current, Config.GetDecryptionkey());
                     decryptedText = current;
                 }
                 else


### PR DESCRIPTION
Fixed an issue that prevented sending smtp test emails Due to the UI changes in #5152 the frontend now posts an obfuscated password unless the user is currently changing the password. That scenario got handled correctly for UpdateSmtpSettings but the same logic needed to be implements in SendTestEmail for that button to work fine.

Closes #5391
