### PR TITLE
Log all loader errors at once, at warning level

### DIFF
--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs
@@ -4,22 +4,17 @@
 namespace DotNetNuke.DependencyInjection.Extensions
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Text;
 
     using DotNetNuke.Instrumentation;
 
-    /// <summary>
-    /// <see cref="Type"/> specific extensions to be used
-    /// in Dependency Injection invocations.
-    /// </summary>
+    /// <summary><see cref="Type"/> specific extensions to be used in Dependency Injection invocations.</summary>
     public static class TypeExtensions
     {
-        /// <summary>
-        /// Safely Get all Types from the assembly. If there
-        /// is an error while retrieving the types it will
-        /// return an empty array of <see cref="Type"/>.
-        /// </summary>
+        /// <summary>Safely Get all Types from the assembly. If there is an error while retrieving the types it will return an empty array of <see cref="Type"/>.</summary>
         /// <param name="assembly">The assembly to retrieve all types from.</param>
         /// <returns>An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.</returns>
         /// <remarks>This is obsolete because logging is not added. Please use the SafeGetTypes with the ILog parameter.</remarks>
@@ -29,53 +24,156 @@ namespace DotNetNuke.DependencyInjection.Extensions
             return assembly.SafeGetTypes(null);
         }
 
-        /// <summary>
-        /// Safely Get all Types from the assembly. If there
-        /// is an error while retrieving the types it will
-        /// return an empty array of <see cref="Type"/>.
-        /// </summary>
-        /// <param name="assembly">
-        /// The assembly to retrieve all types from.
-        /// </param>
-        /// <param name="logger">
-        /// A optional <see cref="ILog"/> object. This will log any messages from the exception catching to the logs as an Error.
-        /// </param>
-        /// <returns>
-        /// An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.
-        /// </returns>
-        public static Type[] SafeGetTypes(this Assembly assembly, ILog logger = null)
+        /// <summary>Safely Get all Types from the assembly. If there is an error while retrieving the types it will return an empty array of <see cref="Type"/>.</summary>
+        /// <param name="assembly">The assembly to retrieve all types from.</param>
+        /// <param name="logger">A optional <see cref="ILog"/> object. This will log issues loading the types.</param>
+        /// <returns>An array of all <see cref="Type"/> in the given <see cref="Assembly"/>.</returns>
+        public static Type[] SafeGetTypes(this Assembly assembly, ILog logger)
         {
-            Type[] types = null;
+            var (types, exception) = assembly.GetTypesAndException();
+            if (logger is null || exception is null)
+            {
+                return types.ToArray();
+            }
+
+            if (exception is ReflectionTypeLoadException loadException)
+            {
+                var messageBuilder = BuildLoaderExceptionMessage(
+                    new StringBuilder($"Unable to get all types for {assembly.FullName}, see exception for details").AppendLine(),
+                    assembly,
+                    loadException);
+
+                logger.Warn(messageBuilder.ToString(), loadException);
+            }
+            else
+            {
+                logger.Error($"Unable to get any types for {assembly.FullName}, see exception for details", exception);
+            }
+
+            return types.ToArray();
+        }
+
+        /// <summary>Safely get all types from all assemblies.</summary>
+        /// <returns>A sequence of all available <see cref="Type"/> instances, along with errors and warnings.</returns>
+        public static TypesResult SafeGetTypes()
+        {
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .OrderBy(DotNetNukeFirstThenDnnThenOthers)
+                .ThenBy(assembly => assembly.FullName)
+                .SafeGetTypes();
+
+            static int DotNetNukeFirstThenDnnThenOthers(Assembly assembly)
+            {
+                if (assembly.FullName.StartsWith("DotNetNuke", StringComparison.OrdinalIgnoreCase))
+                {
+                    return 0;
+                }
+
+                if (assembly.FullName.StartsWith("DNN", StringComparison.OrdinalIgnoreCase))
+                {
+                    return 1;
+                }
+
+                return 2;
+            }
+        }
+
+        /// <summary>Safely get all types from a set of assemblies.</summary>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <returns>A sequence of all available <see cref="Type"/> instances, along with errors and warnings.</returns>
+        public static TypesResult SafeGetTypes(this IEnumerable<Assembly> assemblies)
+        {
+            var loadExceptions = new Dictionary<Assembly, ReflectionTypeLoadException>();
+            var otherExceptions = new Dictionary<Assembly, Exception>();
+            var types = assemblies.SafeGetTypes(loadExceptions, otherExceptions);
+            return new TypesResult(types.ToList(), loadExceptions, otherExceptions);
+        }
+
+        /// <summary>Logs the exceptions in <see cref="TypesResult.OtherExceptions"/> of <paramref name="result" /> using <paramref name="logger"/>.</summary>
+        /// <param name="result">The types result to log.</param>
+        /// <param name="logger">The logger.</param>
+        public static void LogOtherExceptions(this TypesResult result, ILog logger)
+        {
+            if (logger is null)
+            {
+                return;
+            }
+
+            foreach (var exceptionPair in result.OtherExceptions)
+            {
+                var assembly = exceptionPair.Key;
+                var exception = exceptionPair.Value;
+                logger.Error($"Unable to get any types for {assembly.FullName}, see exception for details", exception);
+            }
+        }
+
+        /// <summary>Builds a message to load for a collection of <see cref="ReflectionTypeLoadException"/> instances.</summary>
+        /// <param name="loadExceptions">A dictionary mapping <see cref="Assembly"/> to <see cref="ReflectionTypeLoadException"/>.</param>
+        /// <returns>A <see cref="StringBuilder"/> containing the message.</returns>
+        public static StringBuilder BuildLoaderExceptionsMessage(this IReadOnlyDictionary<Assembly, ReflectionTypeLoadException> loadExceptions)
+        {
+            return
+                loadExceptions.Aggregate(
+                    new StringBuilder("Unable to get all types for some assemblies:").AppendLine(),
+                    (builder, exceptionPair) =>
+                    {
+                        var assembly = exceptionPair.Key;
+                        var loadException = exceptionPair.Value;
+                        return BuildLoaderExceptionMessage(builder, assembly, loadException).AppendLine();
+                    });
+        }
+
+        private static StringBuilder BuildLoaderExceptionMessage(StringBuilder builder, Assembly assembly, ReflectionTypeLoadException loadException)
+        {
+            var foundTypes = loadException.Types.Count(x => x != null);
+            var allTypes = loadException.Types.Length;
+            var loaderMessages = loadException.LoaderExceptions.Select(e => e.Message).Distinct();
+
+            return loaderMessages.Aggregate(
+                builder.AppendLine($"- Found {foundTypes} of {allTypes} types from {assembly.FullName}"),
+                (theBuilder, message) => theBuilder.AppendLine($"    - {message}"));
+        }
+
+        private static IEnumerable<Type> SafeGetTypes(this IEnumerable<Assembly> assemblies, Dictionary<Assembly, ReflectionTypeLoadException> loadExceptions, Dictionary<Assembly, Exception> otherExceptions)
+        {
+            return assemblies.SelectMany(assembly =>
+            {
+                var (types, exception) = assembly.GetTypesAndException();
+                if (exception is ReflectionTypeLoadException loadException)
+                {
+                    loadExceptions.Add(assembly, loadException);
+                }
+                else if (exception is not null)
+                {
+                    otherExceptions.Add(assembly, exception);
+                }
+
+                return types;
+            });
+        }
+
+        private static (IEnumerable<Type> Types, Exception Exception) GetTypesAndException(this Assembly assembly)
+        {
+            Exception exception = null;
+            IEnumerable<Type> types;
             try
             {
                 types = assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException ex)
             {
-                if (logger != null)
-                {
-                    // The loaderexceptions will repeat. Need to get distinct messages here.
-                    string distinctLoaderExceptions = string.Join(
-                        Environment.NewLine,
-                        ex.LoaderExceptions.Select(i => i.Message).Distinct().Select(i => $"- LoaderException: {i}"));
+                exception = ex;
 
-                    logger.Error($"Unable to configure services for {assembly.FullName}, see exception for details {Environment.NewLine}{distinctLoaderExceptions}", ex);
-                }
-
-                // Ensure that Dnn obtains all types that were loaded, ignoring the failure(s)
-                types = ex.Types.Where(x => x != null).ToArray<Type>();
+                // Ensure that DNN obtains all types that were loaded, ignoring the failure(s)
+                types = ex.Types.Where(x => x != null);
             }
             catch (Exception ex)
             {
-                if (logger != null)
-                {
-                    logger.Error($"Unable to configure services for {assembly.FullName}, see exception for details", ex);
-                }
-
-                types = new Type[0];
+                exception = ex;
+                types = Enumerable.Empty<Type>();
             }
 
-            return types;
+            return (types.OrderBy(type => type.FullName ?? type.Name), exception);
         }
     }
 }

