### PR TITLE
Scheduler Validate Servers - #5575

### DIFF
--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -2206,6 +2206,11 @@ namespace DotNetNuke.Data
             this.ExecuteNonQuery("RemoveUser", userId, this.GetNull(portalId));
         }
 
+        public virtual void ReplaceServerOnSchedules(string oldServername, string newServerName)
+        {
+            this.ExecuteNonQuery("ReplaceServerOnSchedules", oldServername, newServerName);
+        }
+        
         public virtual void ResetTermsAgreement(int portalId)
         {
             this.ExecuteNonQuery("ResetTermsAgreement", portalId);

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -917,6 +917,7 @@
     <Compile Include="Services\Social\Messaging\IUserPreferencesController.cs" />
     <Compile Include="Services\Social\Messaging\UserPreference.cs" />
     <Compile Include="Services\Social\Messaging\UserPreferencesController.cs" />
+    <Compile Include="Services\SystemHealth\WebServerMonitor.cs" />
     <Compile Include="Services\Tokens\CacheLevel.cs" />
     <Compile Include="Services\Tokens\HtmlTokenReplace.cs" />
     <Compile Include="Services\Tokens\PropertyAccess\AntiForgeryTokenPropertyAccess.cs" />

--- a/DNN Platform/Library/Entities/Host/ServerController.cs
+++ b/DNN Platform/Library/Entities/Host/ServerController.cs
@@ -136,6 +136,12 @@ namespace DotNetNuke.Entities.Host
                 server.UniqueId = existServer == null || string.IsNullOrEmpty(existServer.UniqueId) ? GetServerUniqueId() : existServer.UniqueId;
 
                 UpdateServer(server);
+                ClearCachedServers(); // Only clear the cache if we added a server
+            }
+            else 
+            {
+                // Just update the existing item in the cache
+                existServer.LastActivityDate = server.LastActivityDate;
             }
 
             // log the server info
@@ -146,8 +152,6 @@ namespace DotNetNuke.Entities.Host
             log.LogTypeKey = existServer != null ? EventLogController.EventLogType.WEBSERVER_UPDATED.ToString()
                                         : EventLogController.EventLogType.WEBSERVER_CREATED.ToString();
             LogController.Instance.AddLog(log);
-
-            ClearCachedServers();
         }
 
         public static IServerWebRequestAdapter GetServerWebRequestAdapter()

--- a/DNN Platform/Library/Entities/Host/ServerController.cs
+++ b/DNN Platform/Library/Entities/Host/ServerController.cs
@@ -70,6 +70,19 @@ namespace DotNetNuke.Entities.Host
                 .ToList();
         }
 
