### PR TITLE
Use DI for auth message handlers & routing

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Routing/MvcRoutingManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Routing/MvcRoutingManager.cs
@@ -9,13 +9,14 @@ namespace DotNetNuke.Web.Mvc.Routing
     using System.Web.Routing;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Internal;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Framework.Reflections;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.Mvc.Common;
 
-    public sealed class MvcRoutingManager : IMapRoute
+    public sealed class MvcRoutingManager : IMapRoute, IRoutingManager
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(MvcRoutingManager));
         private readonly Dictionary<string, int> moduleUsage = new Dictionary<string, int>();

--- a/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Startup.cs
@@ -7,8 +7,10 @@ namespace DotNetNuke.Web.Mvc
     using System.Web.Mvc;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Internal;
     using DotNetNuke.DependencyInjection;
     using DotNetNuke.Web.Mvc.Extensions;
+    using DotNetNuke.Web.Mvc.Routing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -19,6 +21,7 @@ namespace DotNetNuke.Web.Mvc
         {
             services.TryAddSingleton<IControllerFactory, DefaultControllerFactory>();
             services.AddSingleton<MvcModuleControlFactory>();
+            services.TryAddEnumerable(new ServiceDescriptor(typeof(IRoutingManager), typeof(MvcRoutingManager), ServiceLifetime.Singleton));
 
             services.AddMvcControllers();
 

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -56,7 +56,7 @@
     <DocumentationFile>bin\DotNetNuke.Web.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -67,7 +67,7 @@
     <DocumentationFile>bin\DotNetNuke.Web.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <NoWarn>1591</NoWarn>

--- a/DNN Platform/DotNetNuke.Web/Startup.cs
+++ b/DNN Platform/DotNetNuke.Web/Startup.cs
@@ -5,11 +5,15 @@ namespace DotNetNuke.Web
 {
     using System.Web.Http.Filters;
 
+    using DotNetNuke.Common.Internal;
     using DotNetNuke.DependencyInjection;
     using DotNetNuke.Web.Api.Internal;
     using DotNetNuke.Web.Extensions;
 
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+
+    using ServicesRoutingManager = DotNetNuke.Web.Api.Internal.ServicesRoutingManager;
 
     /// <summary>Configures services for The DotNetNuke.Web project.</summary>
     public class Startup : IDnnStartup
@@ -18,6 +22,7 @@ namespace DotNetNuke.Web
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddTransient<IFilterProvider, DnnActionFilterProvider>();
+            services.TryAddEnumerable(new ServiceDescriptor(typeof(IRoutingManager), typeof(ServicesRoutingManager), ServiceLifetime.Singleton));
             services.AddWebApi();
         }
     }

--- a/DNN Platform/Library/Common/Internal/IRoutingManager.cs
+++ b/DNN Platform/Library/Common/Internal/IRoutingManager.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Common.Internal;
+
+/// <summary>A contract specifying the ability for a routing manager to register its routes.</summary>
+public interface IRoutingManager
+{
+    /// <summary>Register the routes.</summary>
+    void RegisterRoutes();
+}

--- a/DNN Platform/Library/Common/Internal/ServicesRoutingManager.cs
+++ b/DNN Platform/Library/Common/Internal/ServicesRoutingManager.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Common.Internal
 
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Services.Cache;
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>Manages http routes for services (WebAPI, MVC, etc).</summary>
     public static class ServicesRoutingManager
@@ -21,16 +22,10 @@ namespace DotNetNuke.Common.Internal
 
             try
             {
-                // new ServicesRoutingManager().RegisterRoutes();
-                var instance = Activator.CreateInstance("DotNetNuke.Web", "DotNetNuke.Web.Api.Internal.ServicesRoutingManager");
-
-                var method = instance.Unwrap().GetType().GetMethod("RegisterRoutes");
-                method.Invoke(instance.Unwrap(), new object[0]);
-
-                var instanceMvc = Activator.CreateInstance("DotNetNuke.Web.Mvc", "DotNetNuke.Web.Mvc.Routing.MvcRoutingManager");
-
-                var methodMvc = instanceMvc.Unwrap().GetType().GetMethod("RegisterRoutes");
-                methodMvc.Invoke(instanceMvc.Unwrap(), new object[0]);
+                foreach (IRoutingManager routingManager in Globals.DependencyProvider.GetServices(typeof(IRoutingManager)))
+                {
+                    routingManager.RegisterRoutes();
+                }
             }
             catch (Exception e)
             {

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Common\Extensions\HttpContextDependencyInjectionExtensions.cs" />
     <Compile Include="Common\Internal\FileSystemUtilsProvider.cs" />
     <Compile Include="Common\Internal\IFileSystemUtils.cs" />
+    <Compile Include="Common\Internal\IRoutingManager.cs" />
     <Compile Include="Common\Lists\ListEntryInfoCollection.cs" />
     <Compile Include="Common\NavigationManager.cs" />
     <Compile Include="Common\ServiceScopeContainer.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/ServiceRoutingManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/ServiceRoutingManagerTests.cs
@@ -8,7 +8,6 @@ namespace DotNetNuke.Tests.Web.Api
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using System.Web.Http.Filters;
     using System.Web.Routing;
 
@@ -16,7 +15,6 @@ namespace DotNetNuke.Tests.Web.Api
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Common;
-    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework.Internal.Reflection;
     using DotNetNuke.Framework.Reflections;
@@ -37,7 +35,6 @@ namespace DotNetNuke.Tests.Web.Api
         // ReSharper restore UnusedMember.Local
         private Mock<IPortalController> mockPortalController;
         private IPortalController portalController;
-
         private Mock<IPortalAliasService> mockPortalAliasService;
 
         [SetUp]
@@ -111,7 +108,7 @@ namespace DotNetNuke.Tests.Web.Api
 
         public void NameSpaceRequiredOnMapRouteCalls([ValueSource(nameof(EmptyStringArrays))] string[] namespaces)
         {
-            var srm = new ServicesRoutingManager(new RouteCollection());
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, new RouteCollection());
 
             Assert.Throws<ArgumentException>(() => srm.MapHttpRoute("usm", "default", "url", null, namespaces));
         }
