### PR TITLE
Fixed an issue with settings caching using SettingsRepository

### DIFF
--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -50,7 +50,7 @@ namespace DotNetNuke.Entities.Modules.Settings
         /// <inheritdoc/>
         public T GetSettings(ModuleInfo moduleContext)
         {
-            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(moduleContext.TabModuleID), 20, CacheItemPriority.AboveNormal, moduleContext), this.Load, false);
+            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(moduleContext.PortalID), 20, CacheItemPriority.AboveNormal, moduleContext), this.Load, false);
         }
 
         /// <inheritdoc/>
@@ -164,7 +164,7 @@ namespace DotNetNuke.Entities.Modules.Settings
                     }
                 }
             });
-            DataCache.SetCache(this.CacheKey(moduleContext == null ? portalId : moduleContext.TabModuleID), settings);
+            DataCache.SetCache(this.CacheKey(portalId), settings);
         }
 
         private T Load(CacheItemArgs args)


### PR DESCRIPTION
One may have a settings class that includes a mix of HostSettings, PortalSettings, ModuleSettings and TabModuleSettings.

The previous mechanism had different cache keys for PortalId or TabModuleId, but that brought 2 problems:

1. It is possible to have the same number for a portalId and TabModuleId which would invalidate the wrong cache.
2. When reading settings using the GetSettings method overload that takes moduleInfo, it would get stale settings for all PortalSettings if it was saved also using moduleInfo overload.

I am on the fence about this PR, but it caches now using always portalId.

PROS: It fixed the issue at hand.

CONS: It clears the portal settings cache to be clear, not the whole portal settings cache but only the specified settings class type being requested. This is maybe a tiny tiny bit of a performance hit, but it's not like saving settings is something that gets hammered.

So I believe the benefits here outweigh the drawbacks.

Closes #5739

Possibly a different fix for the workaround in #3756 but I don't have any MVC custom module to test that part...
Would you like to try removing the previous workaround and test an MVC module to see @donker ?
