### PR TITLE
Update GitVersion.Tool and remove .NET 5 SDK

### DIFF
--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Build
                 .UseLifetime<Lifetime>()
                 .UseWorkingDirectory("..")
                 .UseModule<AzurePipelinesModule>()
-                .InstallTool(new Uri("dotnet:?package=GitVersion.Tool&version=5.7.0"))
+                .InstallTool(new Uri("dotnet:?package=GitVersion.Tool&version=5.11.1"))
                 .InstallTool(new Uri("nuget:?package=Microsoft.TestPlatform&version=" + MicrosoftTestPlatformVersion))
                 .InstallTool(new Uri("nuget:?package=NUnit3TestAdapter&version=" + NUnit3TestAdapterVersion))
                 .InstallTool(new Uri("nuget:?package=NuGet.CommandLine&version=5.10.0"))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,11 +54,6 @@ steps:
     path: $(YARN_CACHE_FOLDER)
 
 - task: UseDotNet@2
-  displayName: 'Use .NET 5.x SDK'
-  inputs:
-    version: 5.x
-
-- task: UseDotNet@2
   displayName: 'Use .NET 6.x SDK'
   inputs:
     version: 6.x


### PR DESCRIPTION
## Summary
The build has been failing sometimes due to GitVersion.Tool requiring the .NET 5 SDK, this updates to a version that supports .NET 6 and removes the .NET 5 SDK reference from the build.