### PR TITLE
Resolve warnings in DotNetNuke.Syndication

### DIFF
--- a/DNN Platform/Library/Services/Syndication/RssHandler.cs
+++ b/DNN Platform/Library/Services/Syndication/RssHandler.cs
@@ -16,6 +16,7 @@ namespace DotNetNuke.Services.Syndication
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Services.Search.Internals;
 
+    /// <summary>An HTTP handler for serving an RSS feed.</summary>
     public class RssHandler : SyndicationHandlerBase
     {
         /// <inheritdoc />
@@ -99,7 +100,7 @@ namespace DotNetNuke.Services.Syndication
         }
 
         /// <summary>Creates an RSS Item.</summary>
-        /// <param name="searchResult"></param>
+        /// <param name="searchResult">The search result to convert to an RSS item.</param>
         /// <returns>A new <see cref="GenericRssElement"/> instance.</returns>
         private GenericRssElement GetRssItem(SearchResult searchResult)
         {

--- a/DNN Platform/Library/Services/Syndication/SyndicationHandlerBase.cs
+++ b/DNN Platform/Library/Services/Syndication/SyndicationHandlerBase.cs
@@ -9,20 +9,17 @@ namespace DotNetNuke.Services.Syndication
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
 
+    /// <summary>An HTTP handler for generating an RSS feed.</summary>
     public class SyndicationHandlerBase : GenericRssHttpHandlerBase
     {
         private int moduleId = Null.NullInteger;
 
         private int tabId = Null.NullInteger;
 
-        public PortalSettings Settings
-        {
-            get
-            {
-                return Globals.GetPortalSettings();
-            }
-        }
+        /// <summary>Gets the portal settings.</summary>
+        public PortalSettings Settings => Globals.GetPortalSettings();
 
+        /// <summary>Gets the tab ID of the request.</summary>
         public int TabId
         {
             get
@@ -39,6 +36,7 @@ namespace DotNetNuke.Services.Syndication
             }
         }
 
+        /// <summary>Gets the module ID of the request.</summary>
         public int ModuleId
         {
             get
@@ -55,12 +53,7 @@ namespace DotNetNuke.Services.Syndication
             }
         }
 
-        public HttpRequest Request
-        {
-            get
-            {
-                return HttpContext.Current.Request;
-            }
-        }
+        /// <summary>Gets the HTTP request.</summary>
+        public HttpRequest Request => HttpContext.Current.Request;
     }
 }

--- a/DNN Platform/Syndication/DotNetNuke.Syndication.csproj
+++ b/DNN Platform/Syndication/DotNetNuke.Syndication.csproj
@@ -42,6 +42,7 @@
     <DocumentationFile>bin\DotNetNuke.Services.Syndication.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <LangVersion>7</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -55,6 +56,7 @@
     <DocumentationFile>bin\DotNetNuke.Services.Syndication.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <LangVersion>7</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetNuke.Instrumentation">

--- a/DNN Platform/Syndication/OPML/Opml.cs
+++ b/DNN Platform/Syndication/OPML/Opml.cs
@@ -8,232 +8,74 @@ namespace DotNetNuke.Services.Syndication
 
     using DotNetNuke.Instrumentation;
 
-    /// <summary>  Class for managing an OPML feed.</summary>
+    /// <summary>Class for managing an OPML feed.</summary>
     public class Opml
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(Opml));
-        private DateTime dateCreated = DateTime.MinValue;
-        private DateTime dateModified = DateTime.MinValue;
-        private string docs = string.Empty;
-        private string expansionState = string.Empty;
-        private OpmlOutlines outlines;
-        private string ownerEmail = string.Empty;
-        private string ownerId = string.Empty;
-        private string ownerName = string.Empty;
-        private string title = string.Empty;
-        private DateTime utcExpiry = DateTime.Now.AddMinutes(180);
-        private string vertScrollState = string.Empty;
-        private string windowBottom = string.Empty;
-        private string windowLeft = string.Empty;
-        private string windowRight = string.Empty;
-        private string windowTop = string.Empty;
         private XmlDocument opmlDoc;
 
+        /// <summary>Initializes a new instance of the <see cref="Opml"/> class.</summary>
         public Opml()
         {
-            this.outlines = new OpmlOutlines();
+            this.Outlines = new OpmlOutlines();
         }
 
-        public DateTime UtcExpiry
-        {
-            get
-            {
-                return this.utcExpiry;
-            }
+        /// <summary>Gets or sets the expiration (in UTC).</summary>
+        public DateTime UtcExpiry { get; set; } = DateTime.Now.AddMinutes(180);
 
-            set
-            {
-                this.utcExpiry = value;
-            }
-        }
+        /// <summary>Gets or sets the title.</summary>
+        public string Title { get; set; } = string.Empty;
 
-        public string Title
-        {
-            get
-            {
-                return this.title;
-            }
+        /// <summary>Gets or sets the created date.</summary>
+        public DateTime DateCreated { get; set; } = DateTime.MinValue;
 
-            set
-            {
-                this.title = value;
-            }
-        }
+        /// <summary>Gets or sets the date modified.</summary>
+        public DateTime DateModified { get; set; } = DateTime.MinValue;
 
