### PR TITLE
Introduce Globals.GetCurrentServiceProvider

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnRedirecttoRouteResult.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnRedirecttoRouteResult.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionResults
         public DnnRedirecttoRouteResult(string actionName, string controllerName, string routeName, RouteValueDictionary routeValues, bool permanent)
             : base(routeName, routeValues, permanent)
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.ActionName = actionName;
             this.ControllerName = controllerName;
         }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -47,7 +47,7 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
 
             // ReSharper disable once DoNotCallOverridableMethodsInConstructor
             DisableMvcResponseHeader = disableMvcResponseHeader;
-            this.ControllerFactory = Globals.DependencyProvider.GetRequiredService<IControllerFactory>();
+            this.ControllerFactory = Globals.GetCurrentServiceProvider().GetRequiredService<IControllerFactory>();
             this.ViewEngines = new ViewEngineCollection();
 
             // ViewEngines.Add(new ModuleDelegatingViewEngine());

--- a/DNN Platform/DotNetNuke.Web.Mvc/Routing/StandardModuleRoutingProvider.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Routing/StandardModuleRoutingProvider.cs
@@ -24,7 +24,7 @@ namespace DotNetNuke.Web.Mvc.Routing
 
         public StandardModuleRoutingProvider()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage{TModel}.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNukeWebPage{TModel}.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Web.Razor
 
         public DotNetNukeWebPage()
         {
-            var model = Globals.DependencyProvider.GetService<TModel>();
+            var model = Globals.GetCurrentServiceProvider().GetService<TModel>();
             this.Model = model ?? Activator.CreateInstance<TModel>();
         }
 

