### PR TITLE
Enable Dependency Injection for Prompt commands

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Prompt/ICommandRepository.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Abstractions.Prompt
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>The repository handles retrieving of commands from the entire DNN installation.</summary>
@@ -13,9 +14,10 @@ namespace DotNetNuke.Abstractions.Prompt
         IEnumerable<ICommand> GetCommands();
 
         /// <summary>Get the command. Returns null if no command found for the name.</summary>
+        /// <param name="serviceProvider">The DI container.</param>
         /// <param name="commandName">Name of the command (commonly in verb-noun format).</param>
         /// <returns>An IConsoleCommand or null.</returns>
-        IConsoleCommand GetCommand(string commandName);
+        IConsoleCommand GetCommand(IServiceProvider serviceProvider, string commandName);
 
         /// <summary>Get help for the specified command.</summary>
         /// <param name="consoleCommand">Command to get help for.</param>

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -51,7 +51,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591, 3001, 3002, 1574, 1573</NoWarn>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\</OutputPath>
@@ -65,7 +65,7 @@
     <Optimize>true</Optimize>
     <DefineConstants>
     </DefineConstants>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>
@@ -75,9 +75,11 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
   <ItemGroup>

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -7,6 +7,7 @@ namespace DotNetNuke
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Abstractions.Prompt;
     using DotNetNuke.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
@@ -14,6 +15,7 @@ namespace DotNetNuke
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Modules.Settings;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Prompt;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.UI.Modules.Html5;
@@ -31,9 +33,11 @@ namespace DotNetNuke
             services.AddSingleton<ReflectedModuleControlFactory>();
             services.AddSingleton<IDnnContext, DotNetNukeContext>();
 
+#pragma warning disable CS0618
             services.AddScoped<IEventLogger, EventLogController>();
             services.AddScoped<IEventLogConfigService, EventLogController>();
             services.AddScoped<IEventLogService, EventLogController>();
+#pragma warning restore CS0618
 
             services.AddTransient(x => PortalController.Instance);
             services.AddScoped<IHostSettingsService, HostController>();
@@ -46,6 +50,7 @@ namespace DotNetNuke
             services.AddScoped<IPortalAliasService, PortalAliasController>();
 
             services.AddTransient<IFileSystemUtils, FileSystemUtilsProvider>();
