### PR TITLE
Enhance PersonaBarTheme.css to Resize the PersonaBar Logo

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
@@ -740,8 +740,8 @@ span.dnnFormError:after {
     width: 80px;
     height: 103px;
     background: var(--dnn-pb-menu-brand-background);
-    -ms-background-size: 32px auto;
-    background-size: 32px auto;
+    -ms-background-size: var(--dnn-pb-menu-brand-background-size);
+    background-size: var(--dnn-pb-menu-brand-background-size); /* 32px auto; */
     position: relative;
     border-bottom: 1px solid var(--dnn-color-pb-menu-divider);
     text-align: center;

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
@@ -741,7 +741,7 @@ span.dnnFormError:after {
     height: 103px;
     background: var(--dnn-pb-menu-brand-background);
     -ms-background-size: var(--dnn-pb-menu-brand-background-size);
-    background-size: var(--dnn-pb-menu-brand-background-size); /* 32px auto; */
+    background-size: var(--dnn-pb-menu-brand-background-size);
     position: relative;
     border-bottom: 1px solid var(--dnn-color-pb-menu-divider);
     text-align: center;

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/theme.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/theme.css
@@ -13,4 +13,5 @@ instead of this one.
     --dnn-color-pb-menu-text-highlight: #3c7a9a;
     
     --dnn-pb-menu-brand-background: url('../images/Logo.svg') no-repeat center center;
+    --dnn-pb-menu-brand-background-size: 32px auto;
 }


### PR DESCRIPTION
Fixes #5591

## Summary

Adding the ability for themers or admins to adjust the size of the PersonaBar Logo while keeping the existing size (default).

