### PR TITLE
Commited docs for dnn-resource-manager

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-move-items/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-move-items/readme.md
@@ -33,11 +33,9 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
   dnn-action-create-folder --> dnn-modal
   dnn-action-create-folder --> dnn-rm-create-folder
@@ -66,6 +64,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-rm-actions-bar --> dnn-action-move-items
   dnn-rm-file-context-menu --> dnn-action-move-items

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/context-menus/dnn-rm-file-context-menu/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/context-menus/dnn-rm-file-context-menu/readme.md
@@ -56,11 +56,9 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -77,6 +75,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-rm-items-cardview --> dnn-rm-file-context-menu
   dnn-rm-items-listview --> dnn-rm-file-context-menu

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/context-menus/dnn-rm-folder-context-menu/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/context-menus/dnn-rm-folder-context-menu/readme.md
@@ -16,6 +16,7 @@
 
 ### Used by
 
+ - [dnn-rm-folder-list](../../dnn-rm-folder-list)
  - [dnn-rm-folder-list-item](../../dnn-rm-folder-list-item)
  - [dnn-rm-items-cardview](../../dnn-rm-items-cardview)
  - [dnn-rm-items-listview](../../dnn-rm-items-listview)
@@ -60,7 +61,7 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
-  dnn-rm-folder-list --> dnn-rm-folder-list-item
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
   dnn-treeview-item --> dnn-collapsible
   dnn-action-delete-items --> dnn-modal

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-resource-manager/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-resource-manager/readme.md
@@ -34,11 +34,9 @@ graph TD;
   dnn-resource-manager --> dnn-rm-folder-mappings
   dnn-rm-top-bar --> dnn-searchbox
   dnn-rm-left-pane --> dnn-rm-folder-list
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -76,6 +74,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-rm-right-pane --> dnn-rm-actions-bar
   dnn-rm-right-pane --> dnn-rm-files-pane

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/readme.md
@@ -67,11 +67,9 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -85,6 +83,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-rm-right-pane --> dnn-rm-actions-bar
   style dnn-rm-actions-bar fill:#f9f,stroke:#333,stroke-width:4px

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-files-pane/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-files-pane/readme.md
@@ -60,6 +60,8 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
   dnn-rm-folder-list-item --> dnn-collapsible
   dnn-rm-folder-list-item --> dnn-rm-folder-context-menu

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/readme.md
@@ -7,9 +7,10 @@
 
 ## Events
 
-| Event                         | Description                    | Type                          |
-| ----------------------------- | ------------------------------ | ----------------------------- |
-| `dnnRmFolderListFolderPicked` | Fires when a folder is picked. | `CustomEvent<FolderTreeItem>` |
+| Event                         | Description                                                             | Type                          |
+| ----------------------------- | ----------------------------------------------------------------------- | ----------------------------- |
+| `dnnRmcontextMenuOpened`      | Fires when a context menu is opened for this item. Emits the folder ID. | `CustomEvent<number>`         |
+| `dnnRmFolderListFolderPicked` | Fires when a folder is picked.                                          | `CustomEvent<FolderTreeItem>` |
 
 
 ## Dependencies
@@ -21,16 +22,16 @@
 
 ### Depends on
 
+- dnn-collapsible
+- [dnn-rm-folder-context-menu](../context-menus/dnn-rm-folder-context-menu)
 - [dnn-rm-folder-list-item](../dnn-rm-folder-list-item)
 
 ### Graph
 ```mermaid
 graph TD;
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -66,6 +67,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-rm-left-pane --> dnn-rm-folder-list
   style dnn-rm-folder-list fill:#f9f,stroke:#333,stroke-width:4px

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-cardview/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-cardview/readme.md
@@ -66,6 +66,8 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
   dnn-rm-folder-list-item --> dnn-collapsible
   dnn-rm-folder-list-item --> dnn-rm-folder-context-menu

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-listview/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-listview/readme.md
@@ -66,6 +66,8 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
   dnn-rm-folder-list-item --> dnn-collapsible
   dnn-rm-folder-list-item --> dnn-rm-folder-context-menu

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-left-pane/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-left-pane/readme.md
@@ -19,11 +19,9 @@
 ```mermaid
 graph TD;
   dnn-rm-left-pane --> dnn-rm-folder-list
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -61,6 +59,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-resource-manager --> dnn-rm-left-pane
   style dnn-rm-left-pane fill:#f9f,stroke:#333,stroke-width:4px

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-move-items/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-move-items/readme.md
@@ -37,11 +37,9 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -75,6 +73,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   style dnn-rm-move-items fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-right-pane/readme.md
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-right-pane/readme.md
@@ -63,11 +63,9 @@ graph TD;
   dnn-rm-move-items --> dnn-rm-folder-list
   dnn-rm-move-items --> dnn-rm-progress-bar
   dnn-rm-move-items --> dnn-button
+  dnn-rm-folder-list --> dnn-collapsible
+  dnn-rm-folder-list --> dnn-rm-folder-context-menu
   dnn-rm-folder-list --> dnn-rm-folder-list-item
-  dnn-rm-folder-list-item --> dnn-collapsible
-  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
-  dnn-rm-folder-list-item --> dnn-treeview-item
-  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-rm-folder-context-menu --> dnn-action-create-folder
   dnn-rm-folder-context-menu --> dnn-action-edit-item
   dnn-rm-folder-context-menu --> dnn-action-move-items
@@ -81,6 +79,10 @@ graph TD;
   dnn-action-unlink-items --> dnn-rm-unlink-items
   dnn-rm-unlink-items --> dnn-rm-progress-bar
   dnn-rm-unlink-items --> dnn-button
+  dnn-rm-folder-list-item --> dnn-collapsible
+  dnn-rm-folder-list-item --> dnn-rm-folder-context-menu
+  dnn-rm-folder-list-item --> dnn-treeview-item
+  dnn-rm-folder-list-item --> dnn-rm-folder-list-item
   dnn-treeview-item --> dnn-collapsible
   dnn-rm-files-pane --> dnn-rm-items-listview
   dnn-rm-files-pane --> dnn-rm-items-cardview


### PR DESCRIPTION
As part of stencil pojects, documentation about teach component is auto-generated upon build. In a previous PR I forgot to run a full production build before doing the PR so those docs were not commited.

This PR commits them.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