+        /// <summary>
+        /// Gets the servers, that have no activtiy in the specified time frame.
+        /// </summary>
+        /// <param name="lastMinutes">The number of recent minutes activity had to occur</param>
+        /// <returns>A list of servers with no activity for the specified minutes. Defaults to 24 hours</returns>
+        public static List<ServerInfo> GetInActiveServers(int lastMinutes = 1440)
+        {
+            return GetServers()
+                .Where(i => DateTime.Now.Subtract(i.LastActivityDate).TotalMinutes > lastMinutes && i.ServerName != Environment.MachineName)
+                .OrderByDescending(i => i.LastActivityDate)
+                .ToList();
+        }
+
         public static string GetExecutingServerName()
         {
             string executingServerName = Globals.ServerName;

--- a/DNN Platform/Library/Entities/Host/ServerController.cs
+++ b/DNN Platform/Library/Entities/Host/ServerController.cs
@@ -15,6 +15,7 @@ namespace DotNetNuke.Entities.Host
     using DotNetNuke.Framework;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Log.EventLog;
+    using DotNetNuke.UI.WebControls;
 
     public class ServerController
     {
@@ -53,20 +54,20 @@ namespace DotNetNuke.Entities.Host
 
         public static List<ServerInfo> GetEnabledServers()
         {
-            var servers = new List<ServerInfo>();
-            var storedServers = GetServers();
-            if (storedServers != null)
-            {
-                foreach (ServerInfo server in storedServers)
-                {
-                    if (server.Enabled)
-                    {
-                        servers.Add(server);
-                    }
-                }
-            }
+            return GetServers()?.Where(i => i.Enabled).ToList() ?? new List<ServerInfo>();
+        }
 
-            return servers;
+        /// <summary>
+        /// Gets the servers, order by last activity date in descending order.
+        /// </summary>
+        /// <param name="lastMinutes">The number of recent minutes activity had to occur</param>
+        /// <returns>A list of servers with activity within the specified minutes</returns>
+        public static List<ServerInfo> GetEnabledServersWithActivity(int lastMinutes = 10)
+        {
+            return GetEnabledServers()
+                .Where(i => DateTime.Now.Subtract(i.LastActivityDate).TotalMinutes <= lastMinutes)
+                .OrderByDescending(i => i.LastActivityDate)
+                .ToList();
         }
 
         public static string GetExecutingServerName()

--- a/DNN Platform/Library/Entities/Host/ServerController.cs
+++ b/DNN Platform/Library/Entities/Host/ServerController.cs
@@ -6,6 +6,7 @@ namespace DotNetNuke.Entities.Host
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using System.Web.Caching;
 
     using DotNetNuke.Common;
@@ -121,7 +122,8 @@ namespace DotNetNuke.Entities.Host
 
         public static void UpdateServerActivity(ServerInfo server)
         {
-            var existServer = GetServers().FirstOrDefault(s => s.ServerName == server.ServerName && s.IISAppName == server.IISAppName);
+            var allServers = GetServers();
+            var existServer = allServers.FirstOrDefault(s => s.ServerName == server.ServerName && s.IISAppName == server.IISAppName);
             var serverId = DataProvider.Instance().UpdateServerActivity(server.ServerName, server.IISAppName, server.CreatedDate, server.LastActivityDate, server.PingFailureCount, server.Enabled);
 
             server.ServerID = serverId;
@@ -142,6 +144,7 @@ namespace DotNetNuke.Entities.Host
             {
                 // Just update the existing item in the cache
                 existServer.LastActivityDate = server.LastActivityDate;
+                DataCache.SetCache(ServerController.CacheKey, allServers);
             }
 
             // log the server info

--- a/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
@@ -11,6 +11,7 @@ namespace DotNetNuke.Services.Scheduling
 
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
+    using DotNetNuke.Entities.Host;
     using Microsoft.VisualBasic;
 
     public class DNNScheduler : SchedulingProvider
@@ -192,6 +193,12 @@ namespace DotNetNuke.Services.Scheduling
         /// <inheritdoc/>
         public override void RunScheduleItemNow(ScheduleItem scheduleItem, bool runNow)
         {
+            // If the validation for the server failed, then the server was updated. The update has requeued the scheduled item, so we can exit the request for this instance to run.
+            if (!this.ValidateServersForScheduledItem(scheduleItem))
+            {
+                return;
+            }
+
             // Remove item from queue
             Scheduler.CoreScheduler.RemoveFromScheduleQueue(scheduleItem);
             var scheduleHistoryItem = new ScheduleHistoryItem(scheduleItem) { NextStart = runNow ? DateTime.Now : (scheduleItem.ScheduleStartDate != Null.NullDate ? scheduleItem.ScheduleStartDate : DateTime.Now) };

--- a/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
@@ -193,7 +193,7 @@ namespace DotNetNuke.Services.Scheduling
         /// <inheritdoc/>
         public override void RunScheduleItemNow(ScheduleItem scheduleItem, bool runNow)
         {
-            // If the validation for the server failed, then the server was updated. The update has requeued the scheduled item, so we can exit the request for this instance to run.
+            // If the validation for the server failed, then the server was updated. The scheduled item will be picked up on the next check, so we can exit the request for this instance to run.
             if (!Scheduler.CoreScheduler.ValidateServersAreActiveForScheduledItem(scheduleItem))
             {
                 return;

--- a/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
@@ -194,7 +194,7 @@ namespace DotNetNuke.Services.Scheduling
         public override void RunScheduleItemNow(ScheduleItem scheduleItem, bool runNow)
         {
             // If the validation for the server failed, then the server was updated. The update has requeued the scheduled item, so we can exit the request for this instance to run.
-            if (!this.ValidateServersForScheduledItem(scheduleItem))
+            if (!this.ValidateServersAreActiveForScheduledItem(scheduleItem))
             {
                 return;
             }

--- a/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/DNNScheduler.cs
@@ -194,7 +194,7 @@ namespace DotNetNuke.Services.Scheduling
         public override void RunScheduleItemNow(ScheduleItem scheduleItem, bool runNow)
         {
             // If the validation for the server failed, then the server was updated. The update has requeued the scheduled item, so we can exit the request for this instance to run.
-            if (!this.ValidateServersAreActiveForScheduledItem(scheduleItem))
+            if (!Scheduler.CoreScheduler.ValidateServersAreActiveForScheduledItem(scheduleItem))
             {
                 return;
             }

--- a/DNN Platform/Library/Services/Scheduling/SchedulingController.cs
+++ b/DNN Platform/Library/Services/Scheduling/SchedulingController.cs
@@ -257,5 +257,15 @@ namespace DotNetNuke.Services.Scheduling
 
             return false;
         }
+
+        /// <summary>
+        /// Replaces the old server name, with the new server name on all schedules where the old server name was found.
+        /// </summary>
+        /// <param name="oldServer">The old server to replace</param>
+        /// <param name="newServer">The new server to use</param>
+        internal static void ReplaceServer(ServerInfo oldServer, ServerInfo newServer)
+        {
+            DataProvider.Instance().ReplaceServerOnSchedules(oldServer.ServerName, newServer.ServerName);
+        }
     }
 }

--- a/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
+++ b/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
@@ -248,45 +248,5 @@ namespace DotNetNuke.Services.Scheduling
         }
 
         public abstract void RemoveFromScheduleInProgress(ScheduleItem scheduleItem);
-
-        /// <summary>
-        /// Checks the scheduled item if it has servers specified to run on. If it does, then it checks to see if the server is active.
-        /// </summary>
-        /// <param name="scheduleItem">The schedule to check</param>
-        /// <returns>True if nothing happens to the scheduled item. Returns false if the scheduled item was updated.</returns>
-        /// <remarks>
-        /// If the server specified is not active then the scheduled item will be assigned to the most recent active server.
-        /// This assumes that all schedules will run on a single server if none of the servers specified are active.
-        /// </remarks>
-        protected virtual bool ValidateServersAreActiveForScheduledItem(ScheduleItem scheduleItem)
-        {
-            // If this scheduled items runs on all servers, continue.
-            if (string.IsNullOrEmpty(scheduleItem.Servers))
-            {
-                return true;
-            }
-
-            // Get the individual server names from the scheduled item
-            var servers = scheduleItem.Servers.ToLowerInvariant().Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-
-            // Get the enabled servers with recent activity.
-            var enabledServers = ServerController.GetEnabledServersWithActivity();
-
-            // Validate that any server in the scheduled item is in the enabled server list with activity in the last 10 minutes.
-            bool serverHasRecentActivity = enabledServers.Any(i => servers.Contains(i.ServerName.ToLowerInvariant()));
-
-            // If no servers in the scheduled item had recent activity, assign this scheduled item to the server with the most recent activity
-            if (!serverHasRecentActivity)
-            {
-                // Assign a new server to this task then run it
-                scheduleItem.Servers = $",{enabledServers.First().ServerName.ToLowerInvariant()},";
-
-                // Save the scheduled item back to the database.
-                this.UpdateSchedule(scheduleItem);
-                return false;
-            }
-
-            return true;
-        }
     }
 }

--- a/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
+++ b/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
@@ -258,7 +258,7 @@ namespace DotNetNuke.Services.Scheduling
         /// If the server specified is not active then the scheduled item will be assigned to the most recent active server.
         /// This assumes that all schedules will run on a single server if none of the servers specified are active.
         /// </remarks>
-        protected virtual bool ValidateServersForScheduledItem(ScheduleItem scheduleItem)
+        protected virtual bool ValidateServersAreActiveForScheduledItem(ScheduleItem scheduleItem)
         {
             // If there are servers specified, verify requested server has been active within the last 10 minutes.
             if (string.IsNullOrEmpty(scheduleItem.Servers))

--- a/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
+++ b/DNN Platform/Library/Services/Scheduling/SchedulingProvider.cs
@@ -260,7 +260,7 @@ namespace DotNetNuke.Services.Scheduling
         /// </remarks>
         protected virtual bool ValidateServersAreActiveForScheduledItem(ScheduleItem scheduleItem)
         {
-            // If there are servers specified, verify requested server has been active within the last 10 minutes.
+            // If this scheduled items runs on all servers, continue.
             if (string.IsNullOrEmpty(scheduleItem.Servers))
             {
                 return true;

--- a/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
+++ b/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
@@ -66,10 +66,19 @@
 
         private void DisableServersWithoutRecentActivity()
         {
+            var serversWithActivity = ServerController.GetEnabledServersWithActivity();
+            var newServer = serversWithActivity.FirstOrDefault();
+
             foreach (var s in ServerController.GetInActiveServers(10))
             {
                 s.Enabled = false;
                 ServerController.UpdateServerActivity(s);
+
+                // Update the schedules that were running on that server, that may never have been loaded
+                if (newServer != null)
+                {
+                    SchedulingController.ReplaceServer(s, newServer);
+                }
             }
         }
 

--- a/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
+++ b/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
@@ -37,7 +37,7 @@
                 Logger.Info("Starting WebServerMonitor");
 
                 this.UpdateCurrentServerActivity();
-
+                this.DisableServersWithoutRecentActivity();
                 this.RemoveInActiveServers();
 
                 Logger.Info("Finished WebServerMonitor");
@@ -62,6 +62,15 @@
             ServerController.UpdateServerActivity(currentServer);
 
             Logger.Info("Finished UpdateCurrentServerActivity");
+        }
+
+        private void DisableServersWithoutRecentActivity()
+        {
+            foreach (var s in ServerController.GetInActiveServers(10))
+            {
+                s.Enabled = false;
+                ServerController.UpdateServerActivity(s);
+            }
         }
 
         private void RemoveInActiveServers()

--- a/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
+++ b/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
@@ -1,0 +1,75 @@
+﻿namespace DotNetNuke.Services.SystemHealth
+{
+    using System;
+    using DotNetNuke.Entities.Host;
+    using DotNetNuke.Instrumentation;
+    using DotNetNuke.Services.Exceptions;
+    using DotNetNuke.Services.Scheduling;
+
+    public class WebServerMonitor : SchedulerClient
+    {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(WebServerMonitor));
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebServerMonitor"/> class.
+        /// Constructs a WebServerMonitor SchedulerClient.
+        /// </summary>
+        /// <param name="objScheduleHistoryItem">A SchedulerHistiryItem.</param>
+        /// <remarks>
+        /// This must be run on all servers.
+        /// </remarks>
+        public WebServerMonitor(ScheduleHistoryItem objScheduleHistoryItem)
+        {
+            this.ScheduleHistoryItem = objScheduleHistoryItem;
+        }
+
+        /// <summary>
+        /// Runs on the active server and updates the last activity date for the current server.
+        /// </summary>
+        public override void DoWork()
+        {
+            try
+            {
+                Logger.Info("Starting WebServerMonitor");
+
+                this.UpdateCurrentServerActivity();
+
+                this.RemoveInActiveServers();
+
+                Logger.Info("Finished WebServerMonitor");
+                this.ScheduleHistoryItem.Succeeded = true;
+            }
+            catch (Exception exc)
+            {
+                this.ScheduleHistoryItem.Succeeded = false;
+                this.ScheduleHistoryItem.AddLogNote(string.Format("Updating server health failed: {0}.", exc.ToString()));
+                this.Errored(ref exc);
+                Logger.ErrorFormat("Error in WebServerMonitor: {0}. {1}", exc.Message, exc.StackTrace);
+                Exceptions.LogException(exc);
+            }
+        }
+
+        private void UpdateCurrentServerActivity()
+        {
+            Logger.Info("Starting UpdateCurrentServerActivity");
+
+            // Creating a new ServerInfo object, by default points it at the current server
+            var currentServer = new ServerInfo();
+            ServerController.UpdateServerActivity(currentServer);
+
+            Logger.Info("Finished UpdateCurrentServerActivity");
+        }
+
+        private void RemoveInActiveServers()
+        {
+            Logger.Info("Starting RemoveInActiveServers");
+
+            foreach (var s in ServerController.GetInActiveServers(1440))
+            {
+                ServerController.DeleteServer(s.ServerID);
+            }
+
+            Logger.Info("Finished RemoveInActiveServers");
+        }
+    }
+}

--- a/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
+++ b/DNN Platform/Library/Services/SystemHealth/WebServerMonitor.cs
@@ -1,11 +1,15 @@
 ﻿namespace DotNetNuke.Services.SystemHealth
 {
     using System;
+
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Exceptions;
     using DotNetNuke.Services.Scheduling;
 
+    /// <summary>
+    /// When run on each server it updates the last activity date for the server and removes any servers that havent been seen in 24 hours.
+    /// </summary>
     public class WebServerMonitor : SchedulerClient
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(WebServerMonitor));

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -1248,6 +1248,8 @@
     <Content Include="Providers\DataProviders\SqlDataProvider\08.00.00.26.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\08.00.00.28.SqlDataProvider" />
     <Content Include="web.config" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.11.01.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.11.02.SqlDataProvider" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.02.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.02.SqlDataProvider
@@ -161,6 +161,25 @@ BEGIN
 END
 GO
 
+/****************************************************************
+ * SPROC: Journal_ListForSummary 
+ ****************************************************************/
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}ReplaceServerOnSchedules]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}ReplaceServerOnSchedules]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}ReplaceServerOnSchedules]
+    @oldServerName nvarchar(50),
+    @newServerName nvarchar(50)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    UPDATE {databaseOwner}[{objectQualifier}Schedule] SET Servers = REPLACE(Servers, @oldServerName, @newServerName) WHERE Servers LIKE '%' + @oldServerName + '%'
+END
+GO
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.02.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.02.SqlDataProvider
@@ -157,12 +157,12 @@ GO
 IF NOT EXISTS(SELECT ScheduleID FROM {databaseOwner}[{objectQualifier}Schedule] WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke')
 BEGIN
 	INSERT INTO {databaseOwner}[{objectQualifier}Schedule] ([TypeFullName], [TimeLapse], [TimeLapseMeasurement], [RetryTimeLapse], [RetryTimeLapseMeasurement], [RetainHistoryNum], [AttachToEvent], [CatchUpEnabled], [Enabled], [ObjectDependencies], [Servers], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate], [FriendlyName]) 
