### PR TITLE
Fixes #5645 image upload problem

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -2420,7 +2420,7 @@ namespace DNNConnect.CKEditorProvider.Browser
                 else
                 {
                     // querystring parameter responseType equals "json" when the request comes from drag/drop
-                    if (this.Request.QueryString["responseType"]?.Equals("json", StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    if (this.Request.QueryString["responseType"]?.Equals("json", StringComparison.InvariantCultureIgnoreCase) == true)
                     {
                         var fileUrl = string.Format(!MapUrl(uploadPhysicalPath).EndsWith("/") ? "{0}/{1}" : "{0}{1}", MapUrl(uploadPhysicalPath), fileName);
                         this.Response.ClearContent();

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -2419,10 +2419,20 @@ namespace DNNConnect.CKEditorProvider.Browser
                 }
                 else
                 {
-                    var fileUrl = string.Format(!MapUrl(uploadPhysicalPath).EndsWith("/") ? "{0}/{1}" : "{0}{1}", MapUrl(uploadPhysicalPath), fileName);
-                    this.Response.ClearContent();
-                    this.Response.ContentType = "application/json";
-                    this.Response.Write($"{{\"uploaded\": 1, \"fileName\": \"{fileName}\", \"url\": \"{fileUrl}\"}}");
+                    // querystring parameter responseType equals "json" when the request comes from drag/drop
+                    if (this.Request.QueryString["responseType"]?.Equals("json", StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    {
+                        var fileUrl = string.Format(!MapUrl(uploadPhysicalPath).EndsWith("/") ? "{0}/{1}" : "{0}{1}", MapUrl(uploadPhysicalPath), fileName);
+                        this.Response.ClearContent();
+                        this.Response.ContentType = "application/json";
+                        this.Response.Write($"{{\"uploaded\": 1, \"fileName\": \"{fileName}\", \"url\": \"{fileUrl}\"}}");
+                    }
+                    else
+                    {
+                        this.Response.Write("<script type=\"text/javascript\">");
+                        this.Response.Write(this.GetJsUploadCode(fileName, MapUrl(uploadPhysicalPath)));
+                        this.Response.Write("</script>");
+                    }
                 }
 
                 this.Response.End();


### PR DESCRIPTION
This PR contains a fix for #5645.

The previous fix for drag/drop of images (#5415 ) broke the upload via the dialog. This fix makes sure both uploads are working as expected.

The upload-request coming from Drag/drop contains a querystring variable "responseType" which I'm using here to determine which response to send.
