### PR TITLE
Introduce FakeServiceProvider for tests

### DIFF
--- a/DNN Platform/Library/Services/Search/Controllers/SearchControllerImpl.cs
+++ b/DNN Platform/Library/Services/Search/Controllers/SearchControllerImpl.cs
@@ -526,7 +526,7 @@ namespace DotNetNuke.Services.Search.Controllers
 
         private bool HasPermissionToViewDoc(Document document, SearchQuery searchQuery)
         {
-            // others LuceneResult fields are not impotrant at this moment
+            // others LuceneResult fields are not important at this moment
             var result = GetPartialSearchResult(document, searchQuery);
             var resultController = this.GetSearchResultControllers().SingleOrDefault(sc => sc.Key == result.SearchTypeId).Value;
             return resultController != null && resultController.HasViewPermission(result);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/AttachmentControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/AttachmentControllerTests.cs
@@ -1,24 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Content
 {
     using System.Collections.Generic;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Content.Data;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -34,26 +30,27 @@ namespace DotNetNuke.Tests.Content
     public class AttachmentControllerTests
     {
         private Mock<CachingProvider> mockCache;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
-
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
-            MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            var dataProvider = MockComponentProvider.CreateDataProvider();
+            dataProvider.Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCache.Object);
+                    services.AddSingleton(dataProvider.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentTypeControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ContentTypeControllerTests.cs
@@ -1,22 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Content.Data;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -30,26 +26,27 @@ namespace DotNetNuke.Tests.Content
     public class ContentTypeControllerTests
     {
         private Mock<CachingProvider> mockCache;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
-            // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
-            MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            var dataProvider = MockComponentProvider.CreateDataProvider();
+            dataProvider.Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCache.Object);
+                    services.AddSingleton(dataProvider.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/ScopeTypeControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/ScopeTypeControllerTests.cs
@@ -1,22 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Entities.Content.Taxonomy;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -30,26 +26,28 @@ namespace DotNetNuke.Tests.Content
     public class ScopeTypeControllerTests
     {
         private Mock<CachingProvider> mockCache;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
-            // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
-            MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            var dataProvider = MockComponentProvider.CreateDataProvider();
+            dataProvider.Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCache.Object);
+                    services.AddSingleton(dataProvider.Object);
+                });
+
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/TermControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/TermControllerTests.cs
@@ -1,24 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Entities.Content.Taxonomy;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -32,28 +28,30 @@ namespace DotNetNuke.Tests.Content
     public class TermControllerTests
     {
         private Mock<CachingProvider> mockCache;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            var vocabularyController = MockHelper.CreateMockVocabularyController();
+            var dataProvider = MockComponentProvider.CreateDataProvider();
+            dataProvider.Setup(c => c.GetProviderPath()).Returns(string.Empty);
 
-            Mock<IVocabularyController> vocabularyController = MockHelper.CreateMockVocabularyController();
-            MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
-
-            // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(vocabularyController.Object);
+                    services.AddSingleton(dataProvider.Object);
+                    services.AddSingleton(this.mockCache.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/VocabularyControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/VocabularyControllerTests.cs
@@ -1,22 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Content
 {
     using System;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Common;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Content.Data;
     using DotNetNuke.Entities.Content.Taxonomy;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Tests.Content.Mocks;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -30,26 +26,27 @@ namespace DotNetNuke.Tests.Content
     public class VocabularyControllerTests
     {
         private Mock<CachingProvider> mockCache;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
-            // Register MockCachingProvider
             this.mockCache = MockComponentProvider.CreateNew<CachingProvider>();
-            MockComponentProvider.CreateDataProvider().Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            var dataProvider = MockComponentProvider.CreateDataProvider();
+            dataProvider.Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCache.Object);
+                    services.AddSingleton(dataProvider.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Common/NavigationManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Common/NavigationManagerTests.cs
@@ -1,21 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Common
 {
     using System.Collections.Generic;
     using System.Linq;
 
     using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Services.Localization;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using Microsoft.Extensions.DependencyInjection;
 
     using Moq;
@@ -32,6 +30,7 @@ namespace DotNetNuke.Tests.Core.Common
         private const string ControlKeyPattern = "&ctl={0}";
         private const string LanguagePattern = "&language={0}";
         private INavigationManager navigationManager;
+        private FakeServiceProvider serviceProvider;
 
         [OneTimeSetUp]
 
@@ -100,17 +99,19 @@ namespace DotNetNuke.Tests.Core.Common
                 return mockLocaleController.Object;
             }
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => this.navigationManager);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(PortalController.Instance);
+                    services.AddSingleton(TabController.Instance);
+                    services.AddSingleton(LocaleController.Instance);
+                });
         }
 
         [OneTimeTearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             this.navigationManager = null;
             TabController.ClearInstance();
             LocaleController.ClearInstance();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Host/HostControllerTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Host/HostControllerTest.cs
@@ -17,6 +17,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
     using DotNetNuke.Entities;
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -28,46 +29,46 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
     [TestFixture]
     public class HostControllerTest
     {
-        private DataTable _hostSettingsTable;
-        private Mock<CachingProvider> _mockCache;
-        private Mock<DataProvider> _mockData;
+        private DataTable hostSettingsTable;
+        private Mock<CachingProvider> mockCache;
+        private Mock<DataProvider> mockData;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
-            this._mockCache = MockComponentProvider.CreateDataCacheProvider();
+            this.mockCache = MockComponentProvider.CreateDataCacheProvider();
             MockComponentProvider.CreateEventLogController();
 
-            this._hostSettingsTable = new DataTable("HostSettings");
+            this.hostSettingsTable = new DataTable("HostSettings");
 
-            var nameCol = this._hostSettingsTable.Columns.Add("SettingName");
-            this._hostSettingsTable.Columns.Add("SettingValue");
-            this._hostSettingsTable.Columns.Add("SettingIsSecure");
-            this._hostSettingsTable.PrimaryKey = new[] { nameCol };
+            var nameCol = this.hostSettingsTable.Columns.Add("SettingName");
+            this.hostSettingsTable.Columns.Add("SettingValue");
+            this.hostSettingsTable.Columns.Add("SettingIsSecure");
+            this.hostSettingsTable.PrimaryKey = new[] { nameCol };
 
-            this._hostSettingsTable.Rows.Add("String_1_S", "String_1_S", true);
-            this._hostSettingsTable.Rows.Add("String_2_S", "String_1_S", true);
-            this._hostSettingsTable.Rows.Add("String_3_U", "Value_3_U", false);
-            this._hostSettingsTable.Rows.Add("String_4_U", "Value_4_U", false);
-            this._hostSettingsTable.Rows.Add("Int_5_U", "5", false);
-            this._hostSettingsTable.Rows.Add("Int_6_S", "6", true);
-            this._hostSettingsTable.Rows.Add("Double_7_S", "7", true);
-            this._hostSettingsTable.Rows.Add("Double_8_U", "8", false);
-            this._hostSettingsTable.Rows.Add("Bool_9_U", false, false);
-            this._hostSettingsTable.Rows.Add("Bool_10_S", false, true);
+            this.hostSettingsTable.Rows.Add("String_1_S", "String_1_S", true);
+            this.hostSettingsTable.Rows.Add("String_2_S", "String_1_S", true);
+            this.hostSettingsTable.Rows.Add("String_3_U", "Value_3_U", false);
+            this.hostSettingsTable.Rows.Add("String_4_U", "Value_4_U", false);
+            this.hostSettingsTable.Rows.Add("Int_5_U", "5", false);
+            this.hostSettingsTable.Rows.Add("Int_6_S", "6", true);
+            this.hostSettingsTable.Rows.Add("Double_7_S", "7", true);
+            this.hostSettingsTable.Rows.Add("Double_8_U", "8", false);
+            this.hostSettingsTable.Rows.Add("Bool_9_U", false, false);
+            this.hostSettingsTable.Rows.Add("Bool_10_S", false, true);
 
-            this._mockData = MockComponentProvider.CreateDataProvider();
-            this._mockData.Setup(c => c.GetHostSettings()).Returns(this._hostSettingsTable.CreateDataReader());
-            this._mockData.Setup(c => c.GetProviderPath()).Returns(string.Empty);
+            this.mockData = MockComponentProvider.CreateDataProvider();
+            this.mockData.Setup(c => c.GetHostSettings()).Returns(this.hostSettingsTable.CreateDataReader());
+            this.mockData.Setup(c => c.GetProviderPath()).Returns(string.Empty);
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCache.Object);
+                    services.AddSingleton(this.mockData.Object);
+                });
 
             DataCache.ClearCache();
         }
@@ -75,7 +76,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
         }
 
@@ -86,7 +87,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             var expectedDic = new Dictionary<string, ConfigurationSetting>();
 
-            foreach (DataRow row in this._hostSettingsTable.Rows)
+            foreach (DataRow row in this.hostSettingsTable.Rows)
             {
                 var conf = new ConfigurationSetting();
                 conf.Key = row["SettingName"].ToString();
@@ -115,7 +116,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
         {
             // Arrange
             // Convert table to Dictionary<string,string>
-            var expectedDic = this._hostSettingsTable.Rows.Cast<DataRow>().ToDictionary(row => row["SettingName"].ToString(), row => row["SettingValue"].ToString());
+            var expectedDic = this.hostSettingsTable.Rows.Cast<DataRow>().ToDictionary(row => row["SettingName"].ToString(), row => row["SettingValue"].ToString());
 
             // Act
             var settingsDic = HostController.Instance.GetSettingsDictionary();
@@ -131,14 +132,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "String_1_S";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
+            this.mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
 
             // Act
             HostController.Instance.Update(key, value);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()), Times.Exactly(1));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Exactly(1));
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()), Times.Exactly(1));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Exactly(1));
         }
 
         [Test]
@@ -148,14 +149,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "String_1_S";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
+            this.mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
 
             // Act
             HostController.Instance.Update(key, value);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()), Times.Exactly(1));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Exactly(1));
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()), Times.Exactly(1));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Exactly(1));
         }
 
         [Test]
@@ -165,14 +166,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "String_1_S";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
+            this.mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
 
             // Act
             HostController.Instance.Update(key, value, true);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()), Times.Exactly(1));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Exactly(1));
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()), Times.Exactly(1));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Exactly(1));
         }
 
         [Test]
@@ -182,16 +183,16 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "String_1_S";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
+            this.mockData.Setup(c => c.GetHostSetting(key).Read()).Returns(true);
 
             // Act
             HostController.Instance.Update(key, value, false);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
 
             // Clear was not called a second time
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Never);
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Never);
         }
 
         [Test]
@@ -208,8 +209,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             HostController.Instance.Update(settings);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting("String_1_S", "MyValue", false, It.IsAny<int>()), Times.Exactly(1));
-            this._mockCache.Verify(c => c.Clear("Host", string.Empty), Times.Exactly(1));
+            this.mockData.Verify(c => c.UpdateHostSetting("String_1_S", "MyValue", false, It.IsAny<int>()), Times.Exactly(1));
+            this.mockCache.Verify(c => c.Clear("Host", string.Empty), Times.Exactly(1));
         }
 
         [Test]
@@ -219,14 +220,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "MyKey";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
+            this.mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
 
             // Act
             HostController.Instance.Update(key, value);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Once);
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Once);
         }
 
         [Test]
@@ -236,14 +237,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "MyKey";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
+            this.mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
 
             // Act
             HostController.Instance.Update(key, value, true);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Once);
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Once);
         }
 
         [Test]
@@ -253,14 +254,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "MyKey";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
+            this.mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
 
             // Act
             HostController.Instance.Update(key, value);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Once);
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Once);
         }
 
         [Test]
@@ -270,14 +271,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
             // Arrange
             const string key = "MyKey";
             const string value = "MyValue";
-            this._mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
+            this.mockData.Setup(c => c.GetHostSetting(It.IsAny<string>()).Read()).Returns(false);
 
             // Act
             HostController.Instance.Update(key, value, false);
 
             // Assert
-            this._mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
-            this._mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Never);
+            this.mockData.Verify(c => c.UpdateHostSetting(key, value, false, It.IsAny<int>()));
+            this.mockCache.Verify(c => c.Remove("DNN_HostSettings"), Times.Never);
         }
 
         [Test]
