### PR TITLE
Fixes #2140 issue

### DIFF
--- a/DNN Platform/Controls/CountryListBox/CountryLookup.cs
+++ b/DNN Platform/Controls/CountryListBox/CountryLookup.cs
@@ -122,6 +122,24 @@ namespace DotNetNuke.UI.WebControls
             return memStream;
         }
 
+        /// <summary>
+        /// Get CountryCode by CountryName.
+        /// </summary>
+        /// <param name="stringValue">CountryName.</param>
+        /// <returns>CountryCode.</returns>
+        public static string CodeByName(string stringValue)
+        {
+            for (int i = 0; i < CountryName.Length; i++)
+            {
+                if (stringValue == CountryName[i])
+                {
+                    return CountryCode[i];
+                }
+            }
+
+            return "--";
+        }
+
         /// <summary>Looks up the country code from an IP address.</summary>
         /// <param name="ipAddress">The IP address.</param>
         /// <returns>The country code, e.g. <c>"US"</c>.</returns>

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNCountryAutocompleteControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNCountryAutocompleteControl.cs
@@ -171,7 +171,7 @@ namespace DotNetNuke.UI.WebControls
         {
             this.CountryName.Text = this.StringValue;
             int countryId = -1;
-            string countryCode = this.StringValue;
+            string countryCode = CountryLookup.CodeByName(this.StringValue);
             if (!string.IsNullOrEmpty(this.StringValue) && int.TryParse(this.StringValue, out countryId))
             {
                 var listController = new ListController();


### PR DESCRIPTION
Fixes #2140

## Summary

DNNCountryAutocompleteControl.cs LoadControls() method expects Country code in StringValue but receives Country Name

So in the CountryLookup.cs I made a CodeByName static method that will convert a Country Name to Country Code (based on a list already on the file as an array of strings.

Then now DNNRegionEditControl will receive the countryCode and will load the child items
