### PR TITLE
Remove `Settings` from Resource Manager display for users without permission

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-resource-manager/dnn-resource-manager.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-resource-manager/dnn-resource-manager.tsx
@@ -59,7 +59,15 @@ export class DnnResourceManager {
       console.error(error);
     });
 
-    return Promise.all([getResourcesPromise, getSettingsPromise]);
+    const canManageFolderTypes = this.itemsClient.canManageFolderTypes()
+    .then(canManage => {
+      state.canManageFolderTypes = canManage;
+    })
+    .catch(error => {
+      console.error(error);
+    });
+
+    return Promise.all([getResourcesPromise, getSettingsPromise, canManageFolderTypes]);
   }
 
 
@@ -87,18 +95,22 @@ export class DnnResourceManager {
               </button>
             </div>
             <dnn-rm-left-pane slot="left"></dnn-rm-left-pane>
-            <button
-              slot="left"
-              class="folder-mappings"
-              title={state.localization?.EditFolderMappings}
-              onClick={() => this.folderMappingsModal.show()}>
-              <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="m9.25 22-.4-3.2q-.325-.125-.612-.3-.288-.175-.563-.375L4.7 19.375l-2.75-4.75 2.575-1.95Q4.5 12.5 4.5 12.337v-.675q0-.162.025-.337L1.95 9.375l2.75-4.75 2.975 1.25q.275-.2.575-.375.3-.175.6-.3l.4-3.2h5.5l.4 3.2q.325.125.613.3.287.175.562.375l2.975-1.25 2.75 4.75-2.575 1.95q.025.175.025.337v.675q0 .163-.05.338l2.575 1.95-2.75 4.75-2.95-1.25q-.275.2-.575.375-.3.175-.6.3l-.4 3.2Zm2.8-6.5q1.45 0 2.475-1.025Q15.55 13.45 15.55 12q0-1.45-1.025-2.475Q13.5 8.5 12.05 8.5q-1.475 0-2.488 1.025Q8.55 10.55 8.55 12q0 1.45 1.012 2.475Q10.575 15.5 12.05 15.5Zm0-2q-.625 0-1.062-.438-.438-.437-.438-1.062t.438-1.062q.437-.438 1.062-.438t1.063.438q.437.437.437 1.062t-.437 1.062q-.438.438-1.063.438ZM12 12Zm-1 8h1.975l.35-2.65q.775-.2 1.438-.588.662-.387 1.212-.937l2.475 1.025.975-1.7-2.15-1.625q.125-.35.175-.738.05-.387.05-.787t-.05-.788q-.05-.387-.175-.737l2.15-1.625-.975-1.7-2.475 1.05q-.55-.575-1.212-.963-.663-.387-1.438-.587L13 4h-1.975l-.35 2.65q-.775.2-1.437.587-.663.388-1.213.938L5.55 7.15l-.975 1.7 2.15 1.6q-.125.375-.175.75-.05.375-.05.8 0 .4.05.775t.175.75l-2.15 1.625.975 1.7 2.475-1.05q.55.575 1.213.962.662.388 1.437.588Z"/></svg>
-            </button>
+            {state.canManageFolderTypes &&
+              <button
+                slot="left"
+                class="folder-mappings"
+                title={state.localization?.EditFolderMappings}
+                onClick={() => this.folderMappingsModal.show()}>
+                <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="m9.25 22-.4-3.2q-.325-.125-.612-.3-.288-.175-.563-.375L4.7 19.375l-2.75-4.75 2.575-1.95Q4.5 12.5 4.5 12.337v-.675q0-.162.025-.337L1.95 9.375l2.75-4.75 2.975 1.25q.275-.2.575-.375.3-.175.6-.3l.4-3.2h5.5l.4 3.2q.325.125.613.3.287.175.562.375l2.975-1.25 2.75 4.75-2.575 1.95q.025.175.025.337v.675q0 .163-.05.338l2.575 1.95-2.75 4.75-2.95-1.25q-.275.2-.575.375-.3.175-.6.3l-.4 3.2Zm2.8-6.5q1.45 0 2.475-1.025Q15.55 13.45 15.55 12q0-1.45-1.025-2.475Q13.5 8.5 12.05 8.5q-1.475 0-2.488 1.025Q8.55 10.55 8.55 12q0 1.45 1.012 2.475Q10.575 15.5 12.05 15.5Zm0-2q-.625 0-1.062-.438-.438-.437-.438-1.062t.438-1.062q.437-.438 1.062-.438t1.063.438q.437.437.437 1.062t-.437 1.062q-.438.438-1.063.438ZM12 12Zm-1 8h1.975l.35-2.65q.775-.2 1.438-.588.662-.387 1.212-.937l2.475 1.025.975-1.7-2.15-1.625q.125-.35.175-.738.05-.387.05-.787t-.05-.788q-.05-.387-.175-.737l2.15-1.625-.975-1.7-2.475 1.05q-.55-.575-1.212-.963-.663-.387-1.438-.587L13 4h-1.975l-.35 2.65q-.775.2-1.437.587-.663.388-1.213.938L5.55 7.15l-.975 1.7 2.15 1.6q-.125.375-.175.75-.05.375-.05.8 0 .4.05.775t.175.75l-2.15 1.625.975 1.7 2.475-1.05q.55.575 1.213.962.662.388 1.437.588Z"/></svg>
+              </button>
+            }
             <dnn-rm-right-pane slot="right"></dnn-rm-right-pane>
           </dnn-vertical-splitview>
-          <dnn-modal ref={el => this.folderMappingsModal = el}>
-            <dnn-rm-folder-mappings />
-          </dnn-modal>
+          {state.canManageFolderTypes &&
+            <dnn-modal ref={el => this.folderMappingsModal = el}>
+              <dnn-rm-folder-mappings />
+            </dnn-modal>
+          }
         </div>
       </Host>
     );

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
@@ -33,7 +33,6 @@ export class DnnRmFolderList {
   componentWillLoad() {
     this.getFolders()
     .then(() => {
-      console.log(state.rootFolders);
       this.itemsClient.getFolderContent(
         state.settings.HomeFolderId,
         0,

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -238,6 +238,23 @@ export class ItemsClient{
         });
     }
 
+    public canManageFolderTypes(){
+        return new Promise<boolean>((resolve, reject) => {
+            const url = `${this.requestUrl}CanManageFolderTypes`;
+            fetch(url, {
+                headers: this.sf.getModuleHeaders(),
+            })
+            .then(response => {
+                if (response.status == 200){
+                    response.json().then(data => resolve(data));
+                } else {
+                    response.json().then(error => reject(error.message));
+                }
+            })
+            .catch(error => reject(error));
+        })
+    }
+
     public getAddFolderTypeUrl(){
         return new Promise<string>((resolve, reject) => {
             const url = `${this.requestUrl}GetAddFolderTypeUrl`;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/store/store.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/store/store.ts
@@ -16,12 +16,14 @@ const { state } = createStore<{
     sortField?: SortFieldInfo;
     selectedItems: Item[];
     settings?: GetSettingsResponse;
+    canManageFolderTypes: boolean;
 }>({
     moduleId: -1,
     layout: "list",
     pageSize: 50,
     lastSearchRequestedPage: 1,
     selectedItems: [],
+    canManageFolderTypes: false,
 });
 
 export default state;

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -230,6 +230,20 @@ namespace Dnn.Modules.ResourceManager.Services
         }
 
         /// <summary>
+        /// Determines whether or not the current user has permissions to manage the folder types.
+        /// </summary>
+        /// <returns>
+        /// A boolean indicating whether or not the current user has permissions to manage the folder types.
+        /// </returns>
+        [HttpGet]
+        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
+        public HttpResponseMessage CanManageFolderTypes()
+        {
+            var canManage = this.UserInfo.IsSuperUser || this.UserInfo.IsInRole(this.PortalSettings.AdministratorRoleName);
+            return this.Request.CreateResponse(HttpStatusCode.OK, canManage);
+        }
+
+        /// <summary>
         /// Gets a url to add a new folder type.
         /// </summary>
         /// <returns>A url to the folder providers control that allows adding a new folder type.</returns>


### PR DESCRIPTION
## Summary
Resolves #5437 

This PR addresses multiple issues related to the referenced issue:
* A new `CanManageFolderTypes` endpoint was added.
* The front end was updated to leverage the new `CanManageFolderTypes` endpoint
* Gear icon for managing folder types in the bottom left of Resource Manager is now hiding for users that are not SuperUsers or Admins.
* The modal is also hidden now for users that aren't SuperUsers or Admins, and thus resolving the `401` from the other API call.