### PR TITLE
Use FakeServiceProvider for the rest of the tests

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FolderManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/FolderManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Providers.Folder
 {
     using System;
@@ -9,9 +8,6 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using System.Data;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Services.FileSystem;
@@ -19,6 +15,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Tests.Core.Providers.Builders;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +41,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         private Mock<IPathUtils> pathUtils;
         private Mock<IUserSecurityController> mockUserSecurityController;
         private Mock<IFileDeletionController> mockFileDeletionController;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
@@ -73,13 +71,17 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
 
             this.folderInfo = new Mock<IFolderInfo>();
 
-            var serviceCollection = new ServiceCollection();
-            var mockStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.None);
-
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockFolder.Object);
+                    services.AddSingleton(this.mockData.Object);
+                    services.AddSingleton(this.folderMappingController.Object);
+                    services.AddSingleton(this.cbo.Object);
+                    services.AddSingleton(this.pathUtils.Object);
+                    services.AddSingleton(this.mockUserSecurityController.Object);
+                    services.AddSingleton(this.mockFileDeletionController.Object);
+                });
         }
 
         [TearDown]
@@ -91,7 +93,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             CBO.ClearInstance();
             FileDeletionController.ClearInstance();
             MockComponentProvider.ResetContainer();
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Providers/Folder/StandardFolderProviderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Providers.Folder
 {
     using System;
@@ -9,9 +8,6 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using System.IO;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
@@ -21,6 +17,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     using DotNetNuke.Services.FileSystem.Internal;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -32,77 +29,68 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
     [TestFixture]
     public class StandardFolderProviderTests
     {
-        private StandardFolderProvider _sfp;
-        private Mock<IFolderInfo> _folderInfo;
-        private Mock<IFileInfo> _fileInfo;
-        private Mock<IFile> _fileWrapper;
-        private Mock<IDirectory> _directoryWrapper;
-        private Mock<IFolderManager> _folderManager;
-        private Mock<IFileManager> _fileManager;
-        private Mock<IPathUtils> _pathUtils;
-        private Mock<IPortalController> _portalControllerMock;
-        private Mock<CryptographyProvider> _cryptographyProviderMock;
-        private Mock<ILocaleController> _localeControllerMock;
-
-        [OneTimeSetUp]
-        public void FixtureSetup()
-        {
-            var serviceCollection = new ServiceCollection();
-
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-
-            var navigationManagerMock = new Mock<INavigationManager>();
-
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => navigationManagerMock.Object);
-
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-        }
-
-        [OneTimeTearDown]
-        public void FixtureTearDown()
-        {
-            Globals.DependencyProvider = null;
-        }
+        private StandardFolderProvider sfp;
+        private Mock<IFolderInfo> folderInfo;
+        private Mock<IFileInfo> fileInfo;
+        private Mock<IFile> fileWrapper;
+        private Mock<IDirectory> directoryWrapper;
+        private Mock<IFolderManager> folderManager;
+        private Mock<IFileManager> fileManager;
+        private Mock<IPathUtils> pathUtils;
+        private Mock<IPortalController> portalControllerMock;
+        private Mock<CryptographyProvider> cryptographyProviderMock;
+        private Mock<ILocaleController> localeControllerMock;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
         {
-            this._sfp = new StandardFolderProvider();
-            this._folderInfo = new Mock<IFolderInfo>();
-            this._fileInfo = new Mock<IFileInfo>();
-            this._fileWrapper = new Mock<IFile>();
-            this._directoryWrapper = new Mock<IDirectory>();
-            this._folderManager = new Mock<IFolderManager>();
-            this._fileManager = new Mock<IFileManager>();
-            this._pathUtils = new Mock<IPathUtils>();
-            this._portalControllerMock = new Mock<IPortalController>();
-            this._portalControllerMock.Setup(p => p.GetPortalSettings(Constants.CONTENT_ValidPortalId))
+            this.sfp = new StandardFolderProvider();
+            this.folderInfo = new Mock<IFolderInfo>();
+            this.fileInfo = new Mock<IFileInfo>();
+            this.fileWrapper = new Mock<IFile>();
+            this.directoryWrapper = new Mock<IDirectory>();
+            this.folderManager = new Mock<IFolderManager>();
+            this.fileManager = new Mock<IFileManager>();
+            this.pathUtils = new Mock<IPathUtils>();
+            this.portalControllerMock = new Mock<IPortalController>();
+            this.portalControllerMock.Setup(p => p.GetPortalSettings(Constants.CONTENT_ValidPortalId))
                 .Returns(this.GetPortalSettingsDictionaryMock());
-            this._portalControllerMock.Setup(p => p.GetCurrentPortalSettings()).Returns(this.GetPortalSettingsMock());
-            this._cryptographyProviderMock = new Mock<CryptographyProvider>();
-            this._cryptographyProviderMock.Setup(c => c.EncryptParameter(It.IsAny<string>(), It.IsAny<string>()))
+            this.portalControllerMock.Setup(p => p.GetCurrentPortalSettings()).Returns(this.GetPortalSettingsMock());
+            this.cryptographyProviderMock = new Mock<CryptographyProvider>();
+            this.cryptographyProviderMock.Setup(c => c.EncryptParameter(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(Guid.NewGuid().ToString("N"));
-            this._localeControllerMock = new Mock<ILocaleController>();
-            this._localeControllerMock.Setup(l => l.GetLocales(Constants.CONTENT_ValidPortalId)).Returns(new Dictionary<string, Locale>
+            this.localeControllerMock = new Mock<ILocaleController>();
+            this.localeControllerMock.Setup(l => l.GetLocales(Constants.CONTENT_ValidPortalId)).Returns(new Dictionary<string, Locale>
             {
                 { "en-us", new Locale() },
             });
 
-            FileWrapper.RegisterInstance(this._fileWrapper.Object);
-            DirectoryWrapper.RegisterInstance(this._directoryWrapper.Object);
-            FolderManager.RegisterInstance(this._folderManager.Object);
-            FileManager.RegisterInstance(this._fileManager.Object);
-            PathUtils.RegisterInstance(this._pathUtils.Object);
-            PortalController.SetTestableInstance(this._portalControllerMock.Object);
-            ComponentFactory.RegisterComponentInstance<CryptographyProvider>("CryptographyProviderMock", this._cryptographyProviderMock.Object);
-            LocaleController.RegisterInstance(this._localeControllerMock.Object);
+            FileWrapper.RegisterInstance(this.fileWrapper.Object);
+            DirectoryWrapper.RegisterInstance(this.directoryWrapper.Object);
+            FolderManager.RegisterInstance(this.folderManager.Object);
+            FileManager.RegisterInstance(this.fileManager.Object);
+            PathUtils.RegisterInstance(this.pathUtils.Object);
+            PortalController.SetTestableInstance(this.portalControllerMock.Object);
+            ComponentFactory.RegisterComponentInstance<CryptographyProvider>("CryptographyProviderMock", this.cryptographyProviderMock.Object);
+            LocaleController.RegisterInstance(this.localeControllerMock.Object);
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.folderManager.Object);
+                    services.AddSingleton(this.fileManager.Object);
+                    services.AddSingleton(this.pathUtils.Object);
+                    services.AddSingleton(this.portalControllerMock.Object);
+                    services.AddSingleton(this.cryptographyProviderMock.Object);
+                    services.AddSingleton(this.localeControllerMock.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
+            this.serviceProvider.Dispose();
             MockComponentProvider.ResetContainer();
             TestableGlobals.ClearInstance();
             PortalController.ClearInstance();
@@ -113,7 +101,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.AddFile(null, Constants.FOLDER_ValidFileName, stream.Object));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.AddFile(null, Constants.FOLDER_ValidFileName, stream.Object));
         }
 
         [Test]
@@ -123,74 +111,74 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentException>(() => this._sfp.AddFile(this._folderInfo.Object, fileName, stream.Object));
+            Assert.Throws<ArgumentException>(() => this.sfp.AddFile(this.folderInfo.Object, fileName, stream.Object));
         }
 
         [Test]
         public void AddFile_Throws_On_Null_Content()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.AddFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.AddFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, null));
         }
 
         [Test]
         public void DeleteFile_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.DeleteFile(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.DeleteFile(null));
         }
 
         // [Test]
         // public void DeleteFile_Calls_FileWrapper_Delete_When_File_Exists()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