@@ -436,7 +437,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Host
 
         private string GetValue(string key)
         {
-            return this._hostSettingsTable.Rows.Find(key)["SettingValue"].ToString();
+            return this.hostSettingsTable.Rows.Find(key)["SettingValue"].ToString();
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Messaging/MessagingControllerTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
-// ReSharper disable InconsistentNaming
 namespace DotNetNuke.Tests.Core.Controllers.Messaging
 {
     using System;
@@ -11,9 +9,6 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using System.Globalization;
     using System.Text;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
@@ -29,6 +24,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     using DotNetNuke.Services.Social.Messaging.Exceptions;
     using DotNetNuke.Services.Social.Messaging.Internal;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -41,71 +37,65 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
     [TestFixture]
     public class MessagingControllerTests
     {
-        private Mock<IDataService> _mockDataService;
-        private MessagingController _messagingController;
-        private InternalMessagingControllerImpl _internalMessagingController;
-        private Mock<MessagingController> _mockMessagingController;
-        private Mock<InternalMessagingControllerImpl> _mockInternalMessagingController;
-        private Mock<DataProvider> _dataProvider;
-        private Mock<IPortalController> _portalController;
-        private Mock<RoleProvider> _mockRoleProvider;
-        private Mock<CachingProvider> _mockCacheProvider;
-        private Mock<ILocalizationProvider> _mockLocalizationProvider;
-        private Mock<IFolderManager> _folderManager;
-        private Mock<IFileManager> _fileManager;
-        private Mock<IFolderPermissionController> _folderPermissionController;
+        private Mock<IDataService> mockDataService;
+        private MessagingController messagingController;
+        private InternalMessagingControllerImpl internalMessagingController;
+        private Mock<MessagingController> mockMessagingController;
+        private Mock<InternalMessagingControllerImpl> mockInternalMessagingController;
+        private Mock<DataProvider> dataProvider;
+        private Mock<IPortalController> portalController;
+        private Mock<RoleProvider> mockRoleProvider;
+        private Mock<CachingProvider> mockCacheProvider;
+        private Mock<ILocalizationProvider> mockLocalizationProvider;
+        private Mock<IFolderManager> folderManager;
+        private Mock<IFileManager> fileManager;
+        private Mock<IFolderPermissionController> folderPermissionController;
+        private FakeServiceProvider serviceProvider;
 
-        private DataTable _dtMessages;
-        private DataTable _dtMessageAttachment;
-        private DataTable _dtMessageRecipients;
-        private DataTable _dtPortalSettings;
-        private DataTable _dtMessageConversationView;
-        private DataTable _dtMessageThreadsView;
+        private DataTable dtMessages;
+        private DataTable dtMessageAttachment;
+        private DataTable dtMessageRecipients;
+        private DataTable dtPortalSettings;
+        private DataTable dtMessageConversationView;
+        private DataTable dtMessageThreadsView;
 
-        private UserInfo _adminUserInfo;
-        private UserInfo _hostUserInfo;
-        private UserInfo _user12UserInfo;
-        private UserInfo _groupOwnerUserInfo;
+        private UserInfo adminUserInfo;
+        private UserInfo hostUserInfo;
+        private UserInfo user12UserInfo;
+        private UserInfo groupOwnerUserInfo;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.Container = new SimpleContainer();
-            this._mockDataService = new Mock<IDataService>();
-            this._dataProvider = MockComponentProvider.CreateDataProvider();
-            this._mockRoleProvider = MockComponentProvider.CreateRoleProvider();
-            this._mockCacheProvider = MockComponentProvider.CreateDataCacheProvider();
+            this.mockDataService = new Mock<IDataService>();
+            this.dataProvider = MockComponentProvider.CreateDataProvider();
+            this.mockRoleProvider = MockComponentProvider.CreateRoleProvider();
+            this.mockCacheProvider = MockComponentProvider.CreateDataCacheProvider();
             MockComponentProvider.CreateEventLogController();
 
-            this._mockLocalizationProvider = MockComponentProvider.CreateLocalizationProvider();
-            this._mockLocalizationProvider.Setup(l => l.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns("{0}_{1}");
+            this.mockLocalizationProvider = MockComponentProvider.CreateLocalizationProvider();
+            this.mockLocalizationProvider.Setup(l => l.GetString(It.IsAny<string>(), It.IsAny<string>())).Returns("{0}_{1}");
 
-            this._messagingController = new MessagingController(this._mockDataService.Object);
-            this._internalMessagingController = new InternalMessagingControllerImpl(this._mockDataService.Object);
-            this._mockMessagingController = new Mock<MessagingController> { CallBase = true };
-            this._mockInternalMessagingController = new Mock<InternalMessagingControllerImpl> { CallBase = true };
+            this.messagingController = new MessagingController(this.mockDataService.Object);
+            this.internalMessagingController = new InternalMessagingControllerImpl(this.mockDataService.Object);
+            this.mockMessagingController = new Mock<MessagingController> { CallBase = true };
+            this.mockInternalMessagingController = new Mock<InternalMessagingControllerImpl> { CallBase = true };
 
-            this._portalController = new Mock<IPortalController>();
-            this._portalController.Setup(c => c.GetPortalSettings(It.IsAny<int>())).Returns(new Dictionary<string, string>());
-            PortalController.SetTestableInstance(this._portalController.Object);
+            this.portalController = new Mock<IPortalController>();
+            this.portalController.Setup(c => c.GetPortalSettings(It.IsAny<int>())).Returns(new Dictionary<string, string>());
+            PortalController.SetTestableInstance(this.portalController.Object);
 
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._folderManager = new Mock<IFolderManager>();
-            this._fileManager = new Mock<IFileManager>();
-            this._folderPermissionController = new Mock<IFolderPermissionController>();
+            this.folderManager = new Mock<IFolderManager>();
+            this.fileManager = new Mock<IFileManager>();
+            this.folderPermissionController = new Mock<IFolderPermissionController>();
 
-            FolderManager.RegisterInstance(this._folderManager.Object);
-            FileManager.RegisterInstance(this._fileManager.Object);
-            FolderPermissionController.SetTestableInstance(this._folderPermissionController.Object);
+            FolderManager.RegisterInstance(this.folderManager.Object);
+            FileManager.RegisterInstance(this.fileManager.Object);
+            FolderPermissionController.SetTestableInstance(this.folderPermissionController.Object);
 
             this.SetupDataProvider();
             this.SetupRoleProvider();
@@ -115,13 +105,27 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             this.SetupCachingProvider();
             this.SetupFileControllers();
 
-            this._mockInternalMessagingController.Setup(m => m.GetLastSentMessage(It.IsAny<UserInfo>())).Returns((Message)null);
+            this.mockInternalMessagingController.Setup(m => m.GetLastSentMessage(It.IsAny<UserInfo>())).Returns((Message)null);
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockDataService.Object);
+                    services.AddSingleton(this.dataProvider.Object);
+                    services.AddSingleton(this.portalController.Object);
+                    services.AddSingleton(this.mockRoleProvider.Object);
+                    services.AddSingleton(this.mockCacheProvider.Object);
+                    services.AddSingleton(this.mockLocalizationProvider.Object);
+                    services.AddSingleton(this.folderManager.Object);
+                    services.AddSingleton(this.fileManager.Object);
+                    services.AddSingleton(this.folderPermissionController.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             ComponentFactory.Container = null;
             PortalController.ClearInstance();
         }
@@ -138,24 +142,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         [Test]
         public void AttachmentsAllowed_Returns_True_When_MessagingAllowAttachments_Setting_Is_YES()
         {
-            this._mockMessagingController.Setup(mc => mc.GetPortalSetting("MessagingAllowAttachments", Constants.CONTENT_ValidPortalId, "YES")).Returns("YES");
-            var result = this._mockInternalMessagingController.Object.AttachmentsAllowed(Constants.CONTENT_ValidPortalId);
+            this.mockMessagingController.Setup(mc => mc.GetPortalSetting("MessagingAllowAttachments", Constants.CONTENT_ValidPortalId, "YES")).Returns("YES");
+            var result = this.mockInternalMessagingController.Object.AttachmentsAllowed(Constants.CONTENT_ValidPortalId);
             Assert.IsTrue(result);
         }
 
         [Test]
         public void IncludeAttachments_Returns_True_When_MessagingIncludeAttachments_Setting_Is_YES()
         {
-            this._mockMessagingController.Setup(mc => mc.GetPortalSetting("MessagingAllowAttachments", Constants.CONTENT_ValidPortalId, "YES")).Returns("YES");
-            var result = this._mockInternalMessagingController.Object.IncludeAttachments(Constants.CONTENT_ValidPortalId);
+            this.mockMessagingController.Setup(mc => mc.GetPortalSetting("MessagingAllowAttachments", Constants.CONTENT_ValidPortalId, "YES")).Returns("YES");
+            var result = this.mockInternalMessagingController.Object.IncludeAttachments(Constants.CONTENT_ValidPortalId);
             Assert.IsTrue(result);
         }
 
         [Test]
         public void AttachmentsAllowed_Returns_False_When_MessagingAllowAttachments_Setting_Is_Not_YES()
         {
-            this._mockInternalMessagingController.Setup(mc => mc.GetPortalSetting("MessagingAllowAttachments", Constants.CONTENT_ValidPortalId, "YES")).Returns("NO");
-            var result = this._mockInternalMessagingController.Object.AttachmentsAllowed(Constants.CONTENT_ValidPortalId);
+            this.mockInternalMessagingController.Setup(mc => mc.GetPortalSetting("MessagingAllowAttachments", Constants.CONTENT_ValidPortalId, "YES")).Returns("NO");
+            var result = this.mockInternalMessagingController.Object.AttachmentsAllowed(Constants.CONTENT_ValidPortalId);
             Assert.IsFalse(result);
         }
 
@@ -163,15 +167,15 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
 
         public void GetArchivedMessages_Calls_DataService_GetArchiveBoxView_With_Default_Values()
         {
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
 
-            this._dtMessageConversationView.Clear();
+            this.dtMessageConversationView.Clear();
 
-            this._mockDataService
+            this.mockDataService
                 .Setup(ds => ds.GetArchiveBoxView(
                     Constants.UserID_User12,
                     Constants.PORTAL_Zero,
@@ -179,12 +183,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                     It.IsAny<int>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>()))
-                .Returns(this._dtMessageConversationView.CreateDataReader())
+                .Returns(this.dtMessageConversationView.CreateDataReader())
                 .Verifiable();
 
-            this._mockInternalMessagingController.Object.GetArchivedMessages(Constants.UserID_User12, 0, 0);
+            this.mockInternalMessagingController.Object.GetArchivedMessages(Constants.UserID_User12, 0, 0);
 
-            this._mockInternalMessagingController.Verify();
+            this.mockInternalMessagingController.Verify();
         }
 
         [Test]
@@ -192,13 +196,13 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         {
             var totalRecords = 0;
 
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._dtMessageThreadsView.Clear();
+            this.dtMessageThreadsView.Clear();
 
-            this._mockDataService.Setup(ds => ds.GetMessageThread(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), ref totalRecords)).Returns(this._dtMessageThreadsView.CreateDataReader()).Verifiable();
-            this._mockInternalMessagingController.Object.GetMessageThread(0, 0, 0, 0, string.Empty, false, ref totalRecords);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.GetMessageThread(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), ref totalRecords)).Returns(this.dtMessageThreadsView.CreateDataReader()).Verifiable();
+            this.mockInternalMessagingController.Object.GetMessageThread(0, 0, 0, 0, string.Empty, false, ref totalRecords);
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -206,15 +210,15 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         {
             // Arrange
             var totalRecords = 0;
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._dtMessageThreadsView.Clear();
-            this._mockDataService.Setup(ds => ds.GetMessageThread(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), ref totalRecords)).Returns(this._dtMessageThreadsView.CreateDataReader()).Verifiable();
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.dtMessageThreadsView.Clear();
+            this.mockDataService.Setup(ds => ds.GetMessageThread(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), ref totalRecords)).Returns(this.dtMessageThreadsView.CreateDataReader()).Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetMessageThread(0, 0, 0, 0, ref totalRecords);
+            this.mockInternalMessagingController.Object.GetMessageThread(0, 0, 0, 0, ref totalRecords);
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -222,11 +226,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void GetRecentSentbox_Calls_Overload_With_Default_Values()
         {
             // Arrange
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._dtMessageConversationView.Clear();
-            this._mockDataService
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.dtMessageConversationView.Clear();
+            this.mockDataService
                 .Setup(ds => ds.GetSentBoxView(
                     Constants.UserID_User12,
                     Constants.PORTAL_Zero,
@@ -234,15 +238,15 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                     It.IsAny<int>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>()))
-                .Returns(this._dtMessageConversationView.CreateDataReader())
+                .Returns(this.dtMessageConversationView.CreateDataReader())
                 .Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetRecentSentbox(Constants.UserID_User12);
+            this.mockInternalMessagingController.Object.GetRecentSentbox(Constants.UserID_User12);
 
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -250,11 +254,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void GetRecentSentbox_Calls_GetSentbox_With_Default_Values()
         {
             // Arrange
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._dtMessageConversationView.Clear();
-            this._mockDataService
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.dtMessageConversationView.Clear();
+            this.mockDataService
                 .Setup(ds => ds.GetSentBoxView(
                     Constants.UserID_User12,
                     Constants.PORTAL_Zero,
@@ -262,29 +266,29 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                     It.IsAny<int>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>()))
-                .Returns(this._dtMessageConversationView.CreateDataReader())
+                .Returns(this.dtMessageConversationView.CreateDataReader())
                 .Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetRecentSentbox(Constants.UserID_User12);
+            this.mockInternalMessagingController.Object.GetRecentSentbox(Constants.UserID_User12);
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
 
         public void GetSentbox_Calls_DataService_GetSentBoxView_With_Default_Values()
         {
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
 
-            this._dtMessageConversationView.Clear();
+            this.dtMessageConversationView.Clear();
 
-            this._mockDataService
+            this.mockDataService
                 .Setup(ds => ds.GetSentBoxView(
                     Constants.UserID_User12,
                     Constants.PORTAL_Zero,
@@ -292,10 +296,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                     It.IsAny<int>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>()))
-                .Returns(this._dtMessageConversationView.CreateDataReader())
+                .Returns(this.dtMessageConversationView.CreateDataReader())
                 .Verifiable();
 
-            this._mockInternalMessagingController.Object.GetSentbox(
+            this.mockInternalMessagingController.Object.GetSentbox(
                 Constants.UserID_User12,
                 0,
                 0,
@@ -304,7 +308,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                 MessageReadStatus.Any,
                 MessageArchivedStatus.Any);
 
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -312,11 +316,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void GetSentbox_Calls_Overload_With_Default_Values()
         {
             // Arrange
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._dtMessageConversationView.Clear();
-            this._mockDataService
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.dtMessageConversationView.Clear();
+            this.mockDataService
                 .Setup(ds => ds.GetSentBoxView(
                     Constants.UserID_User12,
                     Constants.PORTAL_Zero,
@@ -324,25 +328,25 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                     It.IsAny<int>(),
                     It.IsAny<string>(),
                     It.IsAny<bool>()))
-                .Returns(this._dtMessageConversationView.CreateDataReader())
+                .Returns(this.dtMessageConversationView.CreateDataReader())
                 .Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetSentbox(Constants.UserID_User12, 0, 0, string.Empty, false);
+            this.mockInternalMessagingController.Object.GetSentbox(Constants.UserID_User12, 0, 0, string.Empty, false);
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void RecipientLimit_Returns_MessagingRecipientLimit_Setting()
         {
             const int expected = 10;
-            this._mockInternalMessagingController
+            this.mockInternalMessagingController
                 .Setup(mc => mc.GetPortalSettingAsInteger("MessagingRecipientLimit", Constants.CONTENT_ValidPortalId, It.IsAny<int>()))
                 .Returns(expected);
 
-            var actual = this._mockInternalMessagingController.Object.RecipientLimit(Constants.CONTENT_ValidPortalId);
+            var actual = this.mockInternalMessagingController.Object.RecipientLimit(Constants.CONTENT_ValidPortalId);
 
             Assert.AreEqual(expected, actual);
         }
@@ -352,7 +356,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void MessagingController_CreateMessage_Throws_On_Null_Message()
         {
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(null, new List<RoleInfo>(), new List<UserInfo>(), new List<int>(), this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(null, new List<RoleInfo>(), new List<UserInfo>(), new List<int>(), this.user12UserInfo));
         }
 
         [Test]
@@ -360,7 +364,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void MessagingController_CreateMessage_Throws_On_Null_Body_And_Subject()
         {
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(new Message(), new List<RoleInfo>(), new List<UserInfo>(), new List<int>(), this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(new Message(), new List<RoleInfo>(), new List<UserInfo>(), new List<int>(), this.user12UserInfo));
         }
 
         [Test]
@@ -371,7 +375,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var message = new Message { Subject = "subject", Body = "body" };
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, null, null, null, this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, null, null, null, this.user12UserInfo));
         }
 
         [Test]
@@ -382,7 +386,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var message = new Message { Subject = "subject", Body = "body" };
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, new List<RoleInfo>(), new List<UserInfo>(), null, this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, new List<RoleInfo>(), new List<UserInfo>(), null, this.user12UserInfo));
         }
 
         [Test]
