### PR TITLE
Match Newtonsoft dependency version for NuGet pkg

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -17,7 +17,7 @@
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.9" />
       <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.9" />
-      <dependency id="NewtonSoft.Json" version="10.0.3" />
+      <dependency id="NewtonSoft.Json" version="13.0.2" />
       <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
## Summary
I noticed that we'd [updated Newtonsoft to 13.0.1 in DNN 9.11](https://github.com/dnnsoftware/Dnn.Platform/pull/5168) (and [subsequently to 13.0.2](https://github.com/dnnsoftware/Dnn.Platform/pull/5417) in 9.11.1), but we hadn't updated [the dependency for the DotNetNuke.WebApi NuGet package](https://www.nuget.org/packages/DotNetNuke.WebApi/9.11.2#dependencies-body-tab).