+        // fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
 
-        // _sfp.DeleteFile(_fileInfo.Object);
+        // sfp.DeleteFile(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
+        // fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
         // }
 
         // [Test]
         // public void DeleteFile_Does_Not_Call_FileWrapper_Delete_When_File_Does_Not_Exist()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
+        // fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
 
-        // _sfp.DeleteFile(_fileInfo.Object);
+        // sfp.DeleteFile(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Never());
+        // fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Never());
         // }
         [Test]
         public void ExistsFile_Throws_On_Null_Folder()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FileExists(null, Constants.FOLDER_ValidFileName));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FileExists(null, Constants.FOLDER_ValidFileName));
         }
 
         [Test]
         public void ExistsFile_Throws_On_Null_FileName()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FileExists(this._folderInfo.Object, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FileExists(this.folderInfo.Object, null));
         }
 
         [Test]
         public void ExistsFile_Calls_FileWrapper_Exists()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.FileExists(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            this.sfp.FileExists(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.Exists(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Exists(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         [Test]
         public void ExistsFile_Returns_True_When_File_Exists()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
 
-            var result = this._sfp.FileExists(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.FileExists(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             Assert.IsTrue(result);
         }
@@ -198,11 +186,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void ExistsFile_Returns_False_When_File_Does_Not_Exist()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
 
-            var result = this._sfp.FileExists(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.FileExists(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             Assert.IsFalse(result);
         }
@@ -210,7 +198,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void ExistsFolder_Throws_On_Null_FolderMapping()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FolderExists(Constants.FOLDER_ValidFolderPath, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FolderExists(Constants.FOLDER_ValidFolderPath, null));
         }
 
         [Test]
@@ -218,7 +206,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.FolderExists(null, folderMapping));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.FolderExists(null, folderMapping));
         }
 
         [Test]
@@ -226,11 +214,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
+            this.sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
 
-            this._directoryWrapper.Verify(dw => dw.Exists(Constants.FOLDER_ValidFolderPath), Times.Once());
+            this.directoryWrapper.Verify(dw => dw.Exists(Constants.FOLDER_ValidFolderPath), Times.Once());
         }
 
         [Test]
@@ -238,11 +226,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(true);
+            this.directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(true);
 
-            var result = this._sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
+            var result = this.sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
 
             Assert.IsTrue(result);
         }
@@ -252,11 +240,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(false);
+            this.directoryWrapper.Setup(dw => dw.Exists(Constants.FOLDER_ValidFolderPath)).Returns(false);
 
-            var result = this._sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
+            var result = this.sfp.FolderExists(Constants.FOLDER_ValidFolderRelativePath, folderMapping);
 
             Assert.IsFalse(result);
         }
@@ -264,17 +252,17 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFileAttributes_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetFileAttributes(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetFileAttributes(null));
         }
 
         // [Test]
         // public void GetFileAttributes_Calls_FileWrapper_GetAttributes()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _sfp.GetFileAttributes(_fileInfo.Object);
+        // sfp.GetFileAttributes(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath), Times.Once());
+        // fileWrapper.Verify(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath), Times.Once());
         // }
 
         // [Test]
@@ -282,22 +270,22 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         // {
         //    var expectedFileAttributes = FileAttributes.Normal;
 
-        // _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        // fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Returns(expectedFileAttributes);
+        // fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Returns(expectedFileAttributes);
 
-        // var result = _sfp.GetFileAttributes(_fileInfo.Object);
+        // var result = sfp.GetFileAttributes(fileInfo.Object);
 
         // Assert.AreEqual(expectedFileAttributes, result);
         // }
         [Test]
         public void GetFileAttributes_Returns_Null_When_File_Does_Not_Exist()
         {
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-            this._fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
+            this.fileWrapper.Setup(fw => fw.GetAttributes(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
 
-            var result = this._sfp.GetFileAttributes(this._fileInfo.Object);
+            var result = this.sfp.GetFileAttributes(this.fileInfo.Object);
 
             Assert.IsNull(result);
         }
@@ -305,29 +293,29 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFiles_Throws_On_Null_Folder()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetFiles(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetFiles(null));
         }
 
         [Test]
         public void GetFiles_Calls_DirectoryWrapper_GetFiles()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.GetFiles(this._folderInfo.Object);
+            this.sfp.GetFiles(this.folderInfo.Object);
 
-            this._directoryWrapper.Verify(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath));
+            this.directoryWrapper.Verify(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath));
         }
 
         [Test]
         public void GetFiles_Count_Equals_DirectoryWrapper_GetFiles_Count()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
             var filesReturned = new[] { string.Empty, string.Empty, string.Empty };
 
-            this._directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
+            this.directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
 
-            var files = this._sfp.GetFiles(this._folderInfo.Object);
+            var files = this.sfp.GetFiles(this.folderInfo.Object);
 
             Assert.AreEqual(filesReturned.Length, files.Length);
         }
@@ -335,14 +323,14 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFiles_Returns_Valid_FileNames_When_Folder_Contains_Files()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
             var filesReturned = new[] { "C:\\folder\\file1.txt", "C:\\folder\\file2.txt", "C:\\folder\\file3.txt" };
             var expectedValues = new[] { "file1.txt", "file2.txt", "file3.txt" };
 
-            this._directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
+            this.directoryWrapper.Setup(dw => dw.GetFiles(Constants.FOLDER_ValidFolderPath)).Returns(filesReturned);
 
-            var files = this._sfp.GetFiles(this._folderInfo.Object);
+            var files = this.sfp.GetFiles(this.folderInfo.Object);
 
             CollectionAssert.AreEqual(expectedValues, files);
         }