--- a/DNN Platform/DotNetNuke.Web.Razor/Helpers/UrlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Razor/Helpers/UrlHelper.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.Web.Razor.Helpers
         public UrlHelper(ModuleInstanceContext context)
         {
             this.context = context;
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/DNN Platform/DotNetNuke.Web/Mvp/ProfileModuleViewBase.cs
+++ b/DNN Platform/DotNetNuke.Web/Mvp/ProfileModuleViewBase.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Web.Mvp
         /// <summary>Initializes a new instance of the <see cref="ProfileModuleViewBase{TModel}"/> class.</summary>
         public ProfileModuleViewBase()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFormEditControlItem.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFormEditControlItem.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnFormEditControlItem"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public DnnFormEditControlItem()
-            : this(HttpContextSource.Current?.GetScope()?.ServiceProvider ?? Globals.DependencyProvider)
+            : this(Globals.GetCurrentServiceProvider())
         {
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnRibbonBarTool.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnRibbonBarTool.cs
@@ -31,9 +31,15 @@ namespace DotNetNuke.Web.UI.WebControls
         private DnnTextLink dnnLink;
         private DnnTextButton dnnLinkButton;
 
+        [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public DnnRibbonBarTool()
+            : this(null)
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        public DnnRibbonBarTool(INavigationManager navigationManager)
+        {
+            this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public virtual RibbonBarToolInfo ToolInfo

--- a/DNN Platform/Library/Application/DotNetNukeContext.cs
+++ b/DNN Platform/Library/Application/DotNetNukeContext.cs
@@ -39,7 +39,7 @@ namespace DotNetNuke.Application
         /// </remarks>
         [Obsolete("Deprecated in DotNetNuke 9.7.1. This constructor has been replaced by parameterized public constructor which is designed to be used with Dependency Injection. Resolve the new interface 'DotNetNuke.Abstractions.IDnnContext' instead. Scheduled removal in v11.0.0.")]
         protected DotNetNukeContext()
-            : this(Globals.DependencyProvider.GetRequiredService<IApplicationInfo>())
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationInfo>())
         {
         }
 
@@ -61,7 +61,7 @@ namespace DotNetNuke.Application
             {
                 if (current == null)
                 {
-                    current = Globals.DependencyProvider.GetRequiredService<IDnnContext>();
+                    current = Globals.GetCurrentServiceProvider().GetRequiredService<IDnnContext>();
                 }
 
                 return current is DotNetNukeContext context ? context : default(DotNetNukeContext);

--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -3485,11 +3485,20 @@ namespace DotNetNuke.Common
             AppStopwatch.Restart();
         }
 
+        /// <summary>Gets an <see cref="IServiceScope"/> that should be disposed, trying to find the current request scope if possible.</summary>
+        /// <returns>An <see cref="IServiceScope"/> instance that should be disposed (but which can be disposed without prematurely disposing the current request scope).</returns>
         internal static IServiceScope GetOrCreateServiceScope()
         {
             return new MaybeDisposableServiceScope(
-                HttpContextSource.Current.GetScope(),
+                HttpContextSource.Current?.GetScope(),
                 DependencyProvider.CreateScope);
+        }
+
+        /// <summary>Gets an <see cref="IServiceProvider"/> for the current request, or the global provider if not available.</summary>
+        /// <returns>An <see cref="IServiceProvider"/> instance.</returns>
+        internal static IServiceProvider GetCurrentServiceProvider()
+        {
+            return HttpContextSource.Current?.GetScope()?.ServiceProvider ?? DependencyProvider;
         }
 
         /// <summary>Check whether the Filename matches extensions.</summary>

--- a/DNN Platform/Library/Common/Initialize.cs
+++ b/DNN Platform/Library/Common/Initialize.cs
@@ -41,7 +41,7 @@ namespace DotNetNuke.Common
         public static void Init(HttpApplication app)
         {
             string redirect;
-            var status = Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>().Status;
+            var status = Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>().Status;
 
             // Check if app is initialised
             if (alreadyInitialized && status == UpgradeStatus.None)
@@ -180,7 +180,7 @@ namespace DotNetNuke.Common
                 Exceptions.LogException(exc);
             }
 
-            var status = Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>().Status;
+            var status = Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>().Status;
             if (status != UpgradeStatus.Install)
             {
                 // purge log buffer
@@ -284,7 +284,7 @@ namespace DotNetNuke.Common
 
             // Determine the Upgrade status and redirect as neccessary to InstallWizard.aspx
             string retValue = Null.NullString;
-            var applicationStatusInfo = Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>();
+            var applicationStatusInfo = Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>();
             switch (applicationStatusInfo.Status)
             {
                 case UpgradeStatus.Install:

--- a/DNN Platform/Library/Common/Internal/EventHandlersContainer.cs
+++ b/DNN Platform/Library/Common/Internal/EventHandlersContainer.cs
@@ -55,7 +55,7 @@ namespace DotNetNuke.Common.Internal
         {
             try
             {
-                return Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>().Status;
+                return Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>().Status;
             }
             catch (NullReferenceException)
             {

--- a/DNN Platform/Library/Common/Internal/GlobalsImpl.cs
+++ b/DNN Platform/Library/Common/Internal/GlobalsImpl.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.Common.Internal
         /// <summary>Initializes a new instance of the <see cref="GlobalsImpl"/> class.</summary>
         public GlobalsImpl()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Library/Common/Internal/ServicesRoutingManager.cs
+++ b/DNN Platform/Library/Common/Internal/ServicesRoutingManager.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Common.Internal
 
             try
             {
-                foreach (IRoutingManager routingManager in Globals.DependencyProvider.GetServices(typeof(IRoutingManager)))
+                foreach (IRoutingManager routingManager in Globals.GetCurrentServiceProvider().GetServices(typeof(IRoutingManager)))
                 {
                     routingManager.RegisterRoutes();
                 }

--- a/DNN Platform/Library/Common/Lists/ListController.cs
+++ b/DNN Platform/Library/Common/Lists/ListController.cs
@@ -45,7 +45,7 @@ namespace DotNetNuke.Common.Lists
         /// <param name="eventLogger">An event logger.</param>
         public ListController(IEventLogger eventLogger)
         {
-            this.eventLogger = eventLogger ?? Globals.DependencyProvider.GetRequiredService<IEventLogger>();
+            this.eventLogger = eventLogger ?? Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>();
         }
 
         /// <summary>Gets the lists that do not support localization.</summary>

--- a/DNN Platform/Library/Common/ServiceScopeContainer.cs
+++ b/DNN Platform/Library/Common/ServiceScopeContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Common
 {
     using System;

--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -117,7 +117,7 @@ namespace DotNetNuke.Common.Utilities
         public static void AddCodeSubDirectory(string name)
         {
             AddCodeSubDirectory(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 name);
         }
 
@@ -168,7 +168,7 @@ namespace DotNetNuke.Common.Utilities
         [Obsolete("Deprecated in DNN 9.11.1, use overload taking an IApplicationStatusInfo. Scheduled for removal in v11.")]
         public static void BackupConfig()
         {
-            BackupConfig(Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+            BackupConfig(Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Creates a backup of the web.config file.</summary>
@@ -256,7 +256,7 @@ namespace DotNetNuke.Common.Utilities
         public static long GetMaxUploadSize()
         {
             return GetMaxUploadSize(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Returns the maximum file size allowed to be uploaded to the application in bytes.</summary>
@@ -298,7 +298,7 @@ namespace DotNetNuke.Common.Utilities
         public static long GetRequestFilterSize()
         {
             return GetRequestFilterSize(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Returns the maximum file size allowed to be uploaded based on the request filter limit.</summary>
@@ -330,7 +330,7 @@ namespace DotNetNuke.Common.Utilities
         public static void SetMaxUploadSize(long newSize)
         {
             SetMaxUploadSize(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 newSize);
         }
 
@@ -457,7 +457,7 @@ namespace DotNetNuke.Common.Utilities
         public static int GetAuthCookieTimeout()
         {
             return GetAuthCookieTimeout(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Gets the authentication cookie timeout value.</summary>
@@ -491,7 +491,7 @@ namespace DotNetNuke.Common.Utilities
         public static int GetPersistentCookieTimeout()
         {
             return GetPersistentCookieTimeout(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Gets optional persistent cookie timeout value from web.config.</summary>
@@ -567,7 +567,7 @@ namespace DotNetNuke.Common.Utilities
         public static string GetCustomErrorMode()
         {
             return GetCustomErrorMode(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Gets the currently configured custom error mode.</summary>
@@ -596,7 +596,7 @@ namespace DotNetNuke.Common.Utilities
         public static XmlDocument Load(string filename)
         {
             return Load(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 filename);
         }
 
@@ -633,7 +633,7 @@ namespace DotNetNuke.Common.Utilities
         public static void RemoveCodeSubDirectory(string name)
         {
             RemoveCodeSubDirectory(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 name);
         }
 
@@ -704,7 +704,7 @@ namespace DotNetNuke.Common.Utilities
         public static string Save(XmlDocument xmlDoc, string filename)
         {
             return Save(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 xmlDoc,
                 filename);
         }
@@ -781,7 +781,7 @@ namespace DotNetNuke.Common.Utilities
         public static bool Touch()
         {
             return Touch(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Touches the web.config file to force the application to reload.</summary>
@@ -809,7 +809,7 @@ namespace DotNetNuke.Common.Utilities
         public static void UpdateConnectionString(string conn)
         {
             UpdateConnectionString(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 conn);
         }
 
@@ -841,7 +841,7 @@ namespace DotNetNuke.Common.Utilities
         public static void UpdateDataProvider(string name, string databaseOwner, string objectQualifier)
         {
             UpdateDataProvider(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 name,
                 databaseOwner,
                 objectQualifier);
@@ -872,7 +872,7 @@ namespace DotNetNuke.Common.Utilities
         public static void UpdateUpgradeConnectionString(string name, string upgradeConnectionString)
         {
             UpdateUpgradeConnectionString(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 name,
                 upgradeConnectionString);
         }
@@ -899,7 +899,7 @@ namespace DotNetNuke.Common.Utilities
         public static string UpdateMachineKey()
         {
             return UpdateMachineKey(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Updates the unique machine key. Warning: Do not change this after installation unless you know what your are doing.</summary>
@@ -957,7 +957,7 @@ namespace DotNetNuke.Common.Utilities
         public static string UpdateValidationKey()
         {
             return UpdateValidationKey(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         /// <summary>Updates the validation key. WARNING: Do not call this API unless you now what you are doing.</summary>
@@ -1037,7 +1037,7 @@ namespace DotNetNuke.Common.Utilities
         public static string GetPathToFile(ConfigFileType file, bool overwrite)
         {
             return GetPathToFile(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 file,
                 overwrite);
         }
@@ -1073,7 +1073,7 @@ namespace DotNetNuke.Common.Utilities
         public static string UpdateInstallVersion(Version version)
         {
             return UpdateInstallVersion(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 version);
         }
 
@@ -1133,7 +1133,7 @@ namespace DotNetNuke.Common.Utilities
         public static string AddFCNMode(FcnMode fcnMode)
         {
             return AddFCNMode(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()),
                 fcnMode);
         }
 

--- a/DNN Platform/Library/Common/Utilities/FileSystemUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/FileSystemUtils.cs
@@ -239,7 +239,7 @@ namespace DotNetNuke.Common.Utilities
         /// <returns>An empty string if succeeded or a list of errors in case of failures.</returns>
         public static string DeleteFiles(Array arrPaths)
         {
-            var applicationStatusInfo = Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>();
+            var applicationStatusInfo = Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>();
             var strExceptions = string.Empty;
             for (var i = 0; i < arrPaths.Length; i++)
             {

--- a/DNN Platform/Library/Common/Utilities/UrlUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/UrlUtils.cs
@@ -19,7 +19,7 @@ namespace DotNetNuke.Common.Utilities
 
     public class UrlUtils
     {
-        private static readonly INavigationManager NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        private static INavigationManager NavigationManager => Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
 
         public static string Combine(string baseUrl, string relativeUrl)
         {

--- a/DNN Platform/Library/Entities/EventManager.cs
+++ b/DNN Platform/Library/Entities/EventManager.cs
@@ -36,7 +36,7 @@ namespace DotNetNuke.Entities
         /// <param name="eventLogger">An event logger.</param>
         public EventManager(IEventLogger eventLogger)
         {
-            this.eventLogger = eventLogger ?? Globals.DependencyProvider.GetRequiredService<IEventLogger>();
+            this.eventLogger = eventLogger ?? Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>();
 
             foreach (var handler in EventHandlersContainer<IFileEventHandlers>.Instance.EventHandlers)
             {
@@ -645,7 +645,7 @@ namespace DotNetNuke.Entities
         /// <inheritdoc/>
         protected override Func<IEventManager> GetFactory()
         {
-            return () => new EventManager(Globals.DependencyProvider.GetRequiredService<IEventLogger>());
+            return () => new EventManager(Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>());
         }
 
         private void AddLog(IFileInfo fileInfo, int userId, EventLogType logType)

--- a/DNN Platform/Library/Entities/Icons/IconController.cs
+++ b/DNN Platform/Library/Entities/Icons/IconController.cs
@@ -94,7 +94,7 @@ namespace DotNetNuke.Entities.Icons
         public static string[] GetIconSets()
         {
             return GetIconSets(
-                Globals.DependencyProvider.GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
+                Globals.GetCurrentServiceProvider().GetService<IApplicationStatusInfo>() ?? new ApplicationStatusInfo(new Application()));
         }
 
         public static string[] GetIconSets(IApplicationStatusInfo appStatus)

--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -42,8 +42,7 @@ namespace DotNetNuke.Entities.Modules.Settings
             }
         }
 
-        private static ISerializationManager SerializationManager =>
-    Globals.DependencyProvider.GetRequiredService<ISerializationManager>();
+        private static ISerializationManager SerializationManager => Globals.GetCurrentServiceProvider().GetRequiredService<ISerializationManager>();
 
         private IList<ParameterMapping> Mapping { get; }
 
@@ -111,7 +110,7 @@ namespace DotNetNuke.Entities.Modules.Settings
 
         private void SaveSettings(int portalId, ModuleInfo moduleContext, T settings)
         {
-            var hostSettingsService = Globals.DependencyProvider.GetRequiredService<Abstractions.Application.IHostSettingsService>();
+            var hostSettingsService = Globals.GetCurrentServiceProvider().GetRequiredService<Abstractions.Application.IHostSettingsService>();
 
             this.Mapping.ForEach(mapping =>
             {
@@ -172,7 +171,7 @@ namespace DotNetNuke.Entities.Modules.Settings
             var ctlModule = (ModuleInfo)args.ParamList[0];
             var portalId = ctlModule == null ? (int)args.ParamList[1] : ctlModule.PortalID;
             var settings = new T();
-            var hostSettings = Globals.DependencyProvider.GetRequiredService<Abstractions.Application.IHostSettingsService>().GetSettings();
+            var hostSettings = Globals.GetCurrentServiceProvider().GetRequiredService<Abstractions.Application.IHostSettingsService>().GetSettings();
 
             this.Mapping.ForEach(mapping =>
             {

--- a/DNN Platform/Library/Entities/Users/Social/RelationshipControllerImpl.cs
+++ b/DNN Platform/Library/Entities/Users/Social/RelationshipControllerImpl.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Entities.Users.Social
 
         /// <summary>Initializes a new instance of the <see cref="RelationshipControllerImpl"/> class.</summary>
         public RelationshipControllerImpl()
-            : this(DataService.Instance, Globals.DependencyProvider.GetRequiredService<IEventLogger>())
+            : this(DataService.Instance, Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>())
         {
         }
 

--- a/DNN Platform/Library/Framework/Reflection.cs
+++ b/DNN Platform/Library/Framework/Reflection.cs
@@ -179,7 +179,7 @@ namespace DotNetNuke.Framework
             bool fixAssemblyName)
         {
             return CreateObject(
-                Globals.DependencyProvider,
+                Globals.GetCurrentServiceProvider(),
                 objectProviderType,
                 objectProviderName,
                 objectNamespace,
@@ -283,7 +283,7 @@ namespace DotNetNuke.Framework
         [Obsolete("Deprecated in DotNetNuke 9.11.3. Please use overload with IServiceProvider. Scheduled removal in v11.0.0.")]
         public static object CreateObject(string typeName, string cacheKey, bool useCache)
         {
-            return CreateObject(Globals.DependencyProvider, typeName, cacheKey, useCache);
+            return CreateObject(Globals.GetCurrentServiceProvider(), typeName, cacheKey, useCache);
         }
 
         /// <summary>Creates an object.</summary>
@@ -305,7 +305,7 @@ namespace DotNetNuke.Framework
         [Obsolete("Deprecated in DotNetNuke 9.11.3. Please use overload with IServiceProvider. Scheduled removal in v11.0.0.")]
         public static T CreateObject<T>()
         {
-            return CreateObject<T>(Globals.DependencyProvider);
+            return CreateObject<T>(Globals.GetCurrentServiceProvider());
         }
 
         /// <summary>Creates an object.</summary>
@@ -331,7 +331,7 @@ namespace DotNetNuke.Framework
         [Obsolete("Deprecated in DotNetNuke 9.11.3. Please use overload with IServiceProvider. Scheduled removal in v11.0.0.")]
         public static object CreateObject(Type type)
         {
-            return CreateObject(Globals.DependencyProvider, type);
+            return CreateObject(Globals.GetCurrentServiceProvider(), type);
         }
 
         /// <summary>Creates an object.</summary>

--- a/DNN Platform/Library/Obsolete/EventLogController.cs
+++ b/DNN Platform/Library/Obsolete/EventLogController.cs
@@ -189,7 +189,7 @@ namespace DotNetNuke.Services.Log.EventLog
 
         [Obsolete("Deprecated in 9.8.0. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.Logging.IEventLogger' instead. Scheduled for removal in v11.0.0.")]
         public static void AddSettingLog(EventLogType logTypeKey, string idFieldName, int idValue, string settingName, string settingValue, int userId) =>
-            Globals.DependencyProvider.GetRequiredService<IEventLogger>()
+            Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>()
                 .AddSettingLog((Abstractions.Logging.EventLogType)logTypeKey, idFieldName, idValue, settingName, settingValue, userId);
 
         /// <inheritdoc/>

--- a/DNN Platform/Library/Obsolete/HostController.cs
+++ b/DNN Platform/Library/Obsolete/HostController.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Entities.Controllers
         {
             get
             {
-                var newHostController = Globals.DependencyProvider.GetRequiredService<IHostSettingsService>();
+                var newHostController = Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettingsService>();
                 return newHostController is IHostController castedController ? castedController : new HostController();
             }
         }

--- a/DNN Platform/Library/Obsolete/PortalAliasController.cs
+++ b/DNN Platform/Library/Obsolete/PortalAliasController.cs
@@ -29,7 +29,7 @@ namespace DotNetNuke.Entities.Portals
         {
             get
             {
-                var portalAliasSettingsService = Globals.DependencyProvider.GetRequiredService<IPortalAliasService>();
+                var portalAliasSettingsService = Globals.GetCurrentServiceProvider().GetRequiredService<IPortalAliasService>();
                 return portalAliasSettingsService is IPortalAliasController castedController ? castedController : new PortalAliasController();
             }
         }

--- a/DNN Platform/Library/Obsolete/SerializationController.cs
+++ b/DNN Platform/Library/Obsolete/SerializationController.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.Entities.Modules.Settings
     public partial class SerializationController
     {
         private static ISerializationManager SerializationManager =>
-            Globals.DependencyProvider.GetRequiredService<ISerializationManager>();
+            Globals.GetCurrentServiceProvider().GetRequiredService<ISerializationManager>();
 
         [Obsolete("Deprecated in 9.8.0. Use Dependency Injection to resolve 'DotNetNuke.Abstractions.ISerializationManager' instead. Scheduled for removal in v11.0.0.")]
         public static string SerializeProperty<T>(T myObject, PropertyInfo property) =>

--- a/DNN Platform/Library/Prompt/CommandRepository.cs
+++ b/DNN Platform/Library/Prompt/CommandRepository.cs
@@ -33,7 +33,7 @@ namespace DotNetNuke.Prompt
         /// <param name="serviceScopeFactory">The service scope factory.</param>
         public CommandRepository(IServiceScopeFactory serviceScopeFactory)
         {
-            this.serviceScopeFactory = serviceScopeFactory ?? Globals.DependencyProvider.GetRequiredService<IServiceScopeFactory>();
+            this.serviceScopeFactory = serviceScopeFactory ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServiceScopeFactory>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Library/Prompt/ConsoleCommand.cs
+++ b/DNN Platform/Library/Prompt/ConsoleCommand.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.Prompt
         protected IDictionary<string, string> Flags { get; private set; }
 
         private static ISerializationManager SerializationManager =>
-            Common.Globals.DependencyProvider.GetRequiredService<ISerializationManager>();
+            Common.Globals.GetCurrentServiceProvider().GetRequiredService<ISerializationManager>();
 
         /// <inheritdoc/>
         public virtual void Initialize(string[] args, IPortalSettings portalSettings, IUserInfo userInfo, int activeTabId)

--- a/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationConfigBase.cs
@@ -32,6 +32,6 @@ namespace DotNetNuke.Services.Authentication
         public int PortalID { get; set; }
 
         /// <summary>Gets the Dependency Provider to resolve registered services with the container.</summary>
-        protected IServiceProvider DependencyProvider => Globals.DependencyProvider;
+        protected IServiceProvider DependencyProvider => Globals.GetCurrentServiceProvider();
     }
 }

--- a/DNN Platform/Library/Services/Authentication/AuthenticationLogoffBase.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationLogoffBase.cs
@@ -18,7 +18,6 @@ namespace DotNetNuke.Services.Authentication
         /// <summary>Initializes a new instance of the <see cref="AuthenticationLogoffBase"/> class.</summary>
         public AuthenticationLogoffBase()
         {
-            this.DependencyProvider = Globals.DependencyProvider;
         }
 
         /// <summary>Fires when a LogOff occurs.</summary>
@@ -37,7 +36,7 @@ namespace DotNetNuke.Services.Authentication
         /// <value>
         /// The Dependency Service.
         /// </value>
-        protected new IServiceProvider DependencyProvider { get; }
+        protected new IServiceProvider DependencyProvider => Globals.GetCurrentServiceProvider();
 
         /// <summary>Handles the <see cref="LogOff"/> event.</summary>
         /// <param name="a">The event arguments.</param>

--- a/DNN Platform/Library/Services/Connections/ConnectionsController.cs
+++ b/DNN Platform/Library/Services/Connections/ConnectionsController.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Services.Connections
         /// <summary>Initializes a new instance of the <see cref="ConnectionsController"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IConnectionsManager. Scheduled removal in v12.0.0.")]
         public ConnectionsController()
-            : this(Globals.DependencyProvider, null)
+            : this(Globals.GetCurrentServiceProvider(), null)
         {
         }
 

--- a/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
@@ -52,7 +52,7 @@ namespace DotNetNuke.Services.GeneratedImage
         /// <summary>Initializes a new instance of the <see cref="DnnImageHandler"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public DnnImageHandler()
-            : this(HttpContextSource.Current.GetScope().ServiceProvider, null)
+            : this(Globals.GetCurrentServiceProvider(), null)
         {
         }
 

--- a/DNN Platform/Library/Services/Installer/Installers/CleanupInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/CleanupInstaller.cs
@@ -32,8 +32,8 @@ namespace DotNetNuke.Services.Installer.Installers
         /// <summary>Initializes a new instance of the <see cref="CleanupInstaller"/> class.</summary>
         public CleanupInstaller()
             : this(
-                Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>(),
-                Globals.DependencyProvider.GetRequiredService<IFileSystemUtils>())
+                Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>(),
+                Globals.GetCurrentServiceProvider().GetRequiredService<IFileSystemUtils>())
         {
         }
 

--- a/DNN Platform/Library/Services/Installer/Writers/PackageWriterBase.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/PackageWriterBase.cs
@@ -40,13 +40,13 @@ namespace DotNetNuke.Services.Installer.Writers
         {
             this.package = package;
             this.package.AttachInstallerInfo(new InstallerInfo());
-            this.applicationStatusInfo = Common.Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>();
+            this.applicationStatusInfo = Common.Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>();
         }
 
         /// <summary>Initializes a new instance of the <see cref="PackageWriterBase"/> class.</summary>
         protected PackageWriterBase()
         {
-            this.applicationStatusInfo = Common.Globals.DependencyProvider.GetRequiredService<IApplicationStatusInfo>();
+            this.applicationStatusInfo = Common.Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>();
         }
 
         /// <summary>Gets a Dictionary of AppCodeFiles that should be included in the Package.</summary>

--- a/DNN Platform/Library/UI/Modules/ModuleHost.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleHost.cs
@@ -35,9 +35,6 @@ namespace DotNetNuke.UI.Modules
 
     using Globals = DotNetNuke.Common.Globals;
 
-    /// Project  : DotNetNuke
-    /// Namespace: DotNetNuke.UI.Modules
-    /// Class    : ModuleHost
     /// <summary>ModuleHost hosts a Module Control (or its cached Content).</summary>
     public sealed class ModuleHost : Panel
     {
@@ -51,7 +48,7 @@ namespace DotNetNuke.UI.Modules
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private readonly ModuleInfo moduleConfiguration;
-        private readonly IModuleControlPipeline moduleControlPipeline = Globals.DependencyProvider.GetRequiredService<IModuleControlPipeline>();
+        private readonly IModuleControlPipeline moduleControlPipeline = Globals.GetCurrentServiceProvider().GetRequiredService<IModuleControlPipeline>();
         private Control control;
         private bool isCached;
 

--- a/DNN Platform/Library/UI/Modules/ProfileModuleUserControlBase.cs
+++ b/DNN Platform/Library/UI/Modules/ProfileModuleUserControlBase.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke.UI.Modules
         /// <summary>Initializes a new instance of the <see cref="ProfileModuleUserControlBase"/> class.</summary>
         public ProfileModuleUserControlBase()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Library/UI/Skins/Skin.cs
+++ b/DNN Platform/Library/UI/Skins/Skin.cs
@@ -71,10 +71,19 @@ namespace DotNetNuke.UI.Skins
         private Dictionary<string, Pane> panes;
 
         /// <summary>Initializes a new instance of the <see cref="Skin"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public Skin()
+            : this(null, null)
         {
-            this.ModuleControlPipeline = Globals.DependencyProvider.GetRequiredService<IModuleControlPipeline>();
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Skin"/> class.</summary>
+        /// <param name="moduleControlPipeline">The module control pipeline.</param>
+        /// <param name="navigationManager">The navigation manager.</param>
+        public Skin(IModuleControlPipeline moduleControlPipeline, INavigationManager navigationManager)
+        {
+            this.ModuleControlPipeline = moduleControlPipeline ?? Globals.GetCurrentServiceProvider().GetRequiredService<IModuleControlPipeline>();
+            this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <summary>Gets a Dictionary of Panes.</summary>

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/CollectionEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/CollectionEditorControl.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="CollectionEditorControl"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public CollectionEditorControl()
-            : this(HttpContextSource.Current?.GetScope()?.ServiceProvider ?? Globals.DependencyProvider)
+            : this(Globals.GetCurrentServiceProvider())
         {
         }
 

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/EditControlFactory.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/EditControlFactory.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.UI.WebControls
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public static EditControl CreateEditControl(EditorInfo editorInfo)
         {
-            return CreateEditControl(Globals.DependencyProvider, editorInfo);
+            return CreateEditControl(Globals.GetCurrentServiceProvider(), editorInfo);
         }
 
         /// <summary>CreateEditControl creates the appropriate Control based on the EditorField or TypeDataField. </summary>

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/FieldEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/FieldEditorControl.cs
@@ -68,7 +68,7 @@ namespace DotNetNuke.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="FieldEditorControl"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public FieldEditorControl()
-            : this(HttpContextSource.Current?.GetScope()?.ServiceProvider ?? Globals.DependencyProvider)
+            : this(Globals.GetCurrentServiceProvider())
         {
         }
 

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/ProfileEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/ProfileEditorControl.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="ProfileEditorControl"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public ProfileEditorControl()
-            : this(HttpContextSource.Current?.GetScope()?.ServiceProvider ?? Globals.DependencyProvider)
+            : this(Globals.GetCurrentServiceProvider())
         {
         }
 

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/PropertyEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/PropertyEditorControl.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="PropertyEditorControl"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public PropertyEditorControl()
-            : this(HttpContextSource.Current?.GetScope()?.ServiceProvider ?? Globals.DependencyProvider)
+            : this(Globals.GetCurrentServiceProvider())
         {
         }
 

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/SettingsEditorControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/SettingsEditorControl.cs
@@ -19,7 +19,7 @@ namespace DotNetNuke.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="SettingsEditorControl"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IServiceProvider. Scheduled removal in v12.0.0.")]
         public SettingsEditorControl()
-            : this(HttpContextSource.Current?.GetScope()?.ServiceProvider ?? Globals.DependencyProvider)
+            : this(Globals.GetCurrentServiceProvider())
         {
         }
 

--- a/DNN Platform/Modules/DDRMenu/DDRMenuNavigationProvider.cs
+++ b/DNN Platform/Modules/DDRMenu/DDRMenuNavigationProvider.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.Web.DDRMenu
         /// <param name="localiser">The localizer.</param>
         public DDRMenuNavigationProvider(ILocaliser localiser)
         {
-            this.localiser = localiser ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<ILocaliser>() ?? Globals.DependencyProvider.GetRequiredService<ILocaliser>();
+            this.localiser = localiser ?? Globals.GetCurrentServiceProvider().GetRequiredService<ILocaliser>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Modules/DDRMenu/DNNAbstract.cs
+++ b/DNN Platform/Modules/DDRMenu/DNNAbstract.cs
@@ -26,10 +26,10 @@ namespace DotNetNuke.Web.DDRMenu
         public static string GetLoginUrl()
         {
             var request = HttpContext.Current.Request;
-
             if (request.IsAuthenticated)
             {
-                return Globals.DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL(PortalSettings.Current.ActiveTab.TabID, "Logoff");
+                var navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
+                return navigationManager.NavigateURL(PortalSettings.Current.ActiveTab.TabID, "Logoff");
             }
 
             var returnUrl = HttpContext.Current.Request.RawUrl;
@@ -53,7 +53,8 @@ namespace DotNetNuke.Web.DDRMenu
             {
                 if (portalSettings.UserRegistration != (int)Globals.PortalRegistrationType.NoRegistration)
                 {
-                    return Globals.RegisterURL(HttpUtility.UrlEncode(Globals.DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL()), Null.NullString);
+                    var navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
+                    return Globals.RegisterURL(HttpUtility.UrlEncode(navigationManager.NavigateURL()), Null.NullString);
                 }
             }
             else

--- a/DNN Platform/Modules/DDRMenu/Localisation/Localiser.cs
+++ b/DNN Platform/Modules/DDRMenu/Localisation/Localiser.cs
@@ -37,8 +37,8 @@ namespace DotNetNuke.Web.DDRMenu.Localisation
         /// <param name="portalController">The portal controller.</param>
         public Localiser(IEnumerable<ILocalisation> localizations, IPortalController portalController)
         {
-            this.localizations = localizations ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetServices<ILocalisation>() ?? Globals.DependencyProvider.GetServices<ILocalisation>();
-            this.portalController = portalController ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<IPortalController>() ?? Globals.DependencyProvider.GetRequiredService<IPortalController>();
+            this.localizations = localizations ?? Globals.GetCurrentServiceProvider().GetServices<ILocalisation>();
+            this.portalController = portalController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IPortalController>();
         }
 
         private ILocalisation LocalisationApi

--- a/DNN Platform/Modules/DDRMenu/MenuBase.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuBase.cs
@@ -54,7 +54,7 @@ namespace DotNetNuke.Web.DDRMenu
         /// <param name="localiser">The tab localizer.</param>
         public MenuBase(ILocaliser localiser)
         {
-            this.localiser = localiser ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<ILocaliser>() ?? Globals.DependencyProvider.GetRequiredService<ILocaliser>();
+            this.localiser = localiser ?? Globals.GetCurrentServiceProvider().GetRequiredService<ILocaliser>();
         }
 
         /// <summary>Gets or sets the template definition.</summary>
@@ -86,7 +86,7 @@ namespace DotNetNuke.Web.DDRMenu
         public static MenuBase Instantiate(string menuStyle)
         {
             return Instantiate(
-                HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<ILocaliser>() ?? Globals.DependencyProvider.GetRequiredService<ILocaliser>(),
+                Globals.GetCurrentServiceProvider().GetRequiredService<ILocaliser>(),
                 menuStyle);
         }
 

--- a/DNN Platform/Modules/DDRMenu/MenuView.ascx.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuView.ascx.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Web.DDRMenu
         /// <param name="localiser">The tab localizer.</param>
         public MenuView(ILocaliser localiser)
         {
-            this.localiser = localiser ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<ILocaliser>() ?? Globals.DependencyProvider.GetRequiredService<ILocaliser>();
+            this.localiser = localiser ?? Globals.GetCurrentServiceProvider().GetRequiredService<ILocaliser>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Modules/DDRMenu/SkinObject.cs
+++ b/DNN Platform/Modules/DDRMenu/SkinObject.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.Web.DDRMenu
         /// <param name="localiser">The tab localizer.</param>
         public SkinObject(ILocaliser localiser)
         {
-            this.localiser = localiser ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<ILocaliser>() ?? Globals.DependencyProvider.GetRequiredService<ILocaliser>();
+            this.localiser = localiser ?? Globals.GetCurrentServiceProvider().GetRequiredService<ILocaliser>();
         }
 
         public string MenuStyle { get; set; }

--- a/DNN Platform/Modules/DnnExportImport/Components/Controllers/BaseController.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Controllers/BaseController.cs
@@ -56,7 +56,7 @@ namespace Dnn.ExportImport.Components.Controllers
         /// <param name="portableServices">The portable services.</param>
         public BaseController(IEnumerable<BasePortableService> portableServices)
         {
-            this.PortableServices = portableServices ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetServices<BasePortableService>() ?? Globals.DependencyProvider.GetServices<BasePortableService>();
+            this.PortableServices = portableServices ?? Globals.GetCurrentServiceProvider().GetServices<BasePortableService>();
         }
 
         protected IEnumerable<BasePortableService> PortableServices { get; }

--- a/DNN Platform/Modules/DnnExportImport/Components/Engines/ExportImportEngine.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Engines/ExportImportEngine.cs
@@ -85,9 +85,8 @@ namespace Dnn.ExportImport.Components.Engines
         /// <param name="exportController">The export controller.</param>
         public ExportImportEngine(IEnumerable<BasePortableService> portableServices, ExportController exportController)
         {
-            this.exportController = exportController ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<ExportController>() ?? Globals.DependencyProvider.GetRequiredService<ExportController>();
-            portableServices ??= HttpContextSource.Current?.GetScope()?.ServiceProvider.GetServices<BasePortableService>() ?? Globals.DependencyProvider.GetServices<BasePortableService>();
-            this.portableServices = portableServices.ToList();
+            this.exportController = exportController ?? Globals.GetCurrentServiceProvider().GetRequiredService<ExportController>();
+            this.portableServices = (portableServices ?? Globals.GetCurrentServiceProvider().GetServices<BasePortableService>()).ToList();
         }
 
         private static string[] NotAllowedCategoriesInRequestArray => new[]

--- a/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
+++ b/DNN Platform/Modules/DnnExportImport/Components/Services/PagesExportService.cs
@@ -72,7 +72,7 @@ namespace Dnn.ExportImport.Components.Services
         /// <param name="businessControllerProvider">The business controller provider.</param>
         public PagesExportService(IBusinessControllerProvider businessControllerProvider)
         {
-            this.businessControllerProvider = businessControllerProvider ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<IBusinessControllerProvider>() ?? Globals.DependencyProvider.GetRequiredService<IBusinessControllerProvider>();
+            this.businessControllerProvider = businessControllerProvider ?? Globals.GetCurrentServiceProvider().GetRequiredService<IBusinessControllerProvider>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Modules/Groups/Components/GroupViewParser.cs
+++ b/DNN Platform/Modules/Groups/Components/GroupViewParser.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Modules.Groups.Components
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Web;
 
@@ -32,7 +29,7 @@ namespace DotNetNuke.Modules.Groups.Components
             this.CurrentUser = currentUser;
             this.Template = template;
             this.GroupViewTabId = groupViewTabId;
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string Template { get; set; }

--- a/DNN Platform/Modules/Groups/Components/Utilities.cs
+++ b/DNN Platform/Modules/Groups/Components/Utilities.cs
@@ -16,7 +16,8 @@ namespace DotNetNuke.Modules.Groups
     {
         public static string NavigateUrl(int tabId, string[] @params)
         {
-            return Globals.DependencyProvider.GetRequiredService<INavigationManager>()?.NavigateURL(tabId, string.Empty, @params);
+            var navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
+            return navigationManager.NavigateURL(tabId, string.Empty, @params);
         }
 
         public static string[] AddParams(string param, string[] currParams)

--- a/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
+++ b/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
@@ -42,7 +42,7 @@ namespace DotNetNuke.Modules.Html
 
         /// <summary>Initializes a new instance of the <see cref="HtmlTextController"/> class.</summary>
         public HtmlTextController()
-            : this(Globals.DependencyProvider.GetRequiredService<INavigationManager>())
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>())
         {
         }
 

--- a/DNN Platform/Modules/Journal/Components/FeatureController.cs
+++ b/DNN Platform/Modules/Journal/Components/FeatureController.cs
@@ -27,9 +27,17 @@ namespace DotNetNuke.Modules.Journal.Components
     public class FeatureController : ModuleSearchBase, IModuleSearchResultController
     {
         /// <summary>Initializes a new instance of the <see cref="FeatureController"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public FeatureController()
+            : this(null)
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="FeatureController"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        public FeatureController(INavigationManager navigationManager)
+        {
+            this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/DNN Platform/Modules/Journal/Components/JournalParser.cs
+++ b/DNN Platform/Modules/Journal/Components/JournalParser.cs
@@ -42,9 +42,25 @@ namespace DotNetNuke.Modules.Journal.Components
         /// <param name="profileId"></param>
         /// <param name="socialGroupId"></param>
         /// <param name="userInfo"></param>
-        public JournalParser(PortalSettings portalSettings, int moduleId, int profileId, int socialGroupId, UserInfo userInfo)
+        public JournalParser(
+            PortalSettings portalSettings,
+            int moduleId,
+            int profileId,
+            int socialGroupId,
+            UserInfo userInfo)
+            : this(null, portalSettings, moduleId, profileId, socialGroupId, userInfo)
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="JournalParser"/> class.</summary>
+        /// <param name="portalSettings"></param>
+        /// <param name="moduleId"></param>
+        /// <param name="profileId"></param>
+        /// <param name="socialGroupId"></param>
+        /// <param name="userInfo"></param>
+        public JournalParser(INavigationManager navigationManager, PortalSettings portalSettings, int moduleId, int profileId, int socialGroupId, UserInfo userInfo)
+        {
+            this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.PortalSettings = portalSettings;
             this.ModuleId = moduleId;
             this.ProfileId = profileId;

--- a/DNN Platform/Modules/RazorHost/AddScript.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/AddScript.ascx.cs
@@ -21,9 +21,17 @@ namespace DotNetNuke.Modules.RazorHost
         private string razorScriptFileFormatString = "~/DesktopModules/RazorModules/RazorHost/Scripts/{0}";
 
         /// <summary>Initializes a new instance of the <see cref="AddScript"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public AddScript()
+            : this(null)
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="AddScript"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        public AddScript(INavigationManager navigationManager)
+        {
+            this.navigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Modules/RazorHost/CreateModule.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/CreateModule.ascx.cs
@@ -34,9 +34,17 @@ namespace DotNetNuke.Modules.RazorHost
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
         /// <summary>Initializes a new instance of the <see cref="CreateModule"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public CreateModule()
+            : this(null)
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="CreateModule"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        public CreateModule(INavigationManager navigationManager)
+        {
+            this.navigationManager = navigationManager ?? Globals.DependencyProvider.GetRequiredService<INavigationManager>();
         }
 
         /// <summary>Gets the module control file name without it's extension.</summary>

--- a/DNN Platform/Modules/RazorHost/EditScript.ascx.cs
+++ b/DNN Platform/Modules/RazorHost/EditScript.ascx.cs
@@ -25,9 +25,17 @@ namespace DotNetNuke.Modules.RazorHost
         private string razorScriptFolder = "~/DesktopModules/RazorModules/RazorHost/Scripts/";
 
         /// <summary>Initializes a new instance of the <see cref="EditScript"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public EditScript()
+            : this(null)
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="EditScript"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        public EditScript(INavigationManager navigationManager)
+        {
+            this.navigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <summary>Gets the razor script file.</summary>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FolderManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FolderManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Providers.Folder
 {
     using System;
@@ -9,9 +8,6 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using System.Data;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Services.FileSystem;
@@ -19,6 +15,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Tests.Core.Providers.Builders;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +41,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         private Mock<IPathUtils> pathUtils;
         private Mock<IUserSecurityController> mockUserSecurityController;
         private Mock<IFileDeletionController> mockFileDeletionController;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
@@ -73,13 +71,17 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
 
             this.folderInfo = new Mock<IFolderInfo>();
 
-            var serviceCollection = new ServiceCollection();
-            var mockStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.None);
-
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockFolder.Object);
+                    services.AddSingleton(this.mockData.Object);
+                    services.AddSingleton(this.folderMappingController.Object);
+                    services.AddSingleton(this.cbo.Object);
+                    services.AddSingleton(this.pathUtils.Object);
+                    services.AddSingleton(this.mockUserSecurityController.Object);
+                    services.AddSingleton(this.mockFileDeletionController.Object);
+                });
         }
 
         [TearDown]
@@ -91,7 +93,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             CBO.ClearInstance();
             FileDeletionController.ClearInstance();
             MockComponentProvider.ResetContainer();
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Providers.Folder
 {
     using System;
@@ -9,9 +8,6 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using System.IO;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
@@ -21,6 +17,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using DotNetNuke.Services.FileSystem.Internal;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -32,77 +29,68 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     [TestFixture]
     public class StandardFolderProviderTests
     {
-        private StandardFolderProvider _sfp;
-        private Mock<IFolderInfo> _folderInfo;
-        private Mock<IFileInfo> _fileInfo;
-        private Mock<IFile> _fileWrapper;
-        private Mock<IDirectory> _directoryWrapper;
-        private Mock<IFolderManager> _folderManager;
-        private Mock<IFileManager> _fileManager;
-        private Mock<IPathUtils> _pathUtils;
-        private Mock<IPortalController> _portalControllerMock;
-        private Mock<CryptographyProvider> _cryptographyProviderMock;
-        private Mock<ILocaleController> _localeControllerMock;
-
-        [OneTimeSetUp]
-        public void FixtureSetup()
-        {
-            var serviceCollection = new ServiceCollection();
-
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-
-            var navigationManagerMock = new Mock<INavigationManager>();
-
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => navigationManagerMock.Object);
-
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-        }
-
-        [OneTimeTearDown]
-        public void FixtureTearDown()
-        {
-            Globals.DependencyProvider = null;
-        }
+        private StandardFolderProvider sfp;
+        private Mock<IFolderInfo> folderInfo;
+        private Mock<IFileInfo> fileInfo;
+        private Mock<IFile> fileWrapper;
+        private Mock<IDirectory> directoryWrapper;
+        private Mock<IFolderManager> folderManager;
+        private Mock<IFileManager> fileManager;
+        private Mock<IPathUtils> pathUtils;
+        private Mock<IPortalController> portalControllerMock;
+        private Mock<CryptographyProvider> cryptographyProviderMock;
+        private Mock<ILocaleController> localeControllerMock;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
         {
-            this._sfp = new StandardFolderProvider();
-            this._folderInfo = new Mock<IFolderInfo>();
-            this._fileInfo = new Mock<IFileInfo>();
-            this._fileWrapper = new Mock<IFile>();
-            this._directoryWrapper = new Mock<IDirectory>();
-            this._folderManager = new Mock<IFolderManager>();
-            this._fileManager = new Mock<IFileManager>();
-            this._pathUtils = new Mock<IPathUtils>();
-            this._portalControllerMock = new Mock<IPortalController>();
-            this._portalControllerMock.Setup(p => p.GetPortalSettings(Constants.CONTENT_ValidPortalId))
+            this.sfp = new StandardFolderProvider();
+            this.folderInfo = new Mock<IFolderInfo>();
+            this.fileInfo = new Mock<IFileInfo>();
+            this.fileWrapper = new Mock<IFile>();
+            this.directoryWrapper = new Mock<IDirectory>();
+            this.folderManager = new Mock<IFolderManager>();
+            this.fileManager = new Mock<IFileManager>();
+            this.pathUtils = new Mock<IPathUtils>();
+            this.portalControllerMock = new Mock<IPortalController>();
+            this.portalControllerMock.Setup(p => p.GetPortalSettings(Constants.CONTENT_ValidPortalId))
                 .Returns(this.GetPortalSettingsDictionaryMock());
-            this._portalControllerMock.Setup(p => p.GetCurrentPortalSettings()).Returns(this.GetPortalSettingsMock());
-            this._cryptographyProviderMock = new Mock<CryptographyProvider>();
-            this._cryptographyProviderMock.Setup(c => c.EncryptParameter(It.IsAny<string>(), It.IsAny<string>()))
+            this.portalControllerMock.Setup(p => p.GetCurrentPortalSettings()).Returns(this.GetPortalSettingsMock());
+            this.cryptographyProviderMock = new Mock<CryptographyProvider>();
+            this.cryptographyProviderMock.Setup(c => c.EncryptParameter(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Guid.NewGuid().ToString("N"));
-            this._localeControllerMock = new Mock<ILocaleController>();
-            this._localeControllerMock.Setup(l => l.GetLocales(Constants.CONTENT_ValidPortalId)).Returns(new Dictionary<string, Locale>
+            this.localeControllerMock = new Mock<ILocaleController>();
+            this.localeControllerMock.Setup(l => l.GetLocales(Constants.CONTENT_ValidPortalId)).Returns(new Dictionary<string, Locale>
             {
                 { "en-us", new Locale() },
             });
 
-            FileWrapper.RegisterInstance(this._fileWrapper.Object);
-            DirectoryWrapper.RegisterInstance(this._directoryWrapper.Object);
-            FolderManager.RegisterInstance(this._folderManager.Object);
-            FileManager.RegisterInstance(this._fileManager.Object);
-            PathUtils.RegisterInstance(this._pathUtils.Object);
-            PortalController.SetTestableInstance(this._portalControllerMock.Object);
-            ComponentFactory.RegisterComponentInstance<CryptographyProvider>("CryptographyProviderMock", this._cryptographyProviderMock.Object);
-            LocaleController.RegisterInstance(this._localeControllerMock.Object);
+            FileWrapper.RegisterInstance(this.fileWrapper.Object);
+            DirectoryWrapper.RegisterInstance(this.directoryWrapper.Object);
+            FolderManager.RegisterInstance(this.folderManager.Object);
+            FileManager.RegisterInstance(this.fileManager.Object);
+            PathUtils.RegisterInstance(this.pathUtils.Object);
+            PortalController.SetTestableInstance(this.portalControllerMock.Object);
+            ComponentFactory.RegisterComponentInstance<CryptographyProvider>("CryptographyProviderMock", this.cryptographyProviderMock.Object);
+            LocaleController.RegisterInstance(this.localeControllerMock.Object);
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.folderManager.Object);
+                    services.AddSingleton(this.fileManager.Object);
+                    services.AddSingleton(this.pathUtils.Object);
+                    services.AddSingleton(this.portalControllerMock.Object);
+                    services.AddSingleton(this.cryptographyProviderMock.Object);
+                    services.AddSingleton(this.localeControllerMock.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
             TestableGlobals.ClearInstance();
             PortalController.ClearInstance();
@@ -113,7 +101,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.AddFile(null, Constants.FOLDER_ValidFileName, stream.Object));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.AddFile(null, Constants.FOLDER_ValidFileName, stream.Object));
         }
 
         [Test]
@@ -123,74 +111,74 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentException>(() => this._sfp.AddFile(this._folderInfo.Object, fileName, stream.Object));
+            Assert.Throws<ArgumentException>(() => this.sfp.AddFile(this.folderInfo.Object, fileName, stream.Object));
         }
 
         [Test]
         public void AddFile_Throws_On_Null_Content()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.AddFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.AddFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, null));
         }
 
         [Test]
         public void DeleteFile_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.DeleteFile(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.DeleteFile(null));
         }
 
         // [Test]
         // public void DeleteFile_Calls_FileWrapper_Delete_When_File_Exists()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
+        // fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
 
-        // _sfp.DeleteFile(_fileInfo.Object);
+        // sfp.DeleteFile(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
+        // fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
         // }
 
         // [Test]
         // public void DeleteFile_Does_Not_Call_FileWrapper_Delete_When_File_Does_Not_Exist()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
+        // fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
 
-        // _sfp.DeleteFile(_fileInfo.Object);
+        // sfp.DeleteFile(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Never());
+        // fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Never());
         // }
         [Test]
         public void ExistsFile_Throws_On_Null_Folder()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FileExists(null, Constants.FOLDER_ValidFileName));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FileExists(null, Constants.FOLDER_ValidFileName));
         }
 
         [Test]
         public void ExistsFile_Throws_On_Null_FileName()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FileExists(this._folderInfo.Object, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FileExists(this.folderInfo.Object, null));
         }
 
         [Test]
         public void ExistsFile_Calls_FileWrapper_Exists()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.FileExists(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            this.sfp.FileExists(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.Exists(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Exists(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         [Test]
         public void ExistsFile_Returns_True_When_File_Exists()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
 
-            var result = this._sfp.FileExists(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.FileExists(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             Assert.IsTrue(result);
         }
@@ -198,11 +186,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void ExistsFile_Returns_False_When_File_Does_Not_Exist()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
 
-            var result = this._sfp.FileExists(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.FileExists(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             Assert.IsFalse(result);
         }
@@ -210,7 +198,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void ExistsFolder_Throws_On_Null_FolderMapping()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FolderExists(Constants.FOLDER_ValidFolderPath, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FolderExists(Constants.FOLDER_ValidFolderPath, null));
         }
 
         [Test]
@@ -218,7 +206,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FolderExists(null, folderMapping));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FolderExists(null, folderMapping));
         }
 
         [Test]
@@ -226,11 +214,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
+            this.sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
 
-            this._directoryWrapper.Verify(dw => dw.Exists(Constants.FOLDER_ValidFolderPath), Times.Once());
+            this.directoryWrapper.Verify(dw => dw.Exists(Constants.FOLDER_ValidFolderPath), Times.Once());
         }
 
         [Test]
@@ -238,11 +226,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(true);
+            this.directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(true);
 
-            var result = this._sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
+            var result = this.sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
 
             Assert.IsTrue(result);
         }
@@ -252,11 +240,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(false);
+            this.directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(false);
 
-            var result = this._sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
+            var result = this.sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
 
             Assert.IsFalse(result);
         }
@@ -264,17 +252,17 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFileAttributes_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetFileAttributes(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetFileAttributes(null));
         }
 
         // [Test]
         // public void GetFileAttributes_Calls_FileWrapper_GetAttributes()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _sfp.GetFileAttributes(_fileInfo.Object);
+        // sfp.GetFileAttributes(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath), Times.Once());
+        // fileWrapper.Verify(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath), Times.Once());
         // }
 
         // [Test]
@@ -282,22 +270,22 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         // {
         //    var expectedFileAttributes = FileAttributes.Normal;
 
-        // _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        // fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Returns(expectedFileAttributes);
+        // fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Returns(expectedFileAttributes);
 
-        // var result = _sfp.GetFileAttributes(_fileInfo.Object);
+        // var result = sfp.GetFileAttributes(fileInfo.Object);
 
         // Assert.AreEqual(expectedFileAttributes, result);
         // }
         [Test]
         public void GetFileAttributes_Returns_Null_When_File_Does_Not_Exist()
         {
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-            this._fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
+            this.fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
 
-            var result = this._sfp.GetFileAttributes(this._fileInfo.Object);
+            var result = this.sfp.GetFileAttributes(this.fileInfo.Object);
 
             Assert.IsNull(result);
         }
@@ -305,29 +293,29 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFiles_Throws_On_Null_Folder()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetFiles(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetFiles(null));
         }
 
         [Test]
         public void GetFiles_Calls_DirectoryWrapper_GetFiles()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.GetFiles(this._folderInfo.Object);
+            this.sfp.GetFiles(this.folderInfo.Object);
 
-            this._directoryWrapper.Verify(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath));
+            this.directoryWrapper.Verify(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath));
         }
 
         [Test]
         public void GetFiles_Count_Equals_DirectoryWrapper_GetFiles_Count()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
             var filesReturned = new[] { string.Empty, string.Empty, string.Empty };
 
-            this._directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
+            this.directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
 
-            var files = this._sfp.GetFiles(this._folderInfo.Object);
+            var files = this.sfp.GetFiles(this.folderInfo.Object);
 
             Assert.AreEqual(filesReturned.Length, files.Length);
         }
@@ -335,14 +323,14 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFiles_Returns_Valid_FileNames_When_Folder_Contains_Files()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
             var filesReturned = new[] { "C:\\folder\\file1.txt", "C:\\folder\\file2.txt", "C:\\folder\\file3.txt" };
             var expectedValues = new[] { "file1.txt", "file2.txt", "file3.txt" };
 
-            this._directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
+            this.directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
 
-            var files = this._sfp.GetFiles(this._folderInfo.Object);
+            var files = this.sfp.GetFiles(this.folderInfo.Object);
 
             CollectionAssert.AreEqual(expectedValues, files);
         }
@@ -350,23 +338,23 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFileStream_Throws_On_Null_Folder()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetFileStream(null, Constants.FOLDER_ValidFileName));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetFileStream(null, Constants.FOLDER_ValidFileName));
         }
 
         [Test]
         public void GetFileStream_Throws_On_Null_FileName()
         {
-            Assert.Throws<ArgumentException>(() => this._sfp.GetFileStream(this._folderInfo.Object, null));
+            Assert.Throws<ArgumentException>(() => this.sfp.GetFileStream(this.folderInfo.Object, null));
         }
 
         [Test]
         public void GetFileStream_Calls_FileWrapper_OpenRead()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.GetFileStream(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            this.sfp.GetFileStream(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         [Test]
@@ -375,11 +363,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var validFileBytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             var memoryStream = new MemoryStream(validFileBytes);
 
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Returns(memoryStream);
+            this.fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Returns(memoryStream);
 
-            var result = this._sfp.GetFileStream(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.GetFileStream(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             byte[] resultBytes;
             var buffer = new byte[16 * 1024];
@@ -400,11 +388,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFileStream_Returns_Null_When_File_Does_Not_Exist()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
+            this.fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
 
-            var result = this._sfp.GetFileStream(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.GetFileStream(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             Assert.IsNull(result);
         }
@@ -415,7 +403,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var iconControllerWrapper = new Mock<IIconController>();
             IconControllerWrapper.RegisterInstance(iconControllerWrapper.Object);
 
-            this._sfp.GetFolderProviderIconPath();
+            this.sfp.GetFolderProviderIconPath();
 
             iconControllerWrapper.Verify(icw => icw.IconURL("FolderStandard", "32x32"), Times.Once());
         }
@@ -423,17 +411,17 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetLastModificationTime_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetLastModificationTime(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetLastModificationTime(null));
         }
 
         // [Test]
         // public void GetLastModificationTime_Calls_FileWrapper_GetLastWriteTime()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _sfp.GetLastModificationTime(_fileInfo.Object);
+        // sfp.GetLastModificationTime(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath), Times.Once());
+        // fileWrapper.Verify(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath), Times.Once());
         // }
 
         // [Test]
@@ -441,11 +429,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         // {
         //    var expectedDate = DateTime.Now;
 
-        // _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        // fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Returns(expectedDate);
+        // fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Returns(expectedDate);
 
-        // var result = _sfp.GetLastModificationTime(_fileInfo.Object);
+        // var result = sfp.GetLastModificationTime(fileInfo.Object);
 
         // Assert.AreEqual(expectedDate, result);
         // }
@@ -454,11 +442,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var expectedDate = Null.NullDate;
 
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-            this._fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
+            this.fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
 
-            var result = this._sfp.GetLastModificationTime(this._fileInfo.Object);
+            var result = this.sfp.GetLastModificationTime(this.fileInfo.Object);
 
             Assert.AreEqual(expectedDate, result);
         }
@@ -466,7 +454,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetSubFolders_Throws_On_Null_FolderMapping()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderPath, null).ToList());
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderPath, null).ToList());
         }
 
         [Test]
@@ -474,7 +462,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetSubFolders(null, folderMapping).ToList());
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetSubFolders(null, folderMapping).ToList());
         }
 
         [Test]
@@ -482,11 +470,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
+            this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
 
-            this._directoryWrapper.Verify(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath), Times.Once());
+            this.directoryWrapper.Verify(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath), Times.Once());
         }
 
         [Test]
@@ -494,9 +482,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
 
             var subFolders = new[]
             {
@@ -504,9 +492,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
                 Constants.FOLDER_OtherValidSubFolderPath,
             };
 
-            this._directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
+            this.directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
 
-            var result = this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
+            var result = this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
 
             Assert.AreEqual(subFolders.Length, result.Count);
         }
@@ -522,9 +510,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
 
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
 
             var subFolders = new[]
             {
@@ -532,9 +520,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
                 Constants.FOLDER_OtherValidSubFolderPath,
             };
 
-            this._directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
+            this.directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
 
-            var result = this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
+            var result = this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
 
             CollectionAssert.AreEqual(expectedSubFolders, result);
         }
@@ -552,18 +540,18 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             sfp.Setup(x => x.GetPortalSettings(Constants.CONTENT_ValidPortalId))
                 .Returns(this.GetPortalSettingsMock());
 
-            this._fileInfo.Setup(x => x.FileName)
+            this.fileInfo.Setup(x => x.FileName)
                 .Returns(Constants.FOLDER_ValidFileName);
 
-            this._fileInfo.Setup(x => x.PortalId)
+            this.fileInfo.Setup(x => x.PortalId)
                 .Returns(Constants.CONTENT_ValidPortalId);
 
-            this._portalControllerMock.Setup(x => x.GetCurrentPortalSettings())
+            this.portalControllerMock.Setup(x => x.GetCurrentPortalSettings())
                 .Returns<PortalSettings>(null);
 
             // act
             string fileUrl = null;
-            TestDelegate action = () => fileUrl = sfp.Object.GetFileUrl(this._fileInfo.Object);
+            TestDelegate action = () => fileUrl = sfp.Object.GetFileUrl(this.fileInfo.Object);
 
             // assert
             Assert.DoesNotThrow(action);
@@ -581,11 +569,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
             var portalSettingsMock = this.GetPortalSettingsMock();
             sfp.Setup(fp => fp.GetPortalSettings(Constants.CONTENT_ValidPortalId)).Returns(portalSettingsMock);
-            this._fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
-            this._fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
+            this.fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
+            this.fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
 
             // Act
-            var fileUrl = sfp.Object.GetFileUrl(this._fileInfo.Object);
+            var fileUrl = sfp.Object.GetFileUrl(this.fileInfo.Object);
 
             // Assert
             Assert.IsFalse(fileUrl.ToLowerInvariant().Contains("linkclick"));
@@ -609,11 +597,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
             var portalSettingsMock = this.GetPortalSettingsMock();
             sfp.Setup(fp => fp.GetPortalSettings(Constants.CONTENT_ValidPortalId)).Returns(portalSettingsMock);
-            this._fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
-            this._fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
+            this.fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
+            this.fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
 
             // Act
-            var fileUrl = sfp.Object.GetFileUrl(this._fileInfo.Object);
+            var fileUrl = sfp.Object.GetFileUrl(this.fileInfo.Object);
 
             // Assert
             Assert.IsTrue(fileUrl.ToLowerInvariant().Contains("linkclick"));
@@ -622,18 +610,18 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void IsInSync_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.IsInSync(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.IsInSync(null));
         }
 
         [Test]
         public void IsInSync_Returns_True_When_File_Is_In_Sync()
         {
-            this._fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
+            this.fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
 
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
-            sfp.Setup(fp => fp.GetHash(this._fileInfo.Object)).Returns(Constants.FOLDER_UnmodifiedFileHash);
+            sfp.Setup(fp => fp.GetHash(this.fileInfo.Object)).Returns(Constants.FOLDER_UnmodifiedFileHash);
 
-            var result = sfp.Object.IsInSync(this._fileInfo.Object);
+            var result = sfp.Object.IsInSync(this.fileInfo.Object);
 
             Assert.IsTrue(result);
         }
@@ -641,12 +629,12 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void IsInSync_Returns_True_When_File_Is_Not_In_Sync()
         {
-            this._fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
+            this.fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
 
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
-            sfp.Setup(fp => fp.GetHash(this._fileInfo.Object)).Returns(Constants.FOLDER_ModifiedFileHash);
+            sfp.Setup(fp => fp.GetHash(this.fileInfo.Object)).Returns(Constants.FOLDER_ModifiedFileHash);
 
-            var result = sfp.Object.IsInSync(this._fileInfo.Object);
+            var result = sfp.Object.IsInSync(this.fileInfo.Object);
 
             Assert.IsTrue(result);
         }
@@ -654,7 +642,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void RenameFile_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.RenameFile(null, Constants.FOLDER_ValidFileName));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.RenameFile(null, Constants.FOLDER_ValidFileName));
         }
 
         [Test]
@@ -662,38 +650,38 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [TestCase("")]
         public void RenameFile_Throws_On_NullOrEmpty_NewFileName(string newFileName)
         {
-            Assert.Throws<ArgumentException>(() => this._sfp.RenameFile(this._fileInfo.Object, newFileName));
+            Assert.Throws<ArgumentException>(() => this.sfp.RenameFile(this.fileInfo.Object, newFileName));
         }
 
         [Test]
         public void RenameFile_Calls_FileWrapper_Move_When_FileNames_Are_Not_Equal()
         {
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
-            this._fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
-            this._fileInfo.Setup(fi => fi.FolderId).Returns(Constants.FOLDER_ValidFolderId);
-            this._folderManager.Setup(fm => fm.GetFolder(Constants.FOLDER_ValidFolderId)).Returns(this._folderInfo.Object);
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
+            this.fileInfo.Setup(fi => fi.FolderId).Returns(Constants.FOLDER_ValidFolderId);
+            this.folderManager.Setup(fm => fm.GetFolder(Constants.FOLDER_ValidFolderId)).Returns(this.folderInfo.Object);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.RenameFile(this._fileInfo.Object, Constants.FOLDER_OtherValidFileName);
+            this.sfp.RenameFile(this.fileInfo.Object, Constants.FOLDER_OtherValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.Move(Constants.FOLDER_ValidFilePath, Constants.FOLDER_OtherValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Move(Constants.FOLDER_ValidFilePath, Constants.FOLDER_OtherValidFilePath), Times.Once());
         }
 
         [Test]
         public void RenameFile_Does_Not_Call_FileWrapper_Move_When_FileNames_Are_Equal()
         {
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
-            this._fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
 
-            this._sfp.RenameFile(this._fileInfo.Object, Constants.FOLDER_ValidFileName);
+            this.sfp.RenameFile(this.fileInfo.Object, Constants.FOLDER_ValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.Move(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            this.fileWrapper.Verify(fw => fw.Move(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
         }
 
         [Test]
         public void SetFileAttributes_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.SetFileAttributes(null, FileAttributes.Archive));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.SetFileAttributes(null, FileAttributes.Archive));
         }
 
         // [Test]
@@ -701,16 +689,16 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         // {
         //    const FileAttributes validFileAttributes = FileAttributes.Archive;
 
-        // _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        // fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _sfp.SetFileAttributes(_fileInfo.Object, validFileAttributes);
+        // sfp.SetFileAttributes(fileInfo.Object, validFileAttributes);
 
-        // _fileWrapper.Verify(fw => fw.SetAttributes(Constants.FOLDER_ValidFilePath, validFileAttributes), Times.Once());
+        // fileWrapper.Verify(fw => fw.SetAttributes(Constants.FOLDER_ValidFilePath, validFileAttributes), Times.Once());
         // }
         [Test]
         public void SupportsFileAttributes_Returns_True()
         {
-            var result = this._sfp.SupportsFileAttributes();
+            var result = this.sfp.SupportsFileAttributes();
 
             Assert.IsTrue(result);
         }
@@ -720,7 +708,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.UpdateFile(null, Constants.FOLDER_ValidFileName, stream.Object));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.UpdateFile(null, Constants.FOLDER_ValidFileName, stream.Object));
         }
 
         [Test]
@@ -730,41 +718,41 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentException>(() => this._sfp.UpdateFile(this._folderInfo.Object, fileName, stream.Object));
+            Assert.Throws<ArgumentException>(() => this.sfp.UpdateFile(this.folderInfo.Object, fileName, stream.Object));
         }
 
         [Test]
         public void UpdateFile_Throws_On_Null_Content()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.UpdateFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.UpdateFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, null));
         }
 
         [Test]
         public void UpdateFile_Calls_FileWrapper_Delete_When_File_Exists()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
 
             var stream = new Mock<Stream>();
 
-            this._sfp.UpdateFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
+            this.sfp.UpdateFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
 
-            this._fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         [Test]
         public void UpdateFile_Calls_FileWrapper_Create()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
 
             var stream = new Mock<Stream>();
 
-            this._sfp.UpdateFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
+            this.sfp.UpdateFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
 
-            this._fileWrapper.Verify(fw => fw.Create(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Create(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         private Dictionary<string, string> GetPortalSettingsDictionaryMock()

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/CoreCryptographyProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/CoreCryptographyProviderTests.cs
@@ -1,34 +1,37 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
 {
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Services.Cryptography;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class CoreCryptographyProviderTests
     {
-        private static CryptographyProvider _provider;
+        private static CryptographyProvider provider;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddSingleton(Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
             ComponentFactory.InstallComponents(new ProviderInstaller("cryptography", typeof(CryptographyProvider), typeof(CoreCryptographyProvider)));
 
-            _provider = ComponentFactory.GetComponent<CryptographyProvider>("CoreCryptographyProvider");
+            this.serviceProvider = FakeServiceProvider.Setup(services => services.AddSingleton<CryptographyProvider, CoreCryptographyProvider>());
+
+            provider = ComponentFactory.GetComponent<CryptographyProvider>("CoreCryptographyProvider");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -40,7 +43,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var encryptedValue = _provider.EncryptParameter(message, encryptionKey);
+            var encryptedValue = provider.EncryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreNotEqual(message, encryptedValue);
@@ -55,7 +58,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var decryptedValue = _provider.DecryptParameter(message, encryptionKey);
+            var decryptedValue = provider.DecryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreEqual(string.Empty, decryptedValue);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/FipsCompilanceCryptographyProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/FipsCompilanceCryptographyProviderTests.cs
@@ -1,35 +1,37 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
 {
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Services.Cryptography;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class FipsCompilanceCryptographyProviderTests
     {
-        private static CryptographyProvider _provider;
+        private static CryptographyProvider provider;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddSingleton(Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.InstallComponents(new ProviderInstaller("cryptography", typeof(CryptographyProvider), typeof(FipsCompilanceCryptographyProvider)));
 
-            _provider = ComponentFactory.GetComponent<CryptographyProvider>("FipsCompilanceCryptographyProvider");
+            this.serviceProvider = FakeServiceProvider.Setup(services => services.AddSingleton<CryptographyProvider, FipsCompilanceCryptographyProvider>());
+
+            provider = ComponentFactory.GetComponent<CryptographyProvider>("FipsCompilanceCryptographyProvider");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -41,7 +43,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var encryptedValue = _provider.EncryptParameter(message, encryptionKey);
+            var encryptedValue = provider.EncryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreNotEqual(message, encryptedValue);
@@ -56,7 +58,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var decryptedValue = _provider.DecryptParameter(message, encryptionKey);
+            var decryptedValue = provider.DecryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreEqual(string.Empty, decryptedValue);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Installer/AssemblyInstallerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Installer/AssemblyInstallerTests.cs
@@ -3,40 +3,47 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Tests.Core.Services.Installer
 {
-    using System;
     using System.IO;
-    using System.Linq;
     using System.Xml.XPath;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Services.Installer;
     using DotNetNuke.Services.Installer.Installers;
     using DotNetNuke.Services.Installer.Packages;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     public class AssemblyInstallerTests : DnnUnitTest
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            var appInfo = new Mock<IApplicationStatusInfo>();
-            appInfo.SetupGet(app => app.Status).Returns(UpgradeStatus.None);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => appInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var dataProvider = MockComponentProvider.CreateDataProvider();
             dataProvider.Setup(p => p.UnRegisterAssembly(It.IsAny<int>(), It.IsAny<string>())).Returns(true);
 
-            LocalizationProvider.SetTestableInstance(new Mock<ILocalizationProvider>().Object);
+            LocalizationProvider.SetTestableInstance(Mock.Of<ILocalizationProvider>());
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(dataProvider.Object);
+                    services.AddSingleton(LocalizationProvider.Instance);
+                });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mobile/PreviewProfileControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mobile/PreviewProfileControllerTests.cs
@@ -1,20 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.Mobile
 {
     using System;
     using System.Collections.Generic;
     using System.Data;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Mobile;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +24,7 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
     public class PreviewProfileControllerTests
     {
         private Mock<DataProvider> dataProvider;
+        private FakeServiceProvider serviceProvider;
 
         private DataTable dtProfiles;
 
@@ -35,12 +32,6 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.Container = new SimpleContainer();
             this.dataProvider = MockComponentProvider.CreateDataProvider();
             this.dataProvider.Setup(d => d.GetProviderPath()).Returns(string.Empty);
@@ -119,12 +110,18 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
                                                                                                     this.dtProfiles.Rows.Remove(rows[0]);
                                                                                                 }
                                                                                             });
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.dataProvider.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
@@ -1,16 +1,21 @@
-﻿namespace DotNetNuke.Tests.Core.Services.Search.Internals
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Core.Services.Search.Internals
 {
     using System.Data;
 
-    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Application;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Services.Search.Internals;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
     using Lucene.Net.Analysis.Cz;
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     public class LuceneControllerImplTests
@@ -19,38 +24,49 @@
 
         public void GetCustomAnalyzer_WithTheProvidedAnalyzer_ReturnsTheAnalyzerCorrectly()
         {
-            // Arrange
-            const string HostSettingsTableName = "HostSettings";
-            const string SettingNameColumnName = "SettingName";
-            const string SettingValueColumnName = "SettingValue";
-            const string SettingIsSecureColumnName = "SettingIsSecure";
-            const string CustomAnalyzerCacheKeyName = "Search_CustomAnalyzer";
-            const string CzechAnalyzerTypeName = "Lucene.Net.Analysis.Cz.CzechAnalyzer, Lucene.Net.Contrib.Analyzers";
-            var services = new ServiceCollection();
-            var mockData = MockComponentProvider.CreateDataProvider();
-            var hostSettings = new DataTable(HostSettingsTableName);
-            var nameCol = hostSettings.Columns.Add(SettingNameColumnName);
-            hostSettings.Columns.Add(SettingValueColumnName);
-            hostSettings.Columns.Add(SettingIsSecureColumnName);
-            hostSettings.PrimaryKey = new[] { nameCol };
-            hostSettings.Rows.Add(CustomAnalyzerCacheKeyName, CzechAnalyzerTypeName, true);
-            mockData.Setup(c => c.GetHostSettings()).Returns(hostSettings.CreateDataReader());
-            var mockedApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockedApplicationStatusInfo.Setup(s => s.Status).Returns(UpgradeStatus.Install);
-            mockedApplicationStatusInfo.Setup(s => s.ApplicationMapPath).Returns(string.Empty);
-            services.AddTransient(container => Mock.Of<IHostSettingsService>());
-            services.AddTransient(container => mockedApplicationStatusInfo.Object);
-            services.AddTransient(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = services.BuildServiceProvider();
-            MockComponentProvider.CreateDataCacheProvider();
-            DataCache.ClearCache();
-            var luceneController = new LuceneControllerImpl();
+            FakeServiceProvider serviceProvider = null;
+            try
+            {
+                // Arrange
+                const string HostSettingsTableName = "HostSettings";
+                const string SettingNameColumnName = "SettingName";
+                const string SettingValueColumnName = "SettingValue";
+                const string SettingIsSecureColumnName = "SettingIsSecure";
+                const string CustomAnalyzerCacheKeyName = "Search_CustomAnalyzer";
+                const string CzechAnalyzerTypeName = "Lucene.Net.Analysis.Cz.CzechAnalyzer, Lucene.Net.Contrib.Analyzers";
+                var mockData = MockComponentProvider.CreateDataProvider();
+                var hostSettings = new DataTable(HostSettingsTableName);
+                var nameCol = hostSettings.Columns.Add(SettingNameColumnName);
+                hostSettings.Columns.Add(SettingValueColumnName);
+                hostSettings.Columns.Add(SettingIsSecureColumnName);
+                hostSettings.PrimaryKey = new[] { nameCol };
+                hostSettings.Rows.Add(CustomAnalyzerCacheKeyName, CzechAnalyzerTypeName, true);
+                mockData.Setup(c => c.GetHostSettings()).Returns(hostSettings.CreateDataReader());
+                var mockedApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+                mockedApplicationStatusInfo.Setup(s => s.Status).Returns(UpgradeStatus.Install);
+                mockedApplicationStatusInfo.Setup(s => s.ApplicationMapPath).Returns(string.Empty);
 
-            // Act
-            var analyzer = luceneController.GetCustomAnalyzer();
+                serviceProvider = FakeServiceProvider.Setup(
+                    services =>
+                    {
+                        services.AddSingleton(mockData.Object);
+                        services.AddSingleton(mockedApplicationStatusInfo.Object);
+                    });
 
-            // Assert
-            Assert.IsInstanceOf<CzechAnalyzer>(analyzer);
+                MockComponentProvider.CreateDataCacheProvider();
+                DataCache.ClearCache();
+                var luceneController = new LuceneControllerImpl();
+
+                // Act
+                var analyzer = luceneController.GetCustomAnalyzer();
+
+                // Assert
+                Assert.IsInstanceOf<CzechAnalyzer>(analyzer);
+            }
+            finally
+            {
+                serviceProvider?.Dispose();
+            }
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/RepositoryBaseTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/RepositoryBaseTests.cs
@@ -7,10 +7,7 @@ namespace DotNetNuke.Tests.Data
     using System.Collections.Generic;
     using System.Web.Caching;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Collections;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Controllers;
@@ -18,20 +15,30 @@ namespace DotNetNuke.Tests.Data
     using DotNetNuke.Tests.Data.Fakes;
     using DotNetNuke.Tests.Data.Models;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
-    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
     using Moq.Protected;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class RepositoryBaseTests
     {
-        // ReSharper disable InconsistentNaming
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
             MockComponentProvider.ResetContainer();
+            this.serviceProvider = FakeServiceProvider.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -510,12 +517,6 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_Get_Calls_GetAllInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();
             mockHostController.Setup(h => h.GetString("PerformanceSetting")).Returns("3");
 
@@ -662,12 +663,6 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_Get_Overload_Calls_GetAllByScopeInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var cacheKey = CachingProvider.GetCacheKey(string.Format(Constants.CACHE_CatsKey + "_" + Constants.CACHE_ScopeModule + "_{0}", Constants.MODULE_ValidId));
 
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();
@@ -1041,12 +1036,6 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_GetPage_Overload_Calls_GetAllByScopeInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var cacheKey = CachingProvider.GetCacheKey(string.Format(Constants.CACHE_CatsKey + "_" + Constants.CACHE_ScopeModule + "_{0}", Constants.MODULE_ValidId));
 
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/ExtensionUrlProviderControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/ExtensionUrlProviderControllerTests.cs
@@ -7,34 +7,32 @@ namespace DotNetNuke.Tests.Urls
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Data;
-    using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Urls;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
-
-    using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
 
     [TestFixture]
     public class ExtensionUrlProviderControllerTests
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/HttpContextHelper.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/HttpContextHelper.cs
@@ -23,23 +23,23 @@ namespace DotNetNuke.Tests.Utilities
         /// <returns>HttpResponseBase.</returns>
         public static Mock<HttpContextBase> RegisterMockHttpContext()
         {
-            var mock = CrateMockHttpContext();
+            var mock = CreateMockHttpContext();
             HttpContextSource.RegisterInstance(mock.Object);
             return mock;
         }
 
-        private static Mock<HttpContextBase> CrateMockHttpContext()
+        private static Mock<HttpContextBase> CreateMockHttpContext()
         {
             var context = new Mock<HttpContextBase>();
             context.SetupGet(x => x.Items).Returns(new Hashtable());
             context.SetupGet(x => x.Request).Returns(GetMockRequestBase());
             context.SetupGet(x => x.Response).Returns(GetMockResponseBase());
             context.SetupGet(x => x.Session).Returns(GetMockSessionStateBase());
-            context.SetupGet(x => x.Server).Returns(GeMocktServerUtilityBase());
+            context.SetupGet(x => x.Server).Returns(GetMockServerUtilityBase());
             return context;
         }
 
-        private static HttpServerUtilityBase GeMocktServerUtilityBase()
+        private static HttpServerUtilityBase GetMockServerUtilityBase()
         {
             var mockServerUtility = new Mock<HttpServerUtilityBase>();
             mockServerUtility.SetupAllProperties();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
@@ -1,15 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Mvc.Framework
 {
     using System.Linq;
     using System.Web.Mvc;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Web.Mvc.Framework;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using DotNetNuke.Web.Mvc.Framework.Modules;
@@ -24,18 +21,22 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework
     [TestFixture]
     public class ModuleDelegatingViewEngineTests
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void Setup()
         {
-            var services = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+                });
+        }
 
-            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            services.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
-
-            Globals.DependencyProvider = services.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
 {
     using System;
@@ -9,10 +8,8 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
     using System.Web.Mvc;
     using System.Web.Routing;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using DotNetNuke.Web.Mvc.Framework.Modules;
@@ -29,18 +26,22 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
         private const string ActionName = "Action";
         private const string ControllerName = "Controller";
 
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void Setup()
         {
-            var services = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+                });
+        }
 
-            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            services.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
-
-            Globals.DependencyProvider = services.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleExecutionEngineTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleExecutionEngineTests.cs
@@ -1,30 +1,43 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Management.Instrumentation;
-    using System.Web;
     using System.Web.Mvc;
 
-    using DotNetNuke.ComponentModel;
-    using DotNetNuke.Entities.Modules;
-    using DotNetNuke.Web.Mvc.Common;
-    using DotNetNuke.Web.Mvc.Framework;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Web.Mvc.Framework.ActionResults;
     using DotNetNuke.Web.Mvc.Framework.Modules;
+
+    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
     using NUnit.Framework;
 
     [TestFixture]
     public class ModuleExecutionEngineTests
     {
-        [Test]
+        private FakeServiceProvider serviceProvider;
 
+        [SetUp]
+        public void Setup()
+        {
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+                });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
+        }
+
+        [Test]
         public void ExecuteModule_Requires_NonNull_ModuleRequestContext()
         {
             var engine = new ModuleExecutionEngine();
@@ -32,7 +45,6 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
         }
 
         [Test]
-
         public void ExecuteModule_Returns_Null_If_Application_Is_Null()
         {
             // Arrange
@@ -47,7 +59,6 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
         }
 
         [Test]
-
         public void ExecuteModule_Executes_ModuleApplication_If_Not_Null()
         {
             // Arrange
@@ -64,7 +75,6 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
         }
 
         [Test]
-
         public void ExecuteModule_Returns_Result_Of_Executing_ModuleApplication()
         {
             // Arrange

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/DnnDependencyResolverTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/DnnDependencyResolverTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api.Internals
 {
     using System;
@@ -16,8 +15,8 @@ namespace DotNetNuke.Tests.Web.Api.Internals
     [TestFixture]
     public class DnnDependencyResolverTests
     {
-        private IServiceProvider _serviceProvider;
-        private IDependencyResolver _dependencyResolver;
+        private IServiceProvider serviceProvider;
+        private IDependencyResolver dependencyResolver;
 
         private interface ITestService
         {
@@ -30,40 +29,40 @@ namespace DotNetNuke.Tests.Web.Api.Internals
             services.AddSingleton<IScopeAccessor>(sp => new FakeScopeAccessor(sp.CreateScope()));
             services.AddScoped(typeof(ITestService), typeof(TestService));
 
-            this._serviceProvider = services.BuildServiceProvider();
-            this._dependencyResolver = new DnnDependencyResolver(this._serviceProvider);
+            this.serviceProvider = services.BuildServiceProvider();
+            this.dependencyResolver = new DnnDependencyResolver(this.serviceProvider);
         }
 
         [OneTimeTearDown]
         public void FixtureTearDown()
         {
-            this._dependencyResolver = null;
+            this.dependencyResolver = null;
 
-            if (this._serviceProvider is IDisposable disposable)
+            if (this.serviceProvider is IDisposable disposable)
             {
                 disposable.Dispose();
             }
 
-            this._serviceProvider = null;
+            this.serviceProvider = null;
         }
 
         [Test]
         public void NotNull()
         {
-            Assert.NotNull(this._dependencyResolver);
+            Assert.NotNull(this.dependencyResolver);
         }
 
         [Test]
         public void IsOfTypeDnnDependencyResolver()
         {
-            Assert.IsInstanceOf<DnnDependencyResolver>(this._dependencyResolver);
+            Assert.IsInstanceOf<DnnDependencyResolver>(this.dependencyResolver);
         }
 
         [Test]
         public void GetTestService()
         {
             var expected = new TestService();
-            var actual = this._dependencyResolver.GetService(typeof(ITestService));
+            var actual = this.dependencyResolver.GetService(typeof(ITestService));
 
             Assert.NotNull(actual);
             Assert.AreEqual(expected.GetType(), actual.GetType());
@@ -73,7 +72,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         public void GetTestServices()
         {
             var expected = new TestService();
-            var actual = this._dependencyResolver.GetServices(typeof(ITestService)).ToArray();
+            var actual = this.dependencyResolver.GetServices(typeof(ITestService)).ToArray();
 
             Assert.NotNull(actual);
             Assert.AreEqual(1, actual.Length);
@@ -83,7 +82,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void BeginScope()
         {
-            var actual = this._dependencyResolver.BeginScope();
+            var actual = this.dependencyResolver.BeginScope();
 
             Assert.NotNull(actual);
             Assert.IsInstanceOf<DnnDependencyResolver>(actual);
@@ -92,7 +91,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void BeginScope_GetService()
         {
-            var scope = this._dependencyResolver.BeginScope();
+            var scope = this.dependencyResolver.BeginScope();
 
             var expected = new TestService();
             var actual = scope.GetService(typeof(ITestService));
@@ -104,7 +103,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void BeginScope_GetServices()
         {
-            var scope = this._dependencyResolver.BeginScope();
+            var scope = this.dependencyResolver.BeginScope();
 
             var expected = new TestService();
             var actual = scope.GetServices(typeof(ITestService)).ToArray();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/WebFormsServiceProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/WebFormsServiceProviderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api.Internals
 {
     using System.Web.UI;
@@ -13,8 +12,11 @@ namespace DotNetNuke.Tests.Web.Api.Internals
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Web.Common;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     public class WebFormsServiceProviderTests

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api
 {
     using System;
@@ -9,12 +8,10 @@ namespace DotNetNuke.Tests.Web.Api
     using System.Collections.Generic;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Web.Api;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -27,30 +24,25 @@ namespace DotNetNuke.Tests.Web.Api
     public class PortalAliasRouteManagerTests
     {
         private Mock<IPortalAliasService> mockPortalAliasService;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void SetUp()
         {
-            var services = new ServiceCollection();
-            var navigationManagerMock = new Mock<INavigationManager>();
-
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-
             this.mockPortalAliasService = new Mock<IPortalAliasService>();
             this.mockPortalAliasService.As<IPortalAliasController>();
 
-            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            services.AddScoped(typeof(INavigationManager), (x) => navigationManagerMock.Object);
-            services.AddScoped<IPortalAliasService>(_ => this.mockPortalAliasService.Object);
-
-            Globals.DependencyProvider = services.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockPortalAliasService.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
 
             this.mockPortalAliasService = null;
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNetNuke.Tests.Web.InternalServices
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Web.InternalServices
 {
     using System.Data;
     using System.Linq;
@@ -6,15 +9,12 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    using Abstractions;
-    using Abstractions.Application;
-    using Abstractions.Logging;
-
-    using Common;
-    using Common.Lists;
-
-    using Data;
+    using DotNetNuke.Common.Lists;
+    using DotNetNuke.Data;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Services.Cache;
+    using DotNetNuke.Tests.Utilities.Fakes;
+    using DotNetNuke.Tests.Utilities.Mocks;
     using DotNetNuke.Web.InternalServices;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -23,29 +23,31 @@
 
     using NUnit.Framework;
 
-    using Services.Cache;
-
-    using Utilities.Mocks;
     /// <summary>Tests FileUploadController methods</summary>
     [TestFixture]
     public class FileUploadControllerTests
     {
-        private Mock<DataProvider> _mockDataProvider;
-        private FileUploadController _testInstance;
-        private Mock<CachingProvider> _mockCachingProvider;
-        private Mock<IPortalController> _mockPortalController;
-        private TestSynchronizationContext _synchronizationContext = new TestSynchronizationContext();
+        private Mock<DataProvider> mockDataProvider;
+        private FileUploadController testInstance;
+        private Mock<CachingProvider> mockCachingProvider;
+        private Mock<IPortalController> mockPortalController;
+        private TestSynchronizationContext synchronizationContext = new TestSynchronizationContext();
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void SetUp()
         {
             this.SetupDataProvider();
-
             this.SetupCachingProvider();
-
             this.SetupPortalSettings();
             this.SetupServiceProvider();
             this.SetupSynchronizationContext();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -58,48 +60,49 @@
 
             var request = new HttpRequestMessage();
             request.Content = formDataContent;
-            this._testInstance.Request = request;
-            await this._testInstance.UploadFromLocal(-1);
+            this.testInstance.Request = request;
+            await this.testInstance.UploadFromLocal(-1);
 
-            Assert.IsTrue(_synchronizationContext.IsUploadFileCalled());
+            Assert.IsTrue(this.synchronizationContext.IsUploadFileCalled());
         }
 
         private void SetupPortalSettings()
         {
-            _mockPortalController = MockComponentProvider.CreatePortalController();
-            _mockPortalController.Setup(x => x.GetCurrentPortalSettings()).Returns(new PortalSettings() { PortalId = 0 });
-            PortalController.SetTestableInstance(_mockPortalController.Object);
+            this.mockPortalController = MockComponentProvider.CreatePortalController();
+            this.mockPortalController.Setup(x => x.GetCurrentPortalSettings()).Returns(new PortalSettings() { PortalId = 0 });
+            PortalController.SetTestableInstance(this.mockPortalController.Object);
         }
 
         private void SetupDataProvider()
         {
-            this._mockDataProvider = MockComponentProvider.CreateDataProvider();
-            this._mockDataProvider.Setup(x => x.GetListEntriesByListName("ImageTypes", string.Empty, It.IsAny<int>()))
+            this.mockDataProvider = MockComponentProvider.CreateDataProvider();
+            this.mockDataProvider.Setup(x => x.GetListEntriesByListName("ImageTypes", string.Empty, It.IsAny<int>()))
                 .Returns(Mock.Of<IDataReader>());
         }
 
         private void SetupCachingProvider()
         {
-            this._mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
-            this._mockCachingProvider.Setup(x => x.GetItem(It.IsAny<string>()))
+            this.mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
+            this.mockCachingProvider.Setup(x => x.GetItem(It.IsAny<string>()))
                 .Returns(Enumerable.Empty<ListEntryInfo>());
         }
 
         private void SetupServiceProvider()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(
-            container => new Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IEventLogger>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockPortalController.Object);
+                    services.AddSingleton(this.mockCachingProvider.Object);
+                    services.AddSingleton(this.mockDataProvider.Object);
+                });
         }
 
         private void SetupSynchronizationContext()
         {
-            _synchronizationContext = new TestSynchronizationContext();
-            SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
-            this._testInstance = new FileUploadController();
+            this.synchronizationContext = new TestSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(this.synchronizationContext);
+            this.testInstance = new FileUploadController();
         }
 
         private class TestSynchronizationContext : SynchronizationContext

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/TabVersionControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/TabVersionControllerTests.cs
@@ -16,6 +16,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +35,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
         private Mock<ICBO> mockCBO;
         private Mock<IUserController> mockUserController;
         private Mock<IHostController> mockHostController;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
@@ -41,12 +43,20 @@ namespace DotNetNuke.Tests.Web.InternalServices
             MockComponentProvider.ResetContainer();
             this.SetupCBO();
             this.SetupHostController();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCBO.Object);
+                    services.AddSingleton(this.mockUserController.Object);
+                    services.AddSingleton(this.mockHostController.Object);
+                    services.AddSingleton((IHostSettingsService)this.mockHostController.Object);
+                });
+        }
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService>(container => (IHostSettingsService)this.mockHostController.Object);
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -50,7 +50,7 @@ namespace DotNetNuke.Framework
 
         public DefaultPage()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string CurrentSkinPath

--- a/DNN Platform/Website/DesktopModules/Admin/EditExtension/AuthenticationEditor.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/EditExtension/AuthenticationEditor.ascx.cs
@@ -26,7 +26,7 @@ namespace DotNetNuke.Modules.Admin.EditExtension
         /// <summary>Initializes a new instance of the <see cref="AuthenticationEditor"/> class.</summary>
         public AuthenticationEditor()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected AuthenticationInfo AuthSystem

--- a/DNN Platform/Website/DesktopModules/Admin/EditExtension/EditExtension.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/EditExtension/EditExtension.ascx.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.Modules.Admin.EditExtension
         /// <summary>Initializes a new instance of the <see cref="EditExtension"/> class.</summary>
         public EditExtension()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string Mode

--- a/DNN Platform/Website/DesktopModules/Admin/UrlManagement/UrlProviderSettings.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/UrlManagement/UrlProviderSettings.ascx.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Modules.UrlManagement
         /// <summary>Initializes a new instance of the <see cref="ProviderSettings"/> class.</summary>
         public ProviderSettings()
         {
-            this.navigationManager = Globals.DependencyProvider.GetService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetService<INavigationManager>();
         }
 
         private string DisplayMode => (this.Request.QueryString["Display"] ?? string.Empty).ToLowerInvariant();

--- a/DNN Platform/Website/DesktopModules/Admin/ViewProfile/ViewProfile.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/ViewProfile/ViewProfile.ascx.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Modules.Admin.ViewProfile
         /// <summary>Initializes a new instance of the <see cref="ViewProfile"/> class.</summary>
         public ViewProfile()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <inheritdoc/>

--- a/DNN Platform/Website/Install/Install.aspx.cs
+++ b/DNN Platform/Website/Install/Install.aspx.cs
@@ -140,7 +140,7 @@ namespace DotNetNuke.Services.Install
 
         private static ITelerikUtils CreateTelerikUtils()
         {
-            return Globals.DependencyProvider.GetRequiredService<ITelerikUtils>();
+            return Globals.GetCurrentServiceProvider().GetRequiredService<ITelerikUtils>();
         }
 
         private void ExecuteScripts()
@@ -405,7 +405,7 @@ namespace DotNetNuke.Services.Install
                     }
 
                     HtmlUtils.WriteFeedback(HttpContext.Current.Response, 2, "Replacing Digital Assets Manager with the new Resource Manager: ");
-                    Globals.DependencyProvider.GetService<IDamUninstaller>().Execute();
+                    Globals.GetCurrentServiceProvider().GetService<IDamUninstaller>().Execute();
                     HtmlUtils.WriteSuccessError(HttpContext.Current.Response, true);
 
                     this.Response.Write("<br>");

--- a/DNN Platform/Website/Install/UpgradeWizard.aspx.cs
+++ b/DNN Platform/Website/Install/UpgradeWizard.aspx.cs
@@ -311,12 +311,9 @@ namespace DotNetNuke.Services.Install
             }
         }
 
-#pragma warning disable SA1124 // Do not use regions
-        #region Security Screen Methods
         private static ITelerikUtils CreateTelerikUtils()
-#pragma warning restore SA1124 // Do not use regions
         {
-            return Globals.DependencyProvider.GetRequiredService<ITelerikUtils>();
+            return Globals.GetCurrentServiceProvider().GetRequiredService<ITelerikUtils>();
         }
 
         private static SecurityTabResult GetTelerikNotInstalledResult()
@@ -533,7 +530,6 @@ namespace DotNetNuke.Services.Install
 
             return true;
         }
-        #endregion
 
         private static string Encrypt(string token)
         {
@@ -547,7 +543,7 @@ namespace DotNetNuke.Services.Install
 
         private static string GetHostSetting(string key)
         {
-            return Globals.DependencyProvider
+            return Globals.GetCurrentServiceProvider()
                 .GetRequiredService<IHostSettingsService>()
                 .GetSettingsDictionary()[key];
         }
@@ -561,7 +557,7 @@ namespace DotNetNuke.Services.Install
                 Value = value,
             };
 
-            Globals.DependencyProvider
+            Globals.GetCurrentServiceProvider()
                 .GetRequiredService<IHostSettingsService>()
                 .Update(setting);
         }
@@ -691,7 +687,7 @@ namespace DotNetNuke.Services.Install
             currentStep = null;
             upgradeProgress = 100;
 
-            Globals.DependencyProvider.GetService<IDamUninstaller>().Execute();
+            Globals.GetCurrentServiceProvider().GetService<IDamUninstaller>().Execute();
 
             CurrentStepActivity(Localization.GetString("UpgradeDone", LocalResourceFile));
 

--- a/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/BreadCrumb.ascx.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         public BreadCrumb()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.CleanerMarkup = false;
         }
 

--- a/DNN Platform/Website/admin/Skins/Login.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Login.ascx.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// <summary>Initializes a new instance of the <see cref="Login"/> class.</summary>
         public Login()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.LegacyMode = true;
         }
 

--- a/DNN Platform/Website/admin/Skins/Logo.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Logo.ascx.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// <summary>Initializes a new instance of the <see cref="Logo"/> class.</summary>
         public Logo()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <summary>Gets or sets the width of the border around the image.</summary>

--- a/DNN Platform/Website/admin/Skins/Privacy.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Privacy.ascx.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// <summary>Initializes a new instance of the <see cref="Privacy"/> class.</summary>
         public Privacy()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string Text { get; set; }

--- a/DNN Platform/Website/admin/Skins/Search.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Search.ascx.cs
@@ -41,7 +41,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         public Search()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string SeeMoreText

--- a/DNN Platform/Website/admin/Skins/Terms.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Terms.ascx.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// <summary>Initializes a new instance of the <see cref="Terms"/> class.</summary>
         public Terms()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string Text { get; set; }

--- a/DNN Platform/Website/admin/Skins/Toast.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Toast.ascx.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         public Toast()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected string ServiceModuleName { get; private set; }

--- a/DNN Platform/Website/admin/Skins/User.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/User.ascx.cs
@@ -32,7 +32,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         public User()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.ShowUnreadMessages = true;
             this.ShowAvatar = true;
             this.LegacyMode = true;

--- a/DNN Platform/Website/admin/Skins/UserAndLogin.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/UserAndLogin.ascx.cs
@@ -29,7 +29,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         public UserAndLogin()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <summary>Gets or sets a value indicating whether set this to true to show in custom 404/500 page.</summary>

--- a/DNN Platform/Website/admin/Skins/tags.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/tags.ascx.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// <summary>Initializes a new instance of the <see cref="Tags"/> class.</summary>
         public Tags()
         {
-            this.navigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.navigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         public string AddImageUrl { get; set; } = IconController.IconURL("Add");

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/CreateModuleController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/CreateModuleController.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.PersonaBar.Extensions.Components
 {
     using System;
@@ -29,7 +28,7 @@ namespace Dnn.PersonaBar.Extensions.Components
         /// <summary>Initializes a new instance of the <see cref="CreateModuleController"/> class.</summary>
         public CreateModuleController()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Dto/PackageInfoDto.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Dto/PackageInfoDto.cs
@@ -30,7 +30,7 @@ namespace Dnn.PersonaBar.Extensions.Components.Dto
         /// <param name="package"></param>
         public PackageInfoDto(int portalId, PackageInfo package)
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
 
             this.PackageType = package.PackageType;
             this.FriendlyName = package.FriendlyName;

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Editors/AuthSystemPackageEditor.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Editors/AuthSystemPackageEditor.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.PersonaBar.Extensions.Components.Editors
 {
     using System;
@@ -21,7 +20,8 @@ namespace Dnn.PersonaBar.Extensions.Components.Editors
     public class AuthSystemPackageEditor : IPackageEditor
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(AuthSystemPackageEditor));
-        private static readonly INavigationManager NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+
+        private static INavigationManager NavigationManager => Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
 
         /// <inheritdoc/>
         public PackageInfoDto GetPackageDetail(int portalId, PackageInfo package)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Editors/CoreLanguagePackageEditor.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Editors/CoreLanguagePackageEditor.cs
@@ -23,7 +23,7 @@ namespace Dnn.PersonaBar.Extensions.Components.Editors
 
         public CoreLanguagePackageEditor()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Editors/ExtensionLanguagePackageEditor.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/Editors/ExtensionLanguagePackageEditor.cs
@@ -24,7 +24,7 @@ namespace Dnn.PersonaBar.Extensions.Components.Editors
         /// <summary>Initializes a new instance of the <see cref="ExtensionLanguagePackageEditor"/> class.</summary>
         public ExtensionLanguagePackageEditor()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/ExtensionsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Extensions/ExtensionsController.cs
@@ -31,7 +31,7 @@ namespace Dnn.PersonaBar.Extensions.Components
 
         public ExtensionsController()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/Converters.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/Converters.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.PersonaBar.Pages.Components
 {
     using System;
@@ -27,7 +26,7 @@ namespace Dnn.PersonaBar.Pages.Components
 
     public static class Converters
     {
-        private static readonly INavigationManager NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        private static INavigationManager NavigationManager => Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
 
         public static T ConvertToPageItem<T>(TabInfo tab, IEnumerable<TabInfo> portalTabs)
             where T : PageItem, new()

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Repositories/CommandRepository.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Repositories/CommandRepository.cs
@@ -35,7 +35,7 @@ namespace Dnn.PersonaBar.Prompt.Components.Repositories
 
         public CommandRepository(IServiceScopeFactory serviceScopeFactory)
         {
-            this.serviceScopeFactory = serviceScopeFactory ?? Globals.DependencyProvider.GetRequiredService<IServiceScopeFactory>();
+            this.serviceScopeFactory = serviceScopeFactory ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServiceScopeFactory>();
         }
 
         /// <inheritdoc/>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/CheckTelerikPresence.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Security/Checks/CheckTelerikPresence.cs
@@ -26,7 +26,7 @@ namespace Dnn.PersonaBar.Security.Components.Checks
 
         /// <summary>Initializes a new instance of the <see cref="CheckTelerikPresence"/> class.</summary>
         public CheckTelerikPresence()
-            : this(Globals.DependencyProvider.GetRequiredService<ITelerikUtils>())
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<ITelerikUtils>())
         {
         }
 

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/TaskScheduler/TaskSchedulerController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/TaskScheduler/TaskSchedulerController.cs
@@ -164,7 +164,7 @@ namespace Dnn.PersonaBar.TaskScheduler.Components
         /// <returns>List of recommended servers for specified <paramref name="schedulerId"/>.</returns>
         public IEnumerable<string> GetRecommendedServers(int schedulerId)
         {
-            var hostSettingsService = Globals.DependencyProvider.GetRequiredService<IHostSettingsService>();
+            var hostSettingsService = Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettingsService>();
 
             var schedulerIds = hostSettingsService.GetString(SchedulersToRunOnSameWebServerKey, string.Empty)
                 .Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/Dto/UserDetailDto.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Users/Dto/UserDetailDto.cs
@@ -21,7 +21,7 @@ namespace Dnn.PersonaBar.Users.Components.Dto
     [DataContract]
     public class UserDetailDto : UserBasicDto
     {
-        private static readonly INavigationManager NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+        private static INavigationManager NavigationManager => Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
 
         public UserDetailDto()
         {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/ExtensionMenuController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/ExtensionMenuController.cs
@@ -20,7 +20,7 @@ namespace Dnn.PersonaBar.Extensions.MenuControllers
         /// <summary>Initializes a new instance of the <see cref="ExtensionMenuController"/> class.</summary>
         public ExtensionMenuController()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         /// <summary>Gets an <see cref="INavigationManager"/> instance to provide navigation services.</summary>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/ThemeMenuController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/MenuControllers/ThemeMenuController.cs
@@ -31,7 +31,7 @@ namespace Dnn.PersonaBar.Themes.MenuControllers
         {
             return new Dictionary<string, object>
             {
-                { "previewUrl", Globals.DependencyProvider.GetRequiredService<INavigationManager>().NavigateURL() },
+                { "previewUrl", Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>().NavigateURL() },
             };
         }
     }

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
@@ -48,8 +48,8 @@ namespace Dnn.PersonaBar.Library.Containers
         /// <param name="personaBarController">The Persona Bar controller.</param>
         public PersonaBarContainer(INavigationManager navigationManager, IPersonaBarController personaBarController)
         {
-            this.NavigationManager = navigationManager ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<INavigationManager>() ?? Globals.DependencyProvider.GetRequiredService<INavigationManager>();
-            this.personaBarController = personaBarController ?? HttpContextSource.Current?.GetScope()?.ServiceProvider.GetRequiredService<IPersonaBarController>() ?? Globals.DependencyProvider.GetRequiredService<IPersonaBarController>();
+            this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
+            this.personaBarController = personaBarController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IPersonaBarController>();
         }
 
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please resolve via dependency injection. Scheduled removal in v12.0.0.")]

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/MenuControllers/LinkMenuController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/MenuControllers/LinkMenuController.cs
@@ -23,7 +23,7 @@ namespace Dnn.PersonaBar.UI.MenuControllers
         /// <summary>Initializes a new instance of the <see cref="LinkMenuController"/> class.</summary>
         public LinkMenuController()
         {
-            this.NavigationManager = Globals.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.NavigationManager = Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
         }
 
         protected INavigationManager NavigationManager { get; }

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/ConfigConsoleControllerTests.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/ConfigConsoleControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.PersonaBar.ConfigConsole.Tests
 {
     using System;
@@ -9,11 +8,14 @@ namespace Dnn.PersonaBar.ConfigConsole.Tests
     using System.Linq;
 
     using Dnn.PersonaBar.ConfigConsole.Components;
-    using DotNetNuke.Abstractions;
+
     using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary><see cref="ConfigConsoleController"/> unit tests.</summary>
@@ -24,21 +26,28 @@ namespace Dnn.PersonaBar.ConfigConsole.Tests
         private const string BadConfigXml = "<configuration1></configuration1>";
         private const string BadXml = "<configuration></configuration1>";
 
+        private FakeServiceProvider serviceProvider;
+
         /// <summary>Method that is called immediately before each test is run.</summary>
         [SetUp]
-        public static void Setup()
+        public void Setup()
         {
             var applicationStatusInfoMock = new Mock<IApplicationStatusInfo>();
 
             applicationStatusInfoMock
                 .Setup(info => info.ApplicationMapPath)
                 .Returns(Environment.CurrentDirectory);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(applicationStatusInfoMock.Object);
+                });
+        }
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => applicationStatusInfoMock.Object);
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         /// <summary>Unit test for <see cref="ConfigConsoleController.ValidateConfigFile(string, string)"/>.</summary>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/Dnn.PersonaBar.ConfigConsole.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/Dnn.PersonaBar.ConfigConsole.Tests.csproj
@@ -84,6 +84,10 @@
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
       <Name>DotNetNuke.Library</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\DNN Platform\Tests\DotNetNuke.Tests.Utilities\DotNetNuke.Tests.Utilities.csproj">
+      <Project>{68368906-57DD-40D1-AC10-35211A17D617}</Project>
+      <Name>DotNetNuke.Tests.Utilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Library\Dnn.PersonaBar.Library\Dnn.PersonaBar.Library.csproj">
       <Project>{8B50BA8B-0A08-41B8-81B8-EA70707C7379}</Project>
       <Name>Dnn.PersonaBar.Library</Name>


### PR DESCRIPTION
## Summary
This PR introduces `Globals.GetCurrentServiceProvider`. This allows our fallbacks to use the correct scope for the vast majority
of cases where objects lifetimes follow the request scope.