### PR TITLE
Cleaned up format of affected-versions dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,6 +70,7 @@ body:
       label: Affected Versions
       description: | 
         What version of DNN are you running?
+        
         **NOTE:** _If your version is not listed, please upgrade to the latest version. If you cannot upgrade at this time, please open a [Discussion](https://github.com/dnnsoftware/Dnn.Platform/discussions) instead._
       multiple: true
       options:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,7 +68,9 @@ body:
     id: affected-versions
     attributes:
       label: Affected Versions
-      description: What version of DNN are you running? **Note:** _If your version is not listed, please upgrade to the latest version. If you cannot upgrade at this time, please open a [Discussion](https://github.com/dnnsoftware/Dnn.Platform/discussions) instead._
+      description: | 
+        What version of DNN are you running?
+        **NOTE:** _If your version is not listed, please upgrade to the latest version. If you cannot upgrade at this time, please open a [Discussion](https://github.com/dnnsoftware/Dnn.Platform/discussions) instead._
       multiple: true
       options:
         - 9.11.2 (latest release)


### PR DESCRIPTION
## Summary
Attempt to use multi-line markdown in `affected-versions` dropdown description.