@@ -393,7 +397,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var message = new Message { Subject = "subject", Body = "body" };
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, new List<RoleInfo> { new RoleInfo() }, new List<UserInfo> { new UserInfo() }, null, this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, new List<RoleInfo> { new RoleInfo() }, new List<UserInfo> { new UserInfo() }, null, this.user12UserInfo));
         }
 
         [Test]
@@ -411,7 +415,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var message = new Message { Subject = subject.ToString(), Body = "body" };
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, new List<RoleInfo> { new RoleInfo() }, new List<UserInfo> { new UserInfo() }, null, this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, new List<RoleInfo> { new RoleInfo() }, new List<UserInfo> { new UserInfo() }, null, this.user12UserInfo));
         }
 
         [Test]
@@ -430,7 +434,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             }
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, roles, users, null, this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, roles, users, null, this.user12UserInfo));
         }
 
         [Test]
@@ -443,7 +447,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var role = new RoleInfo { RoleName = "role1" };
 
             // Act
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, null));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, null));
         }
 
         [Test]
@@ -457,7 +461,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var sender = new UserInfo { DisplayName = "user11" };
 
             // Act
-            Assert.Throws<ArgumentException>(() => this._messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, sender));
+            Assert.Throws<ArgumentException>(() => this.messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, sender));
         }
 
         [Test]
@@ -472,11 +476,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var mockDataService = new Mock<IDataService>();
             var messagingController = new MessagingController(mockDataService.Object);
 
-            this._dtMessageRecipients.Clear();
-            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this._dtMessageRecipients.CreateDataReader());
+            this.dtMessageRecipients.Clear();
+            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this.dtMessageRecipients.CreateDataReader());
 
             // Act
-            Assert.Throws<ArgumentException>(() => messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._user12UserInfo));
+            Assert.Throws<ArgumentException>(() => messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.user12UserInfo));
         }
 
         // [Test]
@@ -491,17 +495,17 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var messagingController = new MessagingController(mockDataService.Object);
 
             // disable caching
-            this._mockCacheProvider.Setup(mc => mc.GetItem(It.IsAny<string>())).Returns(null);
+            this.mockCacheProvider.Setup(mc => mc.GetItem(It.IsAny<string>())).Returns(null);
 
-            this._dtPortalSettings.Clear();
-            this._dtPortalSettings.Rows.Add(Constants.PORTALSETTING_MessagingAllowAttachments_Name, Constants.PORTALSETTING_MessagingAllowAttachments_Value_NO, Constants.CULTURE_EN_US);
-            this._dataProvider.Setup(d => d.GetPortalSettings(It.IsAny<int>(), It.IsAny<string>())).Returns(this._dtPortalSettings.CreateDataReader());
+            this.dtPortalSettings.Clear();
+            this.dtPortalSettings.Rows.Add(Constants.PORTALSETTING_MessagingAllowAttachments_Name, Constants.PORTALSETTING_MessagingAllowAttachments_Value_NO, Constants.CULTURE_EN_US);
+            this.dataProvider.Setup(d => d.GetPortalSettings(It.IsAny<int>(), It.IsAny<string>())).Returns(this.dtPortalSettings.CreateDataReader());
 
-            this._dtMessageRecipients.Clear();
-            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this._dtMessageRecipients.CreateDataReader());
+            this.dtMessageRecipients.Clear();
+            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this.dtMessageRecipients.CreateDataReader());
 
             // Act
-            Assert.Throws<AttachmentsNotAllowed>(() => messagingController.SendMessage(message, null, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._user12UserInfo));
+            Assert.Throws<AttachmentsNotAllowed>(() => messagingController.SendMessage(message, null, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.user12UserInfo));
         }
 
         [Test]
@@ -513,28 +517,28 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this.adminUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.SaveMessage(
+            this.mockDataService.Verify(ds => ds.SaveMessage(
                 It.Is<Message>(v => v.PortalID == Constants.PORTAL_Zero && v.Subject == "subject"
                                                                              && v.Body == "body"
                                                                              && v.To == "role1,user1"
-                                                                             && v.SenderUserID == this._adminUserInfo.UserID),
+                                                                             && v.SenderUserID == this.adminUserInfo.UserID),
                 It.IsAny<int>(),
                 It.IsAny<int>()));
         }
@@ -548,23 +552,23 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var role = new RoleInfo { RoleName = "role1" };
             var message = new Message { Subject = "subject", Body = "body" };
 
-            this._dtMessageRecipients.Clear();
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this._dtMessageRecipients.CreateDataReader());
+            this.dtMessageRecipients.Clear();
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController
+            this.mockMessagingController
                 .Setup(mc => mc.GetPortalSetting("MessagingProfanityFilters", It.IsAny<int>(), It.IsAny<string>()))
                 .Returns("YES");
 
-            this._mockMessagingController.Setup(mc => mc.InputFilter("subject")).Returns("subject_filtered");
-            this._mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
-            this._mockInternalMessagingController.Setup(mc => mc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>()));
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.InputFilter("subject")).Returns("subject_filtered");
+            this.mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
+            this.mockInternalMessagingController.Setup(mc => mc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>()));
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this.adminUserInfo);
 
             // Assert
             Assert.AreEqual("subject_filtered", message.Subject);
@@ -580,28 +584,28 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var role = new RoleInfo { RoleName = "role1" };
             var message = new Message { Subject = "subject", Body = "body" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
             // this pattern is based on: http://dpwhelan.com/blog/software-development/moq-sequences/
             var callingSequence = 0;
 
             // Arrange for Assert
-            this._mockDataService.Setup(ds => ds.CreateMessageRecipientsForRole(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>())).Callback(() => Assert.That(callingSequence++, Is.EqualTo(0)));
-            this._mockDataService.Setup(ds => ds.SaveMessageRecipient(It.IsAny<MessageRecipient>(), It.IsAny<int>())).Callback(() => Assert.That(callingSequence++, Is.GreaterThan(0)));
+            this.mockDataService.Setup(ds => ds.CreateMessageRecipientsForRole(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>())).Callback(() => Assert.That(callingSequence++, Is.EqualTo(0)));
+            this.mockDataService.Setup(ds => ds.SaveMessageRecipient(It.IsAny<MessageRecipient>(), It.IsAny<int>())).Callback(() => Assert.That(callingSequence++, Is.GreaterThan(0)));
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this.adminUserInfo);
 
             // SaveMessageRecipient is called twice, one for sent message and second for receive
         }
@@ -617,18 +621,18 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var mockDataService = new Mock<IDataService>();
             var messagingController = new MessagingController(mockDataService.Object);
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this._user12UserInfo.PortalID, It.IsAny<double>())).Returns(0);
+            this.mockInternalMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this.user12UserInfo.PortalID, It.IsAny<double>())).Returns(0);
 
             mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
             mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_ElevenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
             messagingController.SendMessage(message, new List<RoleInfo>(), new List<UserInfo> { user }, null, sender);
@@ -649,18 +653,18 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var mockDataService = new Mock<IDataService>();
             var messagingController = new MessagingController(mockDataService.Object);
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this._user12UserInfo.PortalID, It.IsAny<double>())).Returns(0);
+            this.mockInternalMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this.user12UserInfo.PortalID, It.IsAny<double>())).Returns(0);
 
-            this._dtMessageRecipients.Clear();
+            this.dtMessageRecipients.Clear();
             var recipientId = 0;
 
-            // _dtMessageRecipients.Rows.Add(Constants.Messaging_RecipientId_2, Constants.USER_Null, Constants.Messaging_UnReadMessage, Constants.Messaging_UnArchivedMessage);
+            // dtMessageRecipients.Rows.Add(Constants.Messaging_RecipientId_2, Constants.USER_Null, Constants.Messaging_UnReadMessage, Constants.Messaging_UnArchivedMessage);
             mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>()))
-                .Callback(() => this._dtMessageRecipients.Rows.Add(recipientId++, Constants.USER_Null, Constants.Messaging_UnReadMessage, Constants.Messaging_UnArchivedMessage))
-                .Returns(() => this._dtMessageRecipients.CreateDataReader());
+                .Callback(() => this.dtMessageRecipients.Rows.Add(recipientId++, Constants.USER_Null, Constants.Messaging_UnReadMessage, Constants.Messaging_UnArchivedMessage))
+                .Returns(() => this.dtMessageRecipients.CreateDataReader());
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
             messagingController.SendMessage(message, new List<RoleInfo>(), new List<UserInfo> { user10, user11 }, null, sender);
@@ -677,13 +681,13 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var message = new Message { Subject = "subject", Body = "body" };
             var role = new RoleInfo { RoleName = Constants.RoleName_Administrators };
 
-            this._dtMessageRecipients.Clear();
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this._dtMessageRecipients.CreateDataReader());
+            this.dtMessageRecipients.Clear();
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo>(), null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo>(), null, this.adminUserInfo);
 
             // Assert
             Assert.AreEqual(message.To, Constants.RoleName_Administrators);
@@ -698,13 +702,13 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var role1 = new RoleInfo { RoleName = Constants.RoleName_Administrators };
             var role2 = new RoleInfo { RoleName = Constants.RoleName_Subscribers };
 
-            this._dtMessageRecipients.Clear();
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this._dtMessageRecipients.CreateDataReader());
+            this.dtMessageRecipients.Clear();
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), It.IsAny<int>())).Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role1, role2 }, new List<UserInfo>(), null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role1, role2 }, new List<UserInfo>(), null, this.adminUserInfo);
 
             // Assert
             Assert.AreEqual(message.To, Constants.RoleName_Administrators + "," + Constants.RoleName_Subscribers);
@@ -719,51 +723,51 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.adminUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.SaveMessageAttachment(It.Is<MessageAttachment>(v => v.MessageID == message.MessageID), It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.SaveMessageAttachment(It.Is<MessageAttachment>(v => v.MessageID == message.MessageID), It.IsAny<int>()));
         }
 
         [Test]
 
         public void MessagingController_CreateMessage_Calls_DataService_CreateSocialMessageRecipientsForRole_On_Passing_Role_ByAdmin()
         {
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
 
             // Arrange
             var message = new Message { Subject = "subject", Body = "body" };
             var role = new RoleInfo { RoleName = Constants.RoleName_RegisteredUsers, RoleID = Constants.RoleID_RegisteredUsers };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._user12UserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.user12UserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { this._user12UserInfo }, new List<int> { Constants.FOLDER_ValidFileId }, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { this.user12UserInfo }, new List<int> { Constants.FOLDER_ValidFileId }, this.adminUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(message.MessageID, Constants.RoleID_RegisteredUsers.ToString(), It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(message.MessageID, Constants.RoleID_RegisteredUsers.ToString(), It.IsAny<int>()));
         }
 
         [Test]
@@ -777,19 +781,19 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var mockDataService = new Mock<IDataService>();
             var messagingController = new MessagingController(mockDataService.Object);
 
