### PR TITLE
Implemented a workaround to support node v18

### DIFF
--- a/Build/Tasks/BuildNpmPackages.cs
+++ b/Build/Tasks/BuildNpmPackages.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Build.Tasks
 {
+    using System;
+
     using Cake.Common.IO;
     using Cake.Core.Tooling;
     using Cake.Frosting;
@@ -14,6 +16,7 @@ namespace DotNetNuke.Build.Tasks
         /// <inheritdoc/>
         public override void Run(Context context)
         {
+            Environment.SetEnvironmentVariable("NODE_OPTIONS", "--openssl-legacy-provider");
             context.Yarn().Install(c => c
                 .WithArgument("--no-immutable")
                 .WithWorkingDirectory(context.Directory("./")));


### PR DESCRIPTION
Azure pipelines has updated windows-latest to run on node v18.x.x on Febuary 17th.

Node 18 has bumped some requirements about open-ssl and Webpack 4 will not be updated to support this use case.

The correct solution is to upgrade to webpack 5 but this has the potential to be a massive task. In the meantime one can pass openssl-legacy-provider for node v18 to support the legacy ssl methods. This PR is a workaround to make our current build work and be able to release DNN v9.11.1 I'll create an issue to do this in a more proper manner after I can confirm this PR fixes our issue in CI.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