+            services.AddTransient<ICommandRepository, CommandRepository>();
         }
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Repositories/CommandRepository.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Repositories/CommandRepository.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.PersonaBar.Prompt.Components.Repositories
 {
     using System;
@@ -14,22 +13,38 @@ namespace Dnn.PersonaBar.Prompt.Components.Repositories
     using Dnn.PersonaBar.Library.Prompt;
     using Dnn.PersonaBar.Library.Prompt.Attributes;
     using Dnn.PersonaBar.Prompt.Components.Models;
+
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework;
     using DotNetNuke.Framework.Reflections;
     using DotNetNuke.Services.Localization;
 
+    using Microsoft.Extensions.DependencyInjection;
+
     [Obsolete("Moved to DotNetNuke.Prompt in the core library project. Will be removed in DNN 11.", false)]
     public class CommandRepository : ServiceLocator<ICommandRepository, CommandRepository>, ICommandRepository
     {
+        private readonly IServiceScopeFactory serviceScopeFactory;
+
+        public CommandRepository()
+            : this(null)
+        {
+        }
+
+        public CommandRepository(IServiceScopeFactory serviceScopeFactory)
+        {
+            this.serviceScopeFactory = serviceScopeFactory ?? Globals.DependencyProvider.GetRequiredService<IServiceScopeFactory>();
+        }
+
         /// <inheritdoc/>
         public SortedDictionary<string, Command> GetCommands()
         {
             return
                 DataCache.GetCachedData<SortedDictionary<string, Command>>(
                     new CacheItemArgs("DnnPromptCommands", CacheItemPriority.Default),
-                    c => GetCommandsInternal());
+                    c => this.GetCommandsInternal());
         }
 
         /// <inheritdoc/>
@@ -44,10 +59,10 @@ namespace Dnn.PersonaBar.Prompt.Components.Repositories
         /// <inheritdoc/>
         protected override Func<ICommandRepository> GetFactory()
         {
-            return () => new CommandRepository();
+            return Globals.DependencyProvider.GetRequiredService<ICommandRepository>;
         }
 
-        private static SortedDictionary<string, Command> GetCommandsInternal()
+        private SortedDictionary<string, Command> GetCommandsInternal()
         {
             var commands = new SortedDictionary<string, Command>();
             var typeLocator = new TypeLocator();
@@ -57,14 +72,18 @@ namespace Dnn.PersonaBar.Prompt.Components.Repositories
                      !t.IsAbstract &&
                      t.IsVisible &&
                      typeof(IConsoleCommand).IsAssignableFrom(t));
-            foreach (var cmd in allCommandTypes)
+
+            using var serviceScope = this.serviceScopeFactory.CreateScope();
+            foreach (var commandType in allCommandTypes)
             {
-                var attr = cmd.GetCustomAttributes(typeof(ConsoleCommandAttribute), false).FirstOrDefault() ?? new ConsoleCommandAttribute(CreateCommandFromClass(cmd.Name), Constants.GeneralCategory, $"Prompt_{cmd.Name}_Description");
-                var assemblyName = cmd.Assembly.GetName();
+                var attr = commandType.GetCustomAttributes(typeof(ConsoleCommandAttribute), false).FirstOrDefault() ?? new ConsoleCommandAttribute(CreateCommandFromClass(commandType.Name), Constants.GeneralCategory, $"Prompt_{commandType.Name}_Description");
+                var assemblyName = commandType.Assembly.GetName();
                 var version = assemblyName.Version.ToString();
                 var commandAttribute = (ConsoleCommandAttribute)attr;
                 var key = commandAttribute.Name.ToUpper();
-                var localResourceFile = ((IConsoleCommand)Activator.CreateInstance(cmd))?.LocalResourceFile;
+
+                var command = (IConsoleCommand)ActivatorUtilities.GetServiceOrCreateInstance(serviceScope.ServiceProvider, commandType);
+                var localResourceFile = command?.LocalResourceFile;
                 commands.Add(key, new Command
                 {
                     Category = LocalizeString(commandAttribute.Category, localResourceFile),
@@ -72,7 +91,7 @@ namespace Dnn.PersonaBar.Prompt.Components.Repositories
                     Key = key,
                     Name = commandAttribute.Name,
                     Version = version,
-                    CommandType = cmd,
+                    CommandType = commandType,
                 });
             }
 
@@ -101,11 +120,11 @@ namespace Dnn.PersonaBar.Prompt.Components.Repositories
             var commandHelp = new CommandHelp();
             if (consoleCommand != null)
             {
-                var cmd = consoleCommand.GetType();
-                var attr = cmd.GetCustomAttributes(typeof(ConsoleCommandAttribute), false).FirstOrDefault() as ConsoleCommandAttribute ?? new ConsoleCommandAttribute(CreateCommandFromClass(cmd.Name), Constants.GeneralCategory, $"Prompt_{cmd.Name}_Description");
+                var commandType = consoleCommand.GetType();
+                var attr = commandType.GetCustomAttributes(typeof(ConsoleCommandAttribute), false).FirstOrDefault() as ConsoleCommandAttribute ?? new ConsoleCommandAttribute(CreateCommandFromClass(commandType.Name), Constants.GeneralCategory, $"Prompt_{commandType.Name}_Description");
                 commandHelp.Name = attr.Name;
                 commandHelp.Description = LocalizeString(attr.Description, consoleCommand.LocalResourceFile);
-                var flagAttributes = cmd.GetFields(BindingFlags.NonPublic | BindingFlags.Static)
+                var flagAttributes = commandType.GetFields(BindingFlags.NonPublic | BindingFlags.Static)
                     .Select(x => x.GetCustomAttributes(typeof(FlagParameterAttribute), false).FirstOrDefault())
                     .Cast<FlagParameterAttribute>().ToList();
                 if (flagAttributes.Any())

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -31,7 +31,7 @@
     <DocumentationFile>bin\Dnn.PersonaBar.Extensions.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -42,7 +42,7 @@
     <DocumentationFile>bin\Dnn.PersonaBar.Extensions.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -475,6 +475,7 @@
     <Compile Include="Services\ThemesController.cs" />
     <Compile Include="Services\UsersController.cs" />
     <Compile Include="Services\VocabulariesController.cs" />
+    <Compile Include="Startup.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="admin\personaBar\Dnn.AdminLogs\AdminLogs.html" />
@@ -598,6 +599,10 @@
     <ProjectReference Include="..\..\DNN Platform\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
       <Project>{6928A9B1-F88A-4581-A132-D3EB38669BB0}</Project>
       <Name>DotNetNuke.Abstractions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DNN Platform\DotNetNuke.DependencyInjection\DotNetNuke.DependencyInjection.csproj">
+      <Project>{0FCA217A-5F9A-4F5B-A31B-86D64AE65198}</Project>
+      <Name>DotNetNuke.DependencyInjection</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\DNN Platform\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
       <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Startup.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Startup.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace Dnn.PersonaBar.Extensions;
+
+using Dnn.PersonaBar.Prompt.Components.Repositories;
+
+using DotNetNuke.DependencyInjection;
+
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>Registers services for the Persona Bar Extensions.</summary>
+public class Startup : IDnnStartup
+{
+    /// <inheritdoc/>
+    public void ConfigureServices(IServiceCollection services)
+    {
+#pragma warning disable CS0618
+        services.AddTransient<ICommandRepository, CommandRepository>();
+#pragma warning restore CS0618
+    }
+}


### PR DESCRIPTION
## Summary
This PR updates creation of Prompt commands to use the dependency injection container.

This includes a breaking change in `ICommandRepository.GetCommand` to take an `IServiceProvider` (in addition to the command name).