-            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._user12UserInfo.UserID))
+            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.user12UserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._hostUserInfo.UserID))
+            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.hostUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { this._user12UserInfo }, new List<int> { Constants.FOLDER_ValidFileId }, this._hostUserInfo);
+            messagingController.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { this.user12UserInfo }, new List<int> { Constants.FOLDER_ValidFileId }, this.hostUserInfo);
 
             // Assert
             mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(message.MessageID, Constants.RoleID_RegisteredUsers.ToString(), It.IsAny<int>()));
@@ -805,24 +809,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var role1 = new RoleInfo { RoleName = "role1", RoleID = Constants.RoleID_RegisteredUsers };
             var role2 = new RoleInfo { RoleName = "role2", RoleID = Constants.RoleID_Administrators };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role1, role2 }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role1, role2 }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.adminUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(message.MessageID, Constants.RoleID_RegisteredUsers + "," + Constants.RoleID_Administrators, It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(message.MessageID, Constants.RoleID_RegisteredUsers + "," + Constants.RoleID_Administrators, It.IsAny<int>()));
         }
 
         [Test]
@@ -834,24 +838,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = Constants.RoleName_FirstSocialGroup, RoleID = Constants.RoleID_FirstSocialGroup };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>()));
+            this.mockInternalMessagingController.Setup(mc => mc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>()));
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._groupOwnerUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.groupOwnerUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.CreateMessageRecipientsForRole(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>()));
         }
 
         [Test]
@@ -863,24 +867,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this.adminUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(v => v.MessageID == message.MessageID && v.UserID == user.UserID), It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(v => v.MessageID == message.MessageID && v.UserID == user.UserID), It.IsAny<int>()));
         }
 
         [Test]
@@ -892,21 +896,21 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1", RoleID = Constants.RoleID_RegisteredUsers };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.adminUserInfo);
 
             // Assert
             Assert.AreEqual(message.ReplyAllAllowed, false);
@@ -924,17 +928,17 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
 
             mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            messagingController.SendMessage(message, new List<RoleInfo>(), new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this._adminUserInfo);
+            messagingController.SendMessage(message, new List<RoleInfo>(), new List<UserInfo> { user }, new List<int> { Constants.FOLDER_ValidFileId }, this.adminUserInfo);
 
             // Assert
             Assert.AreEqual(message.ReplyAllAllowed, true);
@@ -949,24 +953,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this.adminUserInfo);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(v => v.MessageID == message.MessageID && v.UserID == this._adminUserInfo.UserID), It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(v => v.MessageID == message.MessageID && v.UserID == this.adminUserInfo.UserID), It.IsAny<int>()));
         }
 
         [Test]
@@ -978,26 +982,26 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
-            this._mockDataService.Setup(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(mr => mr.UserID == this._adminUserInfo.UserID), It.IsAny<int>())).Returns(Constants.Messaging_RecipientId_1);
+            this.mockDataService.Setup(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(mr => mr.UserID == this.adminUserInfo.UserID), It.IsAny<int>())).Returns(Constants.Messaging_RecipientId_1);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user }, null, this.adminUserInfo);
 
             // Assert
-            this._mockInternalMessagingController.Verify(imc => imc.MarkMessageAsDispatched(It.IsAny<int>(), Constants.Messaging_RecipientId_1));
+            this.mockInternalMessagingController.Verify(imc => imc.MarkMessageAsDispatched(It.IsAny<int>(), Constants.Messaging_RecipientId_1));
         }
 
         [Test]
@@ -1009,26 +1013,26 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
             var role = new RoleInfo { RoleName = "role1" };
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), Constants.USER_TenId))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this._adminUserInfo.UserID))
+            this.mockDataService.Setup(md => md.GetMessageRecipientByMessageAndUser(It.IsAny<int>(), this.adminUserInfo.UserID))
                 .Callback(this.SetupDataTables)
-                .Returns(this._dtMessageRecipients.CreateDataReader());
+                .Returns(this.dtMessageRecipients.CreateDataReader());
 
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(ims => ims.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns((MessageRecipient)null);
 
-            this._mockDataService.Setup(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(mr => mr.UserID == this._adminUserInfo.UserID), It.IsAny<int>())).Returns(Constants.Messaging_RecipientId_1);
+            this.mockDataService.Setup(ds => ds.SaveMessageRecipient(It.Is<MessageRecipient>(mr => mr.UserID == this.adminUserInfo.UserID), It.IsAny<int>())).Returns(Constants.Messaging_RecipientId_1);
 
             // Act
-            this._mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user, this._adminUserInfo }, null, this._adminUserInfo);
+            this.mockMessagingController.Object.SendMessage(message, new List<RoleInfo> { role }, new List<UserInfo> { user, this.adminUserInfo }, null, this.adminUserInfo);
 
             // Assert
-            this._mockInternalMessagingController.Verify(imc => imc.MarkMessageAsDispatched(It.IsAny<int>(), Constants.Messaging_RecipientId_1), Times.Never());
+            this.mockInternalMessagingController.Verify(imc => imc.MarkMessageAsDispatched(It.IsAny<int>(), Constants.Messaging_RecipientId_1), Times.Never());
         }
 
         [Test]
@@ -1038,7 +1042,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             // Arrange
 
             // Act
-            Assert.Throws<ArgumentException>(() => this._internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, "body", null, null));
+            Assert.Throws<ArgumentException>(() => this.internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, "body", null, null));
         }
 
         [Test]
@@ -1049,7 +1053,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var sender = new UserInfo { DisplayName = "user11" };
 
             // Act
-            Assert.Throws<ArgumentException>(() => this._internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, "body", null, sender));
+            Assert.Throws<ArgumentException>(() => this.internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, "body", null, sender));
         }
 
         [Test]
@@ -1060,7 +1064,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId };
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, null, null, sender));
+            Assert.Throws<ArgumentException>(() => this.internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, null, null, sender));
         }
 
         [Test]
@@ -1071,7 +1075,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId };
 
             // Act, Assert
-            Assert.Throws<ArgumentException>(() => this._internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, string.Empty, null, sender));
+            Assert.Throws<ArgumentException>(() => this.internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, string.Empty, null, sender));
         }
 
         [Test]
@@ -1081,11 +1085,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             // Arrange
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId, PortalID = Constants.PORTAL_Zero };
 
-            InternalMessagingController.SetTestableInstance(this._mockInternalMessagingController.Object);
-            this._mockInternalMessagingController.Setup(imc => imc.AttachmentsAllowed(Constants.PORTAL_Zero)).Returns(false);
+            InternalMessagingController.SetTestableInstance(this.mockInternalMessagingController.Object);
+            this.mockInternalMessagingController.Setup(imc => imc.AttachmentsAllowed(Constants.PORTAL_Zero)).Returns(false);
 
             // Act, Assert
-            Assert.Throws<AttachmentsNotAllowed>(() => this._internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, "body", new List<int> { Constants.FOLDER_ValidFileId }, sender));
+            Assert.Throws<AttachmentsNotAllowed>(() => this.internalMessagingController.ReplyMessage(Constants.Messaging_MessageId_1, "body", new List<int> { Constants.FOLDER_ValidFileId }, sender));
         }
 
         [Test]
@@ -1095,20 +1099,20 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             // Arrange
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId, PortalID = Constants.PORTAL_Zero };
 
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
-            this._mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
+            this.mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
+            this.mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
 
-            this._mockMessagingController
+            this.mockMessagingController
                 .Setup(mc => mc.GetPortalSetting("MessagingProfanityFilters", It.IsAny<int>(), It.IsAny<string>()))
                 .Returns("YES");
 
-            this._mockInternalMessagingController.Setup(imc => imc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns(new MessageRecipient());
+            this.mockInternalMessagingController.Setup(imc => imc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns(new MessageRecipient());
 
-            this._mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender);
+            this.mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender);
 
-            this._mockDataService.Verify(ds => ds.CreateMessageReply(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>()));
+            this.mockDataService.Verify(ds => ds.CreateMessageReply(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>()));
         }
 
         [Test]
@@ -1118,18 +1122,18 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             // Arrange
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId, PortalID = Constants.PORTAL_Zero };
 
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
-            this._mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
+            this.mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
+            this.mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
 
-            this._mockMessagingController
+            this.mockMessagingController
                 .Setup(mc => mc.GetPortalSetting("MessagingProfanityFilters", It.IsAny<int>(), It.IsAny<string>()))
                 .Returns("NO");
 
-            this._mockDataService.Setup(ds => ds.CreateMessageReply(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>())).Returns(-1);
+            this.mockDataService.Setup(ds => ds.CreateMessageReply(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>())).Returns(-1);
 
-            Assert.Throws<MessageOrRecipientNotFoundException>(() => this._mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender));
+            Assert.Throws<MessageOrRecipientNotFoundException>(() => this.mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender));
         }
 
         [Test]
@@ -1139,20 +1143,20 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             // Arrange
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId, PortalID = Constants.PORTAL_Zero };
 
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
-            this._mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
+            this.mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
+            this.mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
 
-            this._mockMessagingController
+            this.mockMessagingController
                 .Setup(mc => mc.GetPortalSetting("MessagingProfanityFilters", It.IsAny<int>(), It.IsAny<string>()))
                 .Returns("NO");
 
-            this._mockInternalMessagingController.Setup(imc => imc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns(new MessageRecipient());
+            this.mockInternalMessagingController.Setup(imc => imc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns(new MessageRecipient());
 
-            this._mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender);
+            this.mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender);
 
-            this._mockInternalMessagingController.Verify(imc => imc.MarkRead(It.IsAny<int>(), sender.UserID));
+            this.mockInternalMessagingController.Verify(imc => imc.MarkRead(It.IsAny<int>(), sender.UserID));
         }
 
         [Test]
@@ -1162,20 +1166,20 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             // Arrange
             var sender = new UserInfo { DisplayName = "user11", UserID = Constants.USER_TenId, PortalID = Constants.PORTAL_Zero };
 
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
-            this._mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
+            this.mockMessagingController.Setup(mc => mc.InputFilter("body")).Returns("body_filtered");
+            this.mockMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(new UserInfo());
 
-            this._mockMessagingController
+            this.mockMessagingController
                 .Setup(mc => mc.GetPortalSetting("MessagingProfanityFilters", It.IsAny<int>(), It.IsAny<string>()))
                 .Returns("NO");
 
-            this._mockInternalMessagingController.Setup(imc => imc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns(new MessageRecipient { RecipientID = Constants.Messaging_RecipientId_1 });
+            this.mockInternalMessagingController.Setup(imc => imc.GetMessageRecipient(It.IsAny<int>(), It.IsAny<int>())).Returns(new MessageRecipient { RecipientID = Constants.Messaging_RecipientId_1 });
 
-            this._mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender);
+            this.mockInternalMessagingController.Object.ReplyMessage(0, "body", null, sender);
 
-            this._mockInternalMessagingController.Verify(imc => imc.MarkMessageAsDispatched(It.IsAny<int>(), Constants.Messaging_RecipientId_1));
+            this.mockInternalMessagingController.Verify(imc => imc.MarkMessageAsDispatched(It.IsAny<int>(), Constants.Messaging_RecipientId_1));
         }
 
         [Test]
@@ -1186,10 +1190,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
 
             // Act
-            this._internalMessagingController.MarkRead(messageInstance.ConversationId, user.UserID);
+            this.internalMessagingController.MarkRead(messageInstance.ConversationId, user.UserID);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.UpdateMessageReadStatus(messageInstance.ConversationId, user.UserID, true));
+            this.mockDataService.Verify(ds => ds.UpdateMessageReadStatus(messageInstance.ConversationId, user.UserID, true));
         }
 
         [Test]
@@ -1200,10 +1204,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
 
             // Act
-            this._internalMessagingController.MarkUnRead(messageInstance.ConversationId, user.UserID);
+            this.internalMessagingController.MarkUnRead(messageInstance.ConversationId, user.UserID);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.UpdateMessageReadStatus(messageInstance.ConversationId, user.UserID, false));
+            this.mockDataService.Verify(ds => ds.UpdateMessageReadStatus(messageInstance.ConversationId, user.UserID, false));
         }
 
         [Test]
@@ -1214,10 +1218,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
 
             // Act
-            this._internalMessagingController.MarkArchived(messageInstance.ConversationId, user.UserID);
+            this.internalMessagingController.MarkArchived(messageInstance.ConversationId, user.UserID);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.UpdateMessageArchivedStatus(messageInstance.ConversationId, user.UserID, true));
+            this.mockDataService.Verify(ds => ds.UpdateMessageArchivedStatus(messageInstance.ConversationId, user.UserID, true));
         }
 
         [Test]
@@ -1228,42 +1232,42 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user = new UserInfo { DisplayName = "user1", UserID = Constants.USER_TenId };
 
             // Act
-            this._internalMessagingController.MarkUnArchived(messageInstance.ConversationId, user.UserID);
+            this.internalMessagingController.MarkUnArchived(messageInstance.ConversationId, user.UserID);
 
             // Assert
