### PR TITLE
Correctly save the attribute maxAllowedContentLength

### DIFF
--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -354,6 +354,11 @@ namespace DotNetNuke.Common.Utilities
                        configNav.SelectSingleNode("configuration//location//system.webServer//security//requestFiltering//requestLimits");
             if (httpNode != null)
             {
+                if (httpNode.Attributes["maxAllowedContentLength"] == null)
+                {
+                    httpNode.Attributes.Append(configNav.CreateAttribute("maxAllowedContentLength"));
+                }
+
                 httpNode.Attributes["maxAllowedContentLength"].InnerText = newSize.ToString("#");
             }
 


### PR DESCRIPTION
Fixes #4839

## Summary
When saving the security settings, an error could occur if the web.config file has not had the attribute maxAllowedContentLength for node security//requestFiltering//requestLimits.  On some occasions users may have added the node but not the attribute.  This fix checks for the attribute, if it does not exist it adds it to the node before setting the value.