--- a/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypesResult.cs
+++ b/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypesResult.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.DependencyInjection.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+/// <summary>The result of a request to get types from assemblies.</summary>
+public class TypesResult
+{
+    /// <summary>Initializes a new instance of the <see cref="TypesResult"/> class.</summary>
+    /// <param name="types">The types.</param>
+    /// <param name="loadExceptions">The <see cref="ReflectionTypeLoadException"/> instances that were occurred while loading the assemblies.</param>
+    /// <param name="otherExceptions">The other exceptions that occurred while loading the assemblies.</param>
+    public TypesResult(IReadOnlyCollection<Type> types, IReadOnlyDictionary<Assembly, ReflectionTypeLoadException> loadExceptions, IReadOnlyDictionary<Assembly, Exception> otherExceptions)
+    {
+        this.Types = types;
+        this.LoadExceptions = loadExceptions;
+        this.OtherExceptions = otherExceptions;
+    }
+
+    /// <summary>Gets the types.</summary>
+    public IReadOnlyCollection<Type> Types { get; }
+
+    /// <summary>Gets the <see cref="ReflectionTypeLoadException"/> instances that were occurred while loading the assemblies.</summary>
+    public IReadOnlyDictionary<Assembly, ReflectionTypeLoadException> LoadExceptions { get; }
+
+    /// <summary>Gets any other exceptions that occurred while loading the assemblies.</summary>
+    public IReadOnlyDictionary<Assembly, Exception> OtherExceptions { get; }
+}

