### PR TITLE
Added UserID to the information shown in the Users module

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/UserTable/DetailRow/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/UserTable/DetailRow/index.jsx
@@ -137,7 +137,7 @@ class DetailsRow extends Component {
                     <h6>
                         <TextOverflowWrapper className="email-link" text={user.displayName} maxWidth={125}/>
                     </h6>
-                    {user.displayName !== "-" && <p>{user.userName}</p> }
+                    {user.displayName !== "-" && <p title={`${Localization.get("UserId")} ${user.userId}`}>{user.userName}</p> }
                 </GridCell>
             },
             {

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/UserTable/UserSettings/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/src/components/UserTable/UserSettings/index.jsx
@@ -265,6 +265,14 @@ class UserSettings extends Component {
                         {Localization.get("AccountData")}
                     </div>
                     <GridSystem className="first">
+                        <GridCell  title={Localization.get("UserId.Help")}>
+                            {Localization.get("UserId")}
+                        </GridCell>
+                        <GridCell>
+                            {state.userDetails.userId}
+                        </GridCell>
+                    </GridSystem>
+                    <GridSystem>
                         <GridCell  title={Localization.get("CreatedDate.Help")}>
                             {Localization.get("CreatedDate")}
                         </GridCell>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
@@ -294,6 +294,12 @@
   <data name="LockedOut.Text" xml:space="preserve">
     <value>Locked Out:</value>
   </data>
+  <data name="UserId.Text" xml:space="preserve">
+    <value>User ID:</value>
+  </data>
+  <data name="UserId.Help" xml:space="preserve">
+    <value>The unique identifier of the user.</value>
+  </data>
   <data name="ManageProfile.title" xml:space="preserve">
     <value>Profile Settings</value>
   </data>


### PR DESCRIPTION
Added UserID to the information shown in the Users module

Closes #4412

![image](https://user-images.githubusercontent.com/6371568/217967488-7a122229-dad9-4dc2-807f-dfc9e7e8a549.png)

This displays in the settings details but also if you hover the username in the list...