-            this._mockDataService.Verify(ds => ds.UpdateMessageArchivedStatus(messageInstance.ConversationId, user.UserID, false));
+            this.mockDataService.Verify(ds => ds.UpdateMessageArchivedStatus(messageInstance.ConversationId, user.UserID, false));
         }
 
         [Test]
 
         public void GetSocialMessageRecipient_Calls_DataService_GetSocialMessageRecipientByMessageAndUser()
         {
-            this._dtMessageRecipients.Clear();
-            this._mockDataService
+            this.dtMessageRecipients.Clear();
+            this.mockDataService
                 .Setup(ds => ds.GetMessageRecipientByMessageAndUser(Constants.Messaging_MessageId_1, Constants.UserID_User12))
-                .Returns(this._dtMessageRecipients.CreateDataReader())
+                .Returns(this.dtMessageRecipients.CreateDataReader())
                 .Verifiable();
 
-            this._internalMessagingController.GetMessageRecipient(Constants.Messaging_MessageId_1, Constants.UserID_User12);
+            this.internalMessagingController.GetMessageRecipient(Constants.Messaging_MessageId_1, Constants.UserID_User12);
 
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
 
         public void WaitTimeForNextMessage_Throws_On_Null_Sender()
         {
-            Assert.Throws<ArgumentNullException>(() => this._internalMessagingController.WaitTimeForNextMessage(null));
+            Assert.Throws<ArgumentNullException>(() => this.internalMessagingController.WaitTimeForNextMessage(null));
         }
 
         [Test]
 
         public void WaitTimeForNextMessage_Returns_Zero_When_MessagingThrottlingInterval_Is_Zero()
         {
-            this._user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;
-            this._mockMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this._user12UserInfo.PortalID, 0.5)).Returns(0.5);
+            this.user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;
+            this.mockMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this.user12UserInfo.PortalID, 0.5)).Returns(0.5);
 
-            var result = this._mockInternalMessagingController.Object.WaitTimeForNextMessage(this._user12UserInfo);
+            var result = this.mockInternalMessagingController.Object.WaitTimeForNextMessage(this.user12UserInfo);
 
             Assert.AreEqual(0, result);
         }
@@ -1272,12 +1276,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
 
         public void WaitTimeForNextMessage_Returns_Zero_When_Sender_Is_Admin_Or_Host()
         {
-            this._adminUserInfo.PortalID = Constants.CONTENT_ValidPortalId;
+            this.adminUserInfo.PortalID = Constants.CONTENT_ValidPortalId;
 
-            this._mockMessagingController.Setup(mc => mc.GetPortalSettingAsInteger(It.IsAny<string>(), this._adminUserInfo.PortalID, Null.NullInteger)).Returns(1);
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(true);
+            this.mockMessagingController.Setup(mc => mc.GetPortalSettingAsInteger(It.IsAny<string>(), this.adminUserInfo.PortalID, Null.NullInteger)).Returns(1);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(true);
 
-            var result = this._mockInternalMessagingController.Object.WaitTimeForNextMessage(this._adminUserInfo);
+            var result = this.mockInternalMessagingController.Object.WaitTimeForNextMessage(this.adminUserInfo);
 
             Assert.AreEqual(0, result);
         }
@@ -1286,14 +1290,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
 
         public void WaitTimeForNextMessage_Returns_Zero_When_The_User_Has_No_Previous_Conversations()
         {
-            this._user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;
+            this.user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;
 
-            this._mockMessagingController.Setup(mc => mc.GetPortalSettingAsInteger(It.IsAny<string>(), this._user12UserInfo.PortalID, Null.NullInteger)).Returns(1);
-            this._mockMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(false);
+            this.mockMessagingController.Setup(mc => mc.GetPortalSettingAsInteger(It.IsAny<string>(), this.user12UserInfo.PortalID, Null.NullInteger)).Returns(1);
+            this.mockMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(false);
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetLastSentMessage(this._user12UserInfo)).Returns((Message)null);
+            this.mockInternalMessagingController.Setup(mc => mc.GetLastSentMessage(this.user12UserInfo)).Returns((Message)null);
 
-            var result = this._mockInternalMessagingController.Object.WaitTimeForNextMessage(this._user12UserInfo);
+            var result = this.mockInternalMessagingController.Object.WaitTimeForNextMessage(this.user12UserInfo);
 
             Assert.AreEqual(0, result);
         }
@@ -1308,16 +1312,16 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var culture = CultureInfo.GetCultureInfo("en-US");
             var actualDate = DateTime.Parse(actualDateString, culture);
             var lastMessageDate = DateTime.Parse(lastMessageDateString, culture);
-            this._user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;
-            this._mockInternalMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this._user12UserInfo.PortalID, It.IsAny<double>())).Returns(throttlingInterval);
-            this._mockInternalMessagingController.Setup(mc => mc.IsAdminOrHost(this._adminUserInfo)).Returns(false);
-            this._dtMessages.Clear();
-            this._dtMessages.Rows.Add(-1, 1, 1, string.Empty, string.Empty, string.Empty, string.Empty, -1, -1, -1, -1, lastMessageDate, -1, Null.NullDate);
-            var dr = this._dtMessages.CreateDataReader();
+            this.user12UserInfo.PortalID = Constants.CONTENT_ValidPortalId;
+            this.mockInternalMessagingController.Setup(mc => mc.GetPortalSettingAsDouble(It.IsAny<string>(), this.user12UserInfo.PortalID, It.IsAny<double>())).Returns(throttlingInterval);
+            this.mockInternalMessagingController.Setup(mc => mc.IsAdminOrHost(this.adminUserInfo)).Returns(false);
+            this.dtMessages.Clear();
+            this.dtMessages.Rows.Add(-1, 1, 1, string.Empty, string.Empty, string.Empty, string.Empty, -1, -1, -1, -1, lastMessageDate, -1, Null.NullDate);
+            var dr = this.dtMessages.CreateDataReader();
             var message = CBO.FillObject<Message>(dr);
-            this._mockInternalMessagingController.Setup(mc => mc.GetLastSentMessage(It.IsAny<UserInfo>())).Returns(message);
-            this._mockInternalMessagingController.Setup(mc => mc.GetDateTimeNow()).Returns(actualDate);
-            var result = this._mockInternalMessagingController.Object.WaitTimeForNextMessage(this._user12UserInfo);
+            this.mockInternalMessagingController.Setup(mc => mc.GetLastSentMessage(It.IsAny<UserInfo>())).Returns(message);
+            this.mockInternalMessagingController.Setup(mc => mc.GetDateTimeNow()).Returns(actualDate);
+            var result = this.mockInternalMessagingController.Object.WaitTimeForNextMessage(this.user12UserInfo);
 
             Assert.AreEqual(expected, result);
         }
@@ -1326,16 +1330,16 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
 
         public void GetInbox_Calls_DataService_GetMessageBoxView()
         {
-            DataService.RegisterInstance(this._mockDataService.Object);
+            DataService.RegisterInstance(this.mockDataService.Object);
 
-            this._dtMessageConversationView.Clear();
+            this.dtMessageConversationView.Clear();
 
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
 
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.Any, MessageSentStatus.Received)).Returns(this._dtMessageConversationView.CreateDataReader()).Verifiable();
-            this._mockInternalMessagingController.Object.GetInbox(0, 0, 0, string.Empty, false, MessageReadStatus.Any, MessageArchivedStatus.Any);
-            this._mockDataService.Verify();
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.Any, MessageSentStatus.Received)).Returns(this.dtMessageConversationView.CreateDataReader()).Verifiable();
+            this.mockInternalMessagingController.Object.GetInbox(0, 0, 0, string.Empty, false, MessageReadStatus.Any, MessageArchivedStatus.Any);
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -1343,17 +1347,17 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void GetInbox_Calls_Overload_With_Default_Values()
         {
             // Arrange
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._dtMessageConversationView.Clear();
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.UnArchived, MessageSentStatus.Received)).Returns(this._dtMessageConversationView.CreateDataReader()).Verifiable();
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.dtMessageConversationView.Clear();
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.UnArchived, MessageSentStatus.Received)).Returns(this.dtMessageConversationView.CreateDataReader()).Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetInbox(this._user12UserInfo.UserID, 0, 0, string.Empty, false);
+            this.mockInternalMessagingController.Object.GetInbox(this.user12UserInfo.UserID, 0, 0, string.Empty, false);
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -1361,17 +1365,17 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void GetRecentInbox_Calls_GetInbox_With_Default_Values()
         {
             // Arrange
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._dtMessageConversationView.Clear();
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.UnArchived, MessageSentStatus.Received)).Returns(this._dtMessageConversationView.CreateDataReader()).Verifiable();
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.dtMessageConversationView.Clear();
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.UnArchived, MessageSentStatus.Received)).Returns(this.dtMessageConversationView.CreateDataReader()).Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetRecentInbox(Constants.UserID_User12, 0, 0);
+            this.mockInternalMessagingController.Object.GetRecentInbox(Constants.UserID_User12, 0, 0);
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
@@ -1379,87 +1383,87 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         public void GetRecentInbox_Calls_Overload_With_Default_Values()
         {
             // Arrange
-            DataService.RegisterInstance(this._mockDataService.Object);
-            this._dtMessageConversationView.Clear();
-            this._user12UserInfo.PortalID = Constants.PORTAL_Zero;
-            this._mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this._user12UserInfo);
-            this._mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.UnArchived, MessageSentStatus.Received)).Returns(this._dtMessageConversationView.CreateDataReader()).Verifiable();
+            DataService.RegisterInstance(this.mockDataService.Object);
+            this.dtMessageConversationView.Clear();
+            this.user12UserInfo.PortalID = Constants.PORTAL_Zero;
+            this.mockInternalMessagingController.Setup(mc => mc.GetCurrentUserInfo()).Returns(this.user12UserInfo);
+            this.mockDataService.Setup(ds => ds.GetInBoxView(It.IsAny<int>(), Constants.PORTAL_Zero, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), MessageReadStatus.Any, MessageArchivedStatus.UnArchived, MessageSentStatus.Received)).Returns(this.dtMessageConversationView.CreateDataReader()).Verifiable();
 
             // Act
-            this._mockInternalMessagingController.Object.GetRecentInbox(Constants.UserID_User12);
+            this.mockInternalMessagingController.Object.GetRecentInbox(Constants.UserID_User12);
 
             // Assert