@@ -131,7 +128,7 @@ namespace DotNetNuke.Tests.Web.Api
             var al = new Mock<IAssemblyLocator>();
             al.Setup(x => x.Assemblies).Returns(new[] { assembly.Object });
             var tl = new TypeLocator { AssemblyLocator = al.Object };
-            var srm = new ServicesRoutingManager(new RouteCollection()) { TypeLocator = tl };
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, new RouteCollection()) { TypeLocator = tl };
 
             srm.RegisterRoutes();
 
@@ -148,7 +145,7 @@ namespace DotNetNuke.Tests.Web.Api
             var al = new Mock<IAssemblyLocator>();
             al.Setup(x => x.Assemblies).Returns(new[] { assembly.Object });
             var tl = new TypeLocator { AssemblyLocator = al.Object };
-            var srm = new ServicesRoutingManager(new RouteCollection()) { TypeLocator = tl };
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, new RouteCollection()) { TypeLocator = tl };
 
             srm.RegisterRoutes();
 
@@ -161,7 +158,7 @@ namespace DotNetNuke.Tests.Web.Api
 
         public void UniqueNameRequiredOnMapRouteCalls(string uniqueName)
         {
-            var srm = new ServicesRoutingManager(new RouteCollection());
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, new RouteCollection());
 
             Assert.Throws<ArgumentException>(() => srm.MapHttpRoute(uniqueName, "default", "url", null, new[] { "foo" }));
         }
@@ -174,7 +171,7 @@ namespace DotNetNuke.Tests.Web.Api
             this.mockPortalController.Setup(x => x.GetPortals()).Returns(new ArrayList());
 
             // Act
-            var srm = new ServicesRoutingManager(new RouteCollection());
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, new RouteCollection());
 
             // Assert
             Assert.DoesNotThrow(() => srm.MapHttpRoute("name", "default", "/url", null, new[] { "foo" }));
@@ -192,7 +189,7 @@ namespace DotNetNuke.Tests.Web.Api
             this.mockPortalAliasService.As<IPortalAliasController>().Setup(x => x.GetPortalAliasesByPortalId(0)).Returns(new[] { new PortalAliasInfo { HTTPAlias = "www.foo.com" } });
 
             var routeCollection = new RouteCollection();
-            var srm = new ServicesRoutingManager(routeCollection);
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, routeCollection);
 
             // Act
             srm.MapHttpRoute("folder", "default", "url", new[] { "foo" });
@@ -214,7 +211,7 @@ namespace DotNetNuke.Tests.Web.Api
             this.mockPortalAliasService.As<IPortalAliasController>().Setup(x => x.GetPortalAliasesByPortalId(0)).Returns(new[] { new PortalAliasInfo { HTTPAlias = "www.foo.com" } });
 
             var routeCollection = new RouteCollection();
-            var srm = new ServicesRoutingManager(routeCollection);
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, routeCollection);
 
             // Act
             srm.MapHttpRoute("folder", "default", "url", new[] { "foo" });
@@ -239,7 +236,7 @@ namespace DotNetNuke.Tests.Web.Api
             this.mockPortalAliasService.As<IPortalAliasController>().Setup(x => x.GetPortalAliasesByPortalId(0)).Returns(new[] { new PortalAliasInfo { HTTPAlias = "www.foo.com" } });
 
             var routeCollection = new RouteCollection();
-            var srm = new ServicesRoutingManager(routeCollection);
+            var srm = new ServicesRoutingManager(Globals.DependencyProvider, routeCollection);
 
             // Act
             srm.MapHttpRoute("folder", "default", "url", new[] { "foo" });


### PR DESCRIPTION
## Summary
This PR enables dependency injection for `AuthMessageHandlerBase` (basic, digest, and JWT are built-in).

This also replaces the use of reflection to register routes for Web API and MVC.