### PR TITLE
Resolve connector checkbox saving

### DIFF
--- a/DNN Platform/Connectors/GoogleAnalytics/Scripts/connector.js
+++ b/DNN Platform/Connectors/GoogleAnalytics/Scripts/connector.js
@@ -30,9 +30,9 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
     var onSave = function (conn) {
 
         // Convert boolean to string as the API requires a dictionary of string values
-        conn.configurations[2].value(conn.configurations[2].value().toString());
-        conn.configurations[3].value(conn.configurations[3].value().toString());
-        conn.configurations[4].value(conn.configurations[4].value().toString());
+        conn.configurations[2].value(conn.configurations[2].value() || 'false');
+        conn.configurations[3].value(conn.configurations[3].value() || 'false');
+        conn.configurations[4].value(conn.configurations[4].value() || 'false');
     };
 
     var onSaveComplete = function (conn, id) {

--- a/DNN Platform/Connectors/GoogleAnalytics/connector.htm
+++ b/DNN Platform/Connectors/GoogleAnalytics/connector.htm
@@ -12,19 +12,19 @@
 
     <div>
         <label for="chkTrackAdmins" data-bind="html: configurations[2].localizedName"></label>
-        <input id="chkTrackAdmins" type="checkbox" data-bind="checked: configurations[2].value, checkedValue: configurations[2].value" />
+        <input id="chkTrackAdmins" type="checkbox" data-bind="checked: configurations[2].value, checkedValue: 'true'" />
     </div>
 
     <div>
         <label for="chkAnonymizeIp" data-bind="html: configurations[3].localizedName"></label>
-        <input id="chkAnonymizeIp" type="checkbox" data-bind="checked: configurations[3].value, checkedValue: configurations[3].value, disable: configurations[5].value" />
+        <input id="chkAnonymizeIp" type="checkbox" data-bind="checked: configurations[3].value, checkedValue: 'true', disable: configurations[5].value" />
 
         <span data-bind="visible: configurations[5].value, html: configurations[5].localizedName"></span>
     </div>
 
     <div>
         <label for="chkTrackUserId" data-bind="html: configurations[4].localizedName"></label>
-        <input id="chkTrackUserId" type="checkbox" data-bind="checked: configurations[4].value, checkedValue: configurations[4].value" />
+        <input id="chkTrackUserId" type="checkbox" data-bind="checked: configurations[4].value, checkedValue: 'true'" />
     </div>
 
     <div class="clear"></div>

--- a/DNN Platform/Connectors/GoogleAnalytics4/Scripts/connector.js
+++ b/DNN Platform/Connectors/GoogleAnalytics4/Scripts/connector.js
@@ -30,7 +30,7 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
     var onSave = function (conn) {
 
         // Convert boolean to string as the API requires a dictionary of string values
-        conn.configurations[1].value(conn.configurations[1].value().toString());
+        conn.configurations[1].value(conn.configurations[1].value() || 'false');
     };
 
     var onSaveComplete = function (conn, id) {

--- a/DNN Platform/Connectors/GoogleAnalytics4/connector.htm
+++ b/DNN Platform/Connectors/GoogleAnalytics4/connector.htm
@@ -7,7 +7,7 @@
 
     <div>
         <label for="chkTrackAdmins" data-bind="html: configurations[1].localizedName"></label>
-        <input id="chkTrackAdmins" type="checkbox" data-bind="checked: configurations[1].value, checkedValue: configurations[1].value" />
+        <input id="chkTrackAdmins" type="checkbox" data-bind="checked: configurations[1].value, checkedValue: 'true'" />
     </div>
 
     <div class="clear"></div>

--- a/DNN Platform/Connectors/GoogleTagManager/Scripts/connector.js
+++ b/DNN Platform/Connectors/GoogleTagManager/Scripts/connector.js
@@ -30,7 +30,7 @@ define(["jquery", "knockout", "templatePath/scripts/config", "templatePath/scrip
     var onSave = function (conn) {
 
         // Convert boolean to string as the API requires a dictionary of string values
-        conn.configurations[1].value(conn.configurations[1].value().toString());
+        conn.configurations[1].value(conn.configurations[1].value() || 'false');
     };
 
     var onSaveComplete = function (conn, id) {

--- a/DNN Platform/Connectors/GoogleTagManager/connector.htm
+++ b/DNN Platform/Connectors/GoogleTagManager/connector.htm
@@ -7,7 +7,7 @@
 
     <div>
         <label for="chkTrackAdmins" data-bind="html: configurations[1].localizedName"></label>
-        <input id="chkTrackAdmins" type="checkbox" data-bind="checked: configurations[1].value, checkedValue: configurations[1].value" />
+        <input id="chkTrackAdmins" type="checkbox" data-bind="checked: configurations[1].value, checkedValue: 'true'" />
     </div>
 
     <div class="clear"></div>


### PR DESCRIPTION
Fixes #5667

It appears [the `checked` binding](https://knockoutjs.com/documentation/checked-binding.html) started returning `undefined` when unchecked (probably only alongside using the `checkedValue` binding) when [we upgraded Knockout from 3.3.0 to 3.5.1](https://github.com/dnnsoftware/Dnn.Platform/commit/a0d5273d372fc9db3a2b85860bde839884e5b944).

I'm now using `checkedValue: 'true'` to set the value to a string when checked, and then falling back to the string `'false'` if it's not `'true'`.

Thanks @david-poindexter and @valadas for pointing in the right direction.