### PR TITLE
Fix exception when emailing admin logs

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/AdminLogs/AdminLogsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/AdminLogs/AdminLogsController.cs
@@ -281,7 +281,7 @@ namespace Dnn.PersonaBar.AdminLogs.Components
                     xmlDoc.LoadXml(logInfo.Serialize());
                 }
 
-                var objNode = objXml.ImportNode(xmlDoc, true);
+                var objNode = objXml.ImportNode(xmlDoc.DocumentElement, true);
                 if (objXml.DocumentElement != null)
                 {
                     objXml.DocumentElement.AppendChild(objNode);


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #5573


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Fixes an exception when attempting to email logs - needed to select the document element rather than the XmlDocument object.