-        public DateTime DateCreated
-        {
-            get
-            {
-                return this.dateCreated;
-            }
+        /// <summary>Gets or sets owner name.</summary>
+        public string OwnerName { get; set; } = string.Empty;
 
-            set
-            {
-                this.dateCreated = value;
-            }
-        }
+        /// <summary>Gets or sets the owner email.</summary>
+        public string OwnerEmail { get; set; } = string.Empty;
 
-        public DateTime DateModified
-        {
-            get
-            {
-                return this.dateModified;
-            }
+        /// <summary>Gets or sets the owner ID.</summary>
+        public string OwnerId { get; set; } = string.Empty;
 
-            set
-            {
-                this.dateModified = value;
-            }
-        }
+        /// <summary>Gets or sets the docs.</summary>
+        public string Docs { get; set; } = string.Empty;
 
-        public string OwnerName
-        {
-            get
-            {
-                return this.ownerName;
-            }
+        /// <summary>Gets or sets the expansion state.</summary>
+        public string ExpansionState { get; set; } = string.Empty;
 
-            set
-            {
-                this.ownerName = value;
-            }
-        }
+        /// <summary>Gets or sets the vertical scroll state.</summary>
+        public string VertScrollState { get; set; } = string.Empty;
 
-        public string OwnerEmail
-        {
-            get
-            {
-                return this.ownerEmail;
-            }
+        /// <summary>Gets or sets window top position.</summary>
+        public string WindowTop { get; set; } = string.Empty;
 
-            set
-            {
-                this.ownerEmail = value;
-            }
-        }
+        /// <summary>Gets or sets window left position.</summary>
+        public string WindowLeft { get; set; } = string.Empty;
 
-        public string OwnerId
-        {
-            get
-            {
-                return this.ownerId;
-            }
+        /// <summary>Gets or sets the window bottom position.</summary>
+        public string WindowBottom { get; set; } = string.Empty;
 
-            set
-            {
-                this.ownerId = value;
-            }
-        }
+        /// <summary>Gets or sets the window right position.</summary>
+        public string WindowRight { get; set; } = string.Empty;
 
-        public string Docs
-        {
-            get
-            {
-                return this.docs;
-            }
+        /// <summary>Gets or sets the outlines.</summary>
+        public OpmlOutlines Outlines { get; set; }
 
-            set
-            {
-                this.docs = value;
-            }
-        }
-
-        public string ExpansionState
-        {
-            get
-            {
-                return this.expansionState;
-            }
-
-            set
-            {
-                this.expansionState = value;
-            }
-        }
-
-        public string VertScrollState
-        {
-            get
-            {
-                return this.vertScrollState;
-            }
-
-            set
-            {
-                this.vertScrollState = value;
-            }
-        }
-
-        public string WindowTop
-        {
-            get
-            {
-                return this.windowTop;
-            }
-
-            set
-            {
-                this.windowTop = value;
-            }
-        }
-
-        public string WindowLeft
-        {
-            get
-            {
-                return this.windowLeft;
-            }
-
-            set
-            {
-                this.windowLeft = value;
-            }
-        }
-
-        public string WindowBottom
-        {
-            get
-            {
-                return this.windowBottom;
-            }
-
-            set
-            {
-                this.windowBottom = value;
-            }
-        }
-
-        public string WindowRight
-        {
-            get
-            {
-                return this.windowRight;
-            }
-
-            set
-            {
-                this.windowRight = value;
-            }
-        }
-
-        public OpmlOutlines Outlines
-        {
-            get
-            {
-                return this.outlines;
-            }
-
-            set
-            {
-                this.outlines = value;
-            }
-        }
-
+        /// <summary>Loads an OPML feed from a URL.</summary>
+        /// <param name="uri">The feed's URL.</param>
+        /// <returns>The OPML feed, or an empty OPML feed if there's an error loading it.</returns>
         public static Opml LoadFromUrl(Uri uri)
         {
             return OpmlDownloadManager.GetOpmlFeed(uri);
         }
 
+        /// <summary>Loads an OPML feed from a file path.</summary>
+        /// <param name="path">The file path.</param>
+        /// <returns>The OPML feed, or an empty OPML feed if there's an error loading it.</returns>
         public static Opml LoadFromFile(string path)
         {
             try
@@ -249,6 +91,9 @@ namespace DotNetNuke.Services.Syndication
             }
         }
 
+        /// <summary>Loads an OPML feed from an XML document.</summary>
+        /// <param name="doc">The XML document.</param>
+        /// <returns>The OPML feed, or an empty OPML feed if there's an error loading it.</returns>
         public static Opml LoadFromXml(XmlDocument doc)
         {
             var @out = new Opml();
@@ -351,16 +196,29 @@ namespace DotNetNuke.Services.Syndication
             }
         }
 
+        /// <summary>Adds an <paramref name="item"/> to the <see cref="Outlines"/>.</summary>
+        /// <param name="item">The outline item.</param>
         public void AddOutline(OpmlOutline item)
         {
-            this.outlines.Add(item);
+            this.Outlines.Add(item);
         }
 
+        /// <summary>Adds an item to the <see cref="Outlines"/>.</summary>
+        /// <param name="text">The item text.</param>
+        /// <param name="type">The item type.</param>
+        /// <param name="xmlUrl">The XML URL for the item.</param>
+        /// <param name="category">The item's category.</param>
         public void AddOutline(string text, string type, Uri xmlUrl, string category)
         {
             this.AddOutline(text, type, xmlUrl, category, null);
         }
 
