### PR TITLE
Bumped webpack to v5

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Cake.XdtTransform" Version="2.0.0" />
     <PackageReference Include="Cake.Yarn" Version="0.4.8" />
     <PackageReference Include="Dnn.CakeUtils" Version="2.0.2" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.787" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/Build/Tasks/BuildNpmPackages.cs
+++ b/Build/Tasks/BuildNpmPackages.cs
@@ -16,7 +16,6 @@ namespace DotNetNuke.Build.Tasks
         /// <inheritdoc/>
         public override void Run(Context context)
         {
-            Environment.SetEnvironmentVariable("NODE_OPTIONS", "--openssl-legacy-provider");
             context.Yarn().Install(c => c
                 .WithArgument("--no-immutable")
                 .WithWorkingDirectory(context.Directory("./")));

--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "lint": "eslint --fix"
   },
@@ -49,9 +48,9 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/package.json
@@ -3,9 +3,9 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "lint": "eslint --fix"
   },
@@ -49,9 +49,9 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/webpack.config.js
@@ -32,13 +32,17 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     enforce: "pre",
                     exclude: /node_modules/,
-                    loader: "eslint-loader",
-                    options: { fix: true },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        },
+                    ],
                 },
                 {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
-                    loader: "babel-loader",
+                    use: ["babel-loader"],
                 },
                 {
                     test: /\.(less|css)$/,
@@ -48,7 +52,7 @@ module.exports = (env, argv) => {
                         { loader: "less-loader" },
                     ],
                 },
-                { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
+                { test: /\.(ttf|woff)$/, use: ["url-loader?limit=8192"] },
             ],
         },
 

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -3,10 +3,10 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p --progress",
-    "debug": "set NODE_ENV=debug&&webpack -p --progress",
+    "build": "set NODE_ENV=production&&webpack --mode production --progress",
+    "debug": "set NODE_ENV=debug&&webpack --mode production --progress",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "webpack": "webpack-dev-server -d --port 8070 --hot --inline --content-base dist/ --history-api-fallback",
+    "webpack": "4.46.0",
     "analyze": "set NODE_ENV=production&&webpack --config webpack.config.js --profile --json > stats.json&&webpack-bundle-analyzer stats.json",
     "lint": "eslint --fix"
   },
@@ -61,10 +61,10 @@
     "style-loader": "0.23.1",
     "throttle-debounce": "5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
+    "webpack": "4.46.0",
     "webpack-bundle-analyzer": "^4.4.1",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "3.1.14"
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "@dnnsoftware/dnn-react-common": "9.11.1"

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/package.json
@@ -6,7 +6,6 @@
     "build": "set NODE_ENV=production&&webpack --mode production --progress",
     "debug": "set NODE_ENV=debug&&webpack --mode production --progress",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "webpack": "4.46.0",
     "analyze": "set NODE_ENV=production&&webpack --config webpack.config.js --profile --json > stats.json&&webpack-bundle-analyzer stats.json",
     "lint": "eslint --fix"
   },
@@ -61,9 +60,9 @@
     "style-loader": "0.23.1",
     "throttle-debounce": "5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-analyzer": "^4.4.1",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Bundle.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Bundle.Web/webpack.config.js
@@ -33,27 +33,34 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     enforce: "pre",
                     exclude: /node_modules/,
-                    loader: "eslint-loader",
-                    options: { fix: true },
+                    use:[
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        }
+                    ]
                 },
                 {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
-                    loader: "babel-loader",
+                    use: ["babel-loader"],
                 },
                 {
                     test: /\.(less|css)$/,
-                    loader: "style-loader!css-loader!less-loader",
+                    use: ["style-loader", "css-loader", "less-loader"],
                 },
                 {
                     test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-                    loader: "url-loader?mimetype=application/font-woff",
+                    use: ["url-loader?mimetype=application/font-woff"],
                 },
                 {
                     test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-                    loader: "file-loader?name=[name].[ext]",
+                    use: ["file-loader?name=[name].[ext]"],
                 },
-                { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+                {
+                    test: /\.(gif|png)$/,
+                    use: ["url-loader?mimetype=image/png"],
+                },
             ],
         },
         resolve: {

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/.storybook/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/.storybook/webpack.config.js
@@ -3,13 +3,17 @@ const path = require("path");
 module.exports = {
     module: {
         rules: [
-            { test: /\.less$/, loaders: ["style-loader", "css-loader", "less-loader"], include: path.resolve(__dirname, "../") },
             {
-                test: /\.(svg)$/, exclude: /node_modules/,
-                loader: "raw-loader", 
+                test: /\.less$/,
+                use: ["style-loader", "css-loader", "less-loader"],
                 include: path.resolve(__dirname, "../")
             },
-            { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+            {
+                test: /\.(svg)$/, exclude: /node_modules/,
+                use: ["raw-loader"], 
+                include: path.resolve(__dirname, "../")
+            },
+            { test: /\.(gif|png)$/, use: ["url-loader?mimetype=image/png"] },
         ]
     } 
 };

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/dist.webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/dist.webpack.config.js
@@ -17,15 +17,25 @@ module.exports = {
     },
     module: {
         rules: [
-            { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },
-            { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: ["babel-loader"] },
-            { test: /\.less$/, loader: "style-loader!css-loader!less-loader" },
-            { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-            { test: /\.css$/, loader: "style-loader!css-loader" },
-            { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
-            { test: /\.(svg)$/, loader: "raw-loader" },
-            { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, loader: "url-loader?mimetype=application/font-woff" },
-            { test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/, loader: "file-loader?name=[name].[ext]" }
+            {
+                test: /\.(js|jsx)$/,
+                enforce: "pre",
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: "eslint-loader",
+                        options: { fix: true },
+                    }
+                ],
+            },
+            { test: /\.(js|jsx)$/, exclude: /node_modules/, use: ["babel-loader"] },
+            { test: /\.less$/, use: ["style-loader", "css-loader", "less-loader"] },
+            { test: /\.(ttf|woff)$/, use: ["url-loader?limit=8192"] },
+            { test: /\.css$/, use: ["style-loader!css-loader"] },
+            { test: /\.(gif|png)$/, use: ["url-loader?mimetype=image/png"] },
+            { test: /\.(svg)$/, use: ["raw-loader"] },
+            { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, use: ["url-loader?mimetype=application/font-woff"] },
+            { test: /\.(ttf|eot)(\?v=[0-9].[0-9].[0-9])?$/, use: ["file-loader?name=[name].[ext]"] }
         ]
     },
     externals: ["react", "prop-types", nodeExternals()], // in order to ignore all modules in node_modules folder

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -83,9 +83,9 @@
     "react-test-renderer": "^17.0.2",
     "style-loader": "^0.23.0",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1",
     "webpack-node-externals": "^3.0.0"
   },

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "lint": "eslint --fix",
     "test": "echo \"No tests script specified to run.\"",
-    "build": "set NODE_ENV=production && webpack -p --config dist.webpack.config.js",
-    "debug": "set NODE_ENV=debug && webpack -p --config dist.webpack.config.js",
+    "build": "set NODE_ENV=production && webpack --mode production --config dist.webpack.config.js",
+    "debug": "set NODE_ENV=debug && webpack --mode production --config dist.webpack.config.js",
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "dependencies": {
@@ -83,10 +83,10 @@
     "react-test-renderer": "^17.0.2",
     "style-loader": "^0.23.0",
     "url-loader": "1.1.2",
-    "webpack": "^4.31.0",
-    "webpack-bundle-size-analyzer": "^3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14",
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1",
     "webpack-node-externals": "^3.0.0"
   },
   "peerDependencies": {

--- a/Dnn.AdminExperience/ClientSide/Extensions.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Extensions.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer"
   },
@@ -35,9 +34,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Extensions.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Extensions.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",
@@ -35,9 +35,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Licensing.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Licensing.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer"
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -37,9 +37,9 @@
     "react-modal": "3.6.1",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Licensing.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Licensing.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer"
   },
@@ -37,9 +36,9 @@
     "react-modal": "3.6.1",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
@@ -8,7 +8,6 @@
     "test:watch": "jest --watch",
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -61,9 +60,9 @@
     "throttle-debounce": "^5.0.0",
     "uglifyjs-webpack-plugin": "^2.1.3",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/package.json
@@ -6,11 +6,11 @@
     "start": "npm run webpack",
     "test": "jest",
     "test:watch": "jest --watch",
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server --host localhost -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "jest": {
@@ -61,10 +61,10 @@
     "throttle-debounce": "^5.0.0",
     "uglifyjs-webpack-plugin": "^2.1.3",
     "url-loader": "1.1.2",
-    "webpack": "^4.31.0",
-    "webpack-bundle-size-analyzer": "^3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "dayjs": "^1.10.4",

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/webpack.config.js
@@ -35,9 +35,7 @@ module.exports = (env, argv) => {
                 {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
-                    use: {
-                        loader: "babel-loader",
-                    },
+                    use: [ "babel-loader" ],
                 },
                 {
                     test: /\.less$/,
@@ -68,10 +66,12 @@ module.exports = (env, argv) => {
                 },
                 {
                     test: /\.(ttf|woff|gif|png)$/,
-                    use: {
-                        loader: "url-loader?limit=8192",
-                    },
+                    use: ["url-loader?limit=8192"],
                 },
+                {
+                    test: /\.(d.ts)$/,
+                    use: ["null-loader"],
+                }
             ],
         },
         resolve: {

--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
@@ -4,9 +4,9 @@
   "description": "DNN Prompt",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=analyze&&webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",
     "test": "jest",
@@ -67,9 +67,9 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "^4.31.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "html-react-parser": "^0.7.0"

--- a/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Prompt.Web/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=analyze&&webpack-dev-server -d --port 8100 --hot --inline --content-base dist/ --history-api-fallback",
     "test": "jest",
@@ -67,8 +66,8 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
-    "webpack-cli": "4.10.0",
+    "webpack": "5.76.1",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -42,9 +41,9 @@
     "style-loader": "0.23.1",
     "throttle-debounce": "5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -42,10 +42,10 @@
     "style-loader": "0.23.1",
     "throttle-debounce": "5.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "react-widgets": "^4.4.6"

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/webpack.config.js
@@ -32,13 +32,17 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     enforce: "pre",
                     exclude: /node_modules/,
-                    loader: "eslint-loader",
-                    options: { fix: true },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        }
+                    ],
                 },
                 {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
-                    loader: "babel-loader",
+                    use: ["babel-loader"],
                 },
                 {
                     test: /\.(less|css)$/,
@@ -48,15 +52,15 @@ module.exports = (env, argv) => {
                         { loader: "less-loader" },
                     ],
                 },
-                { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-                { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+                { test: /\.(ttf|woff)$/, use: ["url-loader?limit=8192"] },
+                { test: /\.(gif|png)$/, use: ["url-loader?mimetype=image/png"] },
                 {
                     test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-                    loader: "url-loader?mimetype=application/font-woff",
+                    use: ["url-loader?mimetype=application/font-woff"],
                 },
                 {
                     test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-                    loader: "file-loader?name=[name].[ext]",
+                    use: ["file-loader?name=[name].[ext]"],
                 },
             ],
         },

--- a/Dnn.AdminExperience/ClientSide/Security.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -41,9 +40,9 @@
     "redux-thunk": "^2.3.0",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Security.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --host localhost --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -41,9 +41,9 @@
     "redux-thunk": "^2.3.0",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Security.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/webpack.config.js
@@ -42,10 +42,12 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
                     enforce: "pre",
-                    loader: "eslint-loader",
-                    options: {
-                        fix: true,
-                    },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: {fix: true},
+                        },
+                    ],
                 },
                 {
                     test: /\.less$/,
@@ -74,9 +76,7 @@ module.exports = (env, argv) => {
                 },
                 {
                     test: /\.(ttf|woff)$/,
-                    use: {
-                        loader: "url-loader?limit=8192",
-                    },
+                    use: ["url-loader?limit=8192"],
                 },
             ],
         },

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -42,9 +42,9 @@
     "react-modal": "3.6.1",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Seo.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -42,9 +41,9 @@
     "react-modal": "3.6.1",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -32,6 +31,7 @@
     "file-loader": "3.0.1",
     "less": "4.1.2",
     "less-loader": "5.0.0",
+    "null-loader": "^4.0.1",
     "prop-types": "^15.6.2",
     "raw-loader": "2.0.0",
     "react": "^16.14.0",
@@ -39,9 +39,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -39,10 +39,10 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "react-custom-scrollbars": "^4.1.1"

--- a/Dnn.AdminExperience/ClientSide/Servers.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Servers.Web/webpack.config.js
@@ -74,6 +74,10 @@ module.exports = (env, argv) => {
                         loader: "url-loader?limit=8192",
                     },
                 },
+                {
+                    test: /\.(d.ts)$/,
+                    use: ["null-loader"],
+                }
             ],
         },
         externals: webpackExternals,

--- a/Dnn.AdminExperience/ClientSide/SiteGroups.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteGroups.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -36,9 +35,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/SiteGroups.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteGroups.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -36,9 +36,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/SiteGroups.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/SiteGroups.Web/webpack.config.js
@@ -34,20 +34,28 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     enforce: "pre",
                     exclude: /node_modules/,
-                    loader: "eslint-loader",
-                    options: { fix: true },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        }
+                    ],
                 },
                 {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
-                    loaders: "babel-loader",
-                    options: {
-                        presets: ["@babel/preset-env", "@babel/preset-react"],
-                        plugins: [
-                            "@babel/plugin-transform-react-jsx",
-                            "@babel/plugin-proposal-object-rest-spread",
-                        ],
-                    },
+                    use: [
+                        {
+                            loader: "babel-loader",
+                            options: {
+                                presets: ["@babel/preset-env", "@babel/preset-react"],
+                                plugins: [
+                                    "@babel/plugin-transform-react-jsx",
+                                    "@babel/plugin-proposal-object-rest-spread",
+                                ],
+                            },
+                        }
+                    ],
                 },
                 {
                     test: /\.(less|css)$/,
@@ -57,7 +65,7 @@ module.exports = (env, argv) => {
                         { loader: "less-loader" },
                     ],
                 },
-                { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
+                { test: /\.(ttf|woff)$/, use: ["url-loader?limit=8192"] },
             ],
         },
         resolve: {

--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -54,9 +53,9 @@
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
     "utils": "^0.3.1",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -54,10 +54,10 @@
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
     "utils": "^0.3.1",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "shortid": "^2.2.8"

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
@@ -7,7 +7,6 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -49,9 +48,9 @@
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/package.json
@@ -3,13 +3,13 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
+    "build": "set NODE_ENV=production&&webpack --mode production",
     "test": "jest",
     "test:watch": "jest --watch",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8085 --hot --inline --content-base dist/ --history-api-fallback",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -49,9 +49,9 @@
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/SiteSettings.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/SiteSettings.Web/webpack.config.js
@@ -41,10 +41,14 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
                     enforce: "pre",
-                    loader: "eslint-loader",
-                    options: {
-                        fix: true,
-                    },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: {
+                                fix: true,
+                            },
+                        },
+                    ],
                 },
                 {
                     test: /\.js$/,

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -36,9 +35,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -36,9 +36,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
@@ -4,8 +4,8 @@
   "description": "DNN Sites List View",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "set NODE_ENV=production&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8050 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch"
   },
   "license": "UNLICENSED",
@@ -36,8 +36,8 @@
     "react-dom": "^16.14.0",
     "react-hot-loader": "4.3.5",
     "style-loader": "^0.23.1",
-    "webpack": "4.31.0",
-    "webpack-cli": "3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "set NODE_ENV=production&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch"
   },
   "license": "UNLICENSED",
@@ -31,13 +30,14 @@
     "eslint-plugin-spellcheck": "0.0.11",
     "less": "4.1.2",
     "less-loader": "4.1.0",
+    "null-loader": "^4.0.1",
     "prop-types": "^15.6.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-hot-loader": "4.3.5",
     "style-loader": "^0.23.1",
-    "webpack": "4.46.0",
-    "webpack-cli": "4.10.0",
+    "webpack": "5.76.1",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/webpack.config.js
@@ -2,65 +2,73 @@ const path = require("path");
 const settings = require("../../../../../settings.local.json");
 
 module.exports = (env, argv) => {
-  const isProduction = argv.mode === "production";
-  return {
-    entry: "./index",
-    optimization: {
-      minimize: true,
-    },
-    node: {
-      fs: "empty",
-    },
-    output: {
-      path:
+    const isProduction = argv.mode === "production";
+    return {
+        entry: "./index",
+        optimization: {
+            minimize: true,
+        },
+        node: {
+            fs: "empty",
+        },
+        output: {
+            path:
         isProduction || settings.WebsitePath == ""
-          ? path.resolve(
-              "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Sites/scripts/exportables/Sites"
+            ? path.resolve(
+                "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Sites/scripts/exportables/Sites"
             )
-          : path.join(
-              settings.WebsitePath,
-              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Sites\\scripts\\exportables\\Sites\\"
+            : path.join(
+                settings.WebsitePath,
+                "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Sites\\scripts\\exportables\\Sites\\"
             ),
-      filename: "SitesListView.js",
-      publicPath: isProduction ? "" : "http://localhost:8050/dist/",
-    },
-    module: {
-      rules: [
-        {
-          test: /\.(js|jsx)$/,
-          enforce: "pre",
-          exclude: /node_modules/,
-          loader: "eslint-loader",
-          options: { fix: true },
+            filename: "SitesListView.js",
+            publicPath: isProduction ? "" : "http://localhost:8050/dist/",
         },
-        {
-          test: /\.(js|jsx)$/,
-          exclude: /node_modules/,
-          loaders: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"],
-            plugins: [
-              "@babel/plugin-transform-react-jsx",
-              "@babel/plugin-proposal-object-rest-spread",
+        module: {
+            rules: [
+                {
+                    test: /\.(js|jsx)$/,
+                    enforce: "pre",
+                    exclude: /node_modules/,
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        }
+                    ],
+                },
+                {
+                    test: /\.(js|jsx)$/,
+                    exclude: /node_modules/,
+                    use: [
+                        {
+                            loader: "babel-loader",
+                            options: {
+                                presets: ["@babel/preset-env", "@babel/preset-react"],
+                                plugins: [
+                                    "@babel/plugin-transform-react-jsx",
+                                    "@babel/plugin-proposal-object-rest-spread",
+                                ],
+                            },
+                        }
+                    ],
+                },
+                {
+                    test: /\.(less|css)$/,
+                    use:["style-loader", "css-loader", "less-loader"],
+                },
             ],
-          },
         },
-        {
-          test: /\.(less|css)$/,
-          loader: "style-loader!css-loader!less-loader",
+        externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+        resolve: {
+            extensions: [".js", ".json", ".jsx"],
+            modules: [
+                path.resolve(__dirname, "./src"),
+                path.resolve(__dirname, "../"),
+                path.resolve(__dirname, "node_modules"),
+                path.resolve(__dirname, "../../node_modules"),
+                path.resolve(__dirname, "../../../../../node_modules"),
+            ],
         },
-      ],
-    },
-    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-    resolve: {
-      extensions: [".js", ".json", ".jsx"],
-      modules: [
-        path.resolve(__dirname, "./src"),
-        path.resolve(__dirname, "../"),
-        path.resolve(__dirname, "node_modules"),
-        path.resolve(__dirname, "../../node_modules"),
-        path.resolve(__dirname, "../../../../../node_modules"),
-      ],
-    },
-  };
+    };
 };

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/src/_exportables/webpack.config.js
@@ -8,9 +8,6 @@ module.exports = (env, argv) => {
         optimization: {
             minimize: true,
         },
-        node: {
-            fs: "empty",
-        },
         output: {
             path:
         isProduction || settings.WebsitePath == ""
@@ -57,6 +54,12 @@ module.exports = (env, argv) => {
                     test: /\.(less|css)$/,
                     use:["style-loader", "css-loader", "less-loader"],
                 },
+                {
+                    test: /\.(d.ts)$/,
+                    use:{
+                        loader: "null-loader",
+                    },
+                },
             ],
         },
         externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
@@ -69,6 +72,9 @@ module.exports = (env, argv) => {
                 path.resolve(__dirname, "../../node_modules"),
                 path.resolve(__dirname, "../../../../../node_modules"),
             ],
+            fallback: {
+                fs: false,
+            }
         },
     };
 };

--- a/Dnn.AdminExperience/ClientSide/Sites.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Sites.Web/webpack.config.js
@@ -34,20 +34,28 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     enforce: "pre",
                     exclude: /node_modules/,
-                    loader: "eslint-loader",
-                    options: { fix: true },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        }
+                    ] 
                 },
                 {
                     test: /\.(js|jsx)$/,
                     exclude: /node_modules/,
-                    loaders: "babel-loader",
-                    options: {
-                        presets: ["@babel/preset-env", "@babel/preset-react"],
-                        plugins: [
-                            "@babel/plugin-transform-react-jsx",
-                            "@babel/plugin-proposal-object-rest-spread",
-                        ],
-                    },
+                    use: [
+                        {
+                            loader: "babel-loader",
+                            options: {
+                                presets: ["@babel/preset-env", "@babel/preset-react"],
+                                plugins: [
+                                    "@babel/plugin-transform-react-jsx",
+                                    "@babel/plugin-proposal-object-rest-spread",
+                                ],
+                            },
+                        }
+                    ],
                 },
                 {
                     test: /\.(less|css)$/,
@@ -57,7 +65,7 @@ module.exports = (env, argv) => {
                         { loader: "less-loader" },
                     ],
                 },