@@ -350,23 +338,23 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFileStream_Throws_On_Null_Folder()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetFileStream(null, Constants.FOLDER_ValidFileName));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetFileStream(null, Constants.FOLDER_ValidFileName));
         }
 
         [Test]
         public void GetFileStream_Throws_On_Null_FileName()
         {
-            Assert.Throws<ArgumentException>(() => this._sfp.GetFileStream(this._folderInfo.Object, null));
+            Assert.Throws<ArgumentException>(() => this.sfp.GetFileStream(this.folderInfo.Object, null));
         }
 
         [Test]
         public void GetFileStream_Calls_FileWrapper_OpenRead()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.GetFileStream(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            this.sfp.GetFileStream(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         [Test]
@@ -375,11 +363,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var validFileBytes = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             var memoryStream = new MemoryStream(validFileBytes);
 
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Returns(memoryStream);
+            this.fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Returns(memoryStream);
 
-            var result = this._sfp.GetFileStream(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.GetFileStream(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             byte[] resultBytes;
             var buffer = new byte[16 * 1024];
@@ -400,11 +388,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetFileStream_Returns_Null_When_File_Does_Not_Exist()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
+            this.fileWrapper.Setup(fw => fw.OpenRead(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
 
-            var result = this._sfp.GetFileStream(this._folderInfo.Object, Constants.FOLDER_ValidFileName);
+            var result = this.sfp.GetFileStream(this.folderInfo.Object, Constants.FOLDER_ValidFileName);
 
             Assert.IsNull(result);
         }
@@ -415,7 +403,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var iconControllerWrapper = new Mock<IIconController>();
             IconControllerWrapper.RegisterInstance(iconControllerWrapper.Object);
 
-            this._sfp.GetFolderProviderIconPath();
+            this.sfp.GetFolderProviderIconPath();
 
             iconControllerWrapper.Verify(icw => icw.IconURL("FolderStandard", "32x32"), Times.Once());
         }
@@ -423,17 +411,17 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetLastModificationTime_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetLastModificationTime(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetLastModificationTime(null));
         }
 
         // [Test]
         // public void GetLastModificationTime_Calls_FileWrapper_GetLastWriteTime()
         // {
-        //    _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        //    fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _sfp.GetLastModificationTime(_fileInfo.Object);
+        // sfp.GetLastModificationTime(fileInfo.Object);
 
-        // _fileWrapper.Verify(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath), Times.Once());
+        // fileWrapper.Verify(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath), Times.Once());
         // }
 
         // [Test]
@@ -441,11 +429,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         // {
         //    var expectedDate = DateTime.Now;
 
-        // _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        // fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Returns(expectedDate);
+        // fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Returns(expectedDate);
 
-        // var result = _sfp.GetLastModificationTime(_fileInfo.Object);
+        // var result = sfp.GetLastModificationTime(fileInfo.Object);
 
         // Assert.AreEqual(expectedDate, result);
         // }
@@ -454,11 +442,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var expectedDate = Null.NullDate;
 
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-            this._fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
+            this.fileWrapper.Setup(fw => fw.GetLastWriteTime(Constants.FOLDER_ValidFilePath)).Throws<FileNotFoundException>();
 
-            var result = this._sfp.GetLastModificationTime(this._fileInfo.Object);
+            var result = this.sfp.GetLastModificationTime(this.fileInfo.Object);
 
             Assert.AreEqual(expectedDate, result);
         }
@@ -466,7 +454,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void GetSubFolders_Throws_On_Null_FolderMapping()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderPath, null).ToList());
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderPath, null).ToList());
         }
 
         [Test]
@@ -474,7 +462,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.GetSubFolders(null, folderMapping).ToList());
+            Assert.Throws<ArgumentNullException>(() => this.sfp.GetSubFolders(null, folderMapping).ToList());
         }
 
         [Test]
@@ -482,11 +470,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(folderMapping.PortalID, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
+            this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
 
-            this._directoryWrapper.Verify(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath), Times.Once());
+            this.directoryWrapper.Verify(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath), Times.Once());
         }
 
         [Test]
@@ -494,9 +482,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
 
             var subFolders = new[]
             {
@@ -504,9 +492,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
                 Constants.FOLDER_OtherValidSubFolderPath,
             };
 
-            this._directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
+            this.directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
 
-            var result = this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
+            var result = this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
 
             Assert.AreEqual(subFolders.Length, result.Count);
         }
@@ -522,9 +510,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
 
             var folderMapping = new FolderMappingInfo { PortalID = Constants.CONTENT_ValidPortalId };
 
-            this._pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
-            this._pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetPhysicalPath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidFolderRelativePath)).Returns(Constants.FOLDER_ValidFolderPath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_ValidSubFolderPath)).Returns(Constants.FOLDER_ValidSubFolderRelativePath);
+            this.pathUtils.Setup(pu => pu.GetRelativePath(Constants.CONTENT_ValidPortalId, Constants.FOLDER_OtherValidSubFolderPath)).Returns(Constants.FOLDER_OtherValidSubFolderRelativePath);
 
             var subFolders = new[]
             {
@@ -532,9 +520,9 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
                 Constants.FOLDER_OtherValidSubFolderPath,
             };
 
-            this._directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
+            this.directoryWrapper.Setup(dw => dw.GetDirectories(Constants.FOLDER_ValidFolderPath)).Returns(subFolders);
 
-            var result = this._sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
+            var result = this.sfp.GetSubFolders(Constants.FOLDER_ValidFolderRelativePath, folderMapping).ToList();
 
             CollectionAssert.AreEqual(expectedSubFolders, result);
         }
@@ -552,18 +540,18 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             sfp.Setup(x => x.GetPortalSettings(Constants.CONTENT_ValidPortalId))
                 .Returns(this.GetPortalSettingsMock());
 
-            this._fileInfo.Setup(x => x.FileName)
+            this.fileInfo.Setup(x => x.FileName)
                 .Returns(Constants.FOLDER_ValidFileName);
 
-            this._fileInfo.Setup(x => x.PortalId)
+            this.fileInfo.Setup(x => x.PortalId)
                 .Returns(Constants.CONTENT_ValidPortalId);
 
-            this._portalControllerMock.Setup(x => x.GetCurrentPortalSettings())
+            this.portalControllerMock.Setup(x => x.GetCurrentPortalSettings())
                 .Returns<PortalSettings>(null);
 
             // act
             string fileUrl = null;
-            TestDelegate action = () => fileUrl = sfp.Object.GetFileUrl(this._fileInfo.Object);
+            TestDelegate action = () => fileUrl = sfp.Object.GetFileUrl(this.fileInfo.Object);
 
             // assert
             Assert.DoesNotThrow(action);
@@ -581,11 +569,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
             var portalSettingsMock = this.GetPortalSettingsMock();
             sfp.Setup(fp => fp.GetPortalSettings(Constants.CONTENT_ValidPortalId)).Returns(portalSettingsMock);
-            this._fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
-            this._fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
+            this.fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
+            this.fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
 
             // Act
-            var fileUrl = sfp.Object.GetFileUrl(this._fileInfo.Object);
+            var fileUrl = sfp.Object.GetFileUrl(this.fileInfo.Object);
 
             // Assert
             Assert.IsFalse(fileUrl.ToLowerInvariant().Contains("linkclick"));
@@ -609,11 +597,11 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
             var portalSettingsMock = this.GetPortalSettingsMock();
             sfp.Setup(fp => fp.GetPortalSettings(Constants.CONTENT_ValidPortalId)).Returns(portalSettingsMock);
-            this._fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
-            this._fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
+            this.fileInfo.Setup(f => f.FileName).Returns($"MyFileName {fileNameChar} Copy");
+            this.fileInfo.Setup(f => f.PortalId).Returns(Constants.CONTENT_ValidPortalId);
 
             // Act
