### PR TITLE
Resolve StackOverflowException

### DIFF
--- a/DNN Platform/DotNetNuke.Maintenance/Telerik/Removal/Startup.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Telerik/Removal/Startup.cs
@@ -15,6 +15,7 @@ namespace DotNetNuke.Maintenance.Telerik.Removal
     using DotNetNuke.Services.Installer.Packages;
     using DotNetNuke.Services.Localization;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
 
     /// <inheritdoc />
     public class Startup : IDnnStartup
@@ -30,11 +31,11 @@ namespace DotNetNuke.Maintenance.Telerik.Removal
             services.AddTransient<ILocalizer, Localizer>();
 
             // core
-            services.AddTransient(provider => LocalizationProvider.Instance);
-            services.AddTransient(provider => LoggerSource.Instance);
-            services.AddTransient(provider => ModuleController.Instance);
-            services.AddTransient(provider => PackageController.Instance);
-            services.AddTransient(provider => TabController.Instance);
+            services.TryAddTransient(provider => LocalizationProvider.Instance);
+            services.TryAddTransient(provider => LoggerSource.Instance);
+            services.TryAddTransient(provider => ModuleController.Instance);
+            services.TryAddTransient(provider => PackageController.Instance);
+            services.TryAddTransient(provider => TabController.Instance);
 
             // shims
             services.AddTransient<IDataCache, DataCacheShim>();

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -22,10 +22,14 @@ namespace DotNetNuke
     using DotNetNuke.Entities.Modules.Settings;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Portals.Templates;
+    using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Framework.Reflections;
+    using DotNetNuke.Instrumentation;
     using DotNetNuke.Prompt;
     using DotNetNuke.Services.FileSystem;
+    using DotNetNuke.Services.Installer.Packages;
+    using DotNetNuke.Services.Localization;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Services.Search.Controllers;
     using DotNetNuke.UI.Modules;
@@ -69,6 +73,13 @@ namespace DotNetNuke
             services.AddTransient<ITabVersionBuilder, TabVersionBuilder>();
             services.AddTransient<ISearchController, SearchControllerImpl>();
             services.AddTransient<IFolderMappingController, FolderMappingController>(_ => new FolderMappingController());
+
+            // TODO: LocalizationProvider can be overridden via the ComponentFactory, need to be able to get an instance registered via ComponentFactory without creating a dependency loop
+            services.AddTransient<ILocalizationProvider, LocalizationProvider>();
+            services.AddTransient<ILoggerSource, LoggerSourceImpl>();
+            services.AddTransient<IModuleController, ModuleController>();
+            services.AddTransient<IPackageController, PackageController>();
+            services.AddTransient<ITabController, TabController>();
 
             services.AddTransient<ModuleInjectionManager>();
             RegisterModuleInjectionFilters(services);


### PR DESCRIPTION
#5652 introduced an issue because [the Telerik Removal component registers `LocalizationProvider` with the DI container using a lambda pointing to `LocalizationProvider.Instance`](https://github.com/dnnsoftware/Dnn.Platform/blob/a716272d41a864b263cc4db413caa0ae33f02ce9/DNN%20Platform/DotNetNuke.Maintenance/Telerik/Removal/Startup.cs#L32-L37), which is [`ComponentBase.Instance`](https://github.com/dnnsoftware/Dnn.Platform/blob/a716272d41a864b263cc4db413caa0ae33f02ce9/DNN%20Platform/Library/ComponentModel/ComponentBase.cs#L18-L37). Since `LocalizationProvider` is not registered with `ComponentFactory`, this means that, due to #5652, it falls back to the DI container, which then asks the `ComponentFactory` _again_, creating an infinite loop, and ultimately a `StackOverflowException`.

This PR registers `LocalizationProvider` directly in the DI container, instead of via the `LocalizationProvider.Instance` lambda. 

Ultimately, the best resolution is to ensure that every component using `ComponentBase` is registered first in the DI container. I think we should also mark `ComponentBase` as obsolete.

I also considered adding a check to prevent the infinite loop or fallback in these scenarios, but couldn't come up with a safe way to do it which preserved the existing functionality.