-            this._mockDataService.Verify();
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void CountArchivedMessagesByConversation_Calls_DataService_CountArchivedMessagesByConversation()
         {
-            this._mockDataService.Setup(ds => ds.CountArchivedMessagesByConversation(It.IsAny<int>())).Verifiable();
-            this._internalMessagingController.CountArchivedMessagesByConversation(1);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.CountArchivedMessagesByConversation(It.IsAny<int>())).Verifiable();
+            this.internalMessagingController.CountArchivedMessagesByConversation(1);
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void CountMessagesByConversation_Calls_DataService_CountMessagesByConversation()
         {
-            this._mockDataService.Setup(ds => ds.CountMessagesByConversation(It.IsAny<int>())).Verifiable();
-            this._internalMessagingController.CountMessagesByConversation(1);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.CountMessagesByConversation(It.IsAny<int>())).Verifiable();
+            this.internalMessagingController.CountMessagesByConversation(1);
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void CountConversations_Calls_DataService_CountTotalConversations()
         {
-            this._mockDataService.Setup(ds => ds.CountTotalConversations(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
-            this._internalMessagingController.CountConversations(Constants.UserID_User12, Constants.PORTAL_Zero);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.CountTotalConversations(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
+            this.internalMessagingController.CountConversations(Constants.UserID_User12, Constants.PORTAL_Zero);
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void CountUnreadMessages_Calls_DataService_CountNewThreads()
         {
-            this._mockDataService.Setup(ds => ds.CountNewThreads(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
-            this._internalMessagingController.CountUnreadMessages(Constants.UserID_User12, Constants.PORTAL_Zero);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.CountNewThreads(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
+            this.internalMessagingController.CountUnreadMessages(Constants.UserID_User12, Constants.PORTAL_Zero);
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void CountSentMessages_Calls_DataService_CountSentMessages()
         {
-            this._mockDataService.Setup(ds => ds.CountSentMessages(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
-            this._internalMessagingController.CountSentMessages(Constants.UserID_User12, Constants.PORTAL_Zero);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.CountSentMessages(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
+            this.internalMessagingController.CountSentMessages(Constants.UserID_User12, Constants.PORTAL_Zero);
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void CountArchivedMessages_Calls_DataService_CountArchivedMessages()
         {
-            this._mockDataService.Setup(ds => ds.CountArchivedMessages(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
-            this._internalMessagingController.CountArchivedMessages(Constants.UserID_User12, Constants.PORTAL_Zero);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.CountArchivedMessages(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
+            this.internalMessagingController.CountArchivedMessages(Constants.UserID_User12, Constants.PORTAL_Zero);
+            this.mockDataService.Verify();
         }
 
         [Test]
         public void DeleteMessageRecipient_Calls_DataService_DeleteMessageRecipientByMessageAndUser()
         {
-            this._mockDataService.Setup(ds => ds.DeleteMessageRecipientByMessageAndUser(Constants.Messaging_MessageId_1, Constants.UserID_User12)).Verifiable();
-            this._internalMessagingController.DeleteMessageRecipient(Constants.Messaging_MessageId_1, Constants.UserID_User12);
-            this._mockDataService.Verify();
+            this.mockDataService.Setup(ds => ds.DeleteMessageRecipientByMessageAndUser(Constants.Messaging_MessageId_1, Constants.UserID_User12)).Verifiable();
+            this.internalMessagingController.DeleteMessageRecipient(Constants.Messaging_MessageId_1, Constants.UserID_User12);
+            this.mockDataService.Verify();
         }
 
         [Test]
 
         public void GetMessageRecipients_Calls_DataService_GetMessageRecipientsByMessage()
         {
-            this._dtMessageRecipients.Clear();
+            this.dtMessageRecipients.Clear();
 
-            this._mockDataService
+            this.mockDataService
                 .Setup(ds => ds.GetMessageRecipientsByMessage(Constants.Messaging_MessageId_1))
-                .Returns(this._dtMessageRecipients.CreateDataReader())
+                .Returns(this.dtMessageRecipients.CreateDataReader())
                 .Verifiable();
-            this._internalMessagingController.GetMessageRecipients(Constants.Messaging_MessageId_1);
-            this._mockDataService.Verify();
+            this.internalMessagingController.GetMessageRecipients(Constants.Messaging_MessageId_1);
+            this.mockDataService.Verify();
         }
 
         private static Message CreateValidMessage()
@@ -1480,7 +1484,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
         private void SetupDataProvider()
         {
             // Standard DataProvider Path for Logging
-            this._dataProvider.Setup(d => d.GetProviderPath()).Returns(string.Empty);
+            this.dataProvider.Setup(d => d.GetProviderPath()).Returns(string.Empty);
 
             var dataTable = new DataTable("Languages");
             var pkId = dataTable.Columns.Add("LanguageID", typeof(int));
@@ -1494,15 +1498,15 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             dataTable.PrimaryKey = new[] { pkId };
             dataTable.Rows.Add(1, "en-US", "English (United States)", null, -1, "2011-05-04 09:42:11.530", -1, "2011-05-04 09:42:11.530");
 
-            this._dataProvider.Setup(x => x.GetLanguages()).Returns(dataTable.CreateDataReader());
+            this.dataProvider.Setup(x => x.GetLanguages()).Returns(dataTable.CreateDataReader());
         }
 
         private void SetupUsers()
         {
-            this._adminUserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_Admin, UserID = Constants.UserID_Admin, Roles = new[] { Constants.RoleName_Administrators } };
-            this._hostUserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_Host, UserID = Constants.UserID_Host, IsSuperUser = true };
-            this._user12UserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_User12, UserID = Constants.UserID_User12 };
-            this._groupOwnerUserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_FirstSocialGroupOwner, UserID = Constants.UserID_FirstSocialGroupOwner };
+            this.adminUserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_Admin, UserID = Constants.UserID_Admin, Roles = new[] { Constants.RoleName_Administrators } };
+            this.hostUserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_Host, UserID = Constants.UserID_Host, IsSuperUser = true };
+            this.user12UserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_User12, UserID = Constants.UserID_User12 };
+            this.groupOwnerUserInfo = new UserInfo { DisplayName = Constants.UserDisplayName_FirstSocialGroupOwner, UserID = Constants.UserID_FirstSocialGroupOwner };
         }
 
         private void SetupPortalSettings()
@@ -1512,12 +1516,12 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
                 AdministratorRoleName = Constants.RoleName_Administrators,
             };
 
-            this._portalController.Setup(pc => pc.GetCurrentPortalSettings()).Returns(portalSettings);
+            this.portalController.Setup(pc => pc.GetCurrentPortalSettings()).Returns(portalSettings);
         }
 
         private void SetupCachingProvider()
         {
-            this._mockCacheProvider.Setup(c => c.GetItem(It.IsAny<string>())).Returns<string>(key =>
+            this.mockCacheProvider.Setup(c => c.GetItem(It.IsAny<string>())).Returns<string>(key =>
             {
                 if (key.Contains("Portal-1_"))
                 {
@@ -1542,96 +1546,96 @@ namespace DotNetNuke.Tests.Core.Controllers.Messaging
             var user12RoleInfoforRegisteredUsers = new UserRoleInfo { RoleName = Constants.RoleName_RegisteredUsers, RoleID = Constants.RoleID_RegisteredUsers, UserID = Constants.UserID_User12 };
             var userFirstSocialGroupOwner = new UserRoleInfo { RoleName = Constants.RoleName_FirstSocialGroup, RoleID = Constants.RoleID_FirstSocialGroup, UserID = Constants.UserID_FirstSocialGroupOwner, IsOwner = true };
 
-            this._mockRoleProvider.Setup(rp => rp.GetUserRoles(It.Is<UserInfo>(u => u.UserID == Constants.UserID_Admin), It.IsAny<bool>())).Returns(new List<UserRoleInfo> { adminRoleInfoForAdministrators, adminRoleInfoforRegisteredUsers });
-            this._mockRoleProvider.Setup(rp => rp.GetUserRoles(It.Is<UserInfo>(u => u.UserID == Constants.UserID_User12), It.IsAny<bool>())).Returns(new List<UserRoleInfo> { user12RoleInfoforRegisteredUsers });
-            this._mockRoleProvider.Setup(rp => rp.GetUserRoles(It.Is<UserInfo>(u => u.UserID == Constants.UserID_FirstSocialGroupOwner), It.IsAny<bool>())).Returns(new List<UserRoleInfo> { userFirstSocialGroupOwner });
+            this.mockRoleProvider.Setup(rp => rp.GetUserRoles(It.Is<UserInfo>(u => u.UserID == Constants.UserID_Admin), It.IsAny<bool>())).Returns(new List<UserRoleInfo> { adminRoleInfoForAdministrators, adminRoleInfoforRegisteredUsers });
+            this.mockRoleProvider.Setup(rp => rp.GetUserRoles(It.Is<UserInfo>(u => u.UserID == Constants.UserID_User12), It.IsAny<bool>())).Returns(new List<UserRoleInfo> { user12RoleInfoforRegisteredUsers });
+            this.mockRoleProvider.Setup(rp => rp.GetUserRoles(It.Is<UserInfo>(u => u.UserID == Constants.UserID_FirstSocialGroupOwner), It.IsAny<bool>())).Returns(new List<UserRoleInfo> { userFirstSocialGroupOwner });
         }
 
         private void SetupFileControllers()
         {
-            this._folderManager.Setup(f => f.GetFolder(It.IsAny<int>())).Returns(new FolderInfo());
-            this._fileManager.Setup(f => f.GetFile(It.IsAny<int>())).Returns(new FileInfo());
-            this._folderPermissionController.Setup(f => f.CanViewFolder(It.IsAny<IFolderInfo>())).Returns(true);
+            this.folderManager.Setup(f => f.GetFolder(It.IsAny<int>())).Returns(new FolderInfo());
+            this.fileManager.Setup(f => f.GetFile(It.IsAny<int>())).Returns(new FileInfo());
+            this.folderPermissionController.Setup(f => f.CanViewFolder(It.IsAny<IFolderInfo>())).Returns(true);
         }
 
         private void SetupDataTables()
         {
             // Messages
-            this._dtMessages = new DataTable("Messages");
-            var pkMessagesMessageID = this._dtMessages.Columns.Add("MessageID", typeof(int));
-            this._dtMessages.Columns.Add("PortalId", typeof(int));
-            this._dtMessages.Columns.Add("NotificationTypeID", typeof(int));
-            this._dtMessages.Columns.Add("To", typeof(string));
-            this._dtMessages.Columns.Add("From", typeof(string));
-            this._dtMessages.Columns.Add("Subject", typeof(string));
-            this._dtMessages.Columns.Add("Body", typeof(string));
-            this._dtMessages.Columns.Add("ConversationId", typeof(int));
-            this._dtMessages.Columns.Add("ReplyAllAllowed", typeof(bool));
-            this._dtMessages.Columns.Add("SenderUserID", typeof(int));
-            this._dtMessages.Columns.Add("CreatedByUserID", typeof(int));
-            this._dtMessages.Columns.Add("CreatedOnDate", typeof(DateTime));
-            this._dtMessages.Columns.Add("LastModifiedByUserID", typeof(int));
-            this._dtMessages.Columns.Add("LastModifiedOnDate", typeof(DateTime));
-            this._dtMessages.PrimaryKey = new[] { pkMessagesMessageID };
+            this.dtMessages = new DataTable("Messages");
+            var pkMessagesMessageID = this.dtMessages.Columns.Add("MessageID", typeof(int));
+            this.dtMessages.Columns.Add("PortalId", typeof(int));
+            this.dtMessages.Columns.Add("NotificationTypeID", typeof(int));
+            this.dtMessages.Columns.Add("To", typeof(string));
+            this.dtMessages.Columns.Add("From", typeof(string));
+            this.dtMessages.Columns.Add("Subject", typeof(string));
+            this.dtMessages.Columns.Add("Body", typeof(string));
+            this.dtMessages.Columns.Add("ConversationId", typeof(int));
+            this.dtMessages.Columns.Add("ReplyAllAllowed", typeof(bool));
+            this.dtMessages.Columns.Add("SenderUserID", typeof(int));
+            this.dtMessages.Columns.Add("CreatedByUserID", typeof(int));
+            this.dtMessages.Columns.Add("CreatedOnDate", typeof(DateTime));
+            this.dtMessages.Columns.Add("LastModifiedByUserID", typeof(int));
+            this.dtMessages.Columns.Add("LastModifiedOnDate", typeof(DateTime));
+            this.dtMessages.PrimaryKey = new[] { pkMessagesMessageID };
 
             // MessageRecipients
-            this._dtMessageRecipients = new DataTable("MessageRecipients");
-            var pkMessageRecipientID = this._dtMessageRecipients.Columns.Add("RecipientID", typeof(int));
-            this._dtMessageRecipients.Columns.Add("MessageID", typeof(int));
-            this._dtMessageRecipients.Columns.Add("UserID", typeof(int));
-            this._dtMessageRecipients.Columns.Add("Read", typeof(bool));
-            this._dtMessageRecipients.Columns.Add("Archived", typeof(bool));
-            this._dtMessageRecipients.Columns.Add("CreatedByUserID", typeof(int));
-            this._dtMessageRecipients.Columns.Add("CreatedOnDate", typeof(DateTime));
-            this._dtMessageRecipients.Columns.Add("LastModifiedByUserID", typeof(int));
-            this._dtMessageRecipients.Columns.Add("LastModifiedOnDate", typeof(DateTime));
-            this._dtMessageRecipients.PrimaryKey = new[] { pkMessageRecipientID };
+            this.dtMessageRecipients = new DataTable("MessageRecipients");
+            var pkMessageRecipientID = this.dtMessageRecipients.Columns.Add("RecipientID", typeof(int));
+            this.dtMessageRecipients.Columns.Add("MessageID", typeof(int));
+            this.dtMessageRecipients.Columns.Add("UserID", typeof(int));
+            this.dtMessageRecipients.Columns.Add("Read", typeof(bool));
+            this.dtMessageRecipients.Columns.Add("Archived", typeof(bool));
+            this.dtMessageRecipients.Columns.Add("CreatedByUserID", typeof(int));
+            this.dtMessageRecipients.Columns.Add("CreatedOnDate", typeof(DateTime));
+            this.dtMessageRecipients.Columns.Add("LastModifiedByUserID", typeof(int));
+            this.dtMessageRecipients.Columns.Add("LastModifiedOnDate", typeof(DateTime));
+            this.dtMessageRecipients.PrimaryKey = new[] { pkMessageRecipientID };
 
             // MessageAttachments
-            this._dtMessageAttachment = new DataTable("MessageAttachments");
-            var pkMessageAttachmentID = this._dtMessageAttachment.Columns.Add("MessageAttachmentID", typeof(int));
-            this._dtMessageAttachment.Columns.Add("MessageID", typeof(int));
-            this._dtMessageAttachment.Columns.Add("FileID", typeof(int));
-            this._dtMessageAttachment.Columns.Add("CreatedByUserID", typeof(int));
-            this._dtMessageAttachment.Columns.Add("CreatedOnDate", typeof(DateTime));
-            this._dtMessageAttachment.Columns.Add("LastModifiedByUserID", typeof(int));
-            this._dtMessageAttachment.Columns.Add("LastModifiedOnDate", typeof(DateTime));
-            this._dtMessageAttachment.PrimaryKey = new[] { pkMessageAttachmentID };
+            this.dtMessageAttachment = new DataTable("MessageAttachments");
+            var pkMessageAttachmentID = this.dtMessageAttachment.Columns.Add("MessageAttachmentID", typeof(int));
+            this.dtMessageAttachment.Columns.Add("MessageID", typeof(int));
+            this.dtMessageAttachment.Columns.Add("FileID", typeof(int));
+            this.dtMessageAttachment.Columns.Add("CreatedByUserID", typeof(int));
+            this.dtMessageAttachment.Columns.Add("CreatedOnDate", typeof(DateTime));
+            this.dtMessageAttachment.Columns.Add("LastModifiedByUserID", typeof(int));
+            this.dtMessageAttachment.Columns.Add("LastModifiedOnDate", typeof(DateTime));
+            this.dtMessageAttachment.PrimaryKey = new[] { pkMessageAttachmentID };
 
             // Portal Settings
-            this._dtPortalSettings = new DataTable("PortalSettings");
-            this._dtPortalSettings.Columns.Add("SettingName", typeof(string));
-            this._dtPortalSettings.Columns.Add("SettingValue", typeof(string));
-            this._dtPortalSettings.Columns.Add("CultureCode", typeof(string));
-            this._dtPortalSettings.Columns.Add("CreatedByUserID", typeof(int));
-            this._dtPortalSettings.Columns.Add("CreatedOnDate", typeof(DateTime));
-            this._dtPortalSettings.Columns.Add("LastModifiedByUserID", typeof(int));
-            this._dtPortalSettings.Columns.Add("LastModifiedOnDate", typeof(DateTime));
+            this.dtPortalSettings = new DataTable("PortalSettings");
+            this.dtPortalSettings.Columns.Add("SettingName", typeof(string));
+            this.dtPortalSettings.Columns.Add("SettingValue", typeof(string));
+            this.dtPortalSettings.Columns.Add("CultureCode", typeof(string));
+            this.dtPortalSettings.Columns.Add("CreatedByUserID", typeof(int));
+            this.dtPortalSettings.Columns.Add("CreatedOnDate", typeof(DateTime));
+            this.dtPortalSettings.Columns.Add("LastModifiedByUserID", typeof(int));
+            this.dtPortalSettings.Columns.Add("LastModifiedOnDate", typeof(DateTime));
 
             // Message Conversation
-            this._dtMessageConversationView = new DataTable();
-            this._dtMessageConversationView.Columns.Add("RowNumber", typeof(int));
-            this._dtMessageConversationView.Columns.Add("AttachmentCount", typeof(int));
-            this._dtMessageConversationView.Columns.Add("NewThreadCount", typeof(int));
-            this._dtMessageConversationView.Columns.Add("ThreadCount", typeof(int));
-            this._dtMessageConversationView.Columns.Add("MessageID", typeof(int));
-            this._dtMessageConversationView.Columns.Add("To", typeof(string));
-            this._dtMessageConversationView.Columns.Add("From", typeof(string));
-            this._dtMessageConversationView.Columns.Add("Subject", typeof(string));
-            this._dtMessageConversationView.Columns.Add("Body", typeof(string));
-            this._dtMessageConversationView.Columns.Add("ConversationID", typeof(int));
-            this._dtMessageConversationView.Columns.Add("ReplyAllAllowed", typeof(bool));
-            this._dtMessageConversationView.Columns.Add("SenderUserID", typeof(int));
-            this._dtMessageConversationView.Columns.Add("CreatedByUserID", typeof(int));
-            this._dtMessageConversationView.Columns.Add("CreatedOnDate", typeof(DateTime));
-            this._dtMessageConversationView.Columns.Add("LastModifiedByUserID", typeof(int));
-            this._dtMessageConversationView.Columns.Add("LastModifiedOnDate", typeof(DateTime));
+            this.dtMessageConversationView = new DataTable();
+            this.dtMessageConversationView.Columns.Add("RowNumber", typeof(int));
+            this.dtMessageConversationView.Columns.Add("AttachmentCount", typeof(int));
+            this.dtMessageConversationView.Columns.Add("NewThreadCount", typeof(int));
+            this.dtMessageConversationView.Columns.Add("ThreadCount", typeof(int));
+            this.dtMessageConversationView.Columns.Add("MessageID", typeof(int));
+            this.dtMessageConversationView.Columns.Add("To", typeof(string));
+            this.dtMessageConversationView.Columns.Add("From", typeof(string));
+            this.dtMessageConversationView.Columns.Add("Subject", typeof(string));
+            this.dtMessageConversationView.Columns.Add("Body", typeof(string));
+            this.dtMessageConversationView.Columns.Add("ConversationID", typeof(int));
+            this.dtMessageConversationView.Columns.Add("ReplyAllAllowed", typeof(bool));
+            this.dtMessageConversationView.Columns.Add("SenderUserID", typeof(int));
+            this.dtMessageConversationView.Columns.Add("CreatedByUserID", typeof(int));
+            this.dtMessageConversationView.Columns.Add("CreatedOnDate", typeof(DateTime));
+            this.dtMessageConversationView.Columns.Add("LastModifiedByUserID", typeof(int));
+            this.dtMessageConversationView.Columns.Add("LastModifiedOnDate", typeof(DateTime));
 
             // Thread View
-            this._dtMessageThreadsView = new DataTable();
-            this._dtMessageThreadsView.Columns.Add("TotalThreads", typeof(int));
-            this._dtMessageThreadsView.Columns.Add("TotalNewThreads", typeof(int));
-            this._dtMessageThreadsView.Columns.Add("TotalArchivedThreads", typeof(int));
+            this.dtMessageThreadsView = new DataTable();
+            this.dtMessageThreadsView.Columns.Add("TotalThreads", typeof(int));
+            this.dtMessageThreadsView.Columns.Add("TotalNewThreads", typeof(int));
+            this.dtMessageThreadsView.Columns.Add("TotalArchivedThreads", typeof(int));
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/InternalSearchControllerTests.cs
@@ -9,9 +9,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using System.IO;
     using System.Threading;
 
-    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Application;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Controllers;
@@ -20,6 +19,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Services.Search.Internals;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -73,12 +73,14 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
 
         private const string SearchIndexFolder = @"App_Data\InternalSearchTests";
         private readonly double readerStaleTimeSpan = TimeSpan.FromMilliseconds(100).TotalSeconds;
+
         private Mock<IHostController> mockHostController;
         private Mock<CachingProvider> mockCachingProvider;
         private Mock<DataProvider> mockDataProvider;
         private Mock<ILocaleController> mockLocaleController;
         private Mock<ISearchHelper> mockSearchHelper;
         private Mock<IUserController> mockUserController;
+        private FakeServiceProvider serviceProvider;
 
         private IInternalSearchController internalSearchController;
         private LuceneControllerImpl luceneController;
@@ -103,12 +105,6 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             this.mockHostController = new Mock<IHostController>();
             this.SetupHostController();
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => new DotNetNuke.Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient<IHostSettingsService>(container => (IHostSettingsService)this.mockHostController.Object);
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             this.mockDataProvider = MockComponentProvider.CreateDataProvider();
             this.mockLocaleController = MockComponentProvider.CreateLocaleController();
             this.mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
@@ -123,6 +119,19 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
                 .Returns((int portalId, int userId) => this.GetUserByIdCallback(portalId, userId));
             UserController.SetTestableInstance(this.mockUserController.Object);
 
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockHostController.Object);
+                    services.AddSingleton((IHostSettingsService)this.mockHostController.Object);
+                    services.AddSingleton(this.mockCachingProvider.Object);
+                    services.AddSingleton(this.mockDataProvider.Object);
+                    services.AddSingleton(this.mockLocaleController.Object);
+                    services.AddSingleton(this.mockSearchHelper.Object);
+                    services.AddSingleton(this.mockUserController.Object);
+                    services.AddSingleton<IApplicationStatusInfo>(new ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
+                });
+
             this.CreateNewLuceneControllerInstance();
         }
 
@@ -131,14 +140,13 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
         {
             this.DeleteIndexFolder();
             this.mockHostController = null;
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             this.luceneController.Dispose();
             InternalSearchController.ClearInstance();
             UserController.ClearInstance();
             SearchHelper.ClearInstance();
             LuceneController.ClearInstance();
             this.luceneController = null;
-            Globals.DependencyProvider = null;
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Search/SearchHelperTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Controllers.Search
 {
     using System;
@@ -17,6 +16,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Cache;
     using DotNetNuke.Services.Search.Internals;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -39,34 +39,36 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
         private const string TermHop = "Hop";
         private const int PortalId0 = 0;
         private const string CultureEnUs = "en-US";
-        private Mock<DataProvider> _dataProvider;
-        private Mock<CachingProvider> _cachingProvider;
-        private SearchHelperImpl _searchHelper;
+        private Mock<DataProvider> dataProvider;
+        private Mock<CachingProvider> cachingProvider;
+        private SearchHelperImpl searchHelper;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.Container = new SimpleContainer();
-            this._cachingProvider = MockComponentProvider.CreateDataCacheProvider();
-            this._dataProvider = MockComponentProvider.CreateDataProvider();
+            this.cachingProvider = MockComponentProvider.CreateDataCacheProvider();
+            this.dataProvider = MockComponentProvider.CreateDataProvider();
             this.SetupDataProvider();
-            this._searchHelper = new SearchHelperImpl();
+            this.searchHelper = new SearchHelperImpl();
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.cachingProvider.Object);
+                    services.AddSingleton(this.dataProvider.Object);
+                    services.AddSingleton(this.searchHelper);
+                });
+
             DataCache.ClearCache();
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -76,7 +78,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             // Arrange
 
             // Act
-            var synonyms = this._searchHelper.GetSynonyms(PortalId0, CultureEnUs, TermDNN).ToArray();
+            var synonyms = this.searchHelper.GetSynonyms(PortalId0, CultureEnUs, TermDNN).ToArray();
 
             // Assert
             Assert.AreEqual(1, synonyms.Count());
@@ -90,7 +92,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             // Arrange
 
             // Act
-            var synonyms = this._searchHelper.GetSynonyms(PortalId0, CultureEnUs, TermHop).ToArray();
+            var synonyms = this.searchHelper.GetSynonyms(PortalId0, CultureEnUs, TermHop).ToArray();
 
             // Assert
             Assert.AreEqual(2, synonyms.Count());
@@ -106,7 +108,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = inPhrase;
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, false);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, false);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -120,7 +122,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = inPhrase;
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, false);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, false);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -134,7 +136,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = inPhrase;
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, false);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, false);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -148,7 +150,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(fox OR fox*) (dog OR dog*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -162,7 +164,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(lazy-dog OR lazy-dog*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -176,7 +178,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(fox OR fox*) (dog OR dog*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -190,7 +192,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(dog OR dog*) (fox OR fox*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -204,7 +206,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(brown OR brown*) (fox OR fox*) (lazy OR lazy*) (dog OR dog*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -218,7 +220,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "((brown OR brown*) (fox OR fox*)) (lazy OR lazy*) (dog OR dog*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -232,7 +234,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(brown OR brown*) (fox OR fox*) ((lazy OR lazy*) (dog OR dog*))";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -246,7 +248,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(brown OR brown*) (fox OR fox*) ((lazy OR lazy*) AND (dog OR dog*))";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -260,7 +262,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(brown OR brown*) (fox OR fox*) ((lazy OR lazy*) (and OR and*) (dog OR dog*))";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -274,7 +276,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = inPhrase;
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -288,7 +290,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "\"brown fox\" (dog OR dog*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -302,7 +304,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(The OR The*) +\"brown fox\" -\"Lazy dog\" (jumps OR jumps*)";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -316,7 +318,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             const string expected = "(dog OR dog*) jump~2";
 
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -331,7 +333,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
         public void SearchHelper_Rephrase_AccentedCharsReplaced_Replaced(string inPhrase, string expected)
         {
             // Act
-            var analyzed = this._searchHelper.RephraseSearchText(inPhrase, true);
+            var analyzed = this.searchHelper.RephraseSearchText(inPhrase, true);
 
             // Assert
             Assert.AreEqual(expected, analyzed);
@@ -340,11 +342,11 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
         private void SetupDataProvider()
         {
             // Standard DataProvider Path for Logging
-            this._dataProvider.Setup(d => d.GetProviderPath()).Returns(string.Empty);
+            this.dataProvider.Setup(d => d.GetProviderPath()).Returns(string.Empty);
 
-            this._dataProvider.Setup(d => d.GetPortals(It.IsAny<string>())).Returns<string>(this.GetPortalsCallBack);
+            this.dataProvider.Setup(d => d.GetPortals(It.IsAny<string>())).Returns<string>(this.GetPortalsCallBack);
 
-            this._dataProvider.Setup(d => d.GetPortalSettings(It.IsAny<int>(), It.IsAny<string>())).Returns<int, string>(this.GetPortalSettingsCallBack);
+            this.dataProvider.Setup(d => d.GetPortalSettings(It.IsAny<int>(), It.IsAny<string>())).Returns<int, string>(this.GetPortalSettingsCallBack);
 
             var dataTable = new DataTable("SynonymsGroups");
             var pkId = dataTable.Columns.Add("SynonymsGroupID", typeof(int));
@@ -363,7 +365,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Search
             dataTable.Rows.Add(2, string.Join(",", new[] { TermLaptop, TermNotebook }), 1, now, 1, now, 0);
             dataTable.Rows.Add(3, string.Join(",", new[] { TermJump, TermLeap, TermHop }), 1, now, 1, now, 0);
 
-            this._dataProvider.Setup(x => x.GetAllSynonymsGroups(0, It.IsAny<string>())).Returns(dataTable.CreateDataReader());
+            this.dataProvider.Setup(x => x.GetAllSynonymsGroups(0, It.IsAny<string>())).Returns(dataTable.CreateDataReader());
         }
 
         private IDataReader GetPortalSettingsCallBack(int portalId, string culture)

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Controllers/Social/RelationshipControllerTests.cs
@@ -1,17 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Controllers.Social
 {
     using System;
     using System.Collections.Generic;
     using System.Data;
 
-    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Logging;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Controllers;
@@ -20,8 +17,8 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
     using DotNetNuke.Entities.Users.Social;
     using DotNetNuke.Entities.Users.Social.Data;
     using DotNetNuke.Services.Cache;
-    using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -35,26 +32,19 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
     public class RelationshipControllerTests
     {
         private Mock<CachingProvider> mockCachingProvider;
-        private Mock<IPortalController> _portalController;
-        private Mock<IPortalGroupController> _portalGroupController;
+        private Mock<IPortalController> portalController;
+        private Mock<IPortalGroupController> portalGroupController;
 
         private DataTable dtRelationshipTypes;
         private DataTable dtRelationships;
         private DataTable dtUserRelationships;
         private DataTable dtUserRelationshipPreferences;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.Container = new SimpleContainer();
             var mockDataProvider = MockComponentProvider.CreateDataProvider();
             mockDataProvider.Setup(dp => dp.GetProviderPath()).Returns(string.Empty);
@@ -62,14 +52,15 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             this.mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
             MockComponentProvider.CreateEventLogController();
 
-            this._portalController = new Mock<IPortalController>();
-            PortalController.SetTestableInstance(this._portalController.Object);
+            this.portalController = new Mock<IPortalController>();
+            PortalController.SetTestableInstance(this.portalController.Object);
 
-            this._portalGroupController = new Mock<IPortalGroupController>();
-            PortalGroupController.RegisterInstance(this._portalGroupController.Object);
+            this.portalGroupController = new Mock<IPortalGroupController>();
+            PortalGroupController.RegisterInstance(this.portalGroupController.Object);
 
             var mockHostController = new Mock<IHostController>();
             mockHostController.Setup(c => c.GetString("PerformanceSetting")).Returns("0");
+            mockHostController.As<IHostSettingsService>();
             HostController.RegisterInstance(mockHostController.Object);
 
             var mockUserController = new Mock<IUserController>();
@@ -79,12 +70,24 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             this.CreateLocalizationProvider();
 
             this.SetupDataTables();
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(mockDataProvider.Object);
+                    services.AddSingleton(this.mockCachingProvider.Object);
+                    services.AddSingleton(this.portalController.Object);
+                    services.AddSingleton(this.portalGroupController.Object);
+                    services.AddSingleton(mockHostController.Object);
+                    services.AddSingleton((IHostSettingsService)mockHostController.Object);
+                    services.AddSingleton(mockUserController.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
             ComponentFactory.Container = null;
             PortalController.ClearInstance();
             UserController.ClearInstance();
@@ -483,7 +486,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             var relationshipController = this.CreateRelationshipController(mockDataService);
 
             var mockPortalInfo = CreatePortalInfo(Constants.PORTAL_Zero, Null.NullInteger);
-            this._portalController.Setup(pc => pc.GetPortal(Constants.PORTAL_Zero)).Returns(mockPortalInfo);
+            this.portalController.Setup(pc => pc.GetPortal(Constants.PORTAL_Zero)).Returns(mockPortalInfo);
 
             // Act
             var relationships = relationshipController.GetRelationshipsByPortalId(Constants.PORTAL_Zero);
@@ -513,10 +516,10 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             var relationshipController = this.CreateRelationshipController(mockDataService);
 
             var mockPortalInfo = CreatePortalInfo(Constants.PORTAL_Zero, Constants.PORTALGROUP_ValidPortalGroupId);
-            this._portalController.Setup(pc => pc.GetPortal(Constants.PORTAL_Zero)).Returns(mockPortalInfo);
+            this.portalController.Setup(pc => pc.GetPortal(Constants.PORTAL_Zero)).Returns(mockPortalInfo);
 
             List<PortalGroupInfo> portalGroups = new List<PortalGroupInfo>() { CreatePortalGroupInfo(Constants.PORTALGROUP_ValidPortalGroupId, Constants.PORTAL_Zero) }; // CreatePortalGroupInfo(Constants.PORTALGROUP_ValidPortalGroupId, Constants.PORTAL_Zero);
-            this._portalGroupController.Setup(pgc => pgc.GetPortalGroups()).Returns(portalGroups);
+            this.portalGroupController.Setup(pgc => pgc.GetPortalGroups()).Returns(portalGroups);
 
             // Act
             var relationships = relationshipController.GetRelationshipsByPortalId(Constants.PORTAL_Zero);
@@ -537,7 +540,7 @@ namespace DotNetNuke.Tests.Core.Controllers.Social
             var relationshipController = this.CreateRelationshipController(mockDataService);
 
             var mockPortalInfo = CreatePortalInfo(Constants.PORTAL_Null, Null.NullInteger);
-            this._portalController.Setup(pc => pc.GetPortal(Constants.PORTAL_Null)).Returns(mockPortalInfo);
+            this.portalController.Setup(pc => pc.GetPortal(Constants.PORTAL_Null)).Returns(mockPortalInfo);
 
             // Act
             var relationships = relationshipController.GetRelationshipsByPortalId(Constants.PORTAL_Null);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/BusinessControllerProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/BusinessControllerProviderTests.cs
@@ -6,8 +6,6 @@ namespace DotNetNuke.Tests.Core.Entities.Modules
     using System;
     using System.Collections.Generic;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Modules;
@@ -15,12 +13,31 @@ namespace DotNetNuke.Tests.Core.Entities.Modules
     using DotNetNuke.Services.Search.Entities;
     using DotNetNuke.Tests.Utilities.Fakes;
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
     using NUnit.Framework;
 
     [TestFixture]
     public class BusinessControllerProviderTests
     {
+        private FakeServiceProvider serviceProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    var fakeCachingProvider = new FakeCachingProvider(new Dictionary<string, object>(0));
+                    ComponentFactory.RegisterComponentInstance<CachingProvider>(fakeCachingProvider);
+                    services.AddSingleton<CachingProvider>(fakeCachingProvider);
+                });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
+        }
+
         [TestCase(typeof(PortableControllerClass), true)]
         [TestCase(typeof(SearchableControllerClass), false)]
         [TestCase(typeof(AllFeaturesControllerClass), true)]
@@ -123,12 +140,6 @@ namespace DotNetNuke.Tests.Core.Entities.Modules
 
         private static BusinessControllerProvider CreateProvider()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddSingleton(Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
-            ComponentFactory.RegisterComponentInstance<CachingProvider>(new FakeCachingProvider(new Dictionary<string, object>(0)));
             return new BusinessControllerProvider(Globals.DependencyProvider);
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/ModuleSettingsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/ModuleSettingsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
 {
     using System;
@@ -9,36 +8,32 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
     using System.Globalization;
 
     using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Modules.Settings;
+    using DotNetNuke.Tests.Utilities.Fakes;
 
     using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
 
     [TestFixture]
     public class ModuleSettingsTests : BaseSettingsTests
     {
-        [SetUp]
+        private FakeServiceProvider serviceProvider;
 
+        [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            serviceCollection.AddTransient<ISerializationManager, SerializationManager>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<ISerializationManager, SerializationManager>();
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/NullableSettingsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/NullableSettingsTests.cs
@@ -10,15 +10,11 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
     using System.Globalization;
 
     using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Modules.Settings;
+    using DotNetNuke.Tests.Utilities.Fakes;
 
     using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
 
@@ -32,22 +28,22 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
             new object[] { "lorem ipsum", 456, DateTime.Now, DateTime.Today - DateTime.Now, },
         };
 
-        [SetUp]
+        private FakeServiceProvider serviceProvider;
 
+        [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            serviceCollection.AddTransient<ISerializationManager, SerializationManager>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<ISerializationManager, SerializationManager>();
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/PortalSettingsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/PortalSettingsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
 {
     using System;
@@ -9,37 +8,33 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
     using System.Globalization;
 
     using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Modules.Settings;
+    using DotNetNuke.Tests.Utilities.Fakes;
 
     using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
 
     [TestFixture]
     public class PortalSettingsTests : BaseSettingsTests
     {
-        [SetUp]
+        private FakeServiceProvider serviceProvider;
 
+        [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            serviceCollection.AddTransient<ISerializationManager, SerializationManager>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<ISerializationManager, SerializationManager>();
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/TabModuleSettingsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/TabModuleSettingsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
 {
     using System;
@@ -9,36 +8,32 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
     using System.Globalization;
 
     using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Modules.Settings;
+    using DotNetNuke.Tests.Utilities.Fakes;
 
     using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
 
     [TestFixture]
     public class TabModuleSettingsTests : BaseSettingsTests
     {
-        [SetUp]
+        private FakeServiceProvider serviceProvider;
 
+        [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            serviceCollection.AddTransient<ISerializationManager, SerializationManager>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<ISerializationManager, SerializationManager>();
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Portals/PortalSettingsControllerTests.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Entities.Portals
 {
     using System;
     using System.Collections.Generic;
 
-    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
@@ -15,6 +13,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Services.Localization;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
     using DotNetNuke.UI.Skins;
 
@@ -45,23 +44,22 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         private const string GlobalTabContainer = "[g]TabContainer";
 
         private Mock<IHostController> mockHostController;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void SetUp()
         {
             MockComponentProvider.ResetContainer();
 
-            var serviceCollection = new ServiceCollection();
-            var mockApplicationInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationInfo.Setup(info => info.ApplicationMapPath).Returns("path/to/application");
-
             this.mockHostController = new Mock<IHostController>();
             this.mockHostController.As<IHostSettingsService>();
 
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService>(container => (IHostSettingsService)this.mockHostController.Object);
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockHostController.Object);
+                    services.AddSingleton((IHostSettingsService)this.mockHostController.Object);
+                });
         }
 
         [TearDown]
@@ -69,8 +67,7 @@ namespace DotNetNuke.Tests.Core.Entities.Portals
         {
             PortalController.ClearInstance();
             TabController.ClearInstance();
-            Globals.DependencyProvider = null;
-
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/FileSystemUtilsTests.cs
@@ -1,30 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core
 {
     using System;
     using System.IO;
     using System.IO.Compression;
-    using System.Linq;
-    using System.Reflection;
 
-    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
-    using DotNetNuke.ComponentModel;
-    using DotNetNuke.Entities.Tabs;
-    using DotNetNuke.Tests.Utilities.Mocks;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary>  FileSystemUtilsTests.</summary>
     [TestFixture]
     public class FileSystemUtilsTests
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
@@ -32,18 +31,19 @@ namespace DotNetNuke.Tests.Core
             var rootPath = Path.Combine(applicationStatusInfo.ApplicationMapPath, "FileSystemUtilsTest");
             this.PrepareRootPath(rootPath, applicationStatusInfo.ApplicationMapPath);
 
-            var serviceCollection = new ServiceCollection();
             var mock = new Mock<IApplicationStatusInfo>();
             mock.Setup(info => info.ApplicationMapPath).Returns(rootPath);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mock.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(mock.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [TestCase("/")]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
@@ -1,37 +1,24 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Framework
 {
     using System;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Framework;
-    using DotNetNuke.Tests.Instance.Utilities;
-    using DotNetNuke.Tests.Utilities;
-
-    using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
+    using DotNetNuke.Tests.Utilities.Fakes;
 
     using NUnit.Framework;
 
     public class ServicesFrameworkTests
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup();
 
-            HttpContextHelper.RegisterMockHttpContext();
             var simulator = new Instance.Utilities.HttpSimulator.HttpSimulator("/", "c:\\");
             simulator.SimulateRequest(new Uri("http://localhost/dnn/Default.aspx"));
         }
@@ -39,8 +26,7 @@ namespace DotNetNuke.Tests.Core.Framework
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
-            UnitTestHelper.ClearHttpContext();
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
@@ -51,7 +51,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -62,7 +62,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <NoWarn>1591</NoWarn>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -115,6 +115,7 @@
     <Compile Include="EnumerableAssert.cs" />
     <Compile Include="ExceptionAssert.cs" />
     <Compile Include="Fakes\FakeCachingProvider.cs" />
+    <Compile Include="Fakes\FakeServiceProvider.cs" />
     <Compile Include="FileAssert.cs" />
     <Compile Include="HttpContextHelper.cs" />
     <Compile Include="AssemblyInfo.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Fakes/FakeServiceProvider.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/Fakes/FakeServiceProvider.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Utilities.Fakes
+{
+    using System;
+
+    using DotNetNuke.Common;
+    using DotNetNuke.Common.Extensions;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using Moq;
+
+    public class FakeServiceProvider : IServiceProvider, IServiceScopeFactory, IServiceScope
+    {
+        private readonly IServiceProvider provider;
+
+        private FakeServiceProvider(IServiceProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public IServiceProvider ServiceProvider => this;
+
+        public static FakeServiceProvider Create() => Create(new ServiceCollection());
+
+        public static FakeServiceProvider Create(Action<IServiceCollection> setupServices)
+        {
+            var services = new ServiceCollection();
+            setupServices(services);
+            return Create(services);
+        }
+
+        public static FakeServiceProvider Create(IServiceCollection services) => new FakeServiceProvider(services.BuildServiceProvider());
+
+        public static FakeServiceProvider Setup(bool setupHttpContextScope = true) => Setup(Create(), setupHttpContextScope);
+
+        public static FakeServiceProvider Setup(Action<IServiceCollection> setupServices, bool setupHttpContextScope = true) => Setup(Create(setupServices), setupHttpContextScope);
+
+        public static FakeServiceProvider Setup(IServiceCollection services, bool setupHttpContextScope = true) => Setup(Create(services), setupHttpContextScope);
+
+        public static T Setup<T>(T provider, bool setupHttpContextScope = true)
+            where T : IServiceProvider
+        {
+            Globals.DependencyProvider = provider;
+            if (setupHttpContextScope)
+            {
+                HttpContextHelper.RegisterMockHttpContext().Object.SetScope(provider.CreateScope());
+            }
+
+            return provider;
+        }
+
+        public static void Reset()
+        {
+            Globals.DependencyProvider = null;
+            HttpContextSource.RegisterInstance(null);
+        }
+
+        public object GetService(Type serviceType)
+        {
+            if (serviceType.IsInstanceOfType(this))
+            {
+                return this;
+            }
+
+            var registeredService = this.provider.GetService(serviceType);
+            if (registeredService is not null)
+            {
+                return registeredService;
+            }
+
+            if (serviceType.IsInterface || serviceType.IsAbstract)
+            {
+                var mock = Activator.CreateInstance(typeof(Mock<>).MakeGenericType(serviceType));
+                return ((Mock)mock).Object;
+            }
+
+            return Activator.CreateInstance(serviceType);
+        }
+
+        public IServiceScope CreateScope()
+        {
+            return this;
+        }
+
+        public void Dispose()
+        {
+            Reset();
+            if (this.provider is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces `FakeServiceProvider` to the `DotNetNuke.Tests.Utilities` project. The fake service provider creates automatic mocks for all services requested that aren't registered, and provides a simple interface to register it as `Globals.DependencyProvider` and as the scope on `HttpContextBase`. Finally, when disposed, it resets that global state.