### PR TITLE
Fix error installing DNN after #5463

### DIFF
--- a/DNN Platform/HttpModules/DependencyInjection/ServiceRequestScopeModule.cs
+++ b/DNN Platform/HttpModules/DependencyInjection/ServiceRequestScopeModule.cs
@@ -1,30 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
-
-using System;
-using System.Web;
-
-using DotNetNuke.Common.Extensions;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Web.Infrastructure.DynamicModuleHelper;
-
-[assembly: PreApplicationStartMethod(typeof(DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule), nameof(DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule.InitModule))]
-
 namespace DotNetNuke.HttpModules.DependencyInjection
 {
+    using System;
     using System.Threading.Tasks;
+    using System.Web;
+
+    using DotNetNuke.Common.Extensions;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>An HTTP module which creates dependency injection scopes for each request.</summary>
     public class ServiceRequestScopeModule : IHttpModule
     {
         private static IServiceProvider serviceProvider;
-
-        /// <summary>Initializes this HTTP module before the application starts.</summary>
-        public static void InitModule()
-        {
-            DynamicModuleUtility.RegisterModule(typeof(ServiceRequestScopeModule));
-        }
 
         /// <summary>For internal use only. Allows setting the service provider used to create request scopes.</summary>
         /// <param name="serviceProvider">The service provider.</param>

--- a/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
+++ b/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
@@ -73,9 +73,6 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.7.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />

--- a/DNN Platform/HttpModules/packages.config
+++ b/DNN Platform/HttpModules/packages.config
@@ -6,7 +6,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="7.0.0" targetFramework="net48" />
   <package id="Microsoft.SourceLink.Common" version="1.1.1" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.1.1" targetFramework="net48" developmentDependency="true" />
-  <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net48" developmentDependency="true" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -1246,6 +1246,8 @@
     <Content Include="Providers\DataProviders\SqlDataProvider\09.11.01.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.11.02.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.12.01.SqlDataProvider" />
+    <Content Include="Install\Config\09.09.00.config" />
+    <Content Include="Install\Config\10.00.00.config" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>
@@ -3126,31 +3128,6 @@
     <None Include="controls\CountryListBox\Data\GeoIP.dat" />
     <None Include="development.config" />
     <None Include="Documentation\TELERIK_EULA.pdf" />
-    <Content Include="Install\Config\04.06.00.config" />
-    <Content Include="Install\Config\04.07.00.config" />
-    <Content Include="Install\Config\04.08.00.config" />
-    <Content Include="Install\Config\04.09.00.config" />
-    <Content Include="Install\Config\05.01.00.config" />
-    <Content Include="Install\Config\05.02.00.config" />
-    <Content Include="Install\Config\05.02.01.config" />
-    <Content Include="Install\Config\05.03.00.config" />
-    <Content Include="Install\Config\05.05.00.config" />
-    <Content Include="Install\Config\05.06.00.config" />
-    <Content Include="Install\Config\05.06.01.config" />
-    <Content Include="Install\Config\05.06.03.config" />
-    <Content Include="Install\Config\06.00.00.config" />
-    <Content Include="Install\Config\06.01.00.config" />
-    <Content Include="Install\Config\06.01.01.config" />
-    <Content Include="Install\Config\06.02.00.config" />
-    <Content Include="Install\Config\07.00.00.config" />
-    <Content Include="Install\Config\07.00.05.config" />
-    <Content Include="Install\Config\07.00.06.config" />
-    <Content Include="Install\Config\07.01.01.config" />
-    <Content Include="Install\Config\07.01.02.config" />
-    <Content Include="Install\Config\07.02.00.config" />
-    <Content Include="Install\Config\07.02.01.config" />
-    <Content Include="Install\Config\07.03.00.config" />
-    <Content Include="Install\Config\07.04.01.config" />
     <Content Include="Install\Config\08.00.00.01.config" />
     <Content Include="Install\Config\08.00.00.02.config" />
     <Content Include="Install\Config\08.00.00.03.config" />
@@ -3174,8 +3151,6 @@
     <Content Include="Install\Config\RemoveBindingRedirect.config" />
     <Content Include="Install\Config\09.07.03.config" />
     <Content Include="Install\Config\09.08.00.config" />
-    <Content Include="Install\Config\Net35.config" />
-    <Content Include="Install\Config\Net40.config" />
     <None Include="Install\Template\UserProfile.page.template" />
     <None Include="jquery.min.map" />
     <None Include="js\ClientAPICaps.config" />

--- a/DNN Platform/Website/Install/Config/10.00.00.config
+++ b/DNN Platform/Website/Install/Config/10.00.00.config
@@ -1,0 +1,7 @@
+<configuration>
+  <nodes configfile="web.config">
+    <node path="/configuration/system.webServer/modules/add[@name='RequestFilter']" action="insertbefore">
+      <add name="ServiceRequestScopeModule" type="DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
+    </node>
+  </nodes>
+</configuration>


### PR DESCRIPTION
## Summary
#5463 created an incompatibility in the install and upgrade process because of how Microsoft.Web.Infrastructure was referenced. This PR removes that troublesome reference, making installs work again.

Thanks for [the testing and heads up on this](https://github.com/dnnsoftware/Dnn.Platform/pull/5722#issuecomment-1633425818) @valadas 