-	VALUES ('DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke', 5, 'm', 10, 'm', 10, '', 0, 1, '', NULL, NULL, GETDATE(), NULL, GETDATE(), N'Monitor Web Servers')
+	VALUES ('DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke', 5, 'm', 10, 'm', 10, '', 0, 1, '', NULL, -1, GETDATE(), NULL, GETDATE(), N'Monitor Web Servers')
 END
 GO
 
 /****************************************************************
- * SPROC: Journal_ListForSummary 
+ * SPROC: ReplaceServerOnSchedules 
  ****************************************************************/
 
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}ReplaceServerOnSchedules]') AND type in (N'P', N'PC'))

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.02.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.11.02.SqlDataProvider
@@ -151,6 +151,16 @@ CREATE PROCEDURE {databaseOwner}[{objectQualifier}Journal_ListForSummary]
 	ORDER BY RowNumber ASC;
 GO
 
+/*    Add scheduled task for the web server health checks   */
+/************************************************************/
+
+IF NOT EXISTS(SELECT ScheduleID FROM {databaseOwner}[{objectQualifier}Schedule] WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke')
+BEGIN
+	INSERT INTO {databaseOwner}[{objectQualifier}Schedule] ([TypeFullName], [TimeLapse], [TimeLapseMeasurement], [RetryTimeLapse], [RetryTimeLapseMeasurement], [RetainHistoryNum], [AttachToEvent], [CatchUpEnabled], [Enabled], [ObjectDependencies], [Servers], [CreatedByUserID], [CreatedOnDate], [LastModifiedByUserID], [LastModifiedOnDate], [FriendlyName]) 
+	VALUES ('DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke', 5, 'm', 10, 'm', 10, '', 0, 1, '', NULL, NULL, GETDATE(), NULL, GETDATE(), N'Monitor Web Servers')
+END
+GO
+
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SystemInfoServersController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SystemInfoServersController.cs
@@ -77,12 +77,9 @@ namespace Dnn.PersonaBar.Servers.Services
         {
             try
             {
-                foreach (var s in DotNetNuke.Entities.Host.ServerController.GetServers())
+                foreach (var s in DotNetNuke.Entities.Host.ServerController.GetInActiveServers(1440))
                 {
-                    if (s.LastActivityDate.AddDays(1) < DateTime.Now && s.ServerName != Environment.MachineName)
-                    {
-                        DotNetNuke.Entities.Host.ServerController.DeleteServer(s.ServerID);
-                    }
+                    DotNetNuke.Entities.Host.ServerController.DeleteServer(s.ServerID);
                 }
 
                 return this.Request.CreateResponse(HttpStatusCode.OK, true);


### PR DESCRIPTION
Fixes #5575 

## Summary
Adds a WebServerMonitor scheduled task that runs every 5 minutes. This scheduled task updates the Last Activity Date for a WebServer. If a server hasn't been seen in > 10 minutes then it is disabled. If a WebServer hasn't been seen in > 24 hours then delete the server from the table. Anytime we deactivate or delete a server, we updated the scheduled tasks related to the deactivated server to a new server.