### PR TITLE
Fixes an issue where URLControl checks upload permissions wrong

### DIFF
--- a/DNN Platform/Library/UI/UserControls/URLControl.cs
+++ b/DNN Platform/Library/UI/UserControls/URLControl.cs
@@ -920,7 +920,7 @@ namespace DotNetNuke.UI.UserControls
         protected void cmdUpload_Click(object sender, EventArgs e)
         {
             string strSaveFolder = this.cboFolders.SelectedValue;
-            this.LoadFolders("ADD");
+            this.LoadFolders("WRITE");
             if (this.cboFolders.Items.FindByValue(strSaveFolder) != null)
             {
                 this.cboFolders.Items.FindByValue(strSaveFolder).Selected = true;
@@ -944,7 +944,7 @@ namespace DotNetNuke.UI.UserControls
                 else
                 {
                     // reset controls
-                    this.LoadFolders("BROWSE,ADD");
+                    this.LoadFolders("BROWSE,WRITE");
                     this.cboFolders.Items.FindByValue(strSaveFolder).Selected = true;
                     this.cboFiles.Visible = true;
                     this.cmdUpload.Visible = false;
@@ -1404,7 +1404,7 @@ namespace DotNetNuke.UI.UserControls
 
                         if (this.ViewState["FoldersLoaded"] == null || this.doReloadFolders)
                         {
-                            this.LoadFolders("BROWSE,ADD");
+                            this.LoadFolders("BROWSE,WRITE");
                             this.ViewState["FoldersLoaded"] = "Y";
                         }
 


### PR DESCRIPTION
Fixes #5423

## Summary
The URLControl tries for "ADD" permission on the selected folder, but that doesn't exist (anymore?). It changed it to "WRITE" instead, which seems logical because that's actually the permission you're controlling by giving a user or role Edit permissions on a folder. This seems to fix the issues mentioned in #5423 and in [Links](https://github.com/DNNCommunity/DNN.Links/issues/65) and [Documents](https://github.com/DNNCommunity/DNN.Documents/issues/21).

However, I did find other references to the "ADD" permission in several other places:
- ResourceManager.PermissionsManager
- InternalServices.FileUploadController (but that checks for both ADD and WRITE)
- Modules.Export.ascx.cs

These might need changing too. Happy to do so, by the way. Just let me know.