--- a/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
@@ -30,7 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,7 +39,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DotNetNuke">

--- a/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Extensions/StartupExtensions.cs
@@ -3,37 +3,31 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Web.Mvc.Extensions
 {
-    using System;
     using System.Linq;
 
     using DotNetNuke.DependencyInjection.Extensions;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
+
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
 
-    /// <summary>
-    /// Adds DNN MVC Controller Specific startup extensions to simplify the
-    /// <see cref="Startup"/> Class.
-    /// </summary>
+    /// <summary>Adds DNN MVC Controller Specific startup extensions to simplify the <see cref="Startup"/> Class.</summary>
     public static class StartupExtensions
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(StartupExtensions));
 
-        /// <summary>
-        /// Configures all of the <see cref="DnnController"/>'s to be used
-        /// with the Service Collection for Dependency Injection.
-        /// </summary>
-        /// <param name="services">
-        /// Service Collection used to registering services in the container.
-        /// </param>
+        /// <summary>Configures all of the <see cref="DnnController"/>'s to be used with the Service Collection for Dependency Injection.</summary>
+        /// <param name="services">Service Collection used to registering services in the container.</param>
         public static void AddMvcControllers(this IServiceCollection services)
         {
-            var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.SafeGetTypes(Logger))
-                .Where(x => typeof(IDnnController).IsAssignableFrom(x)
-                    && x.IsClass
-                    && !x.IsAbstract);
+            var allTypes = TypeExtensions.SafeGetTypes();
+            allTypes.LogOtherExceptions(Logger);
+
+            var controllerTypes = allTypes.Types
+                .Where(
+                    type => typeof(IDnnController).IsAssignableFrom(type) &&
+                            type is { IsClass: true, IsAbstract: false });
             foreach (var controller in controllerTypes)
             {
                 services.TryAddTransient(controller);

--- a/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Extensions/StartupExtensions.cs
@@ -1,40 +1,33 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
 namespace DotNetNuke.Web.Extensions
 {
-    using System;
     using System.Linq;
 
     using DotNetNuke.DependencyInjection.Extensions;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Web.Api;
+
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
 
-    /// <summary>
-    /// Adds DNN Web API Specific startup extensions to simplify the
-    /// <see cref="Startup"/> Class.
-    /// </summary>
+    /// <summary>Adds DNN Web API Specific startup extensions to simplify the <see cref="Startup"/> Class.</summary>
     internal static class StartupExtensions
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(StartupExtensions));
 
-        /// <summary>
-        /// Configures all of the <see cref="DnnApiController"/>'s to be used
-        /// with the Service Collection for Dependency Injection.
-        /// </summary>
-        /// <param name="services">
-        /// Service Collection used to registering services in the container.
-        /// </param>
+        /// <summary>Configures all of the <see cref="DnnApiController"/>'s to be used with the Service Collection for Dependency Injection.</summary>
+        /// <param name="services">Service Collection used to registering services in the container.</param>
         public static void AddWebApi(this IServiceCollection services)
         {
-            var controllerTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.SafeGetTypes(Logger))
-                .Where(x => typeof(DnnApiController).IsAssignableFrom(x) &&
-                            x.IsClass &&
-                            !x.IsAbstract);
+            var allTypes = TypeExtensions.SafeGetTypes();
+            allTypes.LogOtherExceptions(Logger);
+
+            var controllerTypes = allTypes.Types
+                .Where(
+                    type => typeof(DnnApiController).IsAssignableFrom(type) &&
+                            type is { IsClass: true, IsAbstract: false });
             foreach (var controller in controllerTypes)
             {
                 services.TryAddScoped(controller);

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -56,7 +56,7 @@
     <DocumentationFile>bin\DotNetNuke.Web.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -67,14 +67,16 @@
     <DocumentationFile>bin\DotNetNuke.Web.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <NoWarn>1591</NoWarn>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fixes #5711.


This PR introduces `DotNetNuke.DependencyInjection.Extensions.TypesResult` into `DotNetNuke.DependencyInjection`, using it as the return value for new methods on `TypeExtensions`. This new type has three properties:
 - `IReadOnlyCollection<Type> Types`
 - `IReadOnlyDictionary<Assembly, ReflectionTypeLoadException> LoadExceptions`
 - `IReadOnlyDictionary<Assembly, Exception> OtherExceptions`

As of DNN 9.12.0, `TypeExtensions` contains one non-obsolete method, `static Type[] SafeGetTypes(this Assembly assembly, ILog logger)`. This PR adds four new public methods:
 - `TypesResult SafeGetTypes()`
 - `TypesResult SafeGetTypes(this IEnumerable<Assembly> assemblies)`
 - `void LogOtherExceptions(this TypesResult result, ILog logger)`
 - `StringBuilder BuildLoaderExceptionsMessage(this IReadOnlyDictionary<Assembly, ReflectionTypeLoadException> loadExceptions)`

The three internal usages of `Type[] SafeGetTypes(this Assembly assembly, ILog logger)` have been updated to use `TypesResult SafeGetTypes()`. The main usage is in `DependencyInjectionInitialize.ConfigureAllStartupServices`, which ends up calling the other two usages in `DotNetNuke.Web.Extensions.StartupExtensions` and `DotNetNuke.Web.Mvc.Extensions.StartupExtensions`. All three get the types and then log any "other" unexpected exceptions. However, only `DependencyInjectionInitialize.ConfigureAllStartupServices` logs the `ReflectionTypeLoadException` exceptions. This prevents these issues being logged three times during startup.

In addition, the `ReflectionTypeLoadException` logging is done at the _Warn_ level, instead of _Error_.

FInally, the messaging has been adjusted, consolidated, with some additional whitespace and contextual information (e.g. the number of types loaded per assembly).

### Previous Behavior
<details>
<summary>DNN 9.12.0 Startup Logging Example</summary>

```
2023-06-28 11:51:15.024-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.DependencyInjectionInitialize - Unable to configure services for DotNetNuke.Modules.Reports, Version=6.1.0.0, Culture=neutral, PublicKeyToken=null, see exception for details 
- LoaderException: Could not load file or assembly 'nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77' or one of its dependencies. The system cannot find the file specified.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:17.045-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Extensions.StartupExtensions - Unable to configure services for DotNetNuke.Modules.Reports, Version=6.1.0.0, Culture=neutral, PublicKeyToken=null, see exception for details 
- LoaderException: Could not load file or assembly 'nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77' or one of its dependencies. The system cannot find the file specified.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:17.580-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Extensions.StartupExtensions - Unable to configure services for JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640, see exception for details 
- LoaderException: Method 'get_SupportsScriptPrecompilation' in type 'JSPool.JsEngineWithOwnThread' from assembly 'JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640' does not have an implementation.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:17.880-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Extensions.StartupExtensions - Unable to configure services for Microsoft.AspNetCore.Mvc.Razor.Host, Version=1.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, see exception for details 
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Generators.SpanChunkGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Chunk' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CodeVisitor`1' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.CSharpCodeGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CSharpDesignTimeCodeVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.CSharpCodeParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.RazorEngineHost' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.RazorParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.TagHelperAttributeValueCodeRenderer' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.TagHelpers.TagHelperDirectiveSpanVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Compilation.TagHelpers.TagHelperDescriptor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:17.894-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Extensions.StartupExtensions - Unable to configure services for Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.11.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, see exception for details 
- LoaderException: Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IParameterInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IPropertyInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:19.517-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Mvc.Extensions.StartupExtensions - Unable to configure services for DotNetNuke.Modules.Reports, Version=6.1.0.0, Culture=neutral, PublicKeyToken=null, see exception for details 
- LoaderException: Could not load file or assembly 'nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77' or one of its dependencies. The system cannot find the file specified.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:19.521-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Mvc.Extensions.StartupExtensions - Unable to configure services for JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640, see exception for details 
- LoaderException: Method 'get_SupportsScriptPrecompilation' in type 'JSPool.JsEngineWithOwnThread' from assembly 'JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640' does not have an implementation.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:19.527-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Mvc.Extensions.StartupExtensions - Unable to configure services for Microsoft.AspNetCore.Mvc.Razor.Host, Version=1.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, see exception for details 
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Generators.SpanChunkGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Chunk' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CodeVisitor`1' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.CSharpCodeGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CSharpDesignTimeCodeVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.CSharpCodeParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.RazorEngineHost' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.RazorParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.TagHelperAttributeValueCodeRenderer' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.TagHelpers.TagHelperDirectiveSpanVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Compilation.TagHelpers.TagHelperDescriptor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:19.530-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.Mvc.Extensions.StartupExtensions - Unable to configure services for Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.11.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, see exception for details 
- LoaderException: Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IParameterInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IPropertyInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:20.208-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.DependencyInjectionInitialize - Unable to configure services for JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640, see exception for details 
- LoaderException: Method 'get_SupportsScriptPrecompilation' in type 'JSPool.JsEngineWithOwnThread' from assembly 'JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640' does not have an implementation.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:20.244-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.DependencyInjectionInitialize - Unable to configure services for Microsoft.AspNetCore.Mvc.Razor.Host, Version=1.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, see exception for details 
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Generators.SpanChunkGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Chunk' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CodeVisitor`1' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.CSharpCodeGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CSharpDesignTimeCodeVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.CSharpCodeParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.RazorEngineHost' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.RazorParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.TagHelperAttributeValueCodeRenderer' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Parser.TagHelpers.TagHelperDirectiveSpanVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Razor.Compilation.TagHelpers.TagHelperDescriptor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
2023-06-28 11:51:20.247-05:00 [dev33][D:2][T:1][ERROR] DotNetNuke.Web.DependencyInjectionInitialize - Unable to configure services for Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.11.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, see exception for details 
- LoaderException: Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IParameterInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
- LoaderException: Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IPropertyInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
   at System.Reflection.Assembly.GetTypes()
   at DotNetNuke.DependencyInjection.Extensions.TypeExtensions.SafeGetTypes(Assembly assembly, ILog logger) in /_/DNN Platform/DotNetNuke.DependencyInjection/Extensions/TypeExtensions.cs:line 51
```
</details>

### New Behavior
<details>
<summary>Updated Startup Logging Example</summary>

```
2023-06-30 10:27:13.859-05:00 [dev33][D:4][T:1][WARN] DotNetNuke.Web.DependencyInjectionInitialize - While loading IDnnStartup types, the following assemblies had types that could not be loaded. This is only an issue if these types contain DNN startup logic that could not be loaded:Unable to get all types for some assemblies:
- Found 71 of 72 types from DotNetNuke.Modules.Reports, Version=6.1.0.0, Culture=neutral, PublicKeyToken=null
    - Could not load file or assembly 'nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77' or one of its dependencies. The system cannot find the file specified.

- Found 32 of 33 types from JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640
    - Method 'get_SupportsScriptPrecompilation' in type 'JSPool.JsEngineWithOwnThread' from assembly 'JSPool, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2fc7775f73072640' does not have an implementation.

- Found 29 of 46 types from Microsoft.AspNetCore.Mvc.Razor.Host, Version=1.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
    - Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Generators.SpanChunkGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.Chunks.Chunk' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CodeVisitor`1' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.CSharpCodeGenerator' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.Visitors.CSharpDesignTimeCodeVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.Parser.CSharpCodeParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.RazorEngineHost' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.Parser.RazorParser' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.CodeGenerators.TagHelperAttributeValueCodeRenderer' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.Parser.TagHelpers.TagHelperDirectiveSpanVisitor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Razor.Compilation.TagHelpers.TagHelperDescriptor' from assembly 'Microsoft.AspNetCore.Razor, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.

- Found 186 of 188 types from Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.11.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
    - Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IParameterInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
    - Could not load type 'Microsoft.AspNetCore.Mvc.Internal.IPropertyInfoParameterDescriptor' from assembly 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.


```
</details>