-                { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
+                { test: /\.(ttf|woff)$/, use: "url-loader?limit=8192" },
             ],
         },
         resolve: {

--- a/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -42,9 +42,9 @@
     "react-modal": "3.6.1",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -42,9 +41,9 @@
     "react-modal": "3.6.1",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -37,9 +36,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Themes.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -37,9 +37,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Users.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/package.json
@@ -7,7 +7,6 @@
     "test": "jest",
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -29,6 +28,7 @@
     "jest": "^28.1.2",
     "less": "4.1.2",
     "less-loader": "5.0.0",
+    "null-loader": "^4.0.1",
     "prop-types": "^15.6.2",
     "raw-loader": "2.0.0",
     "react": "^16.14.0",
@@ -46,9 +46,9 @@
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
     "utils": "^0.3.1",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {

--- a/Dnn.AdminExperience/ClientSide/Users.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "start": "npm run webpack",
     "test": "jest",
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -46,10 +46,10 @@
     "throttle-debounce": "^5.0.0",
     "url-loader": "1.1.2",
     "utils": "^0.3.1",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
     "@dnnsoftware/dnn-react-common": "9.11.1",

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "start": "npm run webpack",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "webpack": "webpack-dev-server -d --port 8050 --hot --inline --content-base dist/ --history-api-fallback"
+    "webpack": "4.46.0"
   },
   "license": "UNLICENSED",
   "devDependencies": {
@@ -42,8 +42,8 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "^5.0.0",
     "utils": "^0.3.1",
-    "webpack": "4.31.0",
-    "webpack-cli": "3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/package.json
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/package.json
@@ -7,8 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "webpack": "4.46.0"
+    "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch"
   },
   "license": "UNLICENSED",
   "devDependencies": {
@@ -32,6 +31,7 @@
     "less": "4.1.2",
     "less-loader": "5.0.0",
     "localization": "^1.0.2",
+    "null-loader": "^4.0.1",
     "prop-types": "15.6.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
@@ -42,8 +42,8 @@
     "style-loader": "^0.23.1",
     "throttle-debounce": "^5.0.0",
     "utils": "^0.3.1",
-    "webpack": "4.46.0",
-    "webpack-cli": "4.10.0",
+    "webpack": "5.76.1",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/webpack.config.js
@@ -2,80 +2,88 @@ const path = require("path");
 const settings = require("../../../../../settings.local.json");
 
 module.exports = (env, argv) => {
-  const isProduction = argv.mode === "production";
-  return {
-    entry: "./index",
-    optimization: {
-      minimize: isProduction,
-    },
-    node: {
-      fs: "empty",
-    },
-    output: {
-      path:
+    const isProduction = argv.mode === "production";
+    return {
+        entry: "./index",
+        optimization: {
+            minimize: isProduction,
+        },
+        node: {
+            fs: "empty",
+        },
+        output: {
+            path:
         isProduction || settings.WebsitePath == ""
-          ? path.resolve(
-              "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/exportables/Users"
+            ? path.resolve(
+                "../../../../Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/exportables/Users"
             )
-          : path.join(
-              settings.WebsitePath,
-              "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Users\\scripts\\exportables\\Users\\"
+            : path.join(
+                settings.WebsitePath,
+                "DesktopModules\\Admin\\Dnn.PersonaBar\\Modules\\Dnn.Users\\scripts\\exportables\\Users\\"
             ),
-      filename: "UsersCommon.js",
-      publicPath: isProduction ? "" : "http://localhost:8050/dist/",
-    },
-    module: {
-      rules: [
-        {
-          test: /\.(js|jsx)$/,
-          enforce: "pre",
-          exclude: /node_modules/,
-          loader: "eslint-loader",
-          options: { fix: true },
+            filename: "UsersCommon.js",
+            publicPath: isProduction ? "" : "http://localhost:8050/dist/",
         },
-        {
-          test: /\.(js|jsx)$/,
-          exclude: /node_modules/,
-          loaders: "babel-loader",
-          options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"],
-            plugins: [
-              "@babel/plugin-transform-react-jsx",
-              "@babel/plugin-proposal-object-rest-spread",
+        module: {
+            rules: [
+                {
+                    test: /\.(js|jsx)$/,
+                    enforce: "pre",
+                    exclude: /node_modules/,
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        },
+                    ],
+                },
+                {
+                    test: /\.(js|jsx)$/,
+                    exclude: /node_modules/,
+                    use: [
+                        {
+                            loader: "babel-loader",
+                            options: {
+                                presets: ["@babel/preset-env", "@babel/preset-react"],
+                                plugins: [
+                                    "@babel/plugin-transform-react-jsx",
+                                    "@babel/plugin-proposal-object-rest-spread",
+                                ],
+                            },
+                        },
+                    ],
+                },
+                {
+                    test: /\.(less|css)$/,
+                    use: [
+                        { loader: "style-loader" },
+                        { loader: "css-loader", options: { modules: "global" } },
+                        { loader: "less-loader" },
+                    ],
+                },
+                { test: /\.(ttf|woff)$/, use: ["url-loader?limit=8192"] },
+                { test: /\.(gif|png)$/, use: ["url-loader?mimetype=image/png"] },
+                {
+                    test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+                    use: ["url-loader?mimetype=application/font-woff"],
+                },
+                {
+                    test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+                    use: ["file-loader?name=[name].[ext]"],
+                },
             ],
-          },
         },
-        {
-          test: /\.(less|css)$/,
-          use: [
-            { loader: "style-loader" },
-            { loader: "css-loader", options: { modules: "global" } },
-            { loader: "less-loader" },
-          ],
+        externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
+        resolve: {
+            extensions: [".js", ".json", ".jsx"],
+            modules: [
+                path.resolve(__dirname, "./src"),
+                path.resolve(__dirname, "../"),
+                path.resolve(__dirname, "node_modules"),
+                path.resolve(__dirname, "../../node_modules"),
+                path.resolve(__dirname, "../../../../../node_modules"),
+            ],
         },
-        { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-        { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
-        {
-          test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-          loader: "url-loader?mimetype=application/font-woff",
-        },
-        {
-          test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-          loader: "file-loader?name=[name].[ext]",
-        },
-      ],
-    },
-    externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
-    resolve: {
-      extensions: [".js", ".json", ".jsx"],
-      modules: [
-        path.resolve(__dirname, "./src"),
-        path.resolve(__dirname, "../"),
-        path.resolve(__dirname, "node_modules"),
-        path.resolve(__dirname, "../../node_modules"),
-        path.resolve(__dirname, "../../../../../node_modules"),
-      ],
-    },
-    devtool: "source-map",
-  };
+        devtool: "source-map",
+    };
 };

--- a/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/src/_exportables/webpack.config.js
@@ -8,9 +8,6 @@ module.exports = (env, argv) => {
         optimization: {
             minimize: isProduction,
         },
-        node: {
-            fs: "empty",
-        },
         output: {
             path:
         isProduction || settings.WebsitePath == ""
@@ -71,6 +68,10 @@ module.exports = (env, argv) => {
                     test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
                     use: ["file-loader?name=[name].[ext]"],
                 },
+                {
+                    test: /\.(d.ts)$/,
+                    use: ["null-loader"],
+                }
             ],
         },
         externals: require("@dnnsoftware/dnn-react-common/WebpackExternals"),
@@ -83,6 +84,9 @@ module.exports = (env, argv) => {
                 path.resolve(__dirname, "../../node_modules"),
                 path.resolve(__dirname, "../../../../../node_modules"),
             ],
+            fallback: {
+                fs: false,
+            }
         },
         devtool: "source-map",
     };

--- a/Dnn.AdminExperience/ClientSide/Users.Web/webpack.config.js
+++ b/Dnn.AdminExperience/ClientSide/Users.Web/webpack.config.js
@@ -33,22 +33,28 @@ module.exports = (env, argv) => {
                     test: /\.(js|jsx)$/,
                     enforce: "pre",
                     exclude: [/node_modules/],
-                    loader: "eslint-loader",
-                    options: { fix: true },
+                    use: [
+                        {
+                            loader: "eslint-loader",
+                            options: { fix: true },
+                        },
+                    ],
                 },
                 {
                     test: /\.(js|jsx)$/,
                     exclude: [/node_modules/],
-                    use: {
-                        loader: "babel-loader",
-                        options: {
-                            presets: ["@babel/preset-env", "@babel/preset-react"],
-                            plugins: [
-                                "@babel/plugin-transform-react-jsx",
-                                "@babel/plugin-proposal-object-rest-spread",
-                            ],
+                    use: [
+                        {
+                            loader: "babel-loader",
+                            options: {
+                                presets: ["@babel/preset-env", "@babel/preset-react"],
+                                plugins: [
+                                    "@babel/plugin-transform-react-jsx",
+                                    "@babel/plugin-proposal-object-rest-spread",
+                                ],
+                            },
                         },
-                    },
+                    ],
                 },
                 {
                     test: /\.(less|css)$/,
@@ -58,16 +64,20 @@ module.exports = (env, argv) => {
                         { loader: "less-loader" },
                     ],
                 },
-                { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
-                { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
+                { test: /\.(ttf|woff)$/, use: ["url-loader?limit=8192"] },
+                { test: /\.(gif|png)$/, use: ["url-loader?mimetype=image/png"] },
                 {
                     test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
-                    loader: "url-loader?mimetype=application/font-woff",
+                    use: ["url-loader?mimetype=application/font-woff"],
                 },
                 {
                     test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
-                    loader: "file-loader?name=[name].[ext]",
+                    use: ["file-loader?name=[name].[ext]"],
                 },
+                {
+                    test: /\.(d.ts)$/,
+                    use: ["null-loader"],
+                }
             ],
         },
         resolve: {

--- a/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
@@ -3,11 +3,11 @@
   "version": "9.11.1",
   "private": true,
   "scripts": {
-    "build": "set NODE_ENV=production&&webpack -p",
-    "debug": "set NODE_ENV=debug&&webpack -p",
-    "webpack": "webpack-dev-server -d --port 8080 --hot --inline --content-base dist/ --history-api-fallback",
+    "build": "set NODE_ENV=production&&webpack --mode production",
+    "debug": "set NODE_ENV=debug&&webpack --mode production",
+    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
-    "analyze": "set NODE_ENV=production&&webpack -p --json | webpack-bundle-size-analyzer",
+    "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
   },
   "devDependencies": {
@@ -42,9 +42,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.31.0",
-    "webpack-bundle-size-analyzer": "3.0.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.14"
+    "webpack": "4.46.0",
+    "webpack-bundle-size-analyzer": "3.1.0",
+    "webpack-cli": "4.10.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
+++ b/Dnn.AdminExperience/ClientSide/Vocabularies.Web/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "set NODE_ENV=production&&webpack --mode production",
     "debug": "set NODE_ENV=debug&&webpack --mode production",
-    "webpack": "4.46.0",
     "watch": "set NODE_ENV=debug & webpack --mode=development --progress --colors --watch",
     "analyze": "set NODE_ENV=production&&webpack --mode production --json | webpack-bundle-size-analyzer",
     "lint": "eslint --fix"
@@ -42,9 +41,9 @@
     "react-hot-loader": "4.8.5",
     "style-loader": "^0.23.1",
     "url-loader": "1.1.2",
-    "webpack": "4.46.0",
+    "webpack": "5.76.1",
     "webpack-bundle-size-analyzer": "3.1.0",
-    "webpack-cli": "4.10.0",
+    "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1"
   }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/scripts/bundles/pages-bundle.js.LICENSE.txt
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/scripts/bundles/pages-bundle.js.LICENSE.txt
@@ -1,0 +1,1 @@
+/*! https://mths.be/startswith v1.0.0 by @mathias */

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Roles/scripts/bundles/roles-bundle.js.LICENSE.txt
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Roles/scripts/bundles/roles-bundle.js.LICENSE.txt
@@ -1,0 +1,14 @@
+/*!
+  Copyright (c) 2017 Jed Watson.
+  Licensed under the MIT License (MIT), see
+  http://jedwatson.github.io/classnames
+*/
+
+/** @license React v16.13.1
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/bundles/users-bundle.js.LICENSE.txt
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/bundles/users-bundle.js.LICENSE.txt
@@ -1,0 +1,14 @@
+/*!
+  Copyright (c) 2017 Jed Watson.
+  Licensed under the MIT License (MIT), see
+  http://jedwatson.github.io/classnames
+*/
+
+/** @license React v16.13.1
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/exportables/Users/UsersCommon.js.LICENSE.txt
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/scripts/exportables/Users/UsersCommon.js.LICENSE.txt
@@ -1,0 +1,14 @@
+/*!
+  Copyright (c) 2017 Jed Watson.
+  Licensed under the MIT License (MIT), see
+  http://jedwatson.github.io/classnames
+*/
+
+/** @license React v16.13.1
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/exports/export-bundle.js.LICENSE.txt
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/exports/export-bundle.js.LICENSE.txt
@@ -1,0 +1,97 @@
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+/*!
+  Copyright (c) 2015 Jed Watson.
+  Based on code that is Copyright 2013-2015, Facebook, Inc.
+  All rights reserved.
+*/
+
+/*!
+  Copyright (c) 2017 Jed Watson.
+  Licensed under the MIT License (MIT), see
+  http://jedwatson.github.io/classnames
+*/
+
+/*!
+ * @overview es6-promise - a tiny implementation of Promises/A+.
+ * @copyright Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors (Conversion to ES6 API by Jake Archibald)
+ * @license   Licensed under MIT license
+ *            See https://raw.githubusercontent.com/stefanpenner/es6-promise/master/LICENSE
+ * @version   v4.2.6+9869a4bc
+ */
+
+/*!
+ * Adapted from jQuery UI core
+ *
+ * http://jqueryui.com
+ *
+ * Copyright 2014 jQuery Foundation and other contributors
+ * Released under the MIT license.
+ * http://jquery.org/license
+ *
+ * http://api.jqueryui.com/category/ui-core/
+ */
+
+/**
+ * @license React
+ * use-sync-external-store-shim.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @license React
+ * use-sync-external-store-shim/with-selector.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/** @license React v0.19.1
+ * scheduler.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/** @license React v16.13.1
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/** @license React v16.14.0
+ * react-dom.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/** @license React v16.14.0
+ * react.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! moment.js
+
+//! moment.js locale configuration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,11 +52,6 @@ steps:
     key: 'yarn | "$(Agent.OS)" | yarn.lock'
     restoreKeys: 'yarn | "$(Agent.OS)"'
     path: $(YARN_CACHE_FOLDER)
-
-- task: NodeTool@0
-  inputs:
-    versionSource: 'spec'
-    versionSpec: '>=18.x'
   
 - task: UseDotNet@2
   displayName: 'Use .NET 6.x SDK'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,9 +1858,9 @@ __metadata:
     style-loader: ^0.23.0
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
     webpack-node-externals: ^3.0.0
   peerDependencies:
@@ -2538,7 +2538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.2":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.2
   resolution: "@jridgewell/gen-mapping@npm:0.3.2"
   dependencies:
@@ -2549,7 +2549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3":
+"@jridgewell/resolve-uri@npm:3.1.0, @jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.1.0
   resolution: "@jridgewell/resolve-uri@npm:3.1.0"
   checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
@@ -2563,7 +2563,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
+"@jridgewell/source-map@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@jridgewell/source-map@npm:0.3.2"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 1b83f0eb944e77b70559a394d5d3b3f98a81fcc186946aceb3ef42d036762b52ef71493c6c0a3b7c1d2f08785f53ba2df1277fe629a06e6109588ff4cdcf7482
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
@@ -2577,6 +2587,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.17":
+  version: 0.3.17
+  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+  dependencies:
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
   languageName: node
   linkType: hard
 
@@ -4080,6 +4100,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-scope@npm:^3.7.3":
+  version: 3.7.4
+  resolution: "@types/eslint-scope@npm:3.7.4"
+  dependencies:
+    "@types/eslint": "*"
+    "@types/estree": "*"
+  checksum: ea6a9363e92f301cd3888194469f9ec9d0021fe0a397a97a6dd689e7545c75de0bd2153dfb13d3ab532853a278b6572c6f678ce846980669e41029d205653460
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:*":
+  version: 8.21.1
+  resolution: "@types/eslint@npm:8.21.1"
+  dependencies:
+    "@types/estree": "*"
+    "@types/json-schema": "*"
+  checksum: 584068441e4000c7b41c8928274fdcc737bc62f564928c30eb64ec41bbdbac31612f9fedaf490bceab31ec8305e99615166428188ea345d58878394683086fae
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*":
+  version: 1.0.0
+  resolution: "@types/estree@npm:1.0.0"
+  checksum: 910d97fb7092c6738d30a7430ae4786a38542023c6302b95d46f49420b797f21619cdde11fa92b338366268795884111c2eb10356e4bd2c8ad5b92941e9e6443
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^0.0.51":
+  version: 0.0.51
+  resolution: "@types/estree@npm:0.0.51"
+  checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
+  languageName: node
+  linkType: hard
+
 "@types/events@npm:*":
   version: 3.0.0
   resolution: "@types/events@npm:3.0.0"
@@ -4207,17 +4261,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+  version: 7.0.11
+  resolution: "@types/json-schema@npm:7.0.11"
+  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6":
   version: 7.0.7
   resolution: "@types/json-schema@npm:7.0.7"
   checksum: ea3b409235862d28122751158f4054e729e31ad844bd7b8b23868f38c518047b1c0e8e4e7cc293e02c31a2fb8cfc8a4506c2de2a745cf78b218e064fb8898cd4
-  languageName: node
-  linkType: hard
-
-"@types/json-schema@npm:^7.0.9":
-  version: 7.0.11
-  resolution: "@types/json-schema@npm:7.0.11"
-  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
   languageName: node
   linkType: hard
 
@@ -4510,6 +4564,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/ast@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/ast@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/helper-numbers": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+  checksum: 1eee1534adebeece635362f8e834ae03e389281972611408d64be7895fc49f48f98fddbbb5339bf8a72cb101bcb066e8bca3ca1bf1ef47dadf89def0395a8d87
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/ast@npm:1.8.5"
@@ -4521,14 +4585,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ast@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/ast@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/helper-module-context": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/wast-parser": 1.9.0
-  checksum: 8a9838dc7fdac358aee8daa75eefa35934ab18dafb594092ff7be79c467ebe9dabb2543e58313c905fd802bdcc3cb8320e4e19af7444e49853a7a24e25138f75
+"@webassemblyjs/floating-point-hex-parser@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.11.1"
+  checksum: b8efc6fa08e4787b7f8e682182d84dfdf8da9d9c77cae5d293818bc4a55c1f419a87fa265ab85252b3e6c1fd323d799efea68d825d341a7c365c64bc14750e97
   languageName: node
   linkType: hard
 
@@ -4539,10 +4599,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/floating-point-hex-parser@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.9.0"
-  checksum: d3aeb19bc30da26f639698daa28e44e0c18d5aa135359ef3c54148e194eec46451a912d0506099d479a71a94bc3eef6ef52d6ec234799528a25a9744789852de
+"@webassemblyjs/helper-api-error@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-api-error@npm:1.11.1"
+  checksum: 0792813f0ed4a0e5ee0750e8b5d0c631f08e927f4bdfdd9fe9105dc410c786850b8c61bff7f9f515fdfb149903bec3c976a1310573a4c6866a94d49bc7271959
   languageName: node
   linkType: hard
 
@@ -4553,10 +4613,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-api-error@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-api-error@npm:1.9.0"
-  checksum: 9179d3148639cc202e89a118145b485cf834613260679a99af6ec487bbc15f238566ca713207394b336160a41bf8c1b75cf2e853b3e96f0cc73c1e5c735b3f64
+"@webassemblyjs/helper-buffer@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-buffer@npm:1.11.1"
+  checksum: a337ee44b45590c3a30db5a8b7b68a717526cf967ada9f10253995294dbd70a58b2da2165222e0b9830cd4fc6e4c833bf441a721128d1fe2e9a7ab26b36003ce
   languageName: node
   linkType: hard
 
@@ -4564,13 +4624,6 @@ __metadata:
   version: 1.8.5
   resolution: "@webassemblyjs/helper-buffer@npm:1.8.5"
   checksum: 5eeb48b135d5ca013c8876228a3a2ccfba98d87dfe12fcf6921e0acf7a272070f369e4e4e8a7f34f2cf22e8faaade24a39a9bcfba76498f103f051384b0f55b3
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-buffer@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-buffer@npm:1.9.0"
-  checksum: dcb85f630f8a2e22b7346ad4dd58c3237a2cad1457699423e8fd19592a0bd3eacbc2639178a1b9a873c3ac217bfc7a23a134ff440a099496b590e82c7a4968d5
   languageName: node
   linkType: hard
 
@@ -4583,26 +4636,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-code-frame@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-code-frame@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/wast-printer": 1.9.0
-  checksum: a28fa057f7beff0fd14bff716561520f8edb8c9c56c7a5559451e6765acfb70aaeb8af718ea2bd2262e7baeba597545af407e28eb2eff8329235afe8605f20d1
-  languageName: node
-  linkType: hard
-
 "@webassemblyjs/helper-fsm@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/helper-fsm@npm:1.8.5"
   checksum: 5026861c39518cf7f8fa6a88ccad8e251d906130a9ccfe2a49da5eb5321bfdf0861f31e5269f76687259f96cc8143f09a9df73a3836c44cb5445bdc01f77fd91
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-fsm@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-fsm@npm:1.9.0"
-  checksum: 374cc510c8f5a7a07d4fe9eb7036cc475a96a670b5d25c31f16757ac8295be8d03a2f29657ff53eaefa9e8315670a48824d430ed910e7c1835788ac79f93124e
   languageName: node
   linkType: hard
 
@@ -4616,12 +4653,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-module-context@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-module-context@npm:1.9.0"
+"@webassemblyjs/helper-numbers@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-numbers@npm:1.11.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-  checksum: 55e8f89c7ea1beaa78fad88403f3753b8413b0f3b6bb32d898ce95078b3e1d1b48ade0919c00b82fc2e3813c0ab6901e415f7a4d4fa9be50944e2431adde75a5
+    "@webassemblyjs/floating-point-hex-parser": 1.11.1
+    "@webassemblyjs/helper-api-error": 1.11.1
+    "@xtuc/long": 4.2.2
+  checksum: 44d2905dac2f14d1e9b5765cf1063a0fa3d57295c6d8930f6c59a36462afecc6e763e8a110b97b342a0f13376166c5d41aa928e6ced92e2f06b071fd0db59d3a
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-bytecode@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.11.1"
+  checksum: eac400113127832c88f5826bcc3ad1c0db9b3dbd4c51a723cfdb16af6bfcbceb608170fdaac0ab7731a7e18b291be7af68a47fcdb41cfe0260c10857e7413d97
   languageName: node
   linkType: hard
 
@@ -4632,10 +4678,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-wasm-bytecode@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.9.0"
-  checksum: 280da4df3c556f73a1a02053277f8a4be481de32df4aa21050b015c8f4d27c46af89f0417eb88e486df117e5df4bccffae593f78cb1e79f212d3b3d4f3ed0f04
+"@webassemblyjs/helper-wasm-section@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-buffer": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/wasm-gen": 1.11.1
+  checksum: 617696cfe8ecaf0532763162aaf748eb69096fb27950219bb87686c6b2e66e11cd0614d95d319d0ab1904bc14ebe4e29068b12c3e7c5e020281379741fe4bedf
   languageName: node
   linkType: hard
 
@@ -4651,15 +4702,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/helper-wasm-section@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/helper-wasm-section@npm:1.9.0"
+"@webassemblyjs/ieee754@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/ieee754@npm:1.11.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-buffer": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/wasm-gen": 1.9.0
-  checksum: b8f7bb45d4194074c82210211a5d3e402a5b5fa63ecae26d2c356ae3978af5a530e91192fb260f32f9d561b18e2828b3da2e2f41c59efadb5f3c6d72446807f0
+    "@xtuc/ieee754": ^1.2.0
+  checksum: 23a0ac02a50f244471631802798a816524df17e56b1ef929f0c73e3cde70eaf105a24130105c60aff9d64a24ce3b640dad443d6f86e5967f922943a7115022ec
   languageName: node
   linkType: hard
 
@@ -4672,12 +4720,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ieee754@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/ieee754@npm:1.9.0"
+"@webassemblyjs/leb128@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/leb128@npm:1.11.1"
   dependencies:
-    "@xtuc/ieee754": ^1.2.0
-  checksum: 7fe4a217ba0f7051e2cfef92919d4a64fac1a63c65411763779bd50907820f33f440255231a474fe3ba03bd1d9ee0328662d1eae3fce4c59b91549d6b62b839b
+    "@xtuc/long": 4.2.2
+  checksum: 33ccc4ade2f24de07bf31690844d0b1ad224304ee2062b0e464a610b0209c79e0b3009ac190efe0e6bd568b0d1578d7c3047fc1f9d0197c92fc061f56224ff4a
   languageName: node
   linkType: hard
 
@@ -4690,12 +4738,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/leb128@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/leb128@npm:1.9.0"
-  dependencies:
-    "@xtuc/long": 4.2.2
-  checksum: 4ca7cbb869530d78d42a414f34ae53249364cb1ecebbfb6ed5d562c2f209fce857502f088822ee82a23876f653a262ddc34ab64e45a7962510a263d39bb3f51a
+"@webassemblyjs/utf8@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/utf8@npm:1.11.1"
+  checksum: 972c5cfc769d7af79313a6bfb96517253a270a4bf0c33ba486aa43cac43917184fb35e51dfc9e6b5601548cd5931479a42e42c89a13bb591ffabebf30c8a6a0b
   languageName: node
   linkType: hard
 
@@ -4706,10 +4752,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/utf8@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/utf8@npm:1.9.0"
-  checksum: e328a30ac8a503bbd015d32e75176e0dedcb45a21d4be051c25dfe89a00035ca7a6dbd8937b442dd5b4b334de3959d4f5fe0b330037bd226a28b9814cd49e84f
+"@webassemblyjs/wasm-edit@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-edit@npm:1.11.1"
+  dependencies:
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-buffer": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/helper-wasm-section": 1.11.1
+    "@webassemblyjs/wasm-gen": 1.11.1
+    "@webassemblyjs/wasm-opt": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    "@webassemblyjs/wast-printer": 1.11.1
+  checksum: 6d7d9efaec1227e7ef7585a5d7ff0be5f329f7c1c6b6c0e906b18ed2e9a28792a5635e450aca2d136770d0207225f204eff70a4b8fd879d3ac79e1dcc26dbeb9
   languageName: node
   linkType: hard
 
@@ -4729,19 +4784,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-edit@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-edit@npm:1.9.0"
+"@webassemblyjs/wasm-gen@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-gen@npm:1.11.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-buffer": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/helper-wasm-section": 1.9.0
-    "@webassemblyjs/wasm-gen": 1.9.0
-    "@webassemblyjs/wasm-opt": 1.9.0
-    "@webassemblyjs/wasm-parser": 1.9.0
-    "@webassemblyjs/wast-printer": 1.9.0
-  checksum: 1997e0c2f4051c33239587fb143242919320bc861a0af03a873c7150a27d6404bd2e063c658193288b0aa88c35aadbe0c4fde601fe642bae0743a8c8eda52717
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/ieee754": 1.11.1
+    "@webassemblyjs/leb128": 1.11.1
+    "@webassemblyjs/utf8": 1.11.1
+  checksum: 1f6921e640293bf99fb16b21e09acb59b340a79f986c8f979853a0ae9f0b58557534b81e02ea2b4ef11e929d946708533fd0693c7f3712924128fdafd6465f5b
   languageName: node
   linkType: hard
 
@@ -4758,16 +4810,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-gen@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-gen@npm:1.9.0"
+"@webassemblyjs/wasm-opt@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-opt@npm:1.11.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/ieee754": 1.9.0
-    "@webassemblyjs/leb128": 1.9.0
-    "@webassemblyjs/utf8": 1.9.0
-  checksum: 2456e84e8e6bedb7ab47f6333a0ee170f7ef62842c90862ca787c08528ca8041061f3f8bc257fc2a01bf6e8d1a76fddaddd43418c738f681066e5b50f88fe7df
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-buffer": 1.11.1
+    "@webassemblyjs/wasm-gen": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+  checksum: 21586883a20009e2b20feb67bdc451bbc6942252e038aae4c3a08e6f67b6bae0f5f88f20bfc7bd0452db5000bacaf5ab42b98cf9aa034a6c70e9fc616142e1db
   languageName: node
   linkType: hard
 
@@ -4783,15 +4834,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-opt@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-opt@npm:1.9.0"
+"@webassemblyjs/wasm-parser@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wasm-parser@npm:1.11.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-buffer": 1.9.0
-    "@webassemblyjs/wasm-gen": 1.9.0
-    "@webassemblyjs/wasm-parser": 1.9.0
-  checksum: 91242205bdbd1aa8045364a5338bfb34880cb2c65f56db8dd19382894209673699fb31a0e5279f25c7e5bcd8f3097d6c9ca84d8969d9613ef2cf166450cc3515
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/helper-api-error": 1.11.1
+    "@webassemblyjs/helper-wasm-bytecode": 1.11.1
+    "@webassemblyjs/ieee754": 1.11.1
+    "@webassemblyjs/leb128": 1.11.1
+    "@webassemblyjs/utf8": 1.11.1
+  checksum: 1521644065c360e7b27fad9f4bb2df1802d134dd62937fa1f601a1975cde56bc31a57b6e26408b9ee0228626ff3ba1131ae6f74ffb7d718415b6528c5a6dbfc2
   languageName: node
   linkType: hard
 
@@ -4809,20 +4862,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wasm-parser@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wasm-parser@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-api-error": 1.9.0
-    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
-    "@webassemblyjs/ieee754": 1.9.0
-    "@webassemblyjs/leb128": 1.9.0
-    "@webassemblyjs/utf8": 1.9.0
-  checksum: 493f6cfc63a5e16073056c81ff0526a9936f461327379ef3c83cc841000e03623b6352704f6bf9f7cb5b3610f0032020a61f9cca78c91b15b8e995854b29c098
-  languageName: node
-  linkType: hard
-
 "@webassemblyjs/wast-parser@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/wast-parser@npm:1.8.5"
@@ -4837,17 +4876,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wast-parser@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wast-parser@npm:1.9.0"
+"@webassemblyjs/wast-printer@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@webassemblyjs/wast-printer@npm:1.11.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/floating-point-hex-parser": 1.9.0
-    "@webassemblyjs/helper-api-error": 1.9.0
-    "@webassemblyjs/helper-code-frame": 1.9.0
-    "@webassemblyjs/helper-fsm": 1.9.0
+    "@webassemblyjs/ast": 1.11.1
     "@xtuc/long": 4.2.2
-  checksum: 705dd48fbbceec7f6bed299b8813631b242fd9312f9594dbb2985dda86c9688048692357d684f6080fc2c5666287cefaa26b263d01abadb6a9049d4c8978b9db
+  checksum: f15ae4c2441b979a3b4fce78f3d83472fb22350c6dc3fd34bfe7c3da108e0b2360718734d961bba20e7716cb8578e964b870da55b035e209e50ec9db0378a3f7
   languageName: node
   linkType: hard
 
@@ -4862,47 +4897,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/wast-printer@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@webassemblyjs/wast-printer@npm:1.9.0"
-  dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/wast-parser": 1.9.0
-    "@xtuc/long": 4.2.2
-  checksum: 3d1e1b2e84745a963f69acd1c02425b321dd2e608e11dabc467cae0c9a808962bc769ec9afc46fbcea7188cc1e47d72370da762d258f716fb367cb1a7865c54b
+"@webpack-cli/configtest@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@webpack-cli/configtest@npm:2.0.1"
+  peerDependencies:
+    webpack: 5.x.x
+    webpack-cli: 5.x.x
+  checksum: 15d0ca835f2e16ec99e9f295f07b676435b9e706d7700df0ad088692fea065e34772fc44b96a4f6a86178b9ca8cf1ff941fbce15269587cf0925d70b18928cea
   languageName: node
   linkType: hard
 
-"@webpack-cli/configtest@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@webpack-cli/configtest@npm:1.2.0"
+"@webpack-cli/info@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@webpack-cli/info@npm:2.0.1"
   peerDependencies:
-    webpack: 4.x.x || 5.x.x
-    webpack-cli: 4.x.x
-  checksum: a2726cd9ec601d2b57e5fc15e0ebf5200a8892065e735911269ac2038e62be4bfc176ea1f88c2c46ff09b4d05d4c10ae045e87b3679372483d47da625a327e28
+    webpack: 5.x.x
+    webpack-cli: 5.x.x
+  checksum: b8fba49fee10d297c2affb0b064c9a81e9038d75517c6728fb85f9fb254cae634e5d33e696dac5171e6944ae329d85fddac72f781c7d833f7e9dfe43151ce60d
   languageName: node
   linkType: hard
 
-"@webpack-cli/info@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@webpack-cli/info@npm:1.5.0"
-  dependencies:
-    envinfo: ^7.7.3
+"@webpack-cli/serve@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@webpack-cli/serve@npm:2.0.1"
   peerDependencies:
-    webpack-cli: 4.x.x
-  checksum: 7f56fe037cd7d1fd5c7428588519fbf04a0cad33925ee4202ffbafd00f8ec1f2f67d991245e687d50e0f3e23f7b7814273d56cb9f7da4b05eed47c8d815c6296
-  languageName: node
-  linkType: hard
-
-"@webpack-cli/serve@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "@webpack-cli/serve@npm:1.7.0"
-  peerDependencies:
-    webpack-cli: 4.x.x
+    webpack: 5.x.x
+    webpack-cli: 5.x.x
   peerDependenciesMeta:
     webpack-dev-server:
       optional: true
-  checksum: d475e8effa23eb7ff9a48b14d4de425989fd82f906ce71c210921cc3852327c22873be00c35e181a25a6bd03d424ae2b83e7f3b3f410ac7ee31b128ab4ac7713
+  checksum: 75c55f8398dd60e4821f81bec6e96287cebb3ab1837ef016779bc2f0c76a1d29c45b99e53daa99ba1fa156b5e2b61c19abf58098de20c2b58391b1f496ecc145
   languageName: node
   linkType: hard
 
@@ -4996,6 +5020,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-import-assertions@npm:^1.7.6":
+  version: 1.8.0
+  resolution: "acorn-import-assertions@npm:1.8.0"
+  peerDependencies:
+    acorn: ^8
+  checksum: 5c4cf7c850102ba7ae0eeae0deb40fb3158c8ca5ff15c0bca43b5c47e307a1de3d8ef761788f881343680ea374631ae9e9615ba8876fee5268dbe068c98bcba6
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.1":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -5018,15 +5051,6 @@ __metadata:
   bin:
     acorn: ./bin/acorn
   checksum: 82e4ac4c0440abc2ca80b44c1edf2e2e5e0bd09e6c9d03f5b1b8c35c75f73d943d3e00fca25f3be1a112d252700bf0c41128798188ce9ac808b4f208cfdbfe2c
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^6.4.1":
-  version: 6.4.2
-  resolution: "acorn@npm:6.4.2"
-  bin:
-    acorn: bin/acorn
-  checksum: 44b07053729db7f44d28343eed32247ed56dc4a6ec6dff2b743141ecd6b861406bbc1c20bf9d4f143ea7dd08add5dc8c290582756539bc03a8db605050ce2fb4
   languageName: node
   linkType: hard
 
@@ -5054,6 +5078,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: e0f79409d68923fbf1aa6d4166f3eedc47955320d25c89a20cc822e6ba7c48c5963d5bc657bc242d68f7a4ac9faf96eef033e8f73656da6c640d4219935fdfd0
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.7.1":
+  version: 8.8.2
+  resolution: "acorn@npm:8.8.2"
+  bin:
+    acorn: bin/acorn
+  checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
   languageName: node
   linkType: hard
 
@@ -5128,9 +5161,9 @@ __metadata:
     style-loader: ^0.23.1
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -5253,7 +5286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
+"ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
   peerDependencies:
@@ -5285,7 +5318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
+"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -7261,13 +7294,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bluebird@npm:^3.5.5":
-  version: 3.7.2
-  resolution: "bluebird@npm:3.7.2"
-  checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
-  languageName: node
-  linkType: hard
-
 "bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.1.1, bn.js@npm:^4.4.0":
   version: 4.11.8
   resolution: "bn.js@npm:4.11.8"
@@ -7479,6 +7505,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.14.5":
+  version: 4.21.5
+  resolution: "browserslist@npm:4.21.5"
+  dependencies:
+    caniuse-lite: ^1.0.30001449
+    electron-to-chromium: ^1.4.284
+    node-releases: ^2.0.8
+    update-browserslist-db: ^1.0.10
+  bin:
+    browserslist: cli.js
+  checksum: 9755986b22e73a6a1497fd8797aedd88e04270be33ce66ed5d85a1c8a798292a65e222b0f251bafa1c2522261e237d73b08b58689d4920a607e5a53d56dc4706
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.16.6":
   version: 4.16.6
   resolution: "browserslist@npm:4.16.6"
@@ -7615,29 +7655,6 @@ __metadata:
     unique-filename: ^1.1.1
     y18n: ^4.0.0
   checksum: 21fd5f5a29c594782a17c1028297053781f1344aec05c72fe437258bbd9cc716d8f037c770d67ad3e15f0008b94e4e4523b5e90420cd477d0ab7f4b9c1bdb556
-  languageName: node
-  linkType: hard
-
-"cacache@npm:^12.0.2":
-  version: 12.0.4
-  resolution: "cacache@npm:12.0.4"
-  dependencies:
-    bluebird: ^3.5.5
-    chownr: ^1.1.1
-    figgy-pudding: ^3.5.1
-    glob: ^7.1.4
-    graceful-fs: ^4.1.15
-    infer-owner: ^1.0.3
-    lru-cache: ^5.1.1
-    mississippi: ^3.0.0
-    mkdirp: ^0.5.1
-    move-concurrently: ^1.0.1
-    promise-inflight: ^1.0.1
-    rimraf: ^2.6.3
-    ssri: ^6.0.1
-    unique-filename: ^1.1.1
-    y18n: ^4.0.0
-  checksum: c88a72f36939b2523533946ffb27828443db5bf5995d761b35ae17af1eb6c8e20ac55b00b74c2ca900b2e1e917f0afba6847bf8cc16bee05ccca6aa150e0830c
   languageName: node
   linkType: hard
 
@@ -7837,6 +7854,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001449":
+  version: 1.0.30001464
+  resolution: "caniuse-lite@npm:1.0.30001464"
+  checksum: 67cdee102c1660d62d7b9dbd4740bb7af096236618f2509fd2e0039d50db5f02fb87c21d90b6d573fdcf50deaf3c84503d009e871502b5c221d0ba1dec18ba11
+  languageName: node
+  linkType: hard
+
 "capture-exit@npm:^2.0.0":
   version: 2.0.0
   resolution: "capture-exit@npm:2.0.0"
@@ -8004,30 +8028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^2.1.8":
-  version: 2.1.8
-  resolution: "chokidar@npm:2.1.8"
-  dependencies:
-    anymatch: ^2.0.0
-    async-each: ^1.0.1
-    braces: ^2.3.2
-    fsevents: ^1.2.7
-    glob-parent: ^3.1.0
-    inherits: ^2.0.3
-    is-binary-path: ^1.0.0
-    is-glob: ^4.0.0
-    normalize-path: ^3.0.0
-    path-is-absolute: ^1.0.0
-    readdirp: ^2.2.1
-    upath: ^1.1.1
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 0c43e89cbf0268ef1e1f41ce8ec5233c7ba022c6f3282c2ef6530e351d42396d389a1148c5a040f291cf1f4083a4c6b2f51dad3f31c726442ea9a337de316bcf
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.4.1, chokidar@npm:^3.5.3":
+"chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -8487,10 +8488,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^7.0.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
+"commander@npm:^9.4.1":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
   languageName: node
   linkType: hard
 
@@ -9880,9 +9881,9 @@ __metadata:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -9912,13 +9913,14 @@ __metadata:
     eslint-plugin-spellcheck: 0.0.11
     less: 4.1.2
     less-loader: 4.1.0
+    null-loader: ^4.0.1
     prop-types: ^15.6.2
     react: ^16.14.0
     react-dom: ^16.14.0
     react-hot-loader: 4.3.5
     style-loader: ^0.23.1
-    webpack: 4.46.0
-    webpack-cli: 4.10.0
+    webpack: 5.76.1
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -9947,6 +9949,7 @@ __metadata:
     less: 4.1.2
     less-loader: 5.0.0
     localization: ^1.0.2
+    null-loader: ^4.0.1
     prop-types: 15.6.2
     react: ^16.14.0
     react-dom: ^16.14.0
@@ -9957,8 +9960,8 @@ __metadata:
     style-loader: ^0.23.1
     throttle-debounce: ^5.0.0
     utils: ^0.3.1
-    webpack: 4.46.0
-    webpack-cli: 4.10.0
+    webpack: 5.76.1
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -10249,6 +10252,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.4.284":
+  version: 1.4.328
+  resolution: "electron-to-chromium@npm:1.4.328"
+  checksum: 82c1617a77e40ac4ca5011749318a2fee8f8c75f8b517fcff7602219c85fd97a9fab2d5a1353ea10fb7f9c7d18acb90c9ed58c2292256f81e2ffa42ee66c4b0b
+  languageName: node
+  linkType: hard
+
 "elliptic@npm:^6.0.0":
   version: 6.4.1
   resolution: "elliptic@npm:6.4.1"
@@ -10391,14 +10401,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "enhanced-resolve@npm:4.5.0"
+"enhanced-resolve@npm:^5.10.0":
+  version: 5.12.0
+  resolution: "enhanced-resolve@npm:5.12.0"
   dependencies:
-    graceful-fs: ^4.1.2
-    memory-fs: ^0.5.0
-    tapable: ^1.0.0
-  checksum: 4d87488584c4d67d356ef4ba04978af4b2d4d18190cb859efac8e8475a34d5d6c069df33faa5a0a22920b0586dbf330f6a08d52bb15a8771a9ce4d70a2da74ba
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: bf3f787facaf4ce3439bef59d148646344e372bef5557f0d37ea8aa02c51f50a925cd1f07b8d338f18992c29f544ec235a8c64bcdb56030196c48832a5494174
   languageName: node
   linkType: hard
 
@@ -10584,6 +10593,13 @@ __metadata:
     string.prototype.trimstart: ^1.0.4
     unbox-primitive: ^1.0.1
   checksum: 9b64145b077863c9572dd8cd50e190833d241a135505ec422efe829c5fc085c475e6daca378b2b45acc288f28bf85e942b3ef2cb0f69daa250240781e1081cc4
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^0.9.0":
+  version: 0.9.3
+  resolution: "es-module-lexer@npm:0.9.3"
+  checksum: 84bbab23c396281db2c906c766af58b1ae2a1a2599844a504df10b9e8dc77ec800b3211fdaa133ff700f5703d791198807bba25d9667392d27a5e9feda344da8
   languageName: node
   linkType: hard
 
@@ -10850,23 +10866,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^4.0.0, eslint-scope@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "eslint-scope@npm:4.0.3"
-  dependencies:
-    esrecurse: ^4.1.0
-    estraverse: ^4.1.1
-  checksum: c5f835f681884469991fe58d76a554688d9c9e50811299ccd4a8f79993a039f5bcb0ee6e8de2b0017d97c794b5832ef3b21c9aac66228e3aa0f7a0485bcfb65b
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:^5.1.1":
+"eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
     esrecurse: ^4.3.0
     estraverse: ^4.1.1
   checksum: 47e4b6a3f0cc29c7feedee6c67b225a2da7e155802c6ea13bbef4ac6b9e10c66cd2dcb987867ef176292bf4e64eccc680a49e35e9e9c669f4a02bac17e86abdb
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "eslint-scope@npm:4.0.3"
+  dependencies:
+    esrecurse: ^4.1.0
+    estraverse: ^4.1.1
+  checksum: c5f835f681884469991fe58d76a554688d9c9e50811299ccd4a8f79993a039f5bcb0ee6e8de2b0017d97c794b5832ef3b21c9aac66228e3aa0f7a0485bcfb65b
   languageName: node
   linkType: hard
 
@@ -11037,6 +11053,13 @@ __metadata:
   version: 3.0.0
   resolution: "events@npm:3.0.0"
   checksum: 25a5117ac67fd2ca6b931a077a309009cc20b79c60da73fd112a479558cd5a5b197c965c13b1e8d0140f65a22860c40d28e3c60e51dbad8faed8b33a042ca753
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.2.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 
@@ -11226,9 +11249,9 @@ __metadata:
     style-loader: 0.23.1
     throttle-debounce: 5.0.0
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-analyzer: ^4.4.1
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -11343,9 +11366,9 @@ __metadata:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -12315,7 +12338,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"glob-to-regexp@npm:^0.4.0":
+"glob-to-regexp@npm:^0.4.0, glob-to-regexp@npm:^0.4.1":
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
   checksum: e795f4e8f06d2a15e86f76e4d92751cf8bbfcf0157cea5c2f0f35678a8195a750b34096b1256e436f0cebc1883b5ff0888c47348443e69546a5a87f9e1eb1167
@@ -12491,7 +12514,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:4.2.10, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
@@ -13393,7 +13416,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"infer-owner@npm:^1.0.3, infer-owner@npm:^1.0.4":
+"infer-owner@npm:^1.0.4":
   version: 1.0.4
   resolution: "infer-owner@npm:1.0.4"
   checksum: 181e732764e4a0611576466b4b87dac338972b839920b2a8cde43642e4ed6bd54dc1fb0b40874728f2a2df9a1b097b8ff83b56d5f8f8e3927f837fdcb47d8a89
@@ -13550,10 +13573,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"interpret@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "interpret@npm:2.2.0"
-  checksum: f51efef7cb8d02da16408ffa3504cd6053014c5aeb7bb8c223727e053e4235bf565e45d67028b0c8740d917c603807aa3c27d7bd2f21bf20b6417e2bb3e5fd6e
+"interpret@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "interpret@npm:3.1.1"
+  checksum: 35cebcf48c7351130437596d9ab8c8fe131ce4038da4561e6d665f25640e0034702a031cf7e3a5cea60ac7ac548bf17465e0571ede126f3d3a6933152171ac82
   languageName: node
   linkType: hard
 
@@ -13768,15 +13791,6 @@ fsevents@^1.2.7:
   dependencies:
     has: ^1.0.3
   checksum: b27034318b4b462f1c8f1dfb1b32baecd651d891a4e2d1922135daeff4141dfced2b82b07aef83ef54275c4a3526aa38da859223664d0868ca24182badb784ce
-  languageName: node
-  linkType: hard
-
-"is-core-module@npm:^2.9.0":
-  version: 2.11.0
-  resolution: "is-core-module@npm:2.11.0"
-  dependencies:
-    has: ^1.0.3
-  checksum: f96fd490c6b48eb4f6d10ba815c6ef13f410b0ba6f7eb8577af51697de523e5f2cd9de1c441b51d27251bf0e4aebc936545e33a5d26d5d51f28d25698d4a8bab
   languageName: node
   linkType: hard
 
@@ -14920,6 +14934,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^27.4.5":
+  version: 27.5.1
+  resolution: "jest-worker@npm:27.5.1"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 98cd68b696781caed61c983a3ee30bf880b5bd021c01d98f47b143d4362b85d0737f8523761e2713d45e18b4f9a2b98af1eaee77afade4111bb65c77d6f7c980
+  languageName: node
+  linkType: hard
+
 "jest-worker@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-worker@npm:28.1.3"
@@ -15592,9 +15617,9 @@ fsevents@^1.2.7:
     react-modal: 3.6.1
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -15646,10 +15671,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"loader-runner@npm:^2.3.0, loader-runner@npm:^2.4.0":
+"loader-runner@npm:^2.3.0":
   version: 2.4.0
   resolution: "loader-runner@npm:2.4.0"
   checksum: e27eebbca5347a03f6b1d1bce5b2736a4984fb742f872c0a4d68e62de10f7637613e79a464d3bcd77c246d9c70fcac112bb4a3123010eb527e8b203a614647db
+  languageName: node
+  linkType: hard
+
+"loader-runner@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "loader-runner@npm:4.3.0"
+  checksum: a90e00dee9a16be118ea43fec3192d0b491fe03a32ed48a4132eb61d498f5536a03a1315531c19d284392a8726a4ecad71d82044c28d7f22ef62e029bf761569
   languageName: node
   linkType: hard
 
@@ -16265,16 +16297,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"memory-fs@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "memory-fs@npm:0.5.0"
-  dependencies:
-    errno: ^0.1.3
-    readable-stream: ^2.0.1
-  checksum: a9f25b0a8ecfb7324277393f19ef68e6ba53b9e6e4b526bbf2ba23055c5440fbf61acc7bf66bfd980e9eb4951a4790f6f777a9a3abd36603f22c87e8a64d3d6b
-  languageName: node
-  linkType: hard
-
 "meow@npm:^5.0.0":
   version: 5.0.0
   resolution: "meow@npm:5.0.0"
@@ -16423,7 +16445,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.31, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -16777,17 +16799,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.3":
-  version: 0.5.6
-  resolution: "mkdirp@npm:0.5.6"
-  dependencies:
-    minimist: ^1.2.6
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
-  languageName: node
-  linkType: hard
-
 "mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -17006,7 +17017,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.6.1":
+"neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
@@ -17181,37 +17192,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-libs-browser@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "node-libs-browser@npm:2.2.1"
-  dependencies:
-    assert: ^1.1.1
-    browserify-zlib: ^0.2.0
-    buffer: ^4.3.0
-    console-browserify: ^1.1.0
-    constants-browserify: ^1.0.0
-    crypto-browserify: ^3.11.0
-    domain-browser: ^1.1.1
-    events: ^3.0.0
-    https-browserify: ^1.0.0
-    os-browserify: ^0.3.0
-    path-browserify: 0.0.1
-    process: ^0.11.10
-    punycode: ^1.2.4
-    querystring-es3: ^0.2.0
-    readable-stream: ^2.3.3
-    stream-browserify: ^2.0.1
-    stream-http: ^2.7.2
-    string_decoder: ^1.0.0
-    timers-browserify: ^2.0.4
-    tty-browserify: 0.0.0
-    url: ^0.11.0
-    util: ^0.11.0
-    vm-browserify: ^1.0.1
-  checksum: 41fa7927378edc0cb98a8cc784d3f4a47e43378d3b42ec57a23f81125baa7287c4b54d6d26d062072226160a3ce4d8b7a62e873d2fb637aceaddf71f5a26eca0
-  languageName: node
-  linkType: hard
-
 "node-pre-gyp@npm:^0.12.0":
   version: 0.12.0
   resolution: "node-pre-gyp@npm:0.12.0"
@@ -17261,6 +17241,13 @@ fsevents@^1.2.7:
   version: 2.0.6
   resolution: "node-releases@npm:2.0.6"
   checksum: e86a926dc9fbb3b41b4c4a89d998afdf140e20a4e8dbe6c0a807f7b2948b42ea97d7fd3ad4868041487b6e9ee98409829c6e4d84a734a4215dff060a7fbeb4bf
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.8":
+  version: 2.0.10
+  resolution: "node-releases@npm:2.0.10"
+  checksum: d784ecde25696a15d449c4433077f5cce620ed30a1656c4abf31282bfc691a70d9618bae6868d247a67914d1be5cc4fde22f65a05f4398cdfb92e0fc83cadfbc
   languageName: node
   linkType: hard
 
@@ -17559,6 +17546,18 @@ fsevents@^1.2.7:
   dependencies:
     boolbase: ~1.0.0
   checksum: 59e115fdd75b971d0030f42ada3aac23898d4c03aa13371fa8b3339d23461d1badf3fde5aad251fb956aaa75c0a3b9bfcd07c08a34a83b4f9dadfdce1d19337c
+  languageName: node
+  linkType: hard
+
+"null-loader@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "null-loader@npm:4.0.1"
+  dependencies:
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: eeb4c4dd2f8f41e46f5665e4500359109e95ec1028a178a60e0161984906572da7dd87644bcc3cb29f0125d77e2b2508fb4f3813cfb1c6604a15865beb4b987b
   languageName: node
   linkType: hard
 
@@ -18318,9 +18317,9 @@ fsevents@^1.2.7:
     uglifyjs-webpack-plugin: ^2.1.3
     url-loader: 1.1.2
     url-parse: ^1.2.0
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   peerDependencies:
     es6-promise: 4.0.5
@@ -18507,13 +18506,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"path-browserify@npm:0.0.1":
-  version: 0.0.1
-  resolution: "path-browserify@npm:0.0.1"
-  checksum: ae8dcd45d0d3cfbaf595af4f206bf3ed82d77f72b4877ae7e77328079e1468c84f9386754bb417d994d5a19bf47882fd253565c18441cd5c5c90ae5187599e35
-  languageName: node
-  linkType: hard
-
 "path-dirname@npm:^1.0.0":
   version: 1.0.2
   resolution: "path-dirname@npm:1.0.2"
@@ -18560,13 +18552,6 @@ fsevents@^1.2.7:
   version: 1.0.6
   resolution: "path-parse@npm:1.0.6"
   checksum: 962a85dd384d68d469ec5ba4010df8f8f9b7e936ce603bbe3211476c5615feb3c2b1ca61211a78445fadc833f0b1a86ea6484c861035ec4ac93011ba9aff9a11
-  languageName: node
-  linkType: hard
-
-"path-parse@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "path-parse@npm:1.0.7"
-  checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
   languageName: node
   linkType: hard
 
@@ -19466,8 +19451,8 @@ fsevents@^1.2.7:
     style-loader: ^0.23.1
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
-    webpack: 4.46.0
-    webpack-cli: 4.10.0
+    webpack: 5.76.1
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -20903,12 +20888,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rechoir@npm:^0.7.0":
-  version: 0.7.1
-  resolution: "rechoir@npm:0.7.1"
+"rechoir@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rechoir@npm:0.8.0"
   dependencies:
-    resolve: ^1.9.0
-  checksum: 2a04aab4e28c05fcd6ee6768446bc8b859d8f108e71fc7f5bcbc5ef25e53330ce2c11d10f82a24591a2df4c49c4f61feabe1fd11f844c66feedd4cd7bb61146a
+    resolve: ^1.20.0
+  checksum: ad3caed8afdefbc33fbc30e6d22b86c35b3d51c2005546f4e79bcc03c074df804b3640ad18945e6bef9ed12caedc035655ec1082f64a5e94c849ff939dc0a788
   languageName: node
   linkType: hard
 
@@ -21477,19 +21462,6 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.9.0":
-  version: 1.22.1
-  resolution: "resolve@npm:1.22.1"
-  dependencies:
-    is-core-module: ^2.9.0
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: 07af5fc1e81aa1d866cbc9e9460fbb67318a10fa3c4deadc35c3ad8a898ee9a71a86a65e4755ac3195e0ea0cfbe201eb323ebe655ce90526fd61917313a34e4e
-  languageName: node
-  linkType: hard
-
 "resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.5.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#~builtin<compat/resolve>":
   version: 1.10.1
   resolution: "resolve@patch:resolve@npm%3A1.10.1#~builtin<compat/resolve>::version=1.10.1&hash=07638b"
@@ -21506,19 +21478,6 @@ resolve@^1.20.0:
     is-core-module: ^2.2.0
     path-parse: ^1.0.6
   checksum: a0dd7d16a8e47af23afa9386df2dff10e3e0debb2c7299a42e581d9d9b04d7ad5d2c53f24f1e043f7b3c250cbdc71150063e53d0b6559683d37f790b7c8c3cd5
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
-  version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
-  dependencies:
-    is-core-module: ^2.9.0
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
   languageName: node
   linkType: hard
 
@@ -21593,7 +21552,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.2.8, rimraf@npm:^2.5.4, rimraf@npm:^2.6.1, rimraf@npm:^2.6.2, rimraf@npm:^2.6.3":
+"rimraf@npm:^2.2.8, rimraf@npm:^2.5.4, rimraf@npm:^2.6.1, rimraf@npm:^2.6.2":
   version: 2.6.3
   resolution: "rimraf@npm:2.6.3"
   dependencies:
@@ -21661,9 +21620,9 @@ resolve@^1.20.0:
     style-loader: 0.23.1
     throttle-debounce: 5.0.0
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -21889,6 +21848,17 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "schema-utils@npm:3.1.1"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: fb73f3d759d43ba033c877628fe9751620a26879f6301d3dbeeb48cf2a65baec5cdf99da65d1bf3b4ff5444b2e59cbe4f81c2456b5e0d2ba7d7fd4aed5da29ce
+  languageName: node
+  linkType: hard
+
 "schema-utils@npm:^4.0.0":
   version: 4.0.0
   resolution: "schema-utils@npm:4.0.0"
@@ -21942,9 +21912,9 @@ resolve@^1.20.0:
     redux-thunk: ^2.3.0
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -22079,9 +22049,9 @@ resolve@^1.20.0:
     react-modal: 3.6.1
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -22093,12 +22063,12 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "serialize-javascript@npm:4.0.0"
+"serialize-javascript@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "serialize-javascript@npm:6.0.1"
   dependencies:
     randombytes: ^2.1.0
-  checksum: 3273b3394b951671fcf388726e9577021870dfbf85e742a1183fb2e91273e6101bdccea81ff230724f6659a7ee4cef924b0ff9baca32b79d9384ec37caf07302
+  checksum: 3c4f4cb61d0893b988415bdb67243637333f3f574e9e9cc9a006a2ced0b390b0b3b44aef8d51c951272a9002ec50885eefdc0298891bc27eb2fe7510ea87dc4f
   languageName: node
   linkType: hard
 
@@ -22167,6 +22137,7 @@ resolve@^1.20.0:
     file-loader: 3.0.1
     less: 4.1.2
     less-loader: 5.0.0
+    null-loader: ^4.0.1
     prop-types: ^15.6.2
     raw-loader: 2.0.0
     react: ^16.14.0
@@ -22175,9 +22146,9 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -22457,9 +22428,9 @@ resolve@^1.20.0:
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
     utils: ^0.3.1
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -22504,9 +22475,9 @@ resolve@^1.20.0:
     source-map-loader: ^0.2.3
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -22540,9 +22511,9 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -22748,7 +22719,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:~0.5.12":
+"source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -23405,13 +23376,6 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"supports-preserve-symlinks-flag@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
-  checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
-  languageName: node
-  linkType: hard
-
 "svg-url-loader@npm:^2.3.2":
   version: 2.3.2
   resolution: "svg-url-loader@npm:2.3.2"
@@ -23495,10 +23459,17 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"tapable@npm:^1.0.0, tapable@npm:^1.1.0, tapable@npm:^1.1.3":
+"tapable@npm:^1.0.0, tapable@npm:^1.1.0":
   version: 1.1.3
   resolution: "tapable@npm:1.1.3"
   checksum: 53ff4e7c3900051c38cc4faab428ebfd7e6ad0841af5a7ac6d5f3045c5b50e88497bfa8295b4b3fbcadd94993c9e358868b78b9fb249a76cb8b018ac8dccafd7
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "tapable@npm:2.2.1"
+  checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
   languageName: node
   linkType: hard
 
@@ -23593,9 +23564,9 @@ resolve@^1.20.0:
     react-modal: 3.6.1
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -23635,9 +23606,9 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -23718,22 +23689,25 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^1.4.3":
-  version: 1.4.5
-  resolution: "terser-webpack-plugin@npm:1.4.5"
+"terser-webpack-plugin@npm:^5.1.3":
+  version: 5.3.7
+  resolution: "terser-webpack-plugin@npm:5.3.7"
   dependencies:
-    cacache: ^12.0.2
-    find-cache-dir: ^2.1.0
-    is-wsl: ^1.1.0
-    schema-utils: ^1.0.0
-    serialize-javascript: ^4.0.0
-    source-map: ^0.6.1
-    terser: ^4.1.2
-    webpack-sources: ^1.4.0
-    worker-farm: ^1.7.0
+    "@jridgewell/trace-mapping": ^0.3.17
+    jest-worker: ^27.4.5
+    schema-utils: ^3.1.1
+    serialize-javascript: ^6.0.1
+    terser: ^5.16.5
   peerDependencies:
-    webpack: ^4.0.0
-  checksum: 02aada80927d3c8105d69cb00384d307b73aed67d180db5d20023a8d649149f3803ad50f9cd2ef9eb2622005de87e677198ecc5088f51422bfac5d4d57472d0e
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 095e699fdeeb553cdf2c6f75f983949271b396d9c201d7ae9fc633c45c1c1ad14c7257ef9d51ccc62213dd3e97f875870ba31550f6d4f1b6674f2615562da7f7
   languageName: node
   linkType: hard
 
@@ -23750,16 +23724,17 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"terser@npm:^4.1.2":
-  version: 4.8.1
-  resolution: "terser@npm:4.8.1"
+"terser@npm:^5.16.5":
+  version: 5.16.6
+  resolution: "terser@npm:5.16.6"
   dependencies:
+    "@jridgewell/source-map": ^0.3.2
+    acorn: ^8.5.0
     commander: ^2.20.0
-    source-map: ~0.6.1
-    source-map-support: ~0.5.12
+    source-map-support: ~0.5.20
   bin:
     terser: bin/terser
-  checksum: b342819bf7e82283059aaa3f22bb74deb1862d07573ba5a8947882190ad525fd9b44a15074986be083fd379c58b9a879457a330b66dcdb77b485c44267f9a55a
+  checksum: f763a7bcc7b98cb2bfc41434f7b92bfe8a701a12c92ea6049377736c8e6de328240d654a20dfe15ce170fd783491b9873fad9f4cd8fee4f6c6fb8ca407859dee
   languageName: node
   linkType: hard
 
@@ -23830,9 +23805,9 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -24544,6 +24519,20 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"update-browserslist-db@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "update-browserslist-db@npm:1.0.10"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    browserslist-lint: cli.js
+  checksum: 12db73b4f63029ac407b153732e7cd69a1ea8206c9100b482b7d12859cd3cd0bc59c602d7ae31e652706189f1acb90d42c53ab24a5ba563ed13aebdddc5561a0
+  languageName: node
+  linkType: hard
+
 "update-browserslist-db@npm:^1.0.5":
   version: 1.0.5
   resolution: "update-browserslist-db@npm:1.0.5"
@@ -24691,6 +24680,7 @@ resolve@^1.20.0:
     less: 4.1.2
     less-loader: 5.0.0
     localization: ^1.0.2
+    null-loader: ^4.0.1
     prop-types: ^15.6.2
     raw-loader: 2.0.0
     react: ^16.14.0
@@ -24709,9 +24699,9 @@ resolve@^1.20.0:
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
     utils: ^0.3.1
-    webpack: 4.46.0
+    webpack: 5.76.1
     webpack-bundle-size-analyzer: 3.1.0
-    webpack-cli: 4.10.0
+    webpack-cli: 5.0.1
     webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
@@ -24953,13 +24943,6 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"vm-browserify@npm:^1.0.1":
-  version: 1.1.2
-  resolution: "vm-browserify@npm:1.1.2"
-  checksum: 10a1c50aab54ff8b4c9042c15fc64aefccce8d2fb90c0640403242db0ee7fb269f9b102bdb69cfb435d7ef3180d61fd4fb004a043a12709abaf9056cfd7e039d
-  languageName: node
-  linkType: hard
-
 "walk-up-path@npm:^1.0.0":
   version: 1.0.0
   resolution: "walk-up-path@npm:1.0.0"
@@ -25003,15 +24986,6 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"watchpack-chokidar2@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "watchpack-chokidar2@npm:2.0.1"
-  dependencies:
-    chokidar: ^2.1.8
-  checksum: acf0f9ebca0c0b2fd1fe87ba557670477a6c0410bf1a653a726e68eb0620aa94fd9a43027a160a76bc793a21ea12e215e1e87dafe762682c13ef92ad4daf7b58
-  languageName: node
-  linkType: hard
-
 "watchpack@npm:^1.5.0":
   version: 1.6.0
   resolution: "watchpack@npm:1.6.0"
@@ -25023,20 +24997,13 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^1.7.4":
-  version: 1.7.5
-  resolution: "watchpack@npm:1.7.5"
+"watchpack@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "watchpack@npm:2.4.0"
   dependencies:
-    chokidar: ^3.4.1
+    glob-to-regexp: ^0.4.1
     graceful-fs: ^4.1.2
-    neo-async: ^2.5.0
-    watchpack-chokidar2: ^2.0.1
-  dependenciesMeta:
-    chokidar:
-      optional: true
-    watchpack-chokidar2:
-      optional: true
-  checksum: 8b7cb8c8df8f4dd0e8ac47693c0141c4f020a4b031411247d600eca31522fde6f1f9a3a6f6518b46e71f7971b0ed5734c08c60d7fdd2530e7262776286f69236
+  checksum: 23d4bc58634dbe13b86093e01c6a68d8096028b664ab7139d58f0c37d962d549a940e98f2f201cecdabd6f9c340338dc73ef8bf094a2249ef582f35183d1a131
   languageName: node
   linkType: hard
 
@@ -25111,28 +25078,27 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:4.10.0":
-  version: 4.10.0
-  resolution: "webpack-cli@npm:4.10.0"
+"webpack-cli@npm:5.0.1":
+  version: 5.0.1
+  resolution: "webpack-cli@npm:5.0.1"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.0
-    "@webpack-cli/configtest": ^1.2.0
-    "@webpack-cli/info": ^1.5.0
-    "@webpack-cli/serve": ^1.7.0
+    "@webpack-cli/configtest": ^2.0.1
+    "@webpack-cli/info": ^2.0.1
+    "@webpack-cli/serve": ^2.0.1
     colorette: ^2.0.14
-    commander: ^7.0.0
+    commander: ^9.4.1
     cross-spawn: ^7.0.3
+    envinfo: ^7.7.3
     fastest-levenshtein: ^1.0.12
     import-local: ^3.0.2
-    interpret: ^2.2.0
-    rechoir: ^0.7.0
+    interpret: ^3.1.1
+    rechoir: ^0.8.0
     webpack-merge: ^5.7.3
   peerDependencies:
-    webpack: 4.x.x || 5.x.x
+    webpack: 5.x.x
   peerDependenciesMeta:
     "@webpack-cli/generators":
-      optional: true
-    "@webpack-cli/migrate":
       optional: true
     webpack-bundle-analyzer:
       optional: true
@@ -25140,7 +25106,7 @@ resolve@^1.20.0:
       optional: true
   bin:
     webpack-cli: bin/cli.js
-  checksum: 2ff5355ac348e6b40f2630a203b981728834dca96d6d621be96249764b2d0fc01dd54edfcc37f02214d02935de2cf0eefd6ce689d970d154ef493f01ba922390
+  checksum: b1544eea669442e78c3dba9f79c0f8d0136759b8b2fe9cd32c0d410250fd719988ae037778ba88993215d44971169f2c268c0c934068be561711615f1951bd53
   languageName: node
   linkType: hard
 
@@ -25266,51 +25232,47 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^1.4.0, webpack-sources@npm:^1.4.1":
-  version: 1.4.3
-  resolution: "webpack-sources@npm:1.4.3"
-  dependencies:
-    source-list-map: ^2.0.0
-    source-map: ~0.6.1
-  checksum: 37463dad8d08114930f4bc4882a9602941f07c9f0efa9b6bc78738cd936275b990a596d801ef450d022bb005b109b9f451dd087db2f3c9baf53e8e22cf388f79
+"webpack-sources@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "webpack-sources@npm:3.2.3"
+  checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
   languageName: node
   linkType: hard
 
-"webpack@npm:4.46.0":
-  version: 4.46.0
-  resolution: "webpack@npm:4.46.0"
+"webpack@npm:5.76.1":
+  version: 5.76.1
+  resolution: "webpack@npm:5.76.1"
   dependencies:
-    "@webassemblyjs/ast": 1.9.0
-    "@webassemblyjs/helper-module-context": 1.9.0
-    "@webassemblyjs/wasm-edit": 1.9.0
-    "@webassemblyjs/wasm-parser": 1.9.0
-    acorn: ^6.4.1
-    ajv: ^6.10.2
-    ajv-keywords: ^3.4.1
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.7.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
     chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^4.5.0
-    eslint-scope: ^4.0.3
-    json-parse-better-errors: ^1.0.2
-    loader-runner: ^2.4.0
-    loader-utils: ^1.2.3
-    memory-fs: ^0.4.1
-    micromatch: ^3.1.10
-    mkdirp: ^0.5.3
-    neo-async: ^2.6.1
-    node-libs-browser: ^2.2.1
-    schema-utils: ^1.0.0
-    tapable: ^1.1.3
-    terser-webpack-plugin: ^1.4.3
-    watchpack: ^1.7.4
-    webpack-sources: ^1.4.1
+    enhanced-resolve: ^5.10.0
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-even-better-errors: ^2.3.1
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.4.0
+    webpack-sources: ^3.2.3
   peerDependenciesMeta:
     webpack-cli:
       optional: true
-    webpack-command:
-      optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 013fa24c00d4261e16ebca60353fa6f848e417b5a44bdf28c16ebebd67fa61e960420bb314c8df05cfe2dad9b90efabcf38fd6875f2361922769a0384085ef1e
+  checksum: b01fe0bc2dbca0e10d290ddb0bf81e807a031de48028176e2b21afd696b4d3f25ab9accdad888ef4a1f7c7f4d41f13d5bf2395b7653fdf3e5e3dafa54e56dab2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,6 +1783,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discoveryjs/json-ext@npm:^0.5.0":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
+  languageName: node
+  linkType: hard
+
 "@dnncommunity/dnn-elements@npm:^0.15.2":
   version: 0.15.2
   resolution: "@dnncommunity/dnn-elements@npm:0.15.2"
@@ -1851,10 +1858,10 @@ __metadata:
     style-loader: ^0.23.0
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
-    webpack: ^4.31.0
-    webpack-bundle-size-analyzer: ^3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
     webpack-node-externals: ^3.0.0
   peerDependencies:
     prop-types: ^15.6.2
@@ -2570,6 +2577,13 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
+  languageName: node
+  linkType: hard
+
+"@leichtgewicht/ip-codec@npm:^2.0.1":
+  version: 2.0.4
+  resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
+  checksum: 468de1f04d33de6d300892683d7c8aecbf96d1e2c5fe084f95f816e50a054d45b7c1ebfb141a1447d844b86a948733f6eebd92234da8581c84a1ad4de2946a2d
   languageName: node
   linkType: hard
 
@@ -3996,6 +4010,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/body-parser@npm:*":
+  version: 1.19.2
+  resolution: "@types/body-parser@npm:1.19.2"
+  dependencies:
+    "@types/connect": "*"
+    "@types/node": "*"
+  checksum: e17840c7d747a549f00aebe72c89313d09fbc4b632b949b2470c5cb3b1cb73863901ae84d9335b567a79ec5efcfb8a28ff8e3f36bc8748a9686756b6d5681f40
+  languageName: node
+  linkType: hard
+
+"@types/bonjour@npm:^3.5.9":
+  version: 3.5.10
+  resolution: "@types/bonjour@npm:3.5.10"
+  dependencies:
+    "@types/node": "*"
+  checksum: bfcadb042a41b124c4e3de4925e3be6d35b78f93f27c4535d5ff86980dc0f8bc407ed99b9b54528952dc62834d5a779392f7a12c2947dd19330eb05a6bcae15a
+  languageName: node
+  linkType: hard
+
 "@types/cheerio@npm:^0.22.22":
   version: 0.22.30
   resolution: "@types/cheerio@npm:0.22.30"
@@ -4021,6 +4054,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/connect-history-api-fallback@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "@types/connect-history-api-fallback@npm:1.3.5"
+  dependencies:
+    "@types/express-serve-static-core": "*"
+    "@types/node": "*"
+  checksum: 464d06e5ab00f113fa89978633d5eb00d225aeb4ebbadc07f6f3bc337aa7cbfcd74957b2a539d6d47f2e128e956a17819973ec7ae62ade2e16e367a6c38b8d3a
+  languageName: node
+  linkType: hard
+
+"@types/connect@npm:*":
+  version: 3.4.35
+  resolution: "@types/connect@npm:3.4.35"
+  dependencies:
+    "@types/node": "*"
+  checksum: fe81351470f2d3165e8b12ce33542eef89ea893e36dd62e8f7d72566dfb7e448376ae962f9f3ea888547ce8b55a40020ca0e01d637fab5d99567673084542641
+  languageName: node
+  linkType: hard
+
 "@types/domhandler@npm:2.4.1":
   version: 2.4.1
   resolution: "@types/domhandler@npm:2.4.1"
@@ -4032,6 +4084,29 @@ __metadata:
   version: 3.0.0
   resolution: "@types/events@npm:3.0.0"
   checksum: 9a424c2da210957d5636e0763e8c9fc3aaeee35bf411284ddec62a56a6abe31de9c7c2e713dabdd8a76ff98b47db2bd52f61310be6609641d6234cc842ecbbe3
+  languageName: node
+  linkType: hard
+
+"@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:^4.17.33":
+  version: 4.17.33
+  resolution: "@types/express-serve-static-core@npm:4.17.33"
+  dependencies:
+    "@types/node": "*"
+    "@types/qs": "*"
+    "@types/range-parser": "*"
+  checksum: dce580d16b85f207445af9d4053d66942b27d0c72e86153089fa00feee3e96ae336b7bedb31ed4eea9e553c99d6dd356ed6e0928f135375d9f862a1a8015adf2
+  languageName: node
+  linkType: hard
+
+"@types/express@npm:*, @types/express@npm:^4.17.13":
+  version: 4.17.17
+  resolution: "@types/express@npm:4.17.17"
+  dependencies:
+    "@types/body-parser": "*"
+    "@types/express-serve-static-core": ^4.17.33
+    "@types/qs": "*"
+    "@types/serve-static": "*"
+  checksum: 0196dacc275ac3ce89d7364885cb08e7fb61f53ca101f65886dbf1daf9b7eb05c0943e2e4bbd01b0cc5e50f37e0eea7e4cbe97d0304094411ac73e1b7998f4da
   languageName: node
   linkType: hard
 
@@ -4071,6 +4146,15 @@ __metadata:
     "@types/react": "*"
     hoist-non-react-statics: ^3.3.0
   checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
+  languageName: node
+  linkType: hard
+
+"@types/http-proxy@npm:^1.17.8":
+  version: 1.17.10
+  resolution: "@types/http-proxy@npm:1.17.10"
+  dependencies:
+    "@types/node": "*"
+  checksum: 8fabee5d01715e338f426715325121d6c4b7a9694dee716ab61c874e0aaccee9a0fff7ccc3c9d7e37a8feeaab7c783c17aaa9943efbc8849c5e79ecd7eaf02ab
   languageName: node
   linkType: hard
 
@@ -4130,6 +4214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.9":
+  version: 7.0.11
+  resolution: "@types/json-schema@npm:7.0.11"
+  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
+  languageName: node
+  linkType: hard
+
 "@types/knockout@npm:^3.4.66":
   version: 3.4.66
   resolution: "@types/knockout@npm:3.4.66"
@@ -4150,6 +4241,13 @@ __metadata:
   version: 4.14.184
   resolution: "@types/lodash@npm:4.14.184"
   checksum: 6d9a4d67f7f9d0ec3fd21174f3dd3d00629dc1227eb469450eace53adbc1f7e2330699c28d0fe093e5f0fef0f0e763098be1f779268857213224af082b62be21
+  languageName: node
+  linkType: hard
+
+"@types/mime@npm:*":
+  version: 3.0.1
+  resolution: "@types/mime@npm:3.0.1"
+  checksum: 4040fac73fd0cea2460e29b348c1a6173da747f3a87da0dbce80dd7a9355a3d0e51d6d9a401654f3e5550620e3718b5a899b2ec1debf18424e298a2c605346e7
   languageName: node
   linkType: hard
 
@@ -4223,10 +4321,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:^6.9.5":
+"@types/qs@npm:*, @types/qs@npm:^6.9.5":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
+  languageName: node
+  linkType: hard
+
+"@types/range-parser@npm:*":
+  version: 1.2.4
+  resolution: "@types/range-parser@npm:1.2.4"
+  checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
   languageName: node
   linkType: hard
 
@@ -4275,10 +4380,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/retry@npm:0.12.0":
+  version: 0.12.0
+  resolution: "@types/retry@npm:0.12.0"
+  checksum: 61a072c7639f6e8126588bf1eb1ce8835f2cb9c2aba795c4491cf6310e013267b0c8488039857c261c387e9728c1b43205099223f160bb6a76b4374f741b5603
+  languageName: node
+  linkType: hard
+
 "@types/scheduler@npm:*":
   version: 0.16.2
   resolution: "@types/scheduler@npm:0.16.2"
   checksum: b6b4dcfeae6deba2e06a70941860fb1435730576d3689225a421280b7742318d1548b3d22c1f66ab68e414f346a9542f29240bc955b6332c5b11e561077583bc
+  languageName: node
+  linkType: hard
+
+"@types/serve-index@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@types/serve-index@npm:1.9.1"
+  dependencies:
+    "@types/express": "*"
+  checksum: 026f3995fb500f6df7c3fe5009e53bad6d739e20b84089f58ebfafb2f404bbbb6162bbe33f72d2f2af32d5b8d3799c8e179793f90d9ed5871fb8591190bb6056
+  languageName: node
+  linkType: hard
+
+"@types/serve-static@npm:*, @types/serve-static@npm:^1.13.10":
+  version: 1.15.1
+  resolution: "@types/serve-static@npm:1.15.1"
+  dependencies:
+    "@types/mime": "*"
+    "@types/node": "*"
+  checksum: 2e078bdc1e458c7dfe69e9faa83cc69194b8896cce57cb745016580543c7ab5af07fdaa8ac1765eb79524208c81017546f66056f44d1204f812d72810613de36
+  languageName: node
+  linkType: hard
+
+"@types/sockjs@npm:^0.3.33":
+  version: 0.3.33
+  resolution: "@types/sockjs@npm:0.3.33"
+  dependencies:
+    "@types/node": "*"
+  checksum: b9bbb2b5c5ead2fb884bb019f61a014e37410bddd295de28184e1b2e71ee6b04120c5ba7b9954617f0bdf962c13d06249ce65004490889c747c80d3f628ea842
   languageName: node
   linkType: hard
 
@@ -4338,6 +4478,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ws@npm:^8.5.1":
+  version: 8.5.4
+  resolution: "@types/ws@npm:8.5.4"
+  dependencies:
+    "@types/node": "*"
+  checksum: fefbad20d211929bb996285c4e6f699b12192548afedbe4930ab4384f8a94577c9cd421acaad163cacd36b88649509970a05a0b8f20615b30c501ed5269038d1
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.0
   resolution: "@types/yargs-parser@npm:21.0.0"
@@ -4372,10 +4521,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/ast@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/ast@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/helper-module-context": 1.9.0
+    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
+    "@webassemblyjs/wast-parser": 1.9.0
+  checksum: 8a9838dc7fdac358aee8daa75eefa35934ab18dafb594092ff7be79c467ebe9dabb2543e58313c905fd802bdcc3cb8320e4e19af7444e49853a7a24e25138f75
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/floating-point-hex-parser@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.8.5"
   checksum: 68a1ff458355fb6b1553c8f7e2df6d76623bf5ef895f3fc30de620b88d1e68224643c8daf517d19b75d4e10a7f663c038b9912970edcae6f5a4fdb85b630bfc3
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/floating-point-hex-parser@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.9.0"
+  checksum: d3aeb19bc30da26f639698daa28e44e0c18d5aa135359ef3c54148e194eec46451a912d0506099d479a71a94bc3eef6ef52d6ec234799528a25a9744789852de
   languageName: node
   linkType: hard
 
@@ -4386,10 +4553,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-api-error@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-api-error@npm:1.9.0"
+  checksum: 9179d3148639cc202e89a118145b485cf834613260679a99af6ec487bbc15f238566ca713207394b336160a41bf8c1b75cf2e853b3e96f0cc73c1e5c735b3f64
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/helper-buffer@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/helper-buffer@npm:1.8.5"
   checksum: 5eeb48b135d5ca013c8876228a3a2ccfba98d87dfe12fcf6921e0acf7a272070f369e4e4e8a7f34f2cf22e8faaade24a39a9bcfba76498f103f051384b0f55b3
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-buffer@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-buffer@npm:1.9.0"
+  checksum: dcb85f630f8a2e22b7346ad4dd58c3237a2cad1457699423e8fd19592a0bd3eacbc2639178a1b9a873c3ac217bfc7a23a134ff440a099496b590e82c7a4968d5
   languageName: node
   linkType: hard
 
@@ -4402,10 +4583,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-code-frame@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-code-frame@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/wast-printer": 1.9.0
+  checksum: a28fa057f7beff0fd14bff716561520f8edb8c9c56c7a5559451e6765acfb70aaeb8af718ea2bd2262e7baeba597545af407e28eb2eff8329235afe8605f20d1
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/helper-fsm@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/helper-fsm@npm:1.8.5"
   checksum: 5026861c39518cf7f8fa6a88ccad8e251d906130a9ccfe2a49da5eb5321bfdf0861f31e5269f76687259f96cc8143f09a9df73a3836c44cb5445bdc01f77fd91
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-fsm@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-fsm@npm:1.9.0"
+  checksum: 374cc510c8f5a7a07d4fe9eb7036cc475a96a670b5d25c31f16757ac8295be8d03a2f29657ff53eaefa9e8315670a48824d430ed910e7c1835788ac79f93124e
   languageName: node
   linkType: hard
 
@@ -4419,10 +4616,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-module-context@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-module-context@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+  checksum: 55e8f89c7ea1beaa78fad88403f3753b8413b0f3b6bb32d898ce95078b3e1d1b48ade0919c00b82fc2e3813c0ab6901e415f7a4d4fa9be50944e2431adde75a5
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/helper-wasm-bytecode@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.8.5"
   checksum: ac560cafe93e5ef07d892cea8ed5f1cb2b7cb8777a335fa92d99068eef650fbc37077e2ac8861bcaed337ac613db477741603554d9784373d41acaeffefd2c01
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/helper-wasm-bytecode@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.9.0"
+  checksum: 280da4df3c556f73a1a02053277f8a4be481de32df4aa21050b015c8f4d27c46af89f0417eb88e486df117e5df4bccffae593f78cb1e79f212d3b3d4f3ed0f04
   languageName: node
   linkType: hard
 
@@ -4438,12 +4651,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/helper-wasm-section@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/helper-wasm-section@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/helper-buffer": 1.9.0
+    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
+    "@webassemblyjs/wasm-gen": 1.9.0
+  checksum: b8f7bb45d4194074c82210211a5d3e402a5b5fa63ecae26d2c356ae3978af5a530e91192fb260f32f9d561b18e2828b3da2e2f41c59efadb5f3c6d72446807f0
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ieee754@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/ieee754@npm:1.8.5"
   dependencies:
     "@xtuc/ieee754": ^1.2.0
   checksum: 20230eb79e4bdf812f49ae73ca145a0a8d0fa1ec8a6353b5a36e57c1955ecc7245f277bfb1bf839e041fff7f300948d938b0672bae9d5764519ed0b6a6aa1bdb
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/ieee754@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/ieee754@npm:1.9.0"
+  dependencies:
+    "@xtuc/ieee754": ^1.2.0
+  checksum: 7fe4a217ba0f7051e2cfef92919d4a64fac1a63c65411763779bd50907820f33f440255231a474fe3ba03bd1d9ee0328662d1eae3fce4c59b91549d6b62b839b
   languageName: node
   linkType: hard
 
@@ -4456,10 +4690,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/leb128@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/leb128@npm:1.9.0"
+  dependencies:
+    "@xtuc/long": 4.2.2
+  checksum: 4ca7cbb869530d78d42a414f34ae53249364cb1ecebbfb6ed5d562c2f209fce857502f088822ee82a23876f653a262ddc34ab64e45a7962510a263d39bb3f51a
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/utf8@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/utf8@npm:1.8.5"
   checksum: 6aac4440996a160f268762a3dad1ef4a02f4d06fe3a7a0189556adbbbc34ed9ec54a2eadc2adb0aea2ba3430e9dbe20ab461df4f224eed73c9066904b17013e4
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/utf8@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/utf8@npm:1.9.0"
+  checksum: e328a30ac8a503bbd015d32e75176e0dedcb45a21d4be051c25dfe89a00035ca7a6dbd8937b442dd5b4b334de3959d4f5fe0b330037bd226a28b9814cd49e84f
   languageName: node
   linkType: hard
 
@@ -4479,6 +4729,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wasm-edit@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-edit@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/helper-buffer": 1.9.0
+    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
+    "@webassemblyjs/helper-wasm-section": 1.9.0
+    "@webassemblyjs/wasm-gen": 1.9.0
+    "@webassemblyjs/wasm-opt": 1.9.0
+    "@webassemblyjs/wasm-parser": 1.9.0
+    "@webassemblyjs/wast-printer": 1.9.0
+  checksum: 1997e0c2f4051c33239587fb143242919320bc861a0af03a873c7150a27d6404bd2e063c658193288b0aa88c35aadbe0c4fde601fe642bae0743a8c8eda52717
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wasm-gen@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/wasm-gen@npm:1.8.5"
@@ -4492,6 +4758,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wasm-gen@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-gen@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
+    "@webassemblyjs/ieee754": 1.9.0
+    "@webassemblyjs/leb128": 1.9.0
+    "@webassemblyjs/utf8": 1.9.0
+  checksum: 2456e84e8e6bedb7ab47f6333a0ee170f7ef62842c90862ca787c08528ca8041061f3f8bc257fc2a01bf6e8d1a76fddaddd43418c738f681066e5b50f88fe7df
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wasm-opt@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/wasm-opt@npm:1.8.5"
@@ -4501,6 +4780,18 @@ __metadata:
     "@webassemblyjs/wasm-gen": 1.8.5
     "@webassemblyjs/wasm-parser": 1.8.5
   checksum: 44b18c328b919ba4510d58b4dfe6244edac8c21cd2b6cf7167ad58feb0ddc61217c98521b2f0ffc0e388a0b5469b060a6908e8cc7753ab72945204b4a87dd31b
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wasm-opt@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-opt@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/helper-buffer": 1.9.0
+    "@webassemblyjs/wasm-gen": 1.9.0
+    "@webassemblyjs/wasm-parser": 1.9.0
+  checksum: 91242205bdbd1aa8045364a5338bfb34880cb2c65f56db8dd19382894209673699fb31a0e5279f25c7e5bcd8f3097d6c9ca84d8969d9613ef2cf166450cc3515
   languageName: node
   linkType: hard
 
@@ -4518,6 +4809,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wasm-parser@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wasm-parser@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/helper-api-error": 1.9.0
+    "@webassemblyjs/helper-wasm-bytecode": 1.9.0
+    "@webassemblyjs/ieee754": 1.9.0
+    "@webassemblyjs/leb128": 1.9.0
+    "@webassemblyjs/utf8": 1.9.0
+  checksum: 493f6cfc63a5e16073056c81ff0526a9936f461327379ef3c83cc841000e03623b6352704f6bf9f7cb5b3610f0032020a61f9cca78c91b15b8e995854b29c098
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wast-parser@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/wast-parser@npm:1.8.5"
@@ -4532,6 +4837,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webassemblyjs/wast-parser@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wast-parser@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/floating-point-hex-parser": 1.9.0
+    "@webassemblyjs/helper-api-error": 1.9.0
+    "@webassemblyjs/helper-code-frame": 1.9.0
+    "@webassemblyjs/helper-fsm": 1.9.0
+    "@xtuc/long": 4.2.2
+  checksum: 705dd48fbbceec7f6bed299b8813631b242fd9312f9594dbb2985dda86c9688048692357d684f6080fc2c5666287cefaa26b263d01abadb6a9049d4c8978b9db
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/wast-printer@npm:1.8.5":
   version: 1.8.5
   resolution: "@webassemblyjs/wast-printer@npm:1.8.5"
@@ -4540,6 +4859,50 @@ __metadata:
     "@webassemblyjs/wast-parser": 1.8.5
     "@xtuc/long": 4.2.2
   checksum: 7c53f5f694b9820cef5e58653a85f5e9b0eba4e59013a2e0fcf3562d7e70501b0202d73ebadbd14b5845ecf958e3639bdde5a197a4245dded722f2015ec45e2a
+  languageName: node
+  linkType: hard
+
+"@webassemblyjs/wast-printer@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@webassemblyjs/wast-printer@npm:1.9.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/wast-parser": 1.9.0
+    "@xtuc/long": 4.2.2
+  checksum: 3d1e1b2e84745a963f69acd1c02425b321dd2e608e11dabc467cae0c9a808962bc769ec9afc46fbcea7188cc1e47d72370da762d258f716fb367cb1a7865c54b
+  languageName: node
+  linkType: hard
+
+"@webpack-cli/configtest@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@webpack-cli/configtest@npm:1.2.0"
+  peerDependencies:
+    webpack: 4.x.x || 5.x.x
+    webpack-cli: 4.x.x
+  checksum: a2726cd9ec601d2b57e5fc15e0ebf5200a8892065e735911269ac2038e62be4bfc176ea1f88c2c46ff09b4d05d4c10ae045e87b3679372483d47da625a327e28
+  languageName: node
+  linkType: hard
+
+"@webpack-cli/info@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@webpack-cli/info@npm:1.5.0"
+  dependencies:
+    envinfo: ^7.7.3
+  peerDependencies:
+    webpack-cli: 4.x.x
+  checksum: 7f56fe037cd7d1fd5c7428588519fbf04a0cad33925ee4202ffbafd00f8ec1f2f67d991245e687d50e0f3e23f7b7814273d56cb9f7da4b05eed47c8d815c6296
+  languageName: node
+  linkType: hard
+
+"@webpack-cli/serve@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@webpack-cli/serve@npm:1.7.0"
+  peerDependencies:
+    webpack-cli: 4.x.x
+  peerDependenciesMeta:
+    webpack-dev-server:
+      optional: true
+  checksum: d475e8effa23eb7ff9a48b14d4de425989fd82f906ce71c210921cc3852327c22873be00c35e181a25a6bd03d424ae2b83e7f3b3f410ac7ee31b128ab4ac7713
   languageName: node
   linkType: hard
 
@@ -4658,6 +5021,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^6.4.1":
+  version: 6.4.2
+  resolution: "acorn@npm:6.4.2"
+  bin:
+    acorn: bin/acorn
+  checksum: 44b07053729db7f44d28343eed32247ed56dc4a6ec6dff2b743141ecd6b861406bbc1c20bf9d4f143ea7dd08add5dc8c290582756539bc03a8db605050ce2fb4
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^7.4.0":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
@@ -4756,10 +5128,10 @@ __metadata:
     style-loader: ^0.23.1
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: 3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -4858,6 +5230,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.1.0":
   version: 3.4.0
   resolution: "ajv-keywords@npm:3.4.0"
@@ -4867,12 +5253,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-keywords@npm:^3.5.2":
+"ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
   peerDependencies:
     ajv: ^6.9.1
   checksum: 7dc5e5931677a680589050f79dcbe1fefbb8fea38a955af03724229139175b433c63c68f7ae5f86cf8f65d55eb7c25f75a046723e2e58296707617ca690feae9
+  languageName: node
+  linkType: hard
+
+"ajv-keywords@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "ajv-keywords@npm:5.1.0"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+  peerDependencies:
+    ajv: ^8.8.2
+  checksum: c35193940b853119242c6757787f09ecf89a2c19bcd36d03ed1a615e710d19d450cb448bfda407b939aba54b002368c8bff30529cc50a0536a8e10bcce300421
   languageName: node
   linkType: hard
 
@@ -4888,7 +5285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
+"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -4897,6 +5294,18 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
+  version: 8.12.0
+  resolution: "ajv@npm:8.12.0"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 4dc13714e316e67537c8b31bc063f99a1d9d9a497eb4bbd55191ac0dcd5e4985bbb71570352ad6f1e76684fb6d790928f96ba3b2d4fd6e10024be9612fe3f001
   languageName: node
   linkType: hard
 
@@ -4966,6 +5375,15 @@ __metadata:
   dependencies:
     type-fest: ^0.21.3
   checksum: 93111c42189c0a6bed9cdb4d7f2829548e943827ee8479c74d6e0b22ee127b2a21d3f8b5ca57723b8ef78ce011fbfc2784350eb2bde3ccfccf2f575fa8489815
+  languageName: node
+  linkType: hard
+
+"ansi-html-community@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "ansi-html-community@npm:0.0.8"
+  bin:
+    ansi-html: bin/ansi-html
+  checksum: 04c568e8348a636963f915e48eaa3e01218322e1169acafdd79c384f22e5558c003f79bbc480c1563865497482817c7eed025f0653ebc17642fededa5cb42089
   languageName: node
   linkType: hard
 
@@ -5072,6 +5490,16 @@ __metadata:
     normalize-path: ^3.0.0
     picomatch: ^2.0.4
   checksum: 985163db2292fac9e5a1e072bf99f1b5baccf196e4de25a0b0b81865ebddeb3b3eb4480734ef0a2ac8c002845396b91aa89121f5b84f93981a4658164a9ec6e9
+  languageName: node
+  linkType: hard
+
+"anymatch@npm:~3.1.2":
+  version: 3.1.3
+  resolution: "anymatch@npm:3.1.3"
+  dependencies:
+    normalize-path: ^3.0.0
+    picomatch: ^2.0.4
+  checksum: 3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
   languageName: node
   linkType: hard
 
@@ -5221,7 +5649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-flatten@npm:^2.1.0":
+"array-flatten@npm:^2.1.2":
   version: 2.1.2
   resolution: "array-flatten@npm:2.1.2"
   checksum: e8988aac1fbfcdaae343d08c9a06a6fddd2c6141721eeeea45c3cf523bf4431d29a46602929455ed548c7a3e0769928cdc630405427297e7081bd118fdec9262
@@ -5442,13 +5870,6 @@ __metadata:
   version: 1.0.3
   resolution: "async-each@npm:1.0.3"
   checksum: 868651cfeb209970b367fbb96df1e1c8dc0b22c681cda7238417005ab2a5fbd944ee524b43f2692977259a57b7cc2547e03ff68f2b5113dbdf953d48cc078dc3
-  languageName: node
-  linkType: hard
-
-"async@npm:^1.5.2":
-  version: 1.5.2
-  resolution: "async@npm:1.5.2"
-  checksum: fe5d6214d8f15bd51eee5ae8ec5079b228b86d2d595f47b16369dec2e11b3ff75a567bb5f70d12d79006665fbbb7ee0a7ec0e388524eefd454ecbe651c124ebd
   languageName: node
   linkType: hard
 
@@ -6815,6 +7236,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "binary-extensions@npm:2.2.0"
+  checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -6830,6 +7258,13 @@ __metadata:
   version: 3.5.4
   resolution: "bluebird@npm:3.5.4"
   checksum: 4566557a63fb6c4e106371cce0f9dd02498791d690360c1169dd0baea6bd67325076231de8b4406ccb7bc1559febc2bdb6bebad0cc8aa313e2ce9c156504899e
+  languageName: node
+  linkType: hard
+
+"bluebird@npm:^3.5.5":
+  version: 3.7.2
+  resolution: "bluebird@npm:3.7.2"
+  checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
   languageName: node
   linkType: hard
 
@@ -6860,17 +7295,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bonjour@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "bonjour@npm:3.5.0"
+"bonjour-service@npm:^1.0.11":
+  version: 1.1.0
+  resolution: "bonjour-service@npm:1.1.0"
   dependencies:
-    array-flatten: ^2.1.0
-    deep-equal: ^1.0.1
+    array-flatten: ^2.1.2
     dns-equal: ^1.0.0
-    dns-txt: ^2.0.2
-    multicast-dns: ^6.0.1
-    multicast-dns-service-types: ^1.1.0
-  checksum: 2cfbe9fa861f4507b5ff3853eeae3ef03a231ede2b7363efedd80880ea3c0576f64416f98056c96e429ed68ff38dc4a70c0583d1eb4dab72e491ca44a0f03444
+    fast-deep-equal: ^3.1.3
+    multicast-dns: ^7.2.5
+  checksum: c0cdf6f6438ef4873ffd17768a9e62300ca30ac2bc3437bcfb6c75a3efd70ad80418c38ec19af2f5fe3a9f1dee725b83ff8e0c4a473b1b9f1718a39033b34cbf
   languageName: node
   linkType: hard
 
@@ -6933,7 +7366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2":
+"braces@npm:^3.0.2, braces@npm:~3.0.2":
   version: 3.0.2
   resolution: "braces@npm:3.0.2"
   dependencies:
@@ -7091,13 +7524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-indexof@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "buffer-indexof@npm:1.1.1"
-  checksum: 0967abc2981a8e7d776324c6b84811e4d84a7ead89b54a3bb8791437f0c4751afd060406b06db90a436f1cf771867331b5ecf5c4aca95b4ccb9f6cb146c22ebc
-  languageName: node
-  linkType: hard
-
 "buffer-xor@npm:^1.0.3":
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
@@ -7189,6 +7615,29 @@ __metadata:
     unique-filename: ^1.1.1
     y18n: ^4.0.0
   checksum: 21fd5f5a29c594782a17c1028297053781f1344aec05c72fe437258bbd9cc716d8f037c770d67ad3e15f0008b94e4e4523b5e90420cd477d0ab7f4b9c1bdb556
+  languageName: node
+  linkType: hard
+
+"cacache@npm:^12.0.2":
+  version: 12.0.4
+  resolution: "cacache@npm:12.0.4"
+  dependencies:
+    bluebird: ^3.5.5
+    chownr: ^1.1.1
+    figgy-pudding: ^3.5.1
+    glob: ^7.1.4
+    graceful-fs: ^4.1.15
+    infer-owner: ^1.0.3
+    lru-cache: ^5.1.1
+    mississippi: ^3.0.0
+    mkdirp: ^0.5.1
+    move-concurrently: ^1.0.1
+    promise-inflight: ^1.0.1
+    rimraf: ^2.6.3
+    ssri: ^6.0.1
+    unique-filename: ^1.1.1
+    y18n: ^4.0.0
+  checksum: c88a72f36939b2523533946ffb27828443db5bf5995d761b35ae17af1eb6c8e20ac55b00b74c2ca900b2e1e917f0afba6847bf8cc16bee05ccca6aa150e0830c
   languageName: node
   linkType: hard
 
@@ -7532,7 +7981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^2.0.0, chokidar@npm:^2.0.2, chokidar@npm:^2.1.5":
+"chokidar@npm:^2.0.2":
   version: 2.1.5
   resolution: "chokidar@npm:2.1.5"
   dependencies:
@@ -7552,6 +8001,48 @@ __metadata:
     fsevents:
       optional: true
   checksum: e370aad2795c2a35d0fd838eb93b866689f2548a60f32f337ae1c4e1051fd011ecc908c0ee896ab10b3dc3d91368a15e4a8c863b2a0ddb8c9c5f53770755cde2
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "chokidar@npm:2.1.8"
+  dependencies:
+    anymatch: ^2.0.0
+    async-each: ^1.0.1
+    braces: ^2.3.2
+    fsevents: ^1.2.7
+    glob-parent: ^3.1.0
+    inherits: ^2.0.3
+    is-binary-path: ^1.0.0
+    is-glob: ^4.0.0
+    normalize-path: ^3.0.0
+    path-is-absolute: ^1.0.0
+    readdirp: ^2.2.1
+    upath: ^1.1.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 0c43e89cbf0268ef1e1f41ce8ec5233c7ba022c6f3282c2ef6530e351d42396d389a1148c5a040f291cf1f4083a4c6b2f51dad3f31c726442ea9a337de316bcf
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.4.1, chokidar@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -7575,6 +8066,13 @@ __metadata:
   dependencies:
     tslib: ^1.9.0
   checksum: c9fe36a7924bee3a489c4bc6a875bf040b5bcb6fadbd795709e58a575c16a0bb8bb2c22714d551d43409b1f625b46d069190a0ed7a3dddbd9fe25f97573865d7
+  languageName: node
+  linkType: hard
+
+"chrome-trace-event@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "chrome-trace-event@npm:1.0.3"
+  checksum: cb8b1fc7e881aaef973bd0c4a43cd353c2ad8323fb471a041e64f7c2dd849cde4aad15f8b753331a32dda45c973f032c8a03b8177fc85d60eaa75e91e08bfb97
   languageName: node
   linkType: hard
 
@@ -7722,17 +8220,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "cliui@npm:4.1.0"
-  dependencies:
-    string-width: ^2.1.1
-    strip-ansi: ^4.0.0
-    wrap-ansi: ^2.0.0
-  checksum: 0f8a77e55c66ab4400f8cc24a46e496af186ebfbf301709341a24c26d398200c2ccc5cac892566d586c3c393a079974f34f0ce05210df336f97b70805c02865e
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -7755,7 +8242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone-deep@npm:4.0.1":
+"clone-deep@npm:4.0.1, clone-deep@npm:^4.0.1":
   version: 4.0.1
   resolution: "clone-deep@npm:4.0.1"
   dependencies:
@@ -7932,6 +8419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^2.0.10, colorette@npm:^2.0.14":
+  version: 2.0.19
+  resolution: "colorette@npm:2.0.19"
+  checksum: 888cf5493f781e5fcf54ce4d49e9d7d698f96ea2b2ef67906834bb319a392c667f9ec69f4a10e268d2946d13a9503d2d19b3abaaaf174e3451bfe91fb9d82427
+  languageName: node
+  linkType: hard
+
 "colors@npm:^1.1.2":
   version: 1.3.3
   resolution: "colors@npm:1.3.3"
@@ -7979,10 +8473,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^2.20.0":
+  version: 2.20.3
+  resolution: "commander@npm:2.20.3"
+  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
 "commander@npm:^6.2.0":
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: d7090410c0de6bc5c67d3ca41c41760d6d268f3c799e530aafb73b7437d1826bbf0d2a3edac33f8b57cc9887b4a986dce307fa5557e109be40eadb7c43b21742
+  languageName: node
+  linkType: hard
+
+"commander@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
   languageName: node
   linkType: hard
 
@@ -8040,7 +8548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compression@npm:^1.5.2, compression@npm:^1.7.4":
+"compression@npm:^1.7.4":
   version: 1.7.4
   resolution: "compression@npm:1.7.4"
   dependencies:
@@ -8112,10 +8620,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"connect-history-api-fallback@npm:^1.3.0, connect-history-api-fallback@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "connect-history-api-fallback@npm:1.6.0"
-  checksum: 804ca2be28c999032ecd37a9f71405e5d7b7a4b3defcebbe41077bb8c5a0a150d7b59f51dcc33b2de30bc7e217a31d10f8cfad27e8e74c2fc7655eeba82d6e7e
+"connect-history-api-fallback@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "connect-history-api-fallback@npm:2.0.0"
+  checksum: dc5368690f4a5c413889792f8df70d5941ca9da44523cde3f87af0745faee5ee16afb8195434550f0504726642734f2683d6c07f8b460f828a12c45fbd4c9a68
   languageName: node
   linkType: hard
 
@@ -8537,7 +9045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:6.0.5, cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
+"cross-spawn@npm:6.0.5, cross-spawn@npm:^6.0.0":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
   dependencies:
@@ -8979,7 +9487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^3.1.0, debug@npm:^3.2.5, debug@npm:^3.2.6":
+"debug@npm:^3.2.5, debug@npm:^3.2.6":
   version: 3.2.6
   resolution: "debug@npm:3.2.6"
   dependencies:
@@ -9035,19 +9543,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.1.0, decamelize@npm:^1.2.0":
+"decamelize@npm:^1.1.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
-  languageName: node
-  linkType: hard
-
-"decamelize@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "decamelize@npm:2.0.0"
-  dependencies:
-    xregexp: 4.0.0
-  checksum: e1d8274e6e6f80654fd5b96a6a3bef50f8979df10f1ab35fe2406f567df9588640a6f29e1414bec30983275e2041fb87e858df7cfd5661ea578196989d73de31
   languageName: node
   linkType: hard
 
@@ -9062,13 +9561,6 @@ __metadata:
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
   checksum: 87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
-  languageName: node
-  linkType: hard
-
-"deep-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "deep-equal@npm:1.0.1"
-  checksum: 5af8cbfcebf190491878a498caccc7dc9592f8ebd1685b976eacc3825619d222b5e929923163b92c4f414494e2b884f7ebf00c022e8198e8292deb70dd9785f4
   languageName: node
   linkType: hard
 
@@ -9100,24 +9592,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"default-gateway@npm:^2.6.0":
-  version: 2.7.2
-  resolution: "default-gateway@npm:2.7.2"
+"default-gateway@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "default-gateway@npm:6.0.3"
   dependencies:
-    execa: ^0.10.0
-    ip-regex: ^2.1.0
-  checksum: 4d1d05a2fb28b03415809b79d828d9981b5b06de583a9c63315ec6fa732d566f01c470f1bcee38fc4cb7eab6d422712ae176a6d9d53f1f265e7aa5ed0b93a8b6
-  conditions: (os=android | os=darwin | os=freebsd | os=linux | os=openbsd | os=sunos | os=win32)
-  languageName: node
-  linkType: hard
-
-"default-gateway@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "default-gateway@npm:4.2.0"
-  dependencies:
-    execa: ^1.0.0
-    ip-regex: ^2.1.0
-  checksum: 1f5be765471689c6bab33e0c8b87363c3e2485cc1ab78904d383a8a8293a79f684da2a3303744b112503f986af4ea87d917c63a468ed913e9b0c31588c02d6a4
+    execa: ^5.0.0
+  checksum: 126f8273ecac8ee9ff91ea778e8784f6cd732d77c3157e8c5bdd6ed03651b5291f71446d05bc02d04073b1e67583604db5394ea3cf992ede0088c70ea15b7378
   languageName: node
   linkType: hard
 
@@ -9171,35 +9651,6 @@ __metadata:
     is-descriptor: ^1.0.2
     isobject: ^3.0.1
   checksum: 3217ed53fc9eed06ba8da6f4d33e28c68a82e2f2a8ab4d562c4920d8169a166fe7271453675e6c69301466f36a65d7f47edf0cf7f474b9aa52a5ead9c1b13c99
-  languageName: node
-  linkType: hard
-
-"del@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "del@npm:3.0.0"
-  dependencies:
-    globby: ^6.1.0
-    is-path-cwd: ^1.0.0
-    is-path-in-cwd: ^1.0.0
-    p-map: ^1.1.1
-    pify: ^3.0.0
-    rimraf: ^2.2.8
-  checksum: 88192c10411b55ba644456ac4881c6ed92029b53b882bb6067011af05e8da8d9c87f5ddacf2999cc45a05a9f03af345b83f17f341a88f456417c7daa04458d38
-  languageName: node
-  linkType: hard
-
-"del@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "del@npm:4.1.1"
-  dependencies:
-    "@types/glob": ^7.1.1
-    globby: ^6.1.0
-    is-path-cwd: ^2.0.0
-    is-path-in-cwd: ^2.0.0
-    p-map: ^2.0.0
-    pify: ^4.0.1
-    rimraf: ^2.6.3
-  checksum: 521f7da44bd79da841c06d573923d1f64f423aee8b8219c973478d3150ce1dcc024d03ad605929292adbff56d6448bca60d96dcdd2d8a53b46dbcb27e265c94b
   languageName: node
   linkType: hard
 
@@ -9259,13 +9710,6 @@ __metadata:
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 0acb300b7478a08b92d810ab229d5afe0d2f4399272045ab22affa0d99dbaf12637659411530a6fcd597a9bdac718fc94373a61a95b4651bbc7b83684a565e38
-  languageName: node
-  linkType: hard
-
-"detect-file@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "detect-file@npm:1.0.0"
-  checksum: 1861e4146128622e847abe0e1ed80fef01e78532665858a792267adf89032b7a9c698436137707fcc6f02956c2a6a0052d6a0cef5be3d4b76b1ff0da88e2158a
   languageName: node
   linkType: hard
 
@@ -9436,10 +9880,10 @@ __metadata:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -9473,9 +9917,9 @@ __metadata:
     react-dom: ^16.14.0
     react-hot-loader: 4.3.5
     style-loader: ^0.23.1
-    webpack: 4.31.0
-    webpack-cli: 3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -9513,9 +9957,9 @@ __metadata:
     style-loader: ^0.23.1
     throttle-debounce: ^5.0.0
     utils: ^0.3.1
-    webpack: 4.31.0
-    webpack-cli: 3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -9526,22 +9970,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dns-packet@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "dns-packet@npm:1.3.1"
+"dns-packet@npm:^5.2.2":
+  version: 5.4.0
+  resolution: "dns-packet@npm:5.4.0"
   dependencies:
-    ip: ^1.1.0
-    safe-buffer: ^5.0.1
-  checksum: 6575edeea6e6e719823a1574cd1adcfebdc96f870cb1b367d6168490dc36c9826a97bf57ad009e6fdcd3dc5000cc43de7cb72a2102ba05b83178c8d0300c5a6e
-  languageName: node
-  linkType: hard
-
-"dns-txt@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "dns-txt@npm:2.0.2"
-  dependencies:
-    buffer-indexof: ^1.0.0
-  checksum: 80130b665379ecd991687ae079fbee25d091e03e4c4cef41e7643b977849ac48c2f56bfcb3727e53594d29029b833749811110d9f3fbee1b26a6e6f8096a5cef
+    "@leichtgewicht/ip-codec": ^2.0.1
+  checksum: a169963848e8539dfd8a19058562f9e1c15c0f82cbf76fa98942f11c46f3c74e7e7c82e3a8a5182d4c9e6ff19e21be738dbd098a876dde755d3aedd2cc730880
   languageName: node
   linkType: hard
 
@@ -9957,6 +10391,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "enhanced-resolve@npm:4.5.0"
+  dependencies:
+    graceful-fs: ^4.1.2
+    memory-fs: ^0.5.0
+    tapable: ^1.0.0
+  checksum: 4d87488584c4d67d356ef4ba04978af4b2d4d18190cb859efac8e8475a34d5d6c069df33faa5a0a22920b0586dbf330f6a08d52bb15a8771a9ce4d70a2da74ba
+  languageName: node
+  linkType: hard
+
 "enquirer@npm:^2.3.5, enquirer@npm:~2.3.6":
   version: 2.3.6
   resolution: "enquirer@npm:2.3.6"
@@ -9980,7 +10425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:^7.7.4":
+"envinfo@npm:^7.7.3, envinfo@npm:^7.7.4":
   version: 7.8.1
   resolution: "envinfo@npm:7.8.1"
   bin:
@@ -10405,7 +10850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^4.0.0":
+"eslint-scope@npm:^4.0.0, eslint-scope@npm:^4.0.3":
   version: 4.0.3
   resolution: "eslint-scope@npm:4.0.3"
   dependencies:
@@ -10574,14 +11019,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^3.0.0, eventemitter3@npm:^3.1.0":
+"eventemitter3@npm:^3.1.0":
   version: 3.1.2
   resolution: "eventemitter3@npm:3.1.2"
   checksum: 81e4e82b8418f5cfd986d2b4a2fa5397ac4eb8134e09bcb47005545e22fdf8e9e61d5c053d34651112245aae411bdfe6d0ad5511da0400743fef5fc38bfcfbe3
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.4":
+"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
@@ -10634,21 +11079,6 @@ __metadata:
     signal-exit: ^3.0.3
     strip-final-newline: ^2.0.0
   checksum: a044367ebdcc68ca019810cb134510fc77bbc55c799122258ee0e00e289c132941ab48c2a331a036699c42bc8d479d451ae67c105fce5ce5cc813e7dd92d642b
-  languageName: node
-  linkType: hard
-
-"execa@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "execa@npm:0.10.0"
-  dependencies:
-    cross-spawn: ^6.0.0
-    get-stream: ^3.0.0
-    is-stream: ^1.1.0
-    npm-run-path: ^2.0.0
-    p-finally: ^1.0.0
-    signal-exit: ^3.0.0
-    strip-eof: ^1.0.0
-  checksum: da132af2b209e69d79f91751ac6d15ddbb8d9414f9e5f7a53405232679a3dca00fe11eb14e0cd5c2c374a749061410a7717fcc3094f6dd779cf4d259faa58d9a
   languageName: node
   linkType: hard
 
@@ -10728,15 +11158,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expand-tilde@npm:^2.0.0, expand-tilde@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "expand-tilde@npm:2.0.2"
-  dependencies:
-    homedir-polyfill: ^1.0.1
-  checksum: 2efe6ed407d229981b1b6ceb552438fbc9e5c7d6a6751ad6ced3e0aa5cf12f0b299da695e90d6c2ac79191b5c53c613e508f7149e4573abfbb540698ddb7301a
-  languageName: node
-  linkType: hard
-
 "expect@npm:^28.1.3":
   version: 28.1.3
   resolution: "expect@npm:28.1.3"
@@ -10805,10 +11226,10 @@ __metadata:
     style-loader: 0.23.1
     throttle-debounce: 5.0.0
     url-loader: 1.1.2
-    webpack: 4.31.0
+    webpack: 4.46.0
     webpack-bundle-analyzer: ^4.4.1
-    webpack-cli: ^3.1.2
-    webpack-dev-server: 3.1.14
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -10828,7 +11249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.16.2, express@npm:^4.16.3, express@npm:^4.16.4":
+"express@npm:^4.16.3, express@npm:^4.17.3":
   version: 4.18.2
   resolution: "express@npm:4.18.2"
   dependencies:
@@ -10922,10 +11343,10 @@ __metadata:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -11045,6 +11466,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fastest-levenshtein@npm:^1.0.12":
+  version: 1.0.16
+  resolution: "fastest-levenshtein@npm:1.0.16"
+  checksum: a78d44285c9e2ae2c25f3ef0f8a73f332c1247b7ea7fb4a191e6bb51aa6ee1ef0dfb3ed113616dcdc7023e18e35a8db41f61c8d88988e877cf510df8edafbc71
+  languageName: node
+  linkType: hard
+
 "fastparse@npm:^1.1.1":
   version: 1.1.2
   resolution: "fastparse@npm:1.1.2"
@@ -11079,12 +11507,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"faye-websocket@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "faye-websocket@npm:0.10.0"
+"faye-websocket@npm:^0.11.3":
+  version: 0.11.4
+  resolution: "faye-websocket@npm:0.11.4"
   dependencies:
     websocket-driver: ">=0.5.1"
-  checksum: 5a2989ec5effc832bd219e3af934966b5a2a2605dd83b995a04edae5d34207ef930635f5c8456b8b7b4209bfb8f7ea991e41594f150a04faa53fca1ee4eb31b6
+  checksum: d49a62caf027f871149fc2b3f3c7104dc6d62744277eb6f9f36e2d5714e847d846b9f7f0d0b7169b25a012e24a594cde11a93034b30732e4c683f20b8a5019fa
   languageName: node
   linkType: hard
 
@@ -11357,18 +11785,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"findup-sync@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "findup-sync@npm:2.0.0"
-  dependencies:
-    detect-file: ^1.0.0
-    is-glob: ^3.1.0
-    micromatch: ^3.0.4
-    resolve-dir: ^1.0.1
-  checksum: af2849f4006208c7c0940ab87a5f816187becf30c430a735377f6163cff8e95f405db504f5435728663099878f2e8002da1bf1976132458c23f5d73f540b1fcc
-  languageName: node
-  linkType: hard
-
 "flat-cache@npm:^3.0.4":
   version: 3.0.4
   resolution: "flat-cache@npm:3.0.4"
@@ -11588,6 +12004,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-monkey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "fs-monkey@npm:1.0.3"
+  checksum: cf50804833f9b88a476911ae911fe50f61a98d986df52f890bd97e7262796d023698cb2309fa9b74fdd8974f04315b648748a0a8ee059e7d5257b293bfc409c0
+  languageName: node
+  linkType: hard
+
 "fs-write-stream-atomic@npm:^1.0.8":
   version: 1.0.10
   resolution: "fs-write-stream-atomic@npm:1.0.10"
@@ -11618,7 +12041,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -11638,7 +12061,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
   dependencies:
@@ -11715,13 +12138,6 @@ fsevents@^1.2.7:
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
   checksum: a7437e58c6be12aa6c90f7730eac7fa9833dc78872b4ad2963d2031b00a3367a93f98aec75f9aaac7220848e4026d67a8655e870b24f20a543d103c0d65952ec
-  languageName: node
-  linkType: hard
-
-"get-caller-file@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "get-caller-file@npm:1.0.3"
-  checksum: 2b90a7f848896abcebcdc0acc627a435bcf05b9cd280599bc980ebfcdc222416c3df12c24c4845f69adc4346728e8966f70b758f9369f3534182791dfbc25c05
   languageName: node
   linkType: hard
 
@@ -11873,7 +12289,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:5.1.2, glob-parent@npm:^5.1.2":
+"glob-parent@npm:5.1.2, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -11920,7 +12336,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.2, glob@npm:^7.1.3":
+"glob@npm:^7.0.0, glob@npm:^7.1.2, glob@npm:^7.1.3":
   version: 7.1.3
   resolution: "glob@npm:7.1.3"
   dependencies:
@@ -11947,43 +12363,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"global-modules-path@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "global-modules-path@npm:2.3.1"
-  checksum: dbe42d7a4aebb424a777ff5396af1a2b273ec9eca0ae37f0631dde55ad5dd64e3965a7ffd7d2946d2638eac9ae5ff9d82a60bdd790eb12f2ca2df6a46a919b74
-  languageName: node
-  linkType: hard
-
 "global-modules@npm:2.0.0":
   version: 2.0.0
   resolution: "global-modules@npm:2.0.0"
   dependencies:
     global-prefix: ^3.0.0
   checksum: d6197f25856c878c2fb5f038899f2dca7cbb2f7b7cf8999660c0104972d5cfa5c68b5a0a77fa8206bb536c3903a4615665acb9709b4d80846e1bb47eaef65430
-  languageName: node
-  linkType: hard
-
-"global-modules@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "global-modules@npm:1.0.0"
-  dependencies:
-    global-prefix: ^1.0.1
-    is-windows: ^1.0.1
-    resolve-dir: ^1.0.0
-  checksum: 10be68796c1e1abc1e2ba87ec4ea507f5629873b119ab0cd29c07284ef2b930f1402d10df01beccb7391dedd9cd479611dd6a24311c71be58937beaf18edf85e
-  languageName: node
-  linkType: hard
-
-"global-prefix@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "global-prefix@npm:1.0.2"
-  dependencies:
-    expand-tilde: ^2.0.2
-    homedir-polyfill: ^1.0.1
-    ini: ^1.3.4
-    is-windows: ^1.0.1
-    which: ^1.2.14
-  checksum: 061b43470fe498271bcd514e7746e8a8535032b17ab9570517014ae27d700ff0dca749f76bbde13ba384d185be4310d8ba5712cb0e74f7d54d59390db63dd9a0
   languageName: node
   linkType: hard
 
@@ -12078,19 +12463,6 @@ fsevents@^1.2.7:
     pify: ^3.0.0
     slash: ^1.0.0
   checksum: 87dc31e0b812d3a6beee200555c252591d23ef12f8347bce3b61fa185a99fbe7ae1694ed30cc01a353e27369d6a8e1e50a97f1c5e2547fa7b1d87d8392ff9264
-  languageName: node
-  linkType: hard
-
-"globby@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "globby@npm:6.1.0"
-  dependencies:
-    array-union: ^1.0.1
-    glob: ^7.0.3
-    object-assign: ^4.0.1
-    pify: ^2.0.0
-    pinkie-promise: ^2.0.0
-  checksum: 18109d6b9d55643d2b98b59c3cfae7073ccfe39829632f353d516cc124d836c2ddebe48a23f04af63d66a621b6d86dd4cbd7e6af906f2458a7fe510ffc4bd424
   languageName: node
   linkType: hard
 
@@ -12465,15 +12837,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"homedir-polyfill@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "homedir-polyfill@npm:1.0.3"
-  dependencies:
-    parse-passwd: ^1.0.0
-  checksum: 18dd4db87052c6a2179d1813adea0c4bfcfa4f9996f0e226fefb29eb3d548e564350fa28ec46b0bf1fbc0a1d2d6922ceceb80093115ea45ff8842a4990139250
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^2.1.4":
   version: 2.7.1
   resolution: "hosted-git-info@npm:2.7.1"
@@ -12561,10 +12924,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"html-entities@npm:^1.2.0, html-entities@npm:^1.2.1":
+"html-entities@npm:^1.2.0":
   version: 1.2.1
   resolution: "html-entities@npm:1.2.1"
   checksum: 97df9c27065e0d0171189d9d301b048ef1de5b5aedb4c733c612c7630b653d26d74a08f9c700ba72fa680677e7cb98b8b7f1d969f3967d549acd6d7efabef4ed
+  languageName: node
+  linkType: hard
+
+"html-entities@npm:^2.3.2":
+  version: 2.3.3
+  resolution: "html-entities@npm:2.3.3"
+  checksum: 92521501da8aa5f66fee27f0f022d6e9ceae62667dae93aa6a2f636afa71ad530b7fb24a18d4d6c124c9885970cac5f8a52dbf1731741161002816ae43f98196
   languageName: node
   linkType: hard
 
@@ -12696,6 +13066,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"http-parser-js@npm:>=0.5.1":
+  version: 0.5.8
+  resolution: "http-parser-js@npm:0.5.8"
+  checksum: 6bbdf2429858e8cf13c62375b0bfb6dc3955ca0f32e58237488bc86cd2378f31d31785fd3ac4ce93f1c74e0189cf8823c91f5cb061696214fd368d2452dc871d
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^4.0.1":
   version: 4.0.1
   resolution: "http-proxy-agent@npm:4.0.1"
@@ -12718,38 +13095,32 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^0.19.1":
-  version: 0.19.1
-  resolution: "http-proxy-middleware@npm:0.19.1"
+"http-proxy-middleware@npm:^2.0.3":
+  version: 2.0.6
+  resolution: "http-proxy-middleware@npm:2.0.6"
   dependencies:
-    http-proxy: ^1.17.0
-    is-glob: ^4.0.0
-    lodash: ^4.17.11
-    micromatch: ^3.1.10
-  checksum: 64df0438417a613bb22b3689d9652a1b7a56f10b145a463f95f4e8a9b9a351f2c63bc5fd3a9cd710baec224897733b6f299cb7f974ea82769b2a4f1e074764ac
+    "@types/http-proxy": ^1.17.8
+    http-proxy: ^1.18.1
+    is-glob: ^4.0.1
+    is-plain-obj: ^3.0.0
+    micromatch: ^4.0.2
+  peerDependencies:
+    "@types/express": ^4.17.13
+  peerDependenciesMeta:
+    "@types/express":
+      optional: true
+  checksum: 2ee85bc878afa6cbf34491e972ece0f5be0a3e5c98a60850cf40d2a9a5356e1fc57aab6cff33c1fc37691b0121c3a42602d2b1956c52577e87a5b77b62ae1c3a
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:~0.18.0":
-  version: 0.18.0
-  resolution: "http-proxy-middleware@npm:0.18.0"
+"http-proxy@npm:^1.18.1":
+  version: 1.18.1
+  resolution: "http-proxy@npm:1.18.1"
   dependencies:
-    http-proxy: ^1.16.2
-    is-glob: ^4.0.0
-    lodash: ^4.17.5
-    micromatch: ^3.1.9
-  checksum: 3b4768e14562d84b6a1167173fc88fc701c173e6ecd8d7f355acb3848276408a99cd15f5655b3018fe0730ed899a03cf3a7eeb33e96fbe6ce2bf2669560080c9
-  languageName: node
-  linkType: hard
-
-"http-proxy@npm:^1.16.2, http-proxy@npm:^1.17.0":
-  version: 1.17.0
-  resolution: "http-proxy@npm:1.17.0"
-  dependencies:
-    eventemitter3: ^3.0.0
+    eventemitter3: ^4.0.0
     follow-redirects: ^1.0.0
     requires-port: ^1.0.0
-  checksum: 39758502d9c340ae192e7b252ba1d5a2c3c691b68f4eccc193aa10d771c1712d5157ba37ca06f037300faaac6aa4ed93b5118c48e26c51088710fc3a7e256cd3
+  checksum: f5bd96bf83e0b1e4226633dbb51f8b056c3e6321917df402deacec31dd7fe433914fc7a2c1831cf7ae21e69c90b3a669b8f434723e9e8b71fd68afe30737b6a5
   languageName: node
   linkType: hard
 
@@ -12975,18 +13346,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"import-local@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "import-local@npm:2.0.0"
-  dependencies:
-    pkg-dir: ^3.0.0
-    resolve-cwd: ^2.0.0
-  bin:
-    import-local-fixture: fixtures/cli.js
-  checksum: b8469252483624379fd65d53c82f3658b32a1136f7168bfeea961a4ea7ca10a45786ea2b02e0006408f9cd22d2f33305a6f17a64e4d5a03274a50942c5e7c949
-  languageName: node
-  linkType: hard
-
 "import-local@npm:^3.0.2":
   version: 3.1.0
   resolution: "import-local@npm:3.1.0"
@@ -13034,7 +13393,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"infer-owner@npm:^1.0.4":
+"infer-owner@npm:^1.0.3, infer-owner@npm:^1.0.4":
   version: 1.0.4
   resolution: "infer-owner@npm:1.0.4"
   checksum: 181e732764e4a0611576466b4b87dac338972b839920b2a8cde43642e4ed6bd54dc1fb0b40874728f2a2df9a1b097b8ff83b56d5f8f8e3927f837fdcb47d8a89
@@ -13166,27 +13525,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"internal-ip@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "internal-ip@npm:3.0.1"
-  dependencies:
-    default-gateway: ^2.6.0
-    ipaddr.js: ^1.5.2
-  checksum: 36e4d7a8791cad43a7acc3bc38c54943278744bf55b2ac3c6834ee4919bf51521c33b59a9715faf92ed813657147feeb5f069af9e852b58dbe4352ee4a725945
-  conditions: (os=android | os=darwin | os=freebsd | os=linux | os=openbsd | os=sunos | os=win32)
-  languageName: node
-  linkType: hard
-
-"internal-ip@npm:^4.2.0":
-  version: 4.3.0
-  resolution: "internal-ip@npm:4.3.0"
-  dependencies:
-    default-gateway: ^4.2.0
-    ipaddr.js: ^1.9.0
-  checksum: c970433c84d9a6b46e2c9f5ab7785d3105b856d0a566891bf919241b5a884c5c1c9bf8e915aebb822a86c14b1b6867e58c1eaf5cd49eb023368083069d1a4a9a
-  languageName: node
-  linkType: hard
-
 "internal-slot@npm:^1.0.3":
   version: 1.0.3
   resolution: "internal-slot@npm:1.0.3"
@@ -13198,7 +13536,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"interpret@npm:^1.0.0, interpret@npm:^1.1.0, interpret@npm:^1.2.0":
+"interpret@npm:^1.0.0, interpret@npm:^1.2.0":
   version: 1.2.0
   resolution: "interpret@npm:1.2.0"
   checksum: 85d5db9a4579f296ec9e63d38b38c768dc33db7ea0c63d5312131b23ffeee9fb8c6021db22dd0b2827030f6214a512e658a319a56ad446f487c6b1fce8b67edd
@@ -13212,6 +13550,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"interpret@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "interpret@npm:2.2.0"
+  checksum: f51efef7cb8d02da16408ffa3504cd6053014c5aeb7bb8c223727e053e4235bf565e45d67028b0c8740d917c603807aa3c27d7bd2f21bf20b6417e2bb3e5fd6e
+  languageName: node
+  linkType: hard
+
 "invariant@npm:^2.1.0, invariant@npm:^2.2.2, invariant@npm:^2.2.3, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
@@ -13221,21 +13566,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"invert-kv@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "invert-kv@npm:2.0.0"
-  checksum: 52ea317354101ad6127c6e4c1c6a2d27ae8d3010b6438b60d76d6a920e55410e03547f97f9d1f52031becf5656bbef91d36ee7daa9e26ebc374a9cb342e1f127
-  languageName: node
-  linkType: hard
-
-"ip-regex@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "ip-regex@npm:2.1.0"
-  checksum: 331d95052aa53ce245745ea0fc3a6a1e2e3c8d6da65fa8ea52bf73768c1b22a9ac50629d1d2b08c04e7b3ac4c21b536693c149ce2c2615ee4796030e5b3e3cba
-  languageName: node
-  linkType: hard
-
-"ip@npm:^1.1.0, ip@npm:^1.1.5":
+"ip@npm:^1.1.5":
   version: 1.1.5
   resolution: "ip@npm:1.1.5"
   checksum: 30133981f082a060a32644f6a7746e9ba7ac9e2bc07ecc8bbdda3ee8ca9bec1190724c390e45a1ee7695e7edfd2a8f7dda2c104ec5f7ac5068c00648504c7e5a
@@ -13256,10 +13587,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"ipaddr.js@npm:^1.5.2, ipaddr.js@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "ipaddr.js@npm:1.9.0"
-  checksum: 56254f753959132884d74355fc45fda74f120283695c831a07bfac3368965bc9452cbdb80d5e38a6211de4e98a32ddbcd2e640137eb3f79a251c5c725a9efbd6
+"ipaddr.js@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "ipaddr.js@npm:2.0.1"
+  checksum: dd194a394a843d470f88d17191b0948f383ed1c8e320813f850c336a0fcb5e9215d97ec26ca35ab4fbbd31392c8b3467f3e8344628029ed3710b2ff6b5d1034e
   languageName: node
   linkType: hard
 
@@ -13332,6 +13663,15 @@ fsevents@^1.2.7:
   dependencies:
     binary-extensions: ^1.0.0
   checksum: a803c99e9d898170c3b44a86fbdc0736d3d7fcbe737345433fb78e810b9fe30c982657782ad0e676644ba4693ddf05601a7423b5611423218663d6b533341ac9
+  languageName: node
+  linkType: hard
+
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: ^2.0.0
+  checksum: 84192eb88cff70d320426f35ecd63c3d6d495da9d805b19bc65b518984b7c0760280e57dbf119b7e9be6b161784a5a673ab2c6abe83abb5198a432232ad5b35c
   languageName: node
   linkType: hard
 
@@ -13428,6 +13768,15 @@ fsevents@^1.2.7:
   dependencies:
     has: ^1.0.3
   checksum: b27034318b4b462f1c8f1dfb1b32baecd651d891a4e2d1922135daeff4141dfced2b82b07aef83ef54275c4a3526aa38da859223664d0868ca24182badb784ce
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.9.0":
+  version: 2.11.0
+  resolution: "is-core-module@npm:2.11.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: f96fd490c6b48eb4f6d10ba815c6ef13f410b0ba6f7eb8577af51697de523e5f2cd9de1c441b51d27251bf0e4aebc936545e33a5d26d5d51f28d25698d4a8bab
   languageName: node
   linkType: hard
 
@@ -13603,6 +13952,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-glob@npm:~4.0.1":
+  version: 4.0.3
+  resolution: "is-glob@npm:4.0.3"
+  dependencies:
+    is-extglob: ^2.1.1
+  checksum: d381c1319fcb69d341cc6e6c7cd588e17cd94722d9a32dbd60660b993c4fb7d0f19438674e68dfec686d09b7c73139c9166b47597f846af387450224a8101ab4
+  languageName: node
+  linkType: hard
+
 "is-hexadecimal@npm:^1.0.0":
   version: 1.0.2
   resolution: "is-hexadecimal@npm:1.0.2"
@@ -13691,60 +14049,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-path-cwd@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-path-cwd@npm:1.0.0"
-  checksum: ade6d8d59bb6a00079fb515ad78a741b757a66bc6208a2dab2c9f8ad535bc61e21b6823ae8b23df2bf4d2b9dac8df4f3df2e68105698eb3e15ceb5ca90dac097
-  languageName: node
-  linkType: hard
-
-"is-path-cwd@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-path-cwd@npm:2.1.0"
-  checksum: 878097278f58be5fe8c1b0494725977dbb725e04a4973776a47bf6bb2d737a9f25b537aee7d251b9c212960eaed47693c82ff3a72b612c4010471a958338f37b
-  languageName: node
-  linkType: hard
-
-"is-path-in-cwd@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "is-path-in-cwd@npm:1.0.1"
-  dependencies:
-    is-path-inside: ^1.0.0
-  checksum: bacfc67c0dacd09002668abb1565fa77ee9593914f1502ec8ecae9821ddd39a2a98e7a95053e3446421b3429c3b3df1a26669c95cecc9f4f556609ec9760ba2a
-  languageName: node
-  linkType: hard
-
-"is-path-in-cwd@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-path-in-cwd@npm:2.1.0"
-  dependencies:
-    is-path-inside: ^2.1.0
-  checksum: 6b01b3f8c9172e9682ea878d001836a0cc5a78cbe6236024365d478c2c9e384da2417e5f21f2ad2da2761d0465309fc5baf6e71187d2a23f0058da69790f7f48
-  languageName: node
-  linkType: hard
-
-"is-path-inside@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "is-path-inside@npm:1.0.1"
-  dependencies:
-    path-is-inside: ^1.0.1
-  checksum: 07e52c81163937ff89b4700b7ad474de3b396846b55ed87530fb0a22cb9103926152939f673bc1a0592448e7e4e9d75eb734be21b4ad411311065c6a509fae54
-  languageName: node
-  linkType: hard
-
-"is-path-inside@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "is-path-inside@npm:2.1.0"
-  dependencies:
-    path-is-inside: ^1.0.2
-  checksum: 6ca34dbd84d5c50a3ee1547afb6ada9b06d556a4ff42da9b303797e4acc3ac086516a4833030aa570f397f8c58dacabd57ee8e6c2ce8b2396a986ad2af10fcaf
-  languageName: node
-  linkType: hard
-
 "is-plain-obj@npm:^1.0.0, is-plain-obj@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-plain-obj@npm:1.1.0"
   checksum: 0ee04807797aad50859652a7467481816cbb57e5cc97d813a7dcd8915da8195dc68c436010bf39d195226cde6a2d352f4b815f16f26b7bf486a5754290629931
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-plain-obj@npm:3.0.0"
+  checksum: a6ebdf8e12ab73f33530641972a72a4b8aed6df04f762070d823808303e4f76d87d5ea5bd76f96a7bbe83d93f04ac7764429c29413bd9049853a69cb630fb21c
   languageName: node
   linkType: hard
 
@@ -13939,7 +14254,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-windows@npm:^1.0.1, is-windows@npm:^1.0.2":
+"is-windows@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
   checksum: 438b7e52656fe3b9b293b180defb4e448088e7023a523ec21a91a80b9ff8cdb3377ddb5b6e60f7c7de4fa8b63ab56e121b6705fe081b3cf1b828b0a380009ad7
@@ -14951,13 +15266,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"killable@npm:^1.0.0, killable@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "killable@npm:1.0.1"
-  checksum: 911a85c6e390c19d72c4e3149347cf44042cbd7d18c3c6c5e4f706fdde6e0ed532473392e282c7ef27f518407e6cb7d2a0e71a2ae8d8d8f8ffdb68891a29a68a
-  languageName: node
-  linkType: hard
-
 "kind-of@npm:^2.0.1":
   version: 2.0.1
   resolution: "kind-of@npm:2.0.1"
@@ -15059,15 +15367,6 @@ fsevents@^1.2.7:
     dotenv: ^6.0.0
     dotenv-expand: ^4.2.0
   checksum: 821e86933e7e7a8f0cc3db40cae19b666a649fb96ef2dde922547fd2fe1b7c7d0270b7a0090f817f61fd063003f49aa859f8ee83a3b7d9ae4ad756457382edc9
-  languageName: node
-  linkType: hard
-
-"lcid@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "lcid@npm:2.0.0"
-  dependencies:
-    invert-kv: ^2.0.0
-  checksum: 278e27b5a0707cf9ab682146963ebff2328795be10cd6f8ea8edae293439325d345ac5e33079cce77ac3a86a3dcfb97a34f279dbc46b03f3e419aa39b5915a16
   languageName: node
   linkType: hard
 
@@ -15293,10 +15592,10 @@ fsevents@^1.2.7:
     react-modal: 3.6.1
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -15347,7 +15646,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"loader-runner@npm:^2.3.0":
+"loader-runner@npm:^2.3.0, loader-runner@npm:^2.4.0":
   version: 2.4.0
   resolution: "loader-runner@npm:2.4.0"
   checksum: e27eebbca5347a03f6b1d1bce5b2736a4984fb742f872c0a4d68e62de10f7637613e79a464d3bcd77c246d9c70fcac112bb4a3123010eb527e8b203a614647db
@@ -15624,13 +15923,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"loglevel@npm:^1.4.1, loglevel@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "loglevel@npm:1.6.1"
-  checksum: 7f0b95835e1206563cd0d2495976919924621efb0ae17db3af9fbff0a62191cb0f70a9fbfa77c3a6338a2ffa58f8c24b7227a122080a879eb424238811f950d4
-  languageName: node
-  linkType: hard
-
 "longest@npm:^1.0.1":
   version: 1.0.1
   resolution: "longest@npm:1.0.1"
@@ -15848,15 +16140,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"map-age-cleaner@npm:^0.1.1":
-  version: 0.1.3
-  resolution: "map-age-cleaner@npm:0.1.3"
-  dependencies:
-    p-defer: ^1.0.0
-  checksum: cb2804a5bcb3cbdfe4b59066ea6d19f5e7c8c196cd55795ea4c28f792b192e4c442426ae52524e5e1acbccf393d3bddacefc3d41f803e66453f6c4eda3650bc1
-  languageName: node
-  linkType: hard
-
 "map-cache@npm:^0.2.2":
   version: 0.2.2
   resolution: "map-cache@npm:0.2.2"
@@ -15947,14 +16230,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mem@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "mem@npm:4.3.0"
+"memfs@npm:^3.4.3":
+  version: 3.4.13
+  resolution: "memfs@npm:3.4.13"
   dependencies:
-    map-age-cleaner: ^0.1.1
-    mimic-fn: ^2.0.0
-    p-is-promise: ^2.0.0
-  checksum: cf488608e5d59c6cb68004b70de317222d4be9f857fd535dfa6a108e04f40821479c080bc763c417b1030569d303538c59d441280078cfce07fefd1c523f98ef
+    fs-monkey: ^1.0.3
+  checksum: 3f9717d6f060919d53f211acb6096a0ea2f566a8cbcc4ef7e1f2561e31e33dc456053fdf951c90a49c8ec55402de7f01b006b81683ab7bd4bdbbd8c9b9cdae5f
   languageName: node
   linkType: hard
 
@@ -15981,6 +16262,16 @@ fsevents@^1.2.7:
     errno: ^0.1.3
     readable-stream: ^2.0.1
   checksum: 6db6c8682eff836664ca9b5b6052ae38d21713dda9d0ef4700fa5c0599a8bc16b2093bee75ac3dedbe59fb2222d368f25bafaa62ba143c41051359cbcb005044
+  languageName: node
+  linkType: hard
+
+"memory-fs@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "memory-fs@npm:0.5.0"
+  dependencies:
+    errno: ^0.1.3
+    readable-stream: ^2.0.1
+  checksum: a9f25b0a8ecfb7324277393f19ef68e6ba53b9e6e4b526bbf2ba23055c5440fbf61acc7bf66bfd980e9eb4951a4790f6f777a9a3abd36603f22c87e8a64d3d6b
   languageName: node
   linkType: hard
 
@@ -16075,7 +16366,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^3.0.4, micromatch@npm:^3.1.10, micromatch@npm:^3.1.4, micromatch@npm:^3.1.8, micromatch@npm:^3.1.9":
+"micromatch@npm:^3.1.10, micromatch@npm:^3.1.4, micromatch@npm:^3.1.8":
   version: 3.1.10
   resolution: "micromatch@npm:3.1.10"
   dependencies:
@@ -16096,7 +16387,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.4":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -16132,7 +16423,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.31, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -16175,7 +16466,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^2.0.0, mimic-fn@npm:^2.1.0":
+"mimic-fn@npm:^2.1.0":
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
@@ -16475,7 +16766,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:0.5.x, mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:~0.5.0, mkdirp@npm:~0.5.1":
+"mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:~0.5.0, mkdirp@npm:~0.5.1":
   version: 0.5.1
   resolution: "mkdirp@npm:0.5.1"
   dependencies:
@@ -16483,6 +16774,17 @@ fsevents@^1.2.7:
   bin:
     mkdirp: bin/cmd.js
   checksum: ed1ab49bb1d06c88dba7cfe930a3186f2605b5465aab7c8f24119baaba6e38f9ab4ac1695c68f476c65a48df2a69a8495049cd6e26c360ea082151a0771343d2
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^0.5.3":
+  version: 0.5.6
+  resolution: "mkdirp@npm:0.5.6"
+  dependencies:
+    minimist: ^1.2.6
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
   languageName: node
   linkType: hard
 
@@ -16558,22 +16860,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"multicast-dns-service-types@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "multicast-dns-service-types@npm:1.1.0"
-  checksum: 0979fca1cce85484d256e4db3af591d941b41a61f134da3607213d2624c12ed5b8a246565cb19a9b3cb542819e8fbc71a90b07e77023ee6a9515540fe1d371f7
-  languageName: node
-  linkType: hard
-
-"multicast-dns@npm:^6.0.1":
-  version: 6.2.3
-  resolution: "multicast-dns@npm:6.2.3"
+"multicast-dns@npm:^7.2.5":
+  version: 7.2.5
+  resolution: "multicast-dns@npm:7.2.5"
   dependencies:
-    dns-packet: ^1.3.1
+    dns-packet: ^5.2.2
     thunky: ^1.0.2
   bin:
     multicast-dns: cli.js
-  checksum: f515b49ca964429ab48a4ac8041fcf969c927aeb49ab65288bd982e52c849a870fc3b03565780b0d194a1a02da8821f28b6425e48e95b8107bc9fcc92f571a6f
+  checksum: 00b8a57df152d4cd0297946320a94b7c3cdf75a46a2247f32f958a8927dea42958177f9b7fdae69fab2e4e033fb3416881af1f5e9055a3e1542888767139e2fb
   languageName: node
   linkType: hard
 
@@ -16711,6 +17006,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"neo-async@npm:^2.6.1":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
+  languageName: node
+  linkType: hard
+
 "nested-error-stacks@npm:^2.0.0, nested-error-stacks@npm:^2.1.0":
   version: 2.1.0
   resolution: "nested-error-stacks@npm:2.1.0"
@@ -16783,10 +17085,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-forge@npm:0.7.5":
-  version: 0.7.5
-  resolution: "node-forge@npm:0.7.5"
-  checksum: ed717cacb8adc977330279a90c0d399a6ad7d118289585da7a59ca407da84e102e6dacabfc0ec23992f84e02982658ad1d3fe184032c77d9ebb84c73d956b3c5
+"node-forge@npm:^1":
+  version: 1.3.1
+  resolution: "node-forge@npm:1.3.1"
+  checksum: 08fb072d3d670599c89a1704b3e9c649ff1b998256737f0e06fbd1a5bf41cae4457ccaee32d95052d80bbafd9ffe01284e078c8071f0267dc9744e51c5ed42a9
   languageName: node
   linkType: hard
 
@@ -16876,6 +17178,37 @@ fsevents@^1.2.7:
     util: ^0.11.0
     vm-browserify: 0.0.4
   checksum: fe0adc0226252517284f743d245efa50513d6f96d59c43a3f073c9e2d32dce7d4957c8c9c210fcc1fef86d055a67dedc304fbc66e9e64feec9b73598e00c22a6
+  languageName: node
+  linkType: hard
+
+"node-libs-browser@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "node-libs-browser@npm:2.2.1"
+  dependencies:
+    assert: ^1.1.1
+    browserify-zlib: ^0.2.0
+    buffer: ^4.3.0
+    console-browserify: ^1.1.0
+    constants-browserify: ^1.0.0
+    crypto-browserify: ^3.11.0
+    domain-browser: ^1.1.1
+    events: ^3.0.0
+    https-browserify: ^1.0.0
+    os-browserify: ^0.3.0
+    path-browserify: 0.0.1
+    process: ^0.11.10
+    punycode: ^1.2.4
+    querystring-es3: ^0.2.0
+    readable-stream: ^2.3.3
+    stream-browserify: ^2.0.1
+    stream-http: ^2.7.2
+    string_decoder: ^1.0.0
+    timers-browserify: ^2.0.4
+    tty-browserify: 0.0.0
+    url: ^0.11.0
+    util: ^0.11.0
+    vm-browserify: ^1.0.1
+  checksum: 41fa7927378edc0cb98a8cc784d3f4a47e43378d3b42ec57a23f81125baa7287c4b54d6d26d062072226160a3ce4d8b7a62e873d2fb637aceaddf71f5a26eca0
   languageName: node
   linkType: hard
 
@@ -17006,7 +17339,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0":
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
@@ -17324,7 +17657,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-assign@npm:*, object-assign@npm:^4.0.1, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
+"object-assign@npm:*, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -17590,6 +17923,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"open@npm:^8.0.9":
+  version: 8.4.2
+  resolution: "open@npm:8.4.2"
+  dependencies:
+    define-lazy-prop: ^2.0.0
+    is-docker: ^2.1.1
+    is-wsl: ^2.2.0
+  checksum: 6388bfff21b40cb9bd8f913f9130d107f2ed4724ea81a8fd29798ee322b361ca31fa2cdfb491a5c31e43a3996cfe9566741238c7a741ada8d7af1cb78d85cf26
+  languageName: node
+  linkType: hard
+
 "open@npm:^8.4.0":
   version: 8.4.0
   resolution: "open@npm:8.4.0"
@@ -17619,7 +17963,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"opn@npm:^5.1.0, opn@npm:^5.4.0, opn@npm:^5.5.0":
+"opn@npm:^5.4.0":
   version: 5.5.0
   resolution: "opn@npm:5.5.0"
   dependencies:
@@ -17685,17 +18029,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"os-locale@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "os-locale@npm:3.1.0"
-  dependencies:
-    execa: ^1.0.0
-    lcid: ^2.0.0
-    mem: ^4.0.0
-  checksum: 53c542b11af3c5fe99624b09c7882b6944f9ae7c69edbc6006b7d42cff630b1f7fd9d63baf84ed31d1ef02b34823b6b31f23a1ecdd593757873d716bc6374099
-  languageName: node
-  linkType: hard
-
 "os-tmpdir@npm:^1.0.0, os-tmpdir@npm:~1.0.2":
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
@@ -17720,24 +18053,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"p-defer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-defer@npm:1.0.0"
-  checksum: 4271b935c27987e7b6f229e5de4cdd335d808465604644cb7b4c4c95bef266735859a93b16415af8a41fd663ee9e3b97a1a2023ca9def613dba1bad2a0da0c7b
-  languageName: node
-  linkType: hard
-
 "p-finally@npm:^1.0.0":
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
   checksum: 93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
-  languageName: node
-  linkType: hard
-
-"p-is-promise@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "p-is-promise@npm:2.1.0"
-  checksum: c9a8248c8b5e306475a5d55ce7808dbce4d4da2e3d69526e4991a391a7809bfd6cfdadd9bf04f1c96a3db366c93d9a0f5ee81d949e7b1684c4e0f61f747199ef
   languageName: node
   linkType: hard
 
@@ -17820,20 +18139,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"p-map@npm:^1.1.1":
-  version: 1.2.0
-  resolution: "p-map@npm:1.2.0"
-  checksum: 1ac7267b1e8c562bfd01d83c1769cd550d50cc518f75ea2b9c9a0b365767365961a00ff5b0edbf0cbd4a8e405a804c211d9c3497245257955645bbd39d4d0fb4
-  languageName: node
-  linkType: hard
-
-"p-map@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "p-map@npm:2.1.0"
-  checksum: 9e3ad3c9f6d75a5b5661bcad78c91f3a63849189737cd75e4f1225bf9ac205194e5c44aac2ef6f09562b1facdb9bd1425584d7ac375bfaa17b3f1a142dab936d
-  languageName: node
-  linkType: hard
-
 "p-pipe@npm:3.1.0":
   version: 3.1.0
   resolution: "p-pipe@npm:3.1.0"
@@ -17855,6 +18160,16 @@ fsevents@^1.2.7:
   version: 2.1.0
   resolution: "p-reduce@npm:2.1.0"
   checksum: 99b26d36066a921982f25c575e78355824da0787c486e3dd9fc867460e8bf17d5fb3ce98d006b41bdc81ffc0aa99edf5faee53d11fe282a20291fb721b0cb1c7
+  languageName: node
+  linkType: hard
+
+"p-retry@npm:^4.5.0":
+  version: 4.6.2
+  resolution: "p-retry@npm:4.6.2"
+  dependencies:
+    "@types/retry": 0.12.0
+    retry: ^0.13.1
+  checksum: 45c270bfddaffb4a895cea16cb760dcc72bdecb6cb45fef1971fa6ea2e91ddeafddefe01e444ac73e33b1b3d5d29fb0dd18a7effb294262437221ddc03ce0f2e
   languageName: node
   linkType: hard
 
@@ -18003,10 +18318,10 @@ fsevents@^1.2.7:
     uglifyjs-webpack-plugin: ^2.1.3
     url-loader: 1.1.2
     url-parse: ^1.2.0
-    webpack: ^4.31.0
-    webpack-bundle-size-analyzer: ^3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   peerDependencies:
     es6-promise: 4.0.5
   languageName: unknown
@@ -18137,13 +18452,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"parse-passwd@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "parse-passwd@npm:1.0.0"
-  checksum: 4e55e0231d58f828a41d0f1da2bf2ff7bcef8f4cb6146e69d16ce499190de58b06199e6bd9b17fbf0d4d8aef9052099cdf8c4f13a6294b1a522e8e958073066e
-  languageName: node
-  linkType: hard
-
 "parse-path@npm:^7.0.0":
   version: 7.0.0
   resolution: "parse-path@npm:7.0.0"
@@ -18199,6 +18507,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"path-browserify@npm:0.0.1":
+  version: 0.0.1
+  resolution: "path-browserify@npm:0.0.1"
+  checksum: ae8dcd45d0d3cfbaf595af4f206bf3ed82d77f72b4877ae7e77328079e1468c84f9386754bb417d994d5a19bf47882fd253565c18441cd5c5c90ae5187599e35
+  languageName: node
+  linkType: hard
+
 "path-dirname@npm:^1.0.0":
   version: 1.0.2
   resolution: "path-dirname@npm:1.0.2"
@@ -18227,13 +18542,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"path-is-inside@npm:^1.0.1, path-is-inside@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "path-is-inside@npm:1.0.2"
-  checksum: 0b5b6c92d3018b82afb1f74fe6de6338c4c654de4a96123cb343f2b747d5606590ac0c890f956ed38220a4ab59baddfd7b713d78a62d240b20b14ab801fa02cb
-  languageName: node
-  linkType: hard
-
 "path-key@npm:^2.0.0, path-key@npm:^2.0.1":
   version: 2.0.1
   resolution: "path-key@npm:2.0.1"
@@ -18252,6 +18560,13 @@ fsevents@^1.2.7:
   version: 1.0.6
   resolution: "path-parse@npm:1.0.6"
   checksum: 962a85dd384d68d469ec5ba4010df8f8f9b7e936ce603bbe3211476c5615feb3c2b1ca61211a78445fadc833f0b1a86ea6484c861035ec4ac93011ba9aff9a11
+  languageName: node
+  linkType: hard
+
+"path-parse@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "path-parse@npm:1.0.7"
+  checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
   languageName: node
   linkType: hard
 
@@ -18319,7 +18634,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
@@ -18333,7 +18648,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pify@npm:^2.0.0, pify@npm:^2.3.0":
+"pify@npm:^2.3.0":
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
@@ -18351,22 +18666,6 @@ fsevents@^1.2.7:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 9c4e34278cb09987685fa5ef81499c82546c033713518f6441778fbec623fc708777fe8ac633097c72d88470d5963094076c7305cafc7ad340aae27cfacd856b
-  languageName: node
-  linkType: hard
-
-"pinkie-promise@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "pinkie-promise@npm:2.0.1"
-  dependencies:
-    pinkie: ^2.0.0
-  checksum: b53a4a2e73bf56b6f421eef711e7bdcb693d6abb474d57c5c413b809f654ba5ee750c6a96dd7225052d4b96c4d053cdcb34b708a86fceed4663303abee52fcca
-  languageName: node
-  linkType: hard
-
-"pinkie@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "pinkie@npm:2.0.4"
-  checksum: b12b10afea1177595aab036fc220785488f67b4b0fc49e7a27979472592e971614fa1c728e63ad3e7eb748b4ec3c3dbd780819331dad6f7d635c77c10537b9db
   languageName: node
   linkType: hard
 
@@ -18435,17 +18734,6 @@ fsevents@^1.2.7:
   version: 1.15.0
   resolution: "popper.js@npm:1.15.0"
   checksum: 49375758d98154563c841fb050450f263e70c7108989a5bfefd6b556f883e081492004efa48ea1efd3728f657e896a8cc86153bc5f86fe26246d7334c6ee1c2f
-  languageName: node
-  linkType: hard
-
-"portfinder@npm:^1.0.20, portfinder@npm:^1.0.9":
-  version: 1.0.20
-  resolution: "portfinder@npm:1.0.20"
-  dependencies:
-    async: ^1.5.2
-    debug: ^2.2.0
-    mkdirp: 0.5.x
-  checksum: 58fe82ade3a5e951aa8384055f3f7a5e1ea8f914735a70f0448dd716dce8f892390c7657c4e8f0c9cbd055ac317a7ab367e3003ab4b92505337d7b1fdb997a73
   languageName: node
   linkType: hard
 
@@ -19178,9 +19466,9 @@ fsevents@^1.2.7:
     style-loader: ^0.23.1
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
-    webpack: ^4.31.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -19458,7 +19746,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5":
+"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
   dependencies:
@@ -19484,7 +19772,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"range-parser@npm:~1.2.1":
+"range-parser@npm:^1.2.1, range-parser@npm:~1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 0a268d4fea508661cf5743dfe3d5f47ce214fd6b7dec1de0da4d669dd4ef3d2144468ebe4179049eff253d9d27e719c88dae55be64f954e80135a0cada804ec9
@@ -20564,6 +20852,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: ^2.2.1
+  checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
+  languageName: node
+  linkType: hard
+
 "realpath-native@npm:^1.1.0":
   version: 1.1.0
   resolution: "realpath-native@npm:1.1.0"
@@ -20603,6 +20900,15 @@ fsevents@^1.2.7:
   dependencies:
     resolve: ^1.1.6
   checksum: fe76bf9c21875ac16e235defedd7cbd34f333c02a92546142b7911a0f7c7059d2e16f441fe6fb9ae203f459c05a31b2bcf26202896d89e390eda7514d5d2702b
+  languageName: node
+  linkType: hard
+
+"rechoir@npm:^0.7.0":
+  version: 0.7.1
+  resolution: "rechoir@npm:0.7.1"
+  dependencies:
+    resolve: ^1.9.0
+  checksum: 2a04aab4e28c05fcd6ee6768446bc8b859d8f108e71fc7f5bcbc5ef25e53330ce2c11d10f82a24591a2df4c49c4f61feabe1fd11f844c66feedd4cd7bb61146a
   languageName: node
   linkType: hard
 
@@ -21080,13 +21386,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"require-main-filename@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "require-main-filename@npm:1.0.1"
-  checksum: 1fef30754da961f4e13c450c3eb60c7ae898a529c6ad6fa708a70bd2eed01564ceb299187b2899f5562804d797a059f39a5789884d0ac7b7ae1defc68fba4abf
-  languageName: node
-  linkType: hard
-
 "require-main-filename@npm:^2.0.0":
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
@@ -21108,31 +21407,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve-cwd@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "resolve-cwd@npm:2.0.0"
-  dependencies:
-    resolve-from: ^3.0.0
-  checksum: e7c16880c460656e77f102d537a6dc82b3657d9173697cd6ea82ffce37df96f6c1fc79d0bb35fd73fff8871ac13f21b4396958b5f0a13e5b99c97d69f5e319fa
-  languageName: node
-  linkType: hard
-
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
   dependencies:
     resolve-from: ^5.0.0
   checksum: 546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
-  languageName: node
-  linkType: hard
-
-"resolve-dir@npm:^1.0.0, resolve-dir@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "resolve-dir@npm:1.0.1"
-  dependencies:
-    expand-tilde: ^2.0.0
-    global-modules: ^1.0.0
-  checksum: ef736b8ed60d6645c3b573da17d329bfb50ec4e1d6c5ffd6df49e3497acef9226f9810ea6823b8ece1560e01dcb13f77a9f6180d4f242d00cc9a8f4de909c65c
   languageName: node
   linkType: hard
 
@@ -21197,6 +21477,19 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.9.0":
+  version: 1.22.1
+  resolution: "resolve@npm:1.22.1"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 07af5fc1e81aa1d866cbc9e9460fbb67318a10fa3c4deadc35c3ad8a898ee9a71a86a65e4755ac3195e0ea0cfbe201eb323ebe655ce90526fd61917313a34e4e
+  languageName: node
+  linkType: hard
+
 "resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.5.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#~builtin<compat/resolve>":
   version: 1.10.1
   resolution: "resolve@patch:resolve@npm%3A1.10.1#~builtin<compat/resolve>::version=1.10.1&hash=07638b"
@@ -21213,6 +21506,19 @@ resolve@^1.20.0:
     is-core-module: ^2.2.0
     path-parse: ^1.0.6
   checksum: a0dd7d16a8e47af23afa9386df2dff10e3e0debb2c7299a42e581d9d9b04d7ad5d2c53f24f1e043f7b3c250cbdc71150063e53d0b6559683d37f790b7c8c3cd5
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
+  version: 1.22.1
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
   languageName: node
   linkType: hard
 
@@ -21247,6 +21553,13 @@ resolve@^1.20.0:
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
   checksum: 623bd7d2e5119467ba66202d733ec3c2e2e26568074923bc0585b6b99db14f357e79bdedb63cab56cec47491c4a0da7e6021a7465ca6dc4f481d3898fdd3158c
+  languageName: node
+  linkType: hard
+
+"retry@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "retry@npm:0.13.1"
+  checksum: 47c4d5be674f7c13eee4cfe927345023972197dbbdfba5d3af7e461d13b44de1bfd663bfc80d2f601f8ef3fc8164c16dd99655a221921954a65d044a2fc1233b
   languageName: node
   linkType: hard
 
@@ -21348,10 +21661,10 @@ resolve@^1.20.0:
     style-loader: 0.23.1
     throttle-debounce: 5.0.0
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: 3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -21438,7 +21751,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -21576,6 +21889,18 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"schema-utils@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "schema-utils@npm:4.0.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    ajv: ^8.8.0
+    ajv-formats: ^2.1.1
+    ajv-keywords: ^5.0.0
+  checksum: c843e92fdd1a5c145dbb6ffdae33e501867f9703afac67bdf35a685e49f85b1dcc10ea250033175a64bd9d31f0555bc6785b8359da0c90bcea30cf6dfbb55a8f
+  languageName: node
+  linkType: hard
+
 "scroll@npm:^3.0.1":
   version: 3.0.1
   resolution: "scroll@npm:3.0.1"
@@ -21617,10 +21942,10 @@ resolve@^1.20.0:
     redux-thunk: ^2.3.0
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -21638,12 +21963,12 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"selfsigned@npm:^1.10.4, selfsigned@npm:^1.9.1":
-  version: 1.10.4
-  resolution: "selfsigned@npm:1.10.4"
+"selfsigned@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "selfsigned@npm:2.1.1"
   dependencies:
-    node-forge: 0.7.5
-  checksum: ce11550b4b31d067660dd6a769ba0e82a4748cb5d088dce546b4fbf5b94f31b7ba8f5a560f8eced3080e5c4099a868a02b848fc6569a4318f176791959f9bb13
+    node-forge: ^1
+  checksum: aa9ce2150a54838978d5c0aee54d7ebe77649a32e4e690eb91775f71fdff773874a4fbafd0ac73d8ec3b702ff8a395c604df4f8e8868528f36fd6c15076fb43a
   languageName: node
   linkType: hard
 
@@ -21754,10 +22079,10 @@ resolve@^1.20.0:
     react-modal: 3.6.1
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -21765,6 +22090,15 @@ resolve@^1.20.0:
   version: 1.7.0
   resolution: "serialize-javascript@npm:1.7.0"
   checksum: 098f309f50ab8978ed4bbdcd5bc9fb6d4898400299111513a1cd55bb265a39ecd783f10afebe02f3e703cdcbb9ffeac342dc8a222c5d60e337db12b86698e8fc
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "serialize-javascript@npm:4.0.0"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: 3273b3394b951671fcf388726e9577021870dfbf85e742a1183fb2e91273e6101bdccea81ff230724f6659a7ee4cef924b0ff9baca32b79d9384ec37caf07302
   languageName: node
   linkType: hard
 
@@ -21781,7 +22115,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"serve-index@npm:^1.7.2, serve-index@npm:^1.9.1":
+"serve-index@npm:^1.9.1":
   version: 1.9.1
   resolution: "serve-index@npm:1.9.1"
   dependencies:
@@ -21841,10 +22175,10 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -22123,10 +22457,10 @@ resolve@^1.20.0:
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
     utils: ^0.3.1
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -22170,10 +22504,10 @@ resolve@^1.20.0:
     source-map-loader: ^0.2.3
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -22206,10 +22540,10 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -22302,13 +22636,14 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"sockjs@npm:0.3.19":
-  version: 0.3.19
-  resolution: "sockjs@npm:0.3.19"
+"sockjs@npm:^0.3.24":
+  version: 0.3.24
+  resolution: "sockjs@npm:0.3.24"
   dependencies:
-    faye-websocket: ^0.10.0
-    uuid: ^3.0.1
-  checksum: f45911487eefc03447b016d08f502d17562f187c5ddb4f2e8c184fe626d45c93f01400a1afbdf89bc1cd92cf8b5871300d3e5d9c6f21f9c536726af32a373628
+    faye-websocket: ^0.11.3
+    uuid: ^8.3.2
+    websocket-driver: ^0.7.4
+  checksum: 355309b48d2c4e9755349daa29cea1c0d9ee23e49b983841c6bf7a20276b00d3c02343f9f33f26d2ee8b261a5a02961b52a25c8da88b2538c5b68d3071b4934c
   languageName: node
   linkType: hard
 
@@ -22413,6 +22748,16 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:~0.5.12":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
+  languageName: node
+  linkType: hard
+
 "source-map-url@npm:^0.4.0":
   version: 0.4.0
   resolution: "source-map-url@npm:0.4.0"
@@ -22505,16 +22850,16 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"spdy@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "spdy@npm:4.0.0"
+"spdy@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "spdy@npm:4.0.2"
   dependencies:
     debug: ^4.1.0
     handle-thing: ^2.0.0
     http-deceiver: ^1.2.7
     select-hose: ^2.0.0
     spdy-transport: ^3.0.0
-  checksum: d35ddae7c2b8476dcd991932d41467cb010ae4ab9834b3b4221de6333b7e610259568fcc0788ca14f681027ed77f6fb40cb28c4697fcf29e22abd90a2d85b786
+  checksum: 2c739d0ff6f56ad36d2d754d0261d5ec358457bea7cbf77b1b05b0c6464f2ce65b85f196305f50b7bd9120723eb94bae9933466f28e67e5cd8cde4e27f1d75f8
   languageName: node
   linkType: hard
 
@@ -22719,7 +23064,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2, string-width@npm:^2.0.0, string-width@npm:^2.1.0, string-width@npm:^2.1.1":
+"string-width@npm:^1.0.2 || 2, string-width@npm:^2.1.0, string-width@npm:^2.1.1":
   version: 2.1.1
   resolution: "string-width@npm:2.1.1"
   dependencies:
@@ -23014,7 +23359,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.1.0, supports-color@npm:^5.3.0, supports-color@npm:^5.4.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0, supports-color@npm:^5.4.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -23057,6 +23402,13 @@ resolve@^1.20.0:
     has-flag: ^4.0.0
     supports-color: ^7.0.0
   checksum: aef04fb41f4a67f1bc128f7c3e88a81b6cf2794c800fccf137006efe5bafde281da3e42e72bf9206c2fcf42e6438f37e3a820a389214d0a88613ca1f2d36076a
+  languageName: node
+  linkType: hard
+
+"supports-preserve-symlinks-flag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
+  checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
   languageName: node
   linkType: hard
 
@@ -23143,7 +23495,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"tapable@npm:^1.0.0, tapable@npm:^1.1.0":
+"tapable@npm:^1.0.0, tapable@npm:^1.1.0, tapable@npm:^1.1.3":
   version: 1.1.3
   resolution: "tapable@npm:1.1.3"
   checksum: 53ff4e7c3900051c38cc4faab428ebfd7e6ad0841af5a7ac6d5f3045c5b50e88497bfa8295b4b3fbcadd94993c9e358868b78b9fb249a76cb8b018ac8dccafd7
@@ -23241,10 +23593,10 @@ resolve@^1.20.0:
     react-modal: 3.6.1
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -23283,10 +23635,10 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -23366,6 +23718,25 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"terser-webpack-plugin@npm:^1.4.3":
+  version: 1.4.5
+  resolution: "terser-webpack-plugin@npm:1.4.5"
+  dependencies:
+    cacache: ^12.0.2
+    find-cache-dir: ^2.1.0
+    is-wsl: ^1.1.0
+    schema-utils: ^1.0.0
+    serialize-javascript: ^4.0.0
+    source-map: ^0.6.1
+    terser: ^4.1.2
+    webpack-sources: ^1.4.0
+    worker-farm: ^1.7.0
+  peerDependencies:
+    webpack: ^4.0.0
+  checksum: 02aada80927d3c8105d69cb00384d307b73aed67d180db5d20023a8d649149f3803ad50f9cd2ef9eb2622005de87e677198ecc5088f51422bfac5d4d57472d0e
+  languageName: node
+  linkType: hard
+
 "terser@npm:^3.16.1":
   version: 3.17.0
   resolution: "terser@npm:3.17.0"
@@ -23376,6 +23747,19 @@ resolve@^1.20.0:
   bin:
     terser: bin/uglifyjs
   checksum: 4fed679470b65a3290b6b5c9b104fb5007aa195824e421d37c0a65656de927f55bf6b210c20b2dff5664101cbdd7c0f93daa03d4d0da7758e660c9716411d279
+  languageName: node
+  linkType: hard
+
+"terser@npm:^4.1.2":
+  version: 4.8.1
+  resolution: "terser@npm:4.8.1"
+  dependencies:
+    commander: ^2.20.0
+    source-map: ~0.6.1
+    source-map-support: ~0.5.12
+  bin:
+    terser: bin/terser
+  checksum: b342819bf7e82283059aaa3f22bb74deb1862d07573ba5a8947882190ad525fd9b44a15074986be083fd379c58b9a879457a330b66dcdb77b485c44267f9a55a
   languageName: node
   linkType: hard
 
@@ -23446,10 +23830,10 @@ resolve@^1.20.0:
     react-hot-loader: 4.8.5
     style-loader: ^0.23.1
     url-loader: 1.1.2
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -24325,10 +24709,10 @@ resolve@^1.20.0:
     throttle-debounce: ^5.0.0
     url-loader: 1.1.2
     utils: ^0.3.1
-    webpack: 4.31.0
-    webpack-bundle-size-analyzer: 3.0.0
-    webpack-cli: ^3.1.2
-    webpack-dev-server: ^3.1.14
+    webpack: 4.46.0
+    webpack-bundle-size-analyzer: 3.1.0
+    webpack-cli: 4.10.0
+    webpack-dev-server: 4.11.1
   languageName: unknown
   linkType: soft
 
@@ -24422,7 +24806,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"uuid@npm:8.3.2":
+"uuid@npm:8.3.2, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
@@ -24431,7 +24815,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.0.1, uuid@npm:^3.3.2":
+"uuid@npm:^3.3.2":
   version: 3.3.2
   resolution: "uuid@npm:3.3.2"
   bin:
@@ -24449,7 +24833,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"v8-compile-cache@npm:2.3.0, v8-compile-cache@npm:^2.0.2, v8-compile-cache@npm:^2.0.3":
+"v8-compile-cache@npm:2.3.0, v8-compile-cache@npm:^2.0.3":
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
   checksum: adb0a271eaa2297f2f4c536acbfee872d0dd26ec2d76f66921aa7fc437319132773483344207bdbeee169225f4739016d8d2dbf0553913a52bb34da6d0334f8e
@@ -24569,6 +24953,13 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"vm-browserify@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "vm-browserify@npm:1.1.2"
+  checksum: 10a1c50aab54ff8b4c9042c15fc64aefccce8d2fb90c0640403242db0ee7fb269f9b102bdb69cfb435d7ef3180d61fd4fb004a043a12709abaf9056cfd7e039d
+  languageName: node
+  linkType: hard
+
 "walk-up-path@npm:^1.0.0":
   version: 1.0.0
   resolution: "walk-up-path@npm:1.0.0"
@@ -24612,6 +25003,15 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"watchpack-chokidar2@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "watchpack-chokidar2@npm:2.0.1"
+  dependencies:
+    chokidar: ^2.1.8
+  checksum: acf0f9ebca0c0b2fd1fe87ba557670477a6c0410bf1a653a726e68eb0620aa94fd9a43027a160a76bc793a21ea12e215e1e87dafe762682c13ef92ad4daf7b58
+  languageName: node
+  linkType: hard
+
 "watchpack@npm:^1.5.0":
   version: 1.6.0
   resolution: "watchpack@npm:1.6.0"
@@ -24620,6 +25020,23 @@ resolve@^1.20.0:
     graceful-fs: ^4.1.2
     neo-async: ^2.5.0
   checksum: 71ae3170b12cd4fb57df46565b6301186dce5833a62b16db683561315f98b7e36cad98a8e5b2a541df6debffeefa33e930a62c53860a4dce791a8530311c0207
+  languageName: node
+  linkType: hard
+
+"watchpack@npm:^1.7.4":
+  version: 1.7.5
+  resolution: "watchpack@npm:1.7.5"
+  dependencies:
+    chokidar: ^3.4.1
+    graceful-fs: ^4.1.2
+    neo-async: ^2.5.0
+    watchpack-chokidar2: ^2.0.1
+  dependenciesMeta:
+    chokidar:
+      optional: true
+    watchpack-chokidar2:
+      optional: true
+  checksum: 8b7cb8c8df8f4dd0e8ac47693c0141c4f020a4b031411247d600eca31522fde6f1f9a3a6f6518b46e71f7971b0ed5734c08c60d7fdd2530e7262776286f69236
   languageName: node
   linkType: hard
 
@@ -24681,79 +25098,53 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"webpack-bundle-size-analyzer@npm:3.0.0, webpack-bundle-size-analyzer@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "webpack-bundle-size-analyzer@npm:3.0.0"
+"webpack-bundle-size-analyzer@npm:3.1.0":
+  version: 3.1.0
+  resolution: "webpack-bundle-size-analyzer@npm:3.1.0"
   dependencies:
     commander: ^2.19.0
     filesize: ^3.6.1
     humanize: 0.0.9
   bin:
     webpack-bundle-size-analyzer: ./webpack-bundle-size-analyzer
-  checksum: ddc5598f8025bba8c19475312bc0f421763f18baac21fa3c13f71cee68c0c52cce16986f9d0d647d1dc70dba614ae4e98afed5203003c710de361dc52b40b96b
+  checksum: f72dd1835b834174a408fac89274f6a5b46854df1b4c2e63d64f2e9c5aa21e17dfd3822aa1dd1a8a1ca7ab427eeaddb2909bb97f2f7a7db872e0ccd83a642322
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:3.1.2":
-  version: 3.1.2
-  resolution: "webpack-cli@npm:3.1.2"
+"webpack-cli@npm:4.10.0":
+  version: 4.10.0
+  resolution: "webpack-cli@npm:4.10.0"
   dependencies:
-    chalk: ^2.4.1
-    cross-spawn: ^6.0.5
-    enhanced-resolve: ^4.1.0
-    global-modules-path: ^2.3.0
-    import-local: ^2.0.0
-    interpret: ^1.1.0
-    loader-utils: ^1.1.0
-    supports-color: ^5.5.0
-    v8-compile-cache: ^2.0.2
-    yargs: ^12.0.2
+    "@discoveryjs/json-ext": ^0.5.0
+    "@webpack-cli/configtest": ^1.2.0
+    "@webpack-cli/info": ^1.5.0
+    "@webpack-cli/serve": ^1.7.0
+    colorette: ^2.0.14
+    commander: ^7.0.0
+    cross-spawn: ^7.0.3
+    fastest-levenshtein: ^1.0.12
+    import-local: ^3.0.2
+    interpret: ^2.2.0
+    rechoir: ^0.7.0
+    webpack-merge: ^5.7.3
   peerDependencies:
-    webpack: ^4.x.x
+    webpack: 4.x.x || 5.x.x
+  peerDependenciesMeta:
+    "@webpack-cli/generators":
+      optional: true
+    "@webpack-cli/migrate":
+      optional: true
+    webpack-bundle-analyzer:
+      optional: true
+    webpack-dev-server:
+      optional: true
   bin:
-    webpack-cli: ./bin/cli.js
-  checksum: 4daa525a2a2b04a9c4e608bf322716691c15e8ba12d3de345f7e909f833588ec5e0b2336173f040b9c8886e960b3ee14790f3c71e2206bd3b56503153f6c3900
+    webpack-cli: bin/cli.js
+  checksum: 2ff5355ac348e6b40f2630a203b981728834dca96d6d621be96249764b2d0fc01dd54edfcc37f02214d02935de2cf0eefd6ce689d970d154ef493f01ba922390
   languageName: node
   linkType: hard
 
-"webpack-cli@npm:^3.1.2":
-  version: 3.3.2
-  resolution: "webpack-cli@npm:3.3.2"
-  dependencies:
-    chalk: ^2.4.1
-    cross-spawn: ^6.0.5
-    enhanced-resolve: ^4.1.0
-    findup-sync: ^2.0.0
-    global-modules: ^1.0.0
-    import-local: ^2.0.0
-    interpret: ^1.1.0
-    loader-utils: ^1.1.0
-    supports-color: ^5.5.0
-    v8-compile-cache: ^2.0.2
-    yargs: ^12.0.5
-  peerDependencies:
-    webpack: 4.x.x
-  bin:
-    webpack-cli: ./bin/cli.js
-  checksum: 971d92062f366cc0e7ac3ce129b70646ebc85fe60282c93e0c030163112e73b3614353e927c376f14cf2f7566184890342978ae245bc8a34215e9ae92fa56794
-  languageName: node
-  linkType: hard
-
-"webpack-dev-middleware@npm:3.4.0":
-  version: 3.4.0
-  resolution: "webpack-dev-middleware@npm:3.4.0"
-  dependencies:
-    memory-fs: ~0.4.1
-    mime: ^2.3.1
-    range-parser: ^1.0.3
-    webpack-log: ^2.0.0
-  peerDependencies:
-    webpack: ^4.0.0
-  checksum: 0767f319fce59b408991731e2748952c4810357671333c2488d46d55a5b02c61f0507f6b22901258babaf19ffdf2cd38d45bde14b03eb55462e2a32d63b4b1ce
-  languageName: node
-  linkType: hard
-
-"webpack-dev-middleware@npm:^3.5.1, webpack-dev-middleware@npm:^3.6.2":
+"webpack-dev-middleware@npm:^3.5.1":
   version: 3.6.2
   resolution: "webpack-dev-middleware@npm:3.6.2"
   dependencies:
@@ -24767,87 +25158,62 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:3.1.14":
-  version: 3.1.14
-  resolution: "webpack-dev-server@npm:3.1.14"
+"webpack-dev-middleware@npm:^5.3.1":
+  version: 5.3.3
+  resolution: "webpack-dev-middleware@npm:5.3.3"
   dependencies:
-    ansi-html: 0.0.7
-    bonjour: ^3.5.0
-    chokidar: ^2.0.0
-    compression: ^1.5.2
-    connect-history-api-fallback: ^1.3.0
-    debug: ^3.1.0
-    del: ^3.0.0
-    express: ^4.16.2
-    html-entities: ^1.2.0
-    http-proxy-middleware: ~0.18.0
-    import-local: ^2.0.0
-    internal-ip: ^3.0.1
-    ip: ^1.1.5
-    killable: ^1.0.0
-    loglevel: ^1.4.1
-    opn: ^5.1.0
-    portfinder: ^1.0.9
-    schema-utils: ^1.0.0
-    selfsigned: ^1.9.1
-    semver: ^5.6.0
-    serve-index: ^1.7.2
-    sockjs: 0.3.19
-    sockjs-client: 1.3.0
-    spdy: ^4.0.0
-    strip-ansi: ^3.0.0
-    supports-color: ^5.1.0
-    url: ^0.11.0
-    webpack-dev-middleware: 3.4.0
-    webpack-log: ^2.0.0
-    yargs: 12.0.2
+    colorette: ^2.0.10
+    memfs: ^3.4.3
+    mime-types: ^2.1.31
+    range-parser: ^1.2.1
+    schema-utils: ^4.0.0
   peerDependencies:
-    webpack: ^4.0.0
-  bin:
-    webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 9082de8e1d1b2c849d52f487650cbcd0e97bbe0fafb9fd3db08ac3c0defe33fbdaaa4397a54d7fc503447483e6b24fd0831af4e8c169579a3b2e7233474d52c1
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: dd332cc6da61222c43d25e5a2155e23147b777ff32fdf1f1a0a8777020c072fbcef7756360ce2a13939c3f534c06b4992a4d659318c4a7fe2c0530b52a8a6621
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^3.1.14":
-  version: 3.3.1
-  resolution: "webpack-dev-server@npm:3.3.1"
+"webpack-dev-server@npm:4.11.1":
+  version: 4.11.1
+  resolution: "webpack-dev-server@npm:4.11.1"
   dependencies:
-    ansi-html: 0.0.7
-    bonjour: ^3.5.0
-    chokidar: ^2.1.5
+    "@types/bonjour": ^3.5.9
+    "@types/connect-history-api-fallback": ^1.3.5
+    "@types/express": ^4.17.13
+    "@types/serve-index": ^1.9.1
+    "@types/serve-static": ^1.13.10
+    "@types/sockjs": ^0.3.33
+    "@types/ws": ^8.5.1
+    ansi-html-community: ^0.0.8
+    bonjour-service: ^1.0.11
+    chokidar: ^3.5.3
+    colorette: ^2.0.10
     compression: ^1.7.4
-    connect-history-api-fallback: ^1.6.0
-    debug: ^4.1.1
-    del: ^4.1.0
-    express: ^4.16.4
-    html-entities: ^1.2.1
-    http-proxy-middleware: ^0.19.1
-    import-local: ^2.0.0
-    internal-ip: ^4.2.0
-    ip: ^1.1.5
-    killable: ^1.0.1
-    loglevel: ^1.6.1
-    opn: ^5.5.0
-    portfinder: ^1.0.20
-    schema-utils: ^1.0.0
-    selfsigned: ^1.10.4
-    semver: ^6.0.0
+    connect-history-api-fallback: ^2.0.0
+    default-gateway: ^6.0.3
+    express: ^4.17.3
+    graceful-fs: ^4.2.6
+    html-entities: ^2.3.2
+    http-proxy-middleware: ^2.0.3
+    ipaddr.js: ^2.0.1
+    open: ^8.0.9
+    p-retry: ^4.5.0
+    rimraf: ^3.0.2
+    schema-utils: ^4.0.0
+    selfsigned: ^2.1.1
     serve-index: ^1.9.1
-    sockjs: 0.3.19
-    sockjs-client: 1.3.0
-    spdy: ^4.0.0
-    strip-ansi: ^3.0.1
-    supports-color: ^6.1.0
-    url: ^0.11.0
-    webpack-dev-middleware: ^3.6.2
-    webpack-log: ^2.0.0
-    yargs: 12.0.5
+    sockjs: ^0.3.24
+    spdy: ^4.0.2
+    webpack-dev-middleware: ^5.3.1
+    ws: ^8.4.2
   peerDependencies:
-    webpack: ^4.0.0
+    webpack: ^4.37.0 || ^5.0.0
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 04971cd21881ce521b7218ae5a8302e87f5a96b30e97b2136b747bdee269b496bc20a64b032ebaed00375026e6b58268cf4dc396afbcfc76572798748bf55f3d
+  checksum: b7601a39ee0f413988259e29a36835b0a68522cfaa161de5b7ec99b3399acdd99d44189add4aaf4a5191258bb130f9cf3e68919324a1955c7557f5fe6ab0d96c
   languageName: node
   linkType: hard
 
@@ -24873,6 +25239,16 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"webpack-merge@npm:^5.7.3":
+  version: 5.8.0
+  resolution: "webpack-merge@npm:5.8.0"
+  dependencies:
+    clone-deep: ^4.0.1
+    wildcard: ^2.0.0
+  checksum: 88786ab91013f1bd2a683834ff381be81c245a4b0f63304a5103e90f6653f44dab496a0768287f8531761f8ad957d1f9f3ccb2cb55df0de1bd9ee343e079da26
+  languageName: node
+  linkType: hard
+
 "webpack-node-externals@npm:^3.0.0":
   version: 3.0.0
   resolution: "webpack-node-externals@npm:3.0.0"
@@ -24890,7 +25266,55 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"webpack@npm:4.31.0, webpack@npm:^4.29.0, webpack@npm:^4.31.0":
+"webpack-sources@npm:^1.4.0, webpack-sources@npm:^1.4.1":
+  version: 1.4.3
+  resolution: "webpack-sources@npm:1.4.3"
+  dependencies:
+    source-list-map: ^2.0.0
+    source-map: ~0.6.1
+  checksum: 37463dad8d08114930f4bc4882a9602941f07c9f0efa9b6bc78738cd936275b990a596d801ef450d022bb005b109b9f451dd087db2f3c9baf53e8e22cf388f79
+  languageName: node
+  linkType: hard
+
+"webpack@npm:4.46.0":
+  version: 4.46.0
+  resolution: "webpack@npm:4.46.0"
+  dependencies:
+    "@webassemblyjs/ast": 1.9.0
+    "@webassemblyjs/helper-module-context": 1.9.0
+    "@webassemblyjs/wasm-edit": 1.9.0
+    "@webassemblyjs/wasm-parser": 1.9.0
+    acorn: ^6.4.1
+    ajv: ^6.10.2
+    ajv-keywords: ^3.4.1
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^4.5.0
+    eslint-scope: ^4.0.3
+    json-parse-better-errors: ^1.0.2
+    loader-runner: ^2.4.0
+    loader-utils: ^1.2.3
+    memory-fs: ^0.4.1
+    micromatch: ^3.1.10
+    mkdirp: ^0.5.3
+    neo-async: ^2.6.1
+    node-libs-browser: ^2.2.1
+    schema-utils: ^1.0.0
+    tapable: ^1.1.3
+    terser-webpack-plugin: ^1.4.3
+    watchpack: ^1.7.4
+    webpack-sources: ^1.4.1
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+    webpack-command:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 013fa24c00d4261e16ebca60353fa6f848e417b5a44bdf28c16ebebd67fa61e960420bb314c8df05cfe2dad9b90efabcf38fd6875f2361922769a0384085ef1e
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^4.29.0":
   version: 4.31.0
   resolution: "webpack@npm:4.31.0"
   dependencies:
@@ -24931,6 +25355,17 @@ resolve@^1.20.0:
     http-parser-js: ">=0.4.0"
     websocket-extensions: ">=0.1.1"
   checksum: b685b429da450031c334109fa431232875ae0b0d9a1494e0d5b905c43304bd2e09ffb92312c72c36feac9527980409407f03aa1a3ab7e2a11c9afd1c670b09e5
+  languageName: node
+  linkType: hard
+
+"websocket-driver@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "websocket-driver@npm:0.7.4"
+  dependencies:
+    http-parser-js: ">=0.5.1"
+    safe-buffer: ">=5.1.0"
+    websocket-extensions: ">=0.1.1"
+  checksum: fffe5a33fe8eceafd21d2a065661d09e38b93877eae1de6ab5d7d2734c6ed243973beae10ae48c6613cfd675f200e5a058d1e3531bc9e6c5d4f1396ff1f0bfb9
   languageName: node
   linkType: hard
 
@@ -24982,14 +25417,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"which-module@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "which-module@npm:2.0.0"
-  checksum: 809f7fd3dfcb2cdbe0180b60d68100c88785084f8f9492b0998c051d7a8efe56784492609d3f09ac161635b78ea29219eb1418a98c15ce87d085bce905705c9c
-  languageName: node
-  linkType: hard
-
-"which@npm:^1.2.14, which@npm:^1.2.9, which@npm:^1.3.1":
+"which@npm:^1.2.9, which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
@@ -25038,6 +25466,13 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"wildcard@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "wildcard@npm:2.0.0"
+  checksum: 1f4fe4c03dfc492777c60f795bbba597ac78794f1b650d68f398fbee9adb765367c516ebd4220889b6a81e9626e7228bbe0d66237abb311573c2ee1f4902a5ad
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.1.0, word-wrap@npm:^1.2.3":
   version: 1.2.3
   resolution: "word-wrap@npm:1.2.3"
@@ -25058,16 +25493,6 @@ resolve@^1.20.0:
   dependencies:
     errno: ~0.1.7
   checksum: eab917530e1feddf157ec749e9c91b73a886142daa7fdf3490bccbf7b548b2576c43ab8d0a98e72ac755cbc101ca8647a7b1ff2485fddb9e8f53c40c77f5a719
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "wrap-ansi@npm:2.1.0"
-  dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-  checksum: 2dacd4b3636f7a53ee13d4d0fe7fa2ed9ad81e9967e17231924ea88a286ec4619a78288de8d41881ee483f4449ab2c0287cde8154ba1bd0126c10271101b2ee3
   languageName: node
   linkType: hard
 
@@ -25171,17 +25596,25 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"ws@npm:^8.4.2":
+  version: 8.13.0
+  resolution: "ws@npm:8.13.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
+  languageName: node
+  linkType: hard
+
 "x-is-string@npm:^0.1.0":
   version: 0.1.0
   resolution: "x-is-string@npm:0.1.0"
   checksum: 38acefe5ae2dd48339996f732c55f55d4b1c1d3f65c02116639989d8a49dd06daca3e907accfc56aac84f23372c88b83af0efc849cc62e702c81aae4de44c0d6
-  languageName: node
-  linkType: hard
-
-"xregexp@npm:4.0.0":
-  version: 4.0.0
-  resolution: "xregexp@npm:4.0.0"
-  checksum: ce644eb022fa3370dbf53e1b6f28d7a25dd6cca711ba463c129141429d11776a1239c604370bdcaf93c5028ff8d75cac2a10644377cb649b985c0094da5ef693
   languageName: node
   linkType: hard
 
@@ -25192,7 +25625,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"y18n@npm:^3.2.1 || ^4.0.0, y18n@npm:^4.0.0":
+"y18n@npm:^4.0.0":
   version: 4.0.0
   resolution: "y18n@npm:4.0.0"
   checksum: 66e22d38bf994723b625dcc0159f6fd4068c511f8c565df39e8aa53426f5f31e4a9664a8d7099fbde2c22a1c71be2cb60e83f4c2961a5ee48672418d825a7bc2
@@ -25248,7 +25681,7 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^10.0.0, yargs-parser@npm:^10.1.0":
+"yargs-parser@npm:^10.0.0":
   version: 10.1.0
   resolution: "yargs-parser@npm:10.1.0"
   dependencies:
@@ -25257,60 +25690,10 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^11.1.1":
-  version: 11.1.1
-  resolution: "yargs-parser@npm:11.1.1"
-  dependencies:
-    camelcase: ^5.0.0
-    decamelize: ^1.2.0
-  checksum: 91a82f4e6295745269f5683d1ab11d636f1d2fa732fb1c1795ad4637f31feb54530c2072ca2c2e39d3c4d506c3645214ff08c781f4a5b48fc959788706a54f83
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
-  languageName: node
-  linkType: hard
-
-"yargs@npm:12.0.2":
-  version: 12.0.2
-  resolution: "yargs@npm:12.0.2"
-  dependencies:
-    cliui: ^4.0.0
-    decamelize: ^2.0.0
-    find-up: ^3.0.0
-    get-caller-file: ^1.0.1
-    os-locale: ^3.0.0
-    require-directory: ^2.1.1
-    require-main-filename: ^1.0.1
-    set-blocking: ^2.0.0
-    string-width: ^2.0.0
-    which-module: ^2.0.0
-    y18n: ^3.2.1 || ^4.0.0
-    yargs-parser: ^10.1.0
-  checksum: c84b6824cd262985dd85cf67fd7f9fd608b884627e326a49ea858cdbc1a7cb2ef1368ffc2806f2a5bad6b931b59ff4631fe48756f9c9d4d9d0e8be112a1c3a6b
-  languageName: node
-  linkType: hard
-
-"yargs@npm:12.0.5, yargs@npm:^12.0.2, yargs@npm:^12.0.5":
-  version: 12.0.5
-  resolution: "yargs@npm:12.0.5"
-  dependencies:
-    cliui: ^4.0.0
-    decamelize: ^1.2.0
-    find-up: ^3.0.0
-    get-caller-file: ^1.0.1
-    os-locale: ^3.0.0
-    require-directory: ^2.1.1
-    require-main-filename: ^1.0.1
-    set-blocking: ^2.0.0
-    string-width: ^2.0.0
-    which-module: ^2.0.0
-    y18n: ^3.2.1 || ^4.0.0
-    yargs-parser: ^11.1.1
-  checksum: 716f467be3f4dd5ed346f7e07eabfbf4b915e818bf2e6582b27c8d23f17c6ee59126b1c6896234d0ca1f615ee09d1901602677c5ee294540e87f914cd27a3c9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumped webpack to v5

This removes the workarounds put in place in 9.11.1 so the build works in CI where node was upgrade to v18. Our build should now work on node 16 and 18 without workaround in place... Hopefully.

I tested a full build and confirmed all the modules still load up fine.