+        /// <summary>Adds an item to the <see cref="Outlines"/>.</summary>
+        /// <param name="text">The item text.</param>
+        /// <param name="type">The item type.</param>
+        /// <param name="xmlUrl">The XML URL for the item.</param>
+        /// <param name="category">The item's category.</param>
+        /// <param name="outlines">The item's outlines.</param>
         public void AddOutline(string text, string type, Uri xmlUrl, string category, OpmlOutlines outlines)
         {
             var item = new OpmlOutline();
@@ -369,14 +227,18 @@ namespace DotNetNuke.Services.Syndication
             item.XmlUrl = xmlUrl;
             item.Category = category;
             item.Outlines = outlines;
-            this.outlines.Add(item);
+            this.Outlines.Add(item);
         }
 
+        /// <summary>Get the OPML doc as XML.</summary>
+        /// <returns>The XML markup for this OPML feed.</returns>
         public string GetXml()
         {
             return this.opmlDoc.OuterXml;
         }
 
+        /// <summary>Saves this OPML feed as an XML file.</summary>
+        /// <param name="fileName">The file path.</param>
         public void Save(string fileName)
         {
             this.opmlDoc = new XmlDocument { XmlResolver = null };
@@ -457,7 +319,7 @@ namespace DotNetNuke.Services.Syndication
             XmlElement opmlBody = this.opmlDoc.CreateElement("body");
             opml.AppendChild(opmlBody);
 
-            foreach (OpmlOutline outline in this.outlines)
+            foreach (OpmlOutline outline in this.Outlines)
             {
                 opmlBody.AppendChild(outline.ToXml);
             }
@@ -465,6 +327,9 @@ namespace DotNetNuke.Services.Syndication
             this.opmlDoc.Save(fileName);
         }
 