-            var fileUrl = sfp.Object.GetFileUrl(this._fileInfo.Object);
+            var fileUrl = sfp.Object.GetFileUrl(this.fileInfo.Object);
 
             // Assert
             Assert.IsTrue(fileUrl.ToLowerInvariant().Contains("linkclick"));
@@ -622,18 +610,18 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void IsInSync_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.IsInSync(null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.IsInSync(null));
         }
 
         [Test]
         public void IsInSync_Returns_True_When_File_Is_In_Sync()
         {
-            this._fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
+            this.fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
 
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
-            sfp.Setup(fp => fp.GetHash(this._fileInfo.Object)).Returns(Constants.FOLDER_UnmodifiedFileHash);
+            sfp.Setup(fp => fp.GetHash(this.fileInfo.Object)).Returns(Constants.FOLDER_UnmodifiedFileHash);
 
-            var result = sfp.Object.IsInSync(this._fileInfo.Object);
+            var result = sfp.Object.IsInSync(this.fileInfo.Object);
 
             Assert.IsTrue(result);
         }
@@ -641,12 +629,12 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void IsInSync_Returns_True_When_File_Is_Not_In_Sync()
         {
-            this._fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
+            this.fileInfo.Setup(fi => fi.SHA1Hash).Returns(Constants.FOLDER_UnmodifiedFileHash);
 
             var sfp = new Mock<StandardFolderProvider> { CallBase = true };
-            sfp.Setup(fp => fp.GetHash(this._fileInfo.Object)).Returns(Constants.FOLDER_ModifiedFileHash);
+            sfp.Setup(fp => fp.GetHash(this.fileInfo.Object)).Returns(Constants.FOLDER_ModifiedFileHash);
 
-            var result = sfp.Object.IsInSync(this._fileInfo.Object);
+            var result = sfp.Object.IsInSync(this.fileInfo.Object);
 
             Assert.IsTrue(result);
         }
@@ -654,7 +642,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [Test]
         public void RenameFile_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.RenameFile(null, Constants.FOLDER_ValidFileName));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.RenameFile(null, Constants.FOLDER_ValidFileName));
         }
 
         [Test]
@@ -662,38 +650,38 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         [TestCase("")]
         public void RenameFile_Throws_On_NullOrEmpty_NewFileName(string newFileName)
         {
-            Assert.Throws<ArgumentException>(() => this._sfp.RenameFile(this._fileInfo.Object, newFileName));
+            Assert.Throws<ArgumentException>(() => this.sfp.RenameFile(this.fileInfo.Object, newFileName));
         }
 
         [Test]
         public void RenameFile_Calls_FileWrapper_Move_When_FileNames_Are_Not_Equal()
         {
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
-            this._fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
-            this._fileInfo.Setup(fi => fi.FolderId).Returns(Constants.FOLDER_ValidFolderId);
-            this._folderManager.Setup(fm => fm.GetFolder(Constants.FOLDER_ValidFolderId)).Returns(this._folderInfo.Object);
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
+            this.fileInfo.Setup(fi => fi.FolderId).Returns(Constants.FOLDER_ValidFolderId);
+            this.folderManager.Setup(fm => fm.GetFolder(Constants.FOLDER_ValidFolderId)).Returns(this.folderInfo.Object);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._sfp.RenameFile(this._fileInfo.Object, Constants.FOLDER_OtherValidFileName);
+            this.sfp.RenameFile(this.fileInfo.Object, Constants.FOLDER_OtherValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.Move(Constants.FOLDER_ValidFilePath, Constants.FOLDER_OtherValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Move(Constants.FOLDER_ValidFilePath, Constants.FOLDER_OtherValidFilePath), Times.Once());
         }
 
         [Test]
         public void RenameFile_Does_Not_Call_FileWrapper_Move_When_FileNames_Are_Equal()
         {
-            this._fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
-            this._fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
+            this.fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+            this.fileInfo.Setup(fi => fi.FileName).Returns(Constants.FOLDER_ValidFileName);
 
-            this._sfp.RenameFile(this._fileInfo.Object, Constants.FOLDER_ValidFileName);
+            this.sfp.RenameFile(this.fileInfo.Object, Constants.FOLDER_ValidFileName);
 
-            this._fileWrapper.Verify(fw => fw.Move(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            this.fileWrapper.Verify(fw => fw.Move(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
         }
 
         [Test]
         public void SetFileAttributes_Throws_On_Null_File()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.SetFileAttributes(null, FileAttributes.Archive));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.SetFileAttributes(null, FileAttributes.Archive));
         }
 
         // [Test]
@@ -701,16 +689,16 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         // {
         //    const FileAttributes validFileAttributes = FileAttributes.Archive;
 
-        // _fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
+        // fileInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFilePath);
 
-        // _sfp.SetFileAttributes(_fileInfo.Object, validFileAttributes);
+        // sfp.SetFileAttributes(fileInfo.Object, validFileAttributes);
 
-        // _fileWrapper.Verify(fw => fw.SetAttributes(Constants.FOLDER_ValidFilePath, validFileAttributes), Times.Once());
+        // fileWrapper.Verify(fw => fw.SetAttributes(Constants.FOLDER_ValidFilePath, validFileAttributes), Times.Once());
         // }
         [Test]
         public void SupportsFileAttributes_Returns_True()
         {
-            var result = this._sfp.SupportsFileAttributes();
+            var result = this.sfp.SupportsFileAttributes();
 
             Assert.IsTrue(result);
         }
@@ -720,7 +708,7 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentNullException>(() => this._sfp.UpdateFile(null, Constants.FOLDER_ValidFileName, stream.Object));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.UpdateFile(null, Constants.FOLDER_ValidFileName, stream.Object));
         }
 
         [Test]
@@ -730,41 +718,41 @@ namespace DotNetNuke.Tests.Core.Providers.Folder
         {
             var stream = new Mock<Stream>();
 
-            Assert.Throws<ArgumentException>(() => this._sfp.UpdateFile(this._folderInfo.Object, fileName, stream.Object));
+            Assert.Throws<ArgumentException>(() => this.sfp.UpdateFile(this.folderInfo.Object, fileName, stream.Object));
         }
 
         [Test]
         public void UpdateFile_Throws_On_Null_Content()
         {
-            Assert.Throws<ArgumentNullException>(() => this._sfp.UpdateFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, null));
+            Assert.Throws<ArgumentNullException>(() => this.sfp.UpdateFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, null));
         }
 
         [Test]
         public void UpdateFile_Calls_FileWrapper_Delete_When_File_Exists()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(true);
 
             var stream = new Mock<Stream>();
 
-            this._sfp.UpdateFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
+            this.sfp.UpdateFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
 
