### PR TITLE
Update azure-pipelines.yml for Azure Pipelines to use node v18

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,11 @@ steps:
     restoreKeys: 'yarn | "$(Agent.OS)"'
     path: $(YARN_CACHE_FOLDER)
 
+- task: NodeTool@0
+  inputs:
+    versionSource: 'spec'
+    versionSpec: '>=18.x'
+  
 - task: UseDotNet@2
   displayName: 'Use .NET 6.x SDK'
   inputs:


### PR DESCRIPTION
Enforces using node >= v18.x.x