### PR TITLE
Fix Path.Combine with glbConfigFolder

### DIFF
--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -1108,7 +1108,8 @@ namespace DotNetNuke.Common.Utilities
                 }
 
                 // save a copy of the web.config
-                strError += Save(appStatus, xmlConfig, GetTimestampedBackupPath(appStatus, "web_.config");
+                strError += Save(appStatus, xmlConfig, GetTimestampedBackupPath(appStatus, "web_.config"));
+
 
                 // save the web.config
                 strError += Save(appStatus, xmlConfig);

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/BusinessController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/BusinessController.cs
@@ -59,7 +59,7 @@ namespace Dnn.PersonaBar.Extensions.Components
                     newKey = Convert.ToBase64String(Encoding.ASCII.GetBytes(newKey));
                     Config.AddAppSetting(xmlConfig, keyName, newKey);
 
-                    // save a copy of the exitsing web.config
+                    // save a copy of the existing web.config
                     var backupFolder = string.Concat(Globals.glbConfigFolder, "Backup_", DateTime.Now.ToString("yyyyMMddHHmm"), "\\");
                     strError += Config.Save(xmlConfig, backupFolder + "web_.config") + Environment.NewLine;
 


### PR DESCRIPTION
## Summary
Since `Globals.glbConfigFolder` starts with a slash (`"\\Config\\"`), using it in `Path.Combine` causes that section of the path to become the path root, instead of being appended to the previous path, as it was with plain string concatenation

Fixes #5522