-            this._fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Delete(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         [Test]
         public void UpdateFile_Calls_FileWrapper_Create()
         {
-            this._folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
+            this.folderInfo.Setup(fi => fi.PhysicalPath).Returns(Constants.FOLDER_ValidFolderPath);
 
-            this._fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
+            this.fileWrapper.Setup(fw => fw.Exists(Constants.FOLDER_ValidFilePath)).Returns(false);
 
             var stream = new Mock<Stream>();
 
-            this._sfp.UpdateFile(this._folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
+            this.sfp.UpdateFile(this.folderInfo.Object, Constants.FOLDER_ValidFileName, stream.Object);
 
-            this._fileWrapper.Verify(fw => fw.Create(Constants.FOLDER_ValidFilePath), Times.Once());
+            this.fileWrapper.Verify(fw => fw.Create(Constants.FOLDER_ValidFilePath), Times.Once());
         }
 
         private Dictionary<string, string> GetPortalSettingsDictionaryMock()

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/CoreCryptographyProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/CoreCryptographyProviderTests.cs
@@ -1,34 +1,37 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
 {
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Services.Cryptography;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class CoreCryptographyProviderTests
     {
-        private static CryptographyProvider _provider;
+        private static CryptographyProvider provider;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddSingleton(Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
             ComponentFactory.InstallComponents(new ProviderInstaller("cryptography", typeof(CryptographyProvider), typeof(CoreCryptographyProvider)));
 
-            _provider = ComponentFactory.GetComponent<CryptographyProvider>("CoreCryptographyProvider");
+            this.serviceProvider = FakeServiceProvider.Setup(services => services.AddSingleton<CryptographyProvider, CoreCryptographyProvider>());
+
+            provider = ComponentFactory.GetComponent<CryptographyProvider>("CoreCryptographyProvider");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -40,7 +43,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var encryptedValue = _provider.EncryptParameter(message, encryptionKey);
+            var encryptedValue = provider.EncryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreNotEqual(message, encryptedValue);
@@ -55,7 +58,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var decryptedValue = _provider.DecryptParameter(message, encryptionKey);
+            var decryptedValue = provider.DecryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreEqual(string.Empty, decryptedValue);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/FipsCompilanceCryptographyProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/CryptographyProviders/FipsCompilanceCryptographyProviderTests.cs
@@ -1,35 +1,37 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
 {
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Services.Cryptography;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
-    using Moq;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class FipsCompilanceCryptographyProviderTests
     {
-        private static CryptographyProvider _provider;
+        private static CryptographyProvider provider;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddSingleton(Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.InstallComponents(new ProviderInstaller("cryptography", typeof(CryptographyProvider), typeof(FipsCompilanceCryptographyProvider)));
 
-            _provider = ComponentFactory.GetComponent<CryptographyProvider>("FipsCompilanceCryptographyProvider");
+            this.serviceProvider = FakeServiceProvider.Setup(services => services.AddSingleton<CryptographyProvider, FipsCompilanceCryptographyProvider>());
+
+            provider = ComponentFactory.GetComponent<CryptographyProvider>("FipsCompilanceCryptographyProvider");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -41,7 +43,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var encryptedValue = _provider.EncryptParameter(message, encryptionKey);
+            var encryptedValue = provider.EncryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreNotEqual(message, encryptedValue);
@@ -56,7 +58,7 @@ namespace DotNetNuke.Tests.Core.Services.CryptographyProviders
             // Arrange
 
             // Act
-            var decryptedValue = _provider.DecryptParameter(message, encryptionKey);
+            var decryptedValue = provider.DecryptParameter(message, encryptionKey);
 
             // Assert
             Assert.AreEqual(string.Empty, decryptedValue);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Installer/AssemblyInstallerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Installer/AssemblyInstallerTests.cs
@@ -3,40 +3,47 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Tests.Core.Services.Installer
 {
-    using System;
     using System.IO;
-    using System.Linq;
     using System.Xml.XPath;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Services.Installer;
     using DotNetNuke.Services.Installer.Installers;
     using DotNetNuke.Services.Installer.Packages;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     public class AssemblyInstallerTests : DnnUnitTest
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            var appInfo = new Mock<IApplicationStatusInfo>();
-            appInfo.SetupGet(app => app.Status).Returns(UpgradeStatus.None);
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => appInfo.Object);
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var dataProvider = MockComponentProvider.CreateDataProvider();
             dataProvider.Setup(p => p.UnRegisterAssembly(It.IsAny<int>(), It.IsAny<string>())).Returns(true);
 
-            LocalizationProvider.SetTestableInstance(new Mock<ILocalizationProvider>().Object);
+            LocalizationProvider.SetTestableInstance(Mock.Of<ILocalizationProvider>());
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(dataProvider.Object);
+                    services.AddSingleton(LocalizationProvider.Instance);
+                });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mobile/PreviewProfileControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Mobile/PreviewProfileControllerTests.cs
@@ -1,20 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Core.Services.Mobile
 {
     using System;
     using System.Collections.Generic;
     using System.Data;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
-    using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Services.Mobile;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +24,7 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
     public class PreviewProfileControllerTests
     {
         private Mock<DataProvider> dataProvider;
+        private FakeServiceProvider serviceProvider;
 
         private DataTable dtProfiles;
 
@@ -35,12 +32,6 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
 
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService, HostController>();
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             ComponentFactory.Container = new SimpleContainer();
             this.dataProvider = MockComponentProvider.CreateDataProvider();
             this.dataProvider.Setup(d => d.GetProviderPath()).Returns(string.Empty);
@@ -119,12 +110,18 @@ namespace DotNetNuke.Tests.Core.Services.Mobile
                                                                                                     this.dtProfiles.Rows.Remove(rows[0]);
                                                                                                 }
                                                                                             });
+
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.dataProvider.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Search/Internals/LuceneControllerImplTests.cs
@@ -1,16 +1,21 @@
-﻿namespace DotNetNuke.Tests.Core.Services.Search.Internals
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Core.Services.Search.Internals
 {
     using System.Data;
 
-    using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Application;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Services.Search.Internals;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
     using Lucene.Net.Analysis.Cz;
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     public class LuceneControllerImplTests
@@ -19,38 +24,49 @@
 
         public void GetCustomAnalyzer_WithTheProvidedAnalyzer_ReturnsTheAnalyzerCorrectly()
         {
-            // Arrange
-            const string HostSettingsTableName = "HostSettings";
-            const string SettingNameColumnName = "SettingName";
-            const string SettingValueColumnName = "SettingValue";
-            const string SettingIsSecureColumnName = "SettingIsSecure";
-            const string CustomAnalyzerCacheKeyName = "Search_CustomAnalyzer";
-            const string CzechAnalyzerTypeName = "Lucene.Net.Analysis.Cz.CzechAnalyzer, Lucene.Net.Contrib.Analyzers";
-            var services = new ServiceCollection();
-            var mockData = MockComponentProvider.CreateDataProvider();
-            var hostSettings = new DataTable(HostSettingsTableName);
-            var nameCol = hostSettings.Columns.Add(SettingNameColumnName);
-            hostSettings.Columns.Add(SettingValueColumnName);
-            hostSettings.Columns.Add(SettingIsSecureColumnName);
-            hostSettings.PrimaryKey = new[] { nameCol };
-            hostSettings.Rows.Add(CustomAnalyzerCacheKeyName, CzechAnalyzerTypeName, true);
-            mockData.Setup(c => c.GetHostSettings()).Returns(hostSettings.CreateDataReader());
-            var mockedApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockedApplicationStatusInfo.Setup(s => s.Status).Returns(UpgradeStatus.Install);
-            mockedApplicationStatusInfo.Setup(s => s.ApplicationMapPath).Returns(string.Empty);
-            services.AddTransient(container => Mock.Of<IHostSettingsService>());
-            services.AddTransient(container => mockedApplicationStatusInfo.Object);
-            services.AddTransient(container => Mock.Of<INavigationManager>());
-            Globals.DependencyProvider = services.BuildServiceProvider();
-            MockComponentProvider.CreateDataCacheProvider();
-            DataCache.ClearCache();
-            var luceneController = new LuceneControllerImpl();
+            FakeServiceProvider serviceProvider = null;
+            try
+            {
+                // Arrange
+                const string HostSettingsTableName = "HostSettings";
+                const string SettingNameColumnName = "SettingName";
+                const string SettingValueColumnName = "SettingValue";
+                const string SettingIsSecureColumnName = "SettingIsSecure";
+                const string CustomAnalyzerCacheKeyName = "Search_CustomAnalyzer";
+                const string CzechAnalyzerTypeName = "Lucene.Net.Analysis.Cz.CzechAnalyzer, Lucene.Net.Contrib.Analyzers";
+                var mockData = MockComponentProvider.CreateDataProvider();
+                var hostSettings = new DataTable(HostSettingsTableName);
+                var nameCol = hostSettings.Columns.Add(SettingNameColumnName);
+                hostSettings.Columns.Add(SettingValueColumnName);
+                hostSettings.Columns.Add(SettingIsSecureColumnName);
+                hostSettings.PrimaryKey = new[] { nameCol };
+                hostSettings.Rows.Add(CustomAnalyzerCacheKeyName, CzechAnalyzerTypeName, true);
+                mockData.Setup(c => c.GetHostSettings()).Returns(hostSettings.CreateDataReader());
+                var mockedApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
+                mockedApplicationStatusInfo.Setup(s => s.Status).Returns(UpgradeStatus.Install);
+                mockedApplicationStatusInfo.Setup(s => s.ApplicationMapPath).Returns(string.Empty);
 
-            // Act
-            var analyzer = luceneController.GetCustomAnalyzer();
+                serviceProvider = FakeServiceProvider.Setup(
+                    services =>
+                    {
+                        services.AddSingleton(mockData.Object);
+                        services.AddSingleton(mockedApplicationStatusInfo.Object);
+                    });
 
-            // Assert
-            Assert.IsInstanceOf<CzechAnalyzer>(analyzer);
+                MockComponentProvider.CreateDataCacheProvider();
+                DataCache.ClearCache();
+                var luceneController = new LuceneControllerImpl();
+
+                // Act
+                var analyzer = luceneController.GetCustomAnalyzer();
+
+                // Assert
+                Assert.IsInstanceOf<CzechAnalyzer>(analyzer);
+            }
+            finally
+            {
+                serviceProvider?.Dispose();
+            }
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/RepositoryBaseTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/RepositoryBaseTests.cs
@@ -7,10 +7,7 @@ namespace DotNetNuke.Tests.Data
     using System.Collections.Generic;
     using System.Web.Caching;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Collections;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Controllers;
@@ -18,20 +15,30 @@ namespace DotNetNuke.Tests.Data
     using DotNetNuke.Tests.Data.Fakes;
     using DotNetNuke.Tests.Data.Models;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
-    using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
     using Moq.Protected;
+
     using NUnit.Framework;
 
     [TestFixture]
     public class RepositoryBaseTests
     {
-        // ReSharper disable InconsistentNaming
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
             MockComponentProvider.ResetContainer();
+            this.serviceProvider = FakeServiceProvider.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -510,12 +517,6 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_Get_Calls_GetAllInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();
             mockHostController.Setup(h => h.GetString("PerformanceSetting")).Returns("3");
 
@@ -662,12 +663,6 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_Get_Overload_Calls_GetAllByScopeInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var cacheKey = CachingProvider.GetCacheKey(string.Format(Constants.CACHE_CatsKey + "_" + Constants.CACHE_ScopeModule + "_{0}", Constants.MODULE_ValidId));
 
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();
@@ -1041,12 +1036,6 @@ namespace DotNetNuke.Tests.Data
         public void RepositoryBase_GetPage_Overload_Calls_GetAllByScopeInternal_If_Cacheable_And_Cache_Expired()
         {
             // Arrange
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
-
             var cacheKey = CachingProvider.GetCacheKey(string.Format(Constants.CACHE_CatsKey + "_" + Constants.CACHE_ScopeModule + "_{0}", Constants.MODULE_ValidId));
 
             var mockHostController = MockComponentProvider.CreateNew<IHostController>();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/ExtensionUrlProviderControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/ExtensionUrlProviderControllerTests.cs
@@ -7,34 +7,32 @@ namespace DotNetNuke.Tests.Urls
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Data;
-    using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Urls;
     using DotNetNuke.Tests.Utilities;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
-
-    using Microsoft.Extensions.DependencyInjection;
-
-    using Moq;
 
     using NUnit.Framework;
 
     [TestFixture]
     public class ExtensionUrlProviderControllerTests
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void SetUp()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient(container => Mock.Of<IHostSettingsService>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/HttpContextHelper.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/HttpContextHelper.cs
@@ -23,23 +23,23 @@ namespace DotNetNuke.Tests.Utilities
         /// <returns>HttpResponseBase.</returns>
         public static Mock<HttpContextBase> RegisterMockHttpContext()
         {
-            var mock = CrateMockHttpContext();
+            var mock = CreateMockHttpContext();
             HttpContextSource.RegisterInstance(mock.Object);
             return mock;
         }
 
-        private static Mock<HttpContextBase> CrateMockHttpContext()
+        private static Mock<HttpContextBase> CreateMockHttpContext()
         {
             var context = new Mock<HttpContextBase>();
             context.SetupGet(x => x.Items).Returns(new Hashtable());
             context.SetupGet(x => x.Request).Returns(GetMockRequestBase());
             context.SetupGet(x => x.Response).Returns(GetMockResponseBase());
             context.SetupGet(x => x.Session).Returns(GetMockSessionStateBase());
-            context.SetupGet(x => x.Server).Returns(GeMocktServerUtilityBase());
+            context.SetupGet(x => x.Server).Returns(GetMockServerUtilityBase());
             return context;
         }
 
-        private static HttpServerUtilityBase GeMocktServerUtilityBase()
+        private static HttpServerUtilityBase GetMockServerUtilityBase()
         {
             var mockServerUtility = new Mock<HttpServerUtilityBase>();
             mockServerUtility.SetupAllProperties();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/ModuleDelegatingViewEngineTests.cs
@@ -1,15 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Mvc.Framework
 {
     using System.Linq;
     using System.Web.Mvc;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Web.Mvc.Framework;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using DotNetNuke.Web.Mvc.Framework.Modules;
@@ -24,18 +21,22 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework
     [TestFixture]
     public class ModuleDelegatingViewEngineTests
     {
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void Setup()
         {
-            var services = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+                });
+        }
 
-            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            services.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
-
-            Globals.DependencyProvider = services.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Framework/Modules/ModuleApplicationTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
 {
     using System;
@@ -9,10 +8,8 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
     using System.Web.Mvc;
     using System.Web.Routing;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
     using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
     using DotNetNuke.Web.Mvc.Framework.Modules;
@@ -29,18 +26,22 @@ namespace DotNetNuke.Tests.Web.Mvc.Framework.Modules
         private const string ActionName = "Action";
         private const string ControllerName = "Controller";
 
+        private FakeServiceProvider serviceProvider;
+
         [SetUp]
         public void Setup()
         {
-            var services = new ServiceCollection();
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
+                });
+        }
 
-            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            services.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            services.AddSingleton<IControllerFactory, DefaultControllerFactory>();
-
-            Globals.DependencyProvider = services.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/DnnDependencyResolverTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/DnnDependencyResolverTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api.Internals
 {
     using System;
@@ -16,8 +15,8 @@ namespace DotNetNuke.Tests.Web.Api.Internals
     [TestFixture]
     public class DnnDependencyResolverTests
     {
-        private IServiceProvider _serviceProvider;
-        private IDependencyResolver _dependencyResolver;
+        private IServiceProvider serviceProvider;
+        private IDependencyResolver dependencyResolver;
 
         private interface ITestService
         {
@@ -30,40 +29,40 @@ namespace DotNetNuke.Tests.Web.Api.Internals
             services.AddSingleton<IScopeAccessor>(sp => new FakeScopeAccessor(sp.CreateScope()));
             services.AddScoped(typeof(ITestService), typeof(TestService));
 
-            this._serviceProvider = services.BuildServiceProvider();
-            this._dependencyResolver = new DnnDependencyResolver(this._serviceProvider);
+            this.serviceProvider = services.BuildServiceProvider();
+            this.dependencyResolver = new DnnDependencyResolver(this.serviceProvider);
         }
 
         [OneTimeTearDown]
         public void FixtureTearDown()
         {
-            this._dependencyResolver = null;
+            this.dependencyResolver = null;
 
-            if (this._serviceProvider is IDisposable disposable)
+            if (this.serviceProvider is IDisposable disposable)
             {
                 disposable.Dispose();
             }
 
-            this._serviceProvider = null;
+            this.serviceProvider = null;
         }
 
         [Test]
         public void NotNull()
         {
-            Assert.NotNull(this._dependencyResolver);
+            Assert.NotNull(this.dependencyResolver);
         }
 
         [Test]
         public void IsOfTypeDnnDependencyResolver()
         {
-            Assert.IsInstanceOf<DnnDependencyResolver>(this._dependencyResolver);
+            Assert.IsInstanceOf<DnnDependencyResolver>(this.dependencyResolver);
         }
 
         [Test]
         public void GetTestService()
         {
             var expected = new TestService();
-            var actual = this._dependencyResolver.GetService(typeof(ITestService));
+            var actual = this.dependencyResolver.GetService(typeof(ITestService));
 
             Assert.NotNull(actual);
             Assert.AreEqual(expected.GetType(), actual.GetType());
@@ -73,7 +72,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         public void GetTestServices()
         {
             var expected = new TestService();
-            var actual = this._dependencyResolver.GetServices(typeof(ITestService)).ToArray();
+            var actual = this.dependencyResolver.GetServices(typeof(ITestService)).ToArray();
 
             Assert.NotNull(actual);
             Assert.AreEqual(1, actual.Length);
@@ -83,7 +82,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void BeginScope()
         {
-            var actual = this._dependencyResolver.BeginScope();
+            var actual = this.dependencyResolver.BeginScope();
 
             Assert.NotNull(actual);
             Assert.IsInstanceOf<DnnDependencyResolver>(actual);
@@ -92,7 +91,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void BeginScope_GetService()
         {
-            var scope = this._dependencyResolver.BeginScope();
+            var scope = this.dependencyResolver.BeginScope();
 
             var expected = new TestService();
             var actual = scope.GetService(typeof(ITestService));
@@ -104,7 +103,7 @@ namespace DotNetNuke.Tests.Web.Api.Internals
         [Test]
         public void BeginScope_GetServices()
         {
-            var scope = this._dependencyResolver.BeginScope();
+            var scope = this.dependencyResolver.BeginScope();
 
             var expected = new TestService();
             var actual = scope.GetServices(typeof(ITestService)).ToArray();

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/WebFormsServiceProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/Internals/WebFormsServiceProviderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api.Internals
 {
     using System.Web.UI;
@@ -13,8 +12,11 @@ namespace DotNetNuke.Tests.Web.Api.Internals
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Tests.Utilities;
     using DotNetNuke.Web.Common;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     public class WebFormsServiceProviderTests

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/Api/PortalAliasRouteManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Tests.Web.Api
 {
     using System;
@@ -9,12 +8,10 @@ namespace DotNetNuke.Tests.Web.Api
     using System.Collections.Generic;
     using System.Linq;
 
-    using DotNetNuke.Abstractions;
-    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
-    using DotNetNuke.Common;
     using DotNetNuke.Common.Internal;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Web.Api;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -27,30 +24,25 @@ namespace DotNetNuke.Tests.Web.Api
     public class PortalAliasRouteManagerTests
     {
         private Mock<IPortalAliasService> mockPortalAliasService;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void SetUp()
         {
-            var services = new ServiceCollection();
-            var navigationManagerMock = new Mock<INavigationManager>();
-
-            var mockApplicationStatusInfo = new Mock<IApplicationStatusInfo>();
-            mockApplicationStatusInfo.Setup(info => info.Status).Returns(UpgradeStatus.Install);
-
             this.mockPortalAliasService = new Mock<IPortalAliasService>();
             this.mockPortalAliasService.As<IPortalAliasController>();
 
-            services.AddTransient<IApplicationStatusInfo>(container => mockApplicationStatusInfo.Object);
-            services.AddScoped(typeof(INavigationManager), (x) => navigationManagerMock.Object);
-            services.AddScoped<IPortalAliasService>(_ => this.mockPortalAliasService.Object);
-
-            Globals.DependencyProvider = services.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockPortalAliasService.Object);
+                });
         }
 
         [TearDown]
         public void TearDown()
         {
-            Globals.DependencyProvider = null;
+            this.serviceProvider.Dispose();
 
             this.mockPortalAliasService = null;
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/FileUploadControllerTests.cs
@@ -1,4 +1,7 @@
-﻿namespace DotNetNuke.Tests.Web.InternalServices
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Web.InternalServices
 {
     using System.Data;
     using System.Linq;
@@ -6,15 +9,12 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    using Abstractions;
-    using Abstractions.Application;
-    using Abstractions.Logging;
-
-    using Common;
-    using Common.Lists;
-
-    using Data;
+    using DotNetNuke.Common.Lists;
+    using DotNetNuke.Data;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Services.Cache;
+    using DotNetNuke.Tests.Utilities.Fakes;
+    using DotNetNuke.Tests.Utilities.Mocks;
     using DotNetNuke.Web.InternalServices;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -23,29 +23,31 @@
 
     using NUnit.Framework;
 
-    using Services.Cache;
-
-    using Utilities.Mocks;
     /// <summary>Tests FileUploadController methods</summary>
     [TestFixture]
     public class FileUploadControllerTests
     {
-        private Mock<DataProvider> _mockDataProvider;
-        private FileUploadController _testInstance;
-        private Mock<CachingProvider> _mockCachingProvider;
-        private Mock<IPortalController> _mockPortalController;
-        private TestSynchronizationContext _synchronizationContext = new TestSynchronizationContext();
+        private Mock<DataProvider> mockDataProvider;
+        private FileUploadController testInstance;
+        private Mock<CachingProvider> mockCachingProvider;
+        private Mock<IPortalController> mockPortalController;
+        private TestSynchronizationContext synchronizationContext = new TestSynchronizationContext();
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void SetUp()
         {
             this.SetupDataProvider();
-
             this.SetupCachingProvider();
-
             this.SetupPortalSettings();
             this.SetupServiceProvider();
             this.SetupSynchronizationContext();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]
@@ -58,48 +60,49 @@
 
             var request = new HttpRequestMessage();
             request.Content = formDataContent;
-            this._testInstance.Request = request;
-            await this._testInstance.UploadFromLocal(-1);
+            this.testInstance.Request = request;
+            await this.testInstance.UploadFromLocal(-1);
 
-            Assert.IsTrue(_synchronizationContext.IsUploadFileCalled());
+            Assert.IsTrue(this.synchronizationContext.IsUploadFileCalled());
         }
 
         private void SetupPortalSettings()
         {
-            _mockPortalController = MockComponentProvider.CreatePortalController();
-            _mockPortalController.Setup(x => x.GetCurrentPortalSettings()).Returns(new PortalSettings() { PortalId = 0 });
-            PortalController.SetTestableInstance(_mockPortalController.Object);
+            this.mockPortalController = MockComponentProvider.CreatePortalController();
+            this.mockPortalController.Setup(x => x.GetCurrentPortalSettings()).Returns(new PortalSettings() { PortalId = 0 });
+            PortalController.SetTestableInstance(this.mockPortalController.Object);
         }
 
         private void SetupDataProvider()
         {
-            this._mockDataProvider = MockComponentProvider.CreateDataProvider();
-            this._mockDataProvider.Setup(x => x.GetListEntriesByListName("ImageTypes", string.Empty, It.IsAny<int>()))
+            this.mockDataProvider = MockComponentProvider.CreateDataProvider();
+            this.mockDataProvider.Setup(x => x.GetListEntriesByListName("ImageTypes", string.Empty, It.IsAny<int>()))
                 .Returns(Mock.Of<IDataReader>());
         }
 
         private void SetupCachingProvider()
         {
-            this._mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
-            this._mockCachingProvider.Setup(x => x.GetItem(It.IsAny<string>()))
+            this.mockCachingProvider = MockComponentProvider.CreateDataCacheProvider();
+            this.mockCachingProvider.Setup(x => x.GetItem(It.IsAny<string>()))
                 .Returns(Enumerable.Empty<ListEntryInfo>());
         }
 
         private void SetupServiceProvider()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(
-            container => new Application.ApplicationStatusInfo(Mock.Of<IApplicationInfo>()));
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient(container => Mock.Of<IEventLogger>());
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockPortalController.Object);
+                    services.AddSingleton(this.mockCachingProvider.Object);
+                    services.AddSingleton(this.mockDataProvider.Object);
+                });
         }
 
         private void SetupSynchronizationContext()
         {
-            _synchronizationContext = new TestSynchronizationContext();
-            SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
-            this._testInstance = new FileUploadController();
+            this.synchronizationContext = new TestSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(this.synchronizationContext);
+            this.testInstance = new FileUploadController();
         }
 
         private class TestSynchronizationContext : SynchronizationContext

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/TabVersionControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/InternalServices/TabVersionControllerTests.cs
@@ -16,6 +16,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Utilities.Mocks;
 
     using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +35,7 @@ namespace DotNetNuke.Tests.Web.InternalServices
         private Mock<ICBO> mockCBO;
         private Mock<IUserController> mockUserController;
         private Mock<IHostController> mockHostController;
+        private FakeServiceProvider serviceProvider;
 
         [SetUp]
         public void Setup()
@@ -41,12 +43,20 @@ namespace DotNetNuke.Tests.Web.InternalServices
             MockComponentProvider.ResetContainer();
             this.SetupCBO();
             this.SetupHostController();
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(this.mockCBO.Object);
+                    services.AddSingleton(this.mockUserController.Object);
+                    services.AddSingleton(this.mockHostController.Object);
+                    services.AddSingleton((IHostSettingsService)this.mockHostController.Object);
+                });
+        }
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient<IApplicationStatusInfo>(container => Mock.Of<IApplicationStatusInfo>());
-            serviceCollection.AddTransient<INavigationManager>(container => Mock.Of<INavigationManager>());
-            serviceCollection.AddTransient<IHostSettingsService>(container => (IHostSettingsService)this.mockHostController.Object);
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         [Test]

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/ConfigConsoleControllerTests.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/ConfigConsoleControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace Dnn.PersonaBar.ConfigConsole.Tests
 {
     using System;
@@ -9,11 +8,14 @@ namespace Dnn.PersonaBar.ConfigConsole.Tests
     using System.Linq;
 
     using Dnn.PersonaBar.ConfigConsole.Components;
-    using DotNetNuke.Abstractions;
+
     using DotNetNuke.Abstractions.Application;
-    using DotNetNuke.Common;
+    using DotNetNuke.Tests.Utilities.Fakes;
+
     using Microsoft.Extensions.DependencyInjection;
+
     using Moq;
+
     using NUnit.Framework;
 
     /// <summary><see cref="ConfigConsoleController"/> unit tests.</summary>
@@ -24,21 +26,28 @@ namespace Dnn.PersonaBar.ConfigConsole.Tests
         private const string BadConfigXml = "<configuration1></configuration1>";
         private const string BadXml = "<configuration></configuration1>";
 
+        private FakeServiceProvider serviceProvider;
+
         /// <summary>Method that is called immediately before each test is run.</summary>
         [SetUp]
-        public static void Setup()
+        public void Setup()
         {
             var applicationStatusInfoMock = new Mock<IApplicationStatusInfo>();
 
             applicationStatusInfoMock
                 .Setup(info => info.ApplicationMapPath)
                 .Returns(Environment.CurrentDirectory);
+            this.serviceProvider = FakeServiceProvider.Setup(
+                services =>
+                {
+                    services.AddSingleton(applicationStatusInfoMock.Object);
+                });
+        }
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddTransient(container => applicationStatusInfoMock.Object);
-            serviceCollection.AddTransient(container => Mock.Of<INavigationManager>());
-
-            Globals.DependencyProvider = serviceCollection.BuildServiceProvider();
+        [TearDown]
+        public void TearDown()
+        {
+            this.serviceProvider.Dispose();
         }
 
         /// <summary>Unit test for <see cref="ConfigConsoleController.ValidateConfigFile(string, string)"/>.</summary>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/Dnn.PersonaBar.ConfigConsole.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/Dnn.PersonaBar.ConfigConsole.Tests.csproj
@@ -84,6 +84,10 @@
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
       <Name>DotNetNuke.Library</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\DNN Platform\Tests\DotNetNuke.Tests.Utilities\DotNetNuke.Tests.Utilities.csproj">
+      <Project>{68368906-57DD-40D1-AC10-35211A17D617}</Project>
+      <Name>DotNetNuke.Tests.Utilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Library\Dnn.PersonaBar.Library\Dnn.PersonaBar.Library.csproj">
       <Project>{8B50BA8B-0A08-41B8-81B8-EA70707C7379}</Project>
       <Name>Dnn.PersonaBar.Library</Name>


### PR DESCRIPTION
## Summary
#5627 introduced `FakeServiceProvider` and applied it to about half of the scenarios where `Globals.DependencyProvider` is being mocked in a test. This PR applies it in all other scenarios (except for the couple where we're directly testing dependency injection and need more control over the container setup).