+        /// <summary>Parses a <paramref name="node"/> into an <see cref="OpmlOutline"/>.</summary>
+        /// <param name="node">The XML element to parse.</param>
+        /// <returns>A new <see cref="OpmlOutline"/> instance.</returns>
         internal static OpmlOutline ParseXml(XmlElement node)
         {
             var newOutline = new OpmlOutline();

--- a/DNN Platform/Syndication/OPML/OpmlDownloadManager.cs
+++ b/DNN Platform/Syndication/OPML/OpmlDownloadManager.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Services.Syndication
 
     using DotNetNuke.Instrumentation;
 
-    /// <summary>  Helper class that provides memory and disk caching of the downloaded feeds.</summary>
+    /// <summary>Helper class that provides memory and disk caching of the downloaded feeds.</summary>
     internal class OpmlDownloadManager
     {
         private const string OPMLDir = "/OPML/";
@@ -34,11 +34,17 @@ namespace DotNetNuke.Services.Syndication
             this.directoryOnDisk = PrepareTempDir();
         }
 
+        /// <summary>Gets the OPML feed at a given <paramref name="uri"/>.</summary>
+        /// <param name="uri">The feed URI.</param>
+        /// <returns>The OPML feed, or an empty OPML feed if there's an error loading it.</returns>
         public static Opml GetOpmlFeed(Uri uri)
         {
             return TheManager.GetFeed(uri);
         }
 
+        /// <summary>Gets the OPML feed at a given <paramref name="uri"/>.</summary>
+        /// <param name="uri">The feed URI.</param>
+        /// <returns>The OPML feed, or an empty OPML feed if there's an error loading it.</returns>
         internal Opml GetFeed(Uri uri)
         {
             Opml opmlFeed = null;

--- a/DNN Platform/Syndication/OPML/OpmlOutline.cs
+++ b/DNN Platform/Syndication/OPML/OpmlOutline.cs
@@ -6,30 +6,19 @@ namespace DotNetNuke.Services.Syndication
     using System;
     using System.Xml;
 
-    /// <summary>  Class for managing an OPML feed outline.</summary>
+    /// <summary>Class for managing an OPML feed outline.</summary>
     public class OpmlOutline
     {
-        private string category = string.Empty;
-        private DateTime created = DateTime.MinValue;
-        private string description = string.Empty;
-        private string language = string.Empty;
-        private string text = string.Empty;
-        private string title = string.Empty;
-        private string type = "rss";
-
+        /// <summary>Initializes a new instance of the <see cref="OpmlOutline"/> class.</summary>
         public OpmlOutline()
         {
             this.Outlines = new OpmlOutlines();
         }
 
-        public string Version
-        {
-            get
-            {
-                return "2.0";
-            }
-        }
+        /// <summary>Gets the OPML outline version.</summary>
+        public string Version => "2.0";
 
+        /// <summary>Gets the OPML outline as an <see cref="XmlElement"/>.</summary>
         public XmlElement ToXml
         {
             get
@@ -99,107 +88,43 @@ namespace DotNetNuke.Services.Syndication
             }
         }
 
-        public string Description
-        {
-            get
-            {
-                return this.description;
-            }
+        /// <summary>Gets or sets the OPML outline description.</summary>
+        public string Description { get; set; } = string.Empty;
 
-            set
-            {
-                this.description = value;
-            }
-        }
+        /// <summary>Gets or sets the OPML outline title.</summary>
+        public string Title { get; set; } = string.Empty;
 
-        public string Title
-        {
-            get
-            {
-                return this.title;
-            }
+        /// <summary>Gets or sets the OPML outline type.</summary>
+        public string Type { get; set; } = "rss";
 
-            set
-            {
-                this.title = value;
-            }
-        }
+        /// <summary>Gets or sets the OPML outline text.</summary>
+        public string Text { get; set; } = string.Empty;
 
-        public string Type
-        {
-            get
-            {
-                return this.type;
-            }
-
-            set
-            {
-                this.type = value;
-            }
-        }
-
-        public string Text
-        {
-            get
-            {
-                return this.text;
-            }
-
-            set
-            {
-                this.text = value;
-            }
-        }
-
+        /// <summary>Gets or sets the OPML outline's HTML URL.</summary>
         public Uri HtmlUrl { get; set; }
 
+        /// <summary>Gets or sets the OPML outline's XML URL.</summary>
         public Uri XmlUrl { get; set; }
 
+        /// <summary>Gets or sets the OPML outline's URL.</summary>
         public Uri Url { get; set; }
 
-        public DateTime Created
-        {
-            get
-            {
-                return this.created;
-            }
+        /// <summary>Gets or sets the creation date for the OPML outline.</summary>
+        public DateTime Created { get; set; } = DateTime.MinValue;
 
-            set
-            {
-                this.created = value;
-            }
-        }
-
+        /// <summary>Gets or sets a value indicating whether this OPML outline is a comment.</summary>
         public bool IsComment { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether this OPML outline is a breakpoint.</summary>
         public bool IsBreakpoint { get; set; }
 
-        public string Category
-        {
-            get
-            {
-                return this.category;
-            }
+        /// <summary>Gets or sets the OPML outline category.</summary>
+        public string Category { get; set; } = string.Empty;
 
-            set
-            {
-                this.category = value;
-            }
-        }
+        /// <summary>Gets or sets the OPML outline language.</summary>
+        public string Language { get; set; } = string.Empty;
 
-        public string Language
-        {
-            get
-            {
-                return this.language;
-            }
-
-            set
-            {
-                this.language = value;
-            }
-        }
-
+        /// <summary>Gets or sets the outlines contained in this OPML outline.</summary>
         public OpmlOutlines Outlines { get; set; }
     }
 }

--- a/DNN Platform/Syndication/OPML/OpmlOutlines.cs
+++ b/DNN Platform/Syndication/OPML/OpmlOutlines.cs
@@ -1,11 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Services.Syndication
 {
     using System.Collections.Generic;
 
+    /// <summary>A collection of OPML outlines.</summary>
     public class OpmlOutlines : List<OpmlOutline>
     {
     }

--- a/DNN Platform/Syndication/RSS/GenericRssChannel.cs
+++ b/DNN Platform/Syndication/RSS/GenericRssChannel.cs
@@ -7,38 +7,26 @@ namespace DotNetNuke.Services.Syndication
     using System.Collections.Generic;
     using System.Xml;
 
-    /// <summary>  Class to consume (or create) a channel in a late-bound way.</summary>
+    /// <summary>Class to consume (or create) a channel in a late-bound way.</summary>
     public sealed class GenericRssChannel : RssChannelBase<GenericRssElement, GenericRssElement>
     {
-        public new Dictionary<string, string> Attributes
-        {
-            get
-            {
-                return base.Attributes;
-            }
-        }
+        /// <inheritdoc cref="RssElementBase.Attributes" />
+        public new Dictionary<string, string> Attributes => base.Attributes;
 
-        public GenericRssElement Image
-        {
-            get
-            {
-                return this.GetImage();
-            }
-        }
+        /// <summary>Gets the channel image.</summary>
+        public GenericRssElement Image => this.GetImage();
 
+        /// <summary>Gets or sets the channel's attributes.</summary>
+        /// <param name="attributeName">The attribute name.</param>
         public string this[string attributeName]
         {
-            get
-            {
-                return this.GetAttributeValue(attributeName);
-            }
-
-            set
-            {
-                this.Attributes[attributeName] = value;
-            }
+            get => this.GetAttributeValue(attributeName);
+            set => this.Attributes[attributeName] = value;
         }
 
+        /// <summary>Loads an RSS channel from a <paramref name="url"/>.</summary>
+        /// <param name="url">The channel's URL.</param>
+        /// <returns>A new <see cref="GenericRssChannel"/> instance.</returns>
         public static GenericRssChannel LoadChannel(string url)
         {
             var channel = new GenericRssChannel();
@@ -46,6 +34,9 @@ namespace DotNetNuke.Services.Syndication
             return channel;
         }
 
+        /// <summary>Loads an RSS channel from a <paramref name="doc"/>.</summary>
+        /// <param name="doc">The XML document.</param>
+        /// <returns>A new <see cref="GenericRssChannel"/> instance.</returns>
         public static GenericRssChannel LoadChannel(XmlDocument doc)
         {
             var channel = new GenericRssChannel();
@@ -53,12 +44,17 @@ namespace DotNetNuke.Services.Syndication
             return channel;
         }
 
-        // Select method for programmatic databinding
+        /// <summary>Get a sequence of the channel's items.</summary>
+        /// <returns>A sequence of <see cref="RssElementCustomTypeDescriptor"/> instances.</returns>
+        /// <remarks>This method is for programmatic data-binding.</remarks>
         public IEnumerable SelectItems()
         {
             return this.SelectItems(-1);
         }
 
+        /// <summary>Get a sequence of the channel's items.</summary>
+        /// <param name="maxItems">The maximum number of items to include, or include all items if the value is not positive.</param>
+        /// <returns>A sequence of <see cref="RssElementCustomTypeDescriptor"/> instances.</returns>
         public IEnumerable SelectItems(int maxItems)
         {
             var data = new ArrayList();

--- a/DNN Platform/Syndication/RSS/GenericRssElement.cs
+++ b/DNN Platform/Syndication/RSS/GenericRssElement.cs
@@ -5,28 +5,18 @@ namespace DotNetNuke.Services.Syndication
 {
     using System.Collections.Generic;
 
-    /// <summary>  Late-bound RSS element (used for late bound item and image).</summary>
+    /// <summary>Late-bound RSS element (used for late bound item and image).</summary>
     public sealed class GenericRssElement : RssElementBase
     {
-        public new Dictionary<string, string> Attributes
-        {
-            get
-            {
-                return base.Attributes;
-            }
-        }
+        /// <inheritdoc cref="RssElementBase.Attributes" />
+        public new Dictionary<string, string> Attributes => base.Attributes;
 
+        /// <summary>Gets or sets the element's attributes.</summary>
+        /// <param name="attributeName">The attribute name.</param>
         public string this[string attributeName]
         {
-            get
-            {
-                return this.GetAttributeValue(attributeName);
-            }
-
-            set
-            {
-                this.Attributes[attributeName] = value;
-            }
+            get => this.GetAttributeValue(attributeName);
+            set => this.Attributes[attributeName] = value;
         }
     }
 }

--- a/DNN Platform/Syndication/RSS/RssChannelBase.cs
+++ b/DNN Platform/Syndication/RSS/RssChannelBase.cs
@@ -13,31 +13,24 @@ namespace DotNetNuke.Services.Syndication
         where TRssItemType : RssElementBase, new()
         where TRssImageType : RssElementBase, new()
     {
-        private readonly List<TRssItemType> items = new List<TRssItemType>();
         private TRssImageType image;
-        private string url;
 
-        public List<TRssItemType> Items
-        {
-            get
-            {
-                return this.items;
-            }
-        }
+        /// <summary>Gets the channel items.</summary>
+        public List<TRssItemType> Items { get; } = new List<TRssItemType>();
 
-        internal string Url
-        {
-            get
-            {
-                return this.url;
-            }
-        }
+        /// <summary>Gets the channel URL.</summary>
+        internal string Url { get; private set; }
 
+        /// <summary>Gets the channel as an XML document.</summary>
+        /// <returns>A new <see cref="XmlDocument"/> instance.</returns>
         public XmlDocument SaveAsXml()
         {
             return this.SaveAsXml(RssXmlHelper.CreateEmptyRssXml());
         }
 
+        /// <summary>Gets the channel as an XML document.</summary>
+        /// <param name="emptyRssXml">An empty <see cref="XmlDocument"/> to save the channel contents into.</param>
+        /// <returns>The <paramref name="emptyRssXml"/> passed in with the channel contents added.</returns>
         public XmlDocument SaveAsXml(XmlDocument emptyRssXml)
         {
             XmlDocument doc = emptyRssXml;
@@ -48,7 +41,7 @@ namespace DotNetNuke.Services.Syndication
                 RssXmlHelper.SaveRssElementAsXml(channelNode, this.image, "image");
             }
 
-            foreach (TRssItemType item in this.items)
+            foreach (TRssItemType item in this.Items)
             {
                 RssXmlHelper.SaveRssElementAsXml(channelNode, item, "item");
             }
@@ -56,6 +49,8 @@ namespace DotNetNuke.Services.Syndication
             return doc;
         }
 
+        /// <summary>Loads the contents from the <paramref name="dom"/> into this channel.</summary>
+        /// <param name="dom">The DOM to load from.</param>
         internal void LoadFromDom(RssChannelDom dom)
         {
             // channel attributes
@@ -74,10 +69,12 @@ namespace DotNetNuke.Services.Syndication
             {
                 var item = new TRssItemType();
                 item.SetAttributes(i);
-                this.items.Add(item);
+                this.Items.Add(item);
             }
         }
 
+        /// <summary>Loads a channel from a <paramref name="url"/> into this channel.</summary>
+        /// <param name="url">The URL to load the channel from.</param>
         protected void LoadFromUrl(string url)
         {
             // download the feed
@@ -87,9 +84,11 @@ namespace DotNetNuke.Services.Syndication
             this.LoadFromDom(dom);
 
             // remember the url
-            this.url = url;
+            this.Url = url;
         }
 
+        /// <summary>Loads a channel from a <paramref name="doc"/> into this channel.</summary>
+        /// <param name="doc">The XML to load the channel from.</param>
         protected void LoadFromXml(XmlDocument doc)
         {
             // parse XML
@@ -99,6 +98,8 @@ namespace DotNetNuke.Services.Syndication
             this.LoadFromDom(dom);
         }
 
+        /// <summary>Gets the channel image.</summary>
+        /// <returns>An <typeparamref name="TRssImageType"/> instance.</returns>
         protected TRssImageType GetImage()
         {
             if (this.image == null)

--- a/DNN Platform/Syndication/RSS/RssChannelDom.cs
+++ b/DNN Platform/Syndication/RSS/RssChannelDom.cs
@@ -6,57 +6,38 @@ namespace DotNetNuke.Services.Syndication
     using System;
     using System.Collections.Generic;
 
-    /// <summary>  Internal representation of parsed RSS channel.</summary>
+    /// <summary>Internal representation of parsed RSS channel.</summary>
     internal class RssChannelDom
     {
-        private readonly Dictionary<string, string> channel;
-        private readonly Dictionary<string, string> image;
-        private readonly List<Dictionary<string, string>> items;
-        private DateTime utcExpiry;
-
+        /// <summary>Initializes a new instance of the <see cref="RssChannelDom"/> class.</summary>
+        /// <param name="channel">The channel attributes.</param>
+        /// <param name="image">The image attributes.</param>
+        /// <param name="items">The items.</param>
         internal RssChannelDom(Dictionary<string, string> channel, Dictionary<string, string> image, List<Dictionary<string, string>> items)
         {
-            this.channel = channel;
-            this.image = image;
-            this.items = items;
-            this.utcExpiry = DateTime.MaxValue;
+            this.Channel = channel;
+            this.Image = image;
+            this.Items = items;
+            this.UtcExpiry = DateTime.MaxValue;
         }
 
-        internal Dictionary<string, string> Channel
-        {
-            get
-            {
-                return this.channel;
-            }
-        }
+        /// <summary>Gets the channel attributes.</summary>
+        internal Dictionary<string, string> Channel { get; }
 
-        internal Dictionary<string, string> Image
-        {
-            get
-            {
-                return this.image;
-            }
-        }
+        /// <summary>Gets the image attributes.</summary>
+        internal Dictionary<string, string> Image { get; }
 
-        internal List<Dictionary<string, string>> Items
-        {
-            get
-            {
-                return this.items;
-            }
-        }
+        /// <summary>Gets the items.</summary>
+        internal List<Dictionary<string, string>> Items { get; }
 
-        internal DateTime UtcExpiry
-        {
-            get
-            {
-                return this.utcExpiry;
-            }
-        }
+        /// <summary>Gets the expiration in UTC.</summary>
+        internal DateTime UtcExpiry { get; private set; }
 
+        /// <summary>Sets the expiration.</summary>
+        /// <param name="utcExpiry">The expiration on UTC.</param>
         internal void SetExpiry(DateTime utcExpiry)
         {
-            this.utcExpiry = utcExpiry;
+            this.UtcExpiry = utcExpiry;
         }
     }
 }

--- a/DNN Platform/Syndication/RSS/RssDataSource.cs
+++ b/DNN Platform/Syndication/RSS/RssDataSource.cs
@@ -6,7 +6,7 @@ namespace DotNetNuke.Services.Syndication
     using System.ComponentModel;
     using System.Web.UI;
 
-    /// <summary>  RSS data source control implementation, including the designer.</summary>
+    /// <summary>RSS data source control implementation, including the designer.</summary>
     [DefaultProperty("Url")]
     public class RssDataSource : DataSourceControl
     {
@@ -14,6 +14,7 @@ namespace DotNetNuke.Services.Syndication
         private RssDataSourceView itemsView;
         private string url;
 
+        /// <summary>Gets the channel.</summary>
         public GenericRssChannel Channel
         {
             get
@@ -34,8 +35,10 @@ namespace DotNetNuke.Services.Syndication
             }
         }
 
+        /// <summary>Gets or sets the maximum number of items.</summary>
         public int MaxItems { get; set; }
 
+        /// <summary>Gets or sets the URL.</summary>
         public string Url
         {
             get

--- a/DNN Platform/Syndication/RSS/RssDataSourceView.cs
+++ b/DNN Platform/Syndication/RSS/RssDataSourceView.cs
@@ -1,19 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Services.Syndication
 {
     using System.Collections;
     using System.Web.UI;
 
+    /// <summary>An RSS <see cref="DataSourceView"/>.</summary>
     public class RssDataSourceView : DataSourceView
     {
         private readonly RssDataSource owner;
 
         /// <summary>Initializes a new instance of the <see cref="RssDataSourceView"/> class.</summary>
-        /// <param name="owner"></param>
-        /// <param name="viewName"></param>
+        /// <inheritdoc cref="DataSourceView(IDataSource, string)"/>
         internal RssDataSourceView(RssDataSource owner, string viewName)
             : base(owner, viewName)
         {

--- a/DNN Platform/Syndication/RSS/RssDownloadManager.cs
+++ b/DNN Platform/Syndication/RSS/RssDownloadManager.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Services.Syndication
 
     using DotNetNuke.Instrumentation;
 
-    /// <summary>  Helper class that provides memory and disk caching of the downloaded feeds.</summary>
+    /// <summary>Helper class that provides memory and disk caching of the downloaded feeds.</summary>
     internal class RssDownloadManager
     {
         private const string RSSDir = "/RSS/";
@@ -34,6 +34,9 @@ namespace DotNetNuke.Services.Syndication
             this.directoryOnDisk = PrepareTempDir();
         }
 
+        /// <summary>Gets the RSS channel at the given <paramref name="url"/>.</summary>
+        /// <param name="url">The URL.</param>
+        /// <returns>The RSS feed, or an empty RSS feed if there's an error loading it.</returns>
         public static RssChannelDom GetChannel(string url)
         {
             return TheManager.GetChannelDom(url);

--- a/DNN Platform/Syndication/RSS/RssElementBase.cs
+++ b/DNN Platform/Syndication/RSS/RssElementBase.cs
@@ -6,36 +6,32 @@ namespace DotNetNuke.Services.Syndication
     using System;
     using System.Collections.Generic;
 
-    /// <summary>
-    ///   The base class for all RSS elements (item, image, channel)
-    ///   has collection of attributes.
-    /// </summary>
+    /// <summary>The base class for all RSS elements (item, image, channel) has collection of attributes.</summary>
     public abstract class RssElementBase
     {
-        private Dictionary<string, string> attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>Gets the attributes.</summary>
+        protected internal Dictionary<string, string> Attributes { get; private set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        protected internal Dictionary<string, string> Attributes
-        {
-            get
-            {
-                return this.attributes;
-            }
-        }
-
+        /// <summary>When overridden in a derived class, initializes the attributes to the defaults.</summary>
         public virtual void SetDefaults()
         {
         }
 
+        /// <summary>Sets the element attributes.</summary>
+        /// <param name="attributes">The attributes.</param>
         internal void SetAttributes(Dictionary<string, string> attributes)
         {
-            this.attributes = attributes;
+            this.Attributes = attributes;
         }
 
+        /// <summary>Gets the attribute value.</summary>
+        /// <param name="attributeName">The attribute name.</param>
+        /// <returns>The value or <see cref="string.Empty"/>.</returns>
         protected string GetAttributeValue(string attributeName)
         {
             string attributeValue;
 
-            if (!this.attributes.TryGetValue(attributeName, out attributeValue))
+            if (!this.Attributes.TryGetValue(attributeName, out attributeValue))
             {
                 attributeValue = string.Empty;
             }
@@ -43,9 +39,12 @@ namespace DotNetNuke.Services.Syndication
             return attributeValue;
         }
 
+        /// <summary>Sets the value of an attribute.</summary>
+        /// <param name="attributeName">The attribute name.</param>
+        /// <param name="attributeValue">The attribute value.</param>
         protected void SetAttributeValue(string attributeName, string attributeValue)
         {
-            this.attributes[attributeName] = attributeValue;
+            this.Attributes[attributeName] = attributeValue;
         }
     }
 }

--- a/DNN Platform/Syndication/RSS/RssElementCustomTypeDescriptor.cs
+++ b/DNN Platform/Syndication/RSS/RssElementCustomTypeDescriptor.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Services.Syndication
         private readonly Dictionary<string, string> attributes;
 
         /// <summary>Initializes a new instance of the <see cref="RssElementCustomTypeDescriptor"/> class.</summary>
-        /// <param name="attributes"></param>
+        /// <param name="attributes">The attributes.</param>
         public RssElementCustomTypeDescriptor(Dictionary<string, string> attributes)
         {
             this.attributes = attributes;
@@ -155,13 +155,9 @@ namespace DotNetNuke.Services.Syndication
 
             public override object GetValue(object o)
             {
-                var element = o as RssElementCustomTypeDescriptor;
-
-                if (element != null)
+                if (o is RssElementCustomTypeDescriptor element)
                 {
-                    string propertyValue;
-
-                    if (element.attributes.TryGetValue(this.Name, out propertyValue))
+                    if (element.attributes.TryGetValue(this.Name, out var propertyValue))
                     {
                         return propertyValue;
                     }

--- a/DNN Platform/Syndication/RSS/RssHttpHandlerHelper.cs
+++ b/DNN Platform/Syndication/RSS/RssHttpHandlerHelper.cs
@@ -7,14 +7,18 @@ namespace DotNetNuke.Services.Syndication
     using System.Web;
     using System.Web.Security;
 
-    /// <summary>  Helper class (for RssHtppHandler) to pack and unpack user name and channel to from/to query string.</summary>
+    /// <summary>Helper class (for <see cref="RssHttpHandlerBase{TRssChannelType,TRssItemType,TRssImageType}"/>) to pack and unpack user name and channel to from/to query string.</summary>
     public class RssHttpHandlerHelper
     {
         private RssHttpHandlerHelper()
         {
         }
 
-        // helper to generate link [to the .ashx] containing channel name and (encoded) userName
+        /// <summary>Generate the link (to the .ashx) containing the channel name and (encoded) userName.</summary>
+        /// <param name="handlerPath">The handler path.</param>
+        /// <param name="channelName">The channel name.</param>
+        /// <param name="userName">The user name.</param>
+        /// <returns>A URL to the channel.</returns>
         public static string GenerateChannelLink(string handlerPath, string channelName, string userName)
         {
             string link = VirtualPathUtility.ToAbsolute(handlerPath);
@@ -34,7 +38,7 @@ namespace DotNetNuke.Services.Syndication
                 }
 
                 userName = "." + userName; // not to confuse the encrypted string with real auth ticket for real user
-                DateTime ticketDate = DateTime.Now.AddDays(-100); // already expried
+                DateTime ticketDate = DateTime.Now.AddDays(-100); // already expired
 
                 var t = new FormsAuthenticationTicket(2, userName, ticketDate, ticketDate.AddDays(2), false, channelName, "/");
 
@@ -44,6 +48,10 @@ namespace DotNetNuke.Services.Syndication
             return link;
         }
 
+        /// <summary>Parses the channel's query-string to extract the channel name and user name.</summary>
+        /// <param name="request">The HTTP request.</param>
+        /// <param name="channelName">The channel name.</param>
+        /// <param name="userName">The user name or <see cref="string.Empty"/>.</param>
         internal static void ParseChannelQueryString(HttpRequest request, out string channelName, out string userName)
         {
             string ticket = request.QueryString["t"];

--- a/DNN Platform/Syndication/RSS/RssHyperLink.cs
+++ b/DNN Platform/Syndication/RSS/RssHyperLink.cs
@@ -7,52 +7,27 @@ namespace DotNetNuke.Services.Syndication
     using System.Web.UI;
     using System.Web.UI.WebControls;
 
-    /// <summary>  RssHyperLink control - works with RssHttpHandler.</summary>
+    /// <summary>RssHyperLink control - works with <see cref="RssHttpHandlerBase{TRssChannelType,TRssItemType,TRssImageType}"/>.</summary>
     public class RssHyperLink : HyperLink
     {
-        private string channelName;
-        private bool includeUserName;
-
         /// <summary>Initializes a new instance of the <see cref="RssHyperLink"/> class.</summary>
         public RssHyperLink()
         {
             this.Text = "RSS";
         }
 
-        // passed to RssHttpHandler
-        public string ChannelName
-        {
-            get
-            {
-                return this.channelName;
-            }
+        /// <summary>Gets or sets the channel name.</summary>
+        public string ChannelName { get; set; }
 
-            set
-            {
-                this.channelName = value;
-            }
-        }
-
-        // when flag is set, the current user'd name is passed to RssHttpHandler
-        public bool IncludeUserName
-        {
-            get
-            {
-                return this.includeUserName;
-            }
-
-            set
-            {
-                this.includeUserName = value;
-            }
-        }
+        /// <summary>Gets or sets a value indicating whether the current user's name is passed to RssHttpHandler.</summary>
+        public bool IncludeUserName { get; set; }
 
         /// <inheritdoc/>
         protected override void OnPreRender(EventArgs e)
         {
             // modify the NavigateUrl to include optional user name and channel name
-            string channel = this.channelName != null ? this.channelName : string.Empty;
-            string user = this.includeUserName ? this.Context.User.Identity.Name : string.Empty;
+            string channel = this.ChannelName ?? string.Empty;
+            string user = this.IncludeUserName ? this.Context.User.Identity.Name : string.Empty;
             this.NavigateUrl = RssHttpHandlerHelper.GenerateChannelLink(this.NavigateUrl, channel, user);
 
             // add <link> to <head> tag (if <head runat=server> is present)
@@ -60,7 +35,8 @@ namespace DotNetNuke.Services.Syndication
             {
                 string title = string.IsNullOrEmpty(channel) ? this.Text : channel;
 
-                this.Page.Header.Controls.Add(new LiteralControl(string.Format("\r\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"{0}\" href=\"{1}\" />", title, this.NavigateUrl)));
+                this.Page.Header.Controls.Add(new LiteralControl(
+                    $"\r\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"{title}\" href=\"{this.NavigateUrl}\" />"));
             }
 
             base.OnPreRender(e);

--- a/DNN Platform/Syndication/RSS/RssXmlHelper.cs
+++ b/DNN Platform/Syndication/RSS/RssXmlHelper.cs
@@ -8,10 +8,11 @@ namespace DotNetNuke.Services.Syndication
     using System.Web;
     using System.Xml;
 
+    /// <summary>A helper class for handling RSS XML.</summary>
     internal class RssXmlHelper
     {
         /// <summary>Internal helper class for XML to RSS conversion (and for generating XML from RSS).</summary>
-        /// <param name="doc"></param>
+        /// <param name="doc">The XML document.</param>
         /// <returns>A new <see cref="RssChannelDom"/> instance.</returns>
         internal static RssChannelDom ParseChannelXml(XmlDocument doc)
         {
@@ -91,6 +92,8 @@ namespace DotNetNuke.Services.Syndication
             return new RssChannelDom(channelAttributes, imageAttributes, itemsAttributesList);
         }
 
+        /// <summary>Creates an empty RSS XML document.</summary>
+        /// <returns>A new <see cref="XmlDocument"/>.</returns>
         internal static XmlDocument CreateEmptyRssXml()
         {
             var doc = new XmlDocument { XmlResolver = null };
@@ -100,6 +103,11 @@ namespace DotNetNuke.Services.Syndication
             return doc;
         }
 
+        /// <summary>Copies the <paramref name="element"/> into the <paramref name="parentNode"/>.</summary>
+        /// <param name="parentNode">The node to which the new element will be added.</param>
+        /// <param name="element">The element to copy.</param>
+        /// <param name="elementName">The name of the new element to copy into.</param>
+        /// <returns>The new XML element.</returns>
         internal static XmlNode SaveRssElementAsXml(XmlNode parentNode, RssElementBase element, string elementName)
         {
             XmlDocument doc = parentNode.OwnerDocument;

--- a/DNN Platform/Syndication/Settings.cs
+++ b/DNN Platform/Syndication/Settings.cs
@@ -5,8 +5,10 @@ namespace DotNetNuke.Services.Syndication
 {
     using System.Diagnostics.CodeAnalysis;
 
+    /// <summary>Holder of settings values.</summary>
     internal static class Settings
     {
+        /// <summary>The path to the root of the cache folder.</summary>
         [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Breaking change")]
         internal static string CacheRoot = "Portals/_default/Cache";
     }


### PR DESCRIPTION
## Summary
Resolve documentation warnings in DotNetNuke.Syndication project, turn on `TreatWarningsAsErrors`