### PR TITLE
Updated the name of the connector for #5700

### DIFF
--- a/DNN Platform/Connectors/GoogleAnalytics/App_LocalResources/SharedResources.resx
+++ b/DNN Platform/Connectors/GoogleAnalytics/App_LocalResources/SharedResources.resx
@@ -121,7 +121,7 @@
     <value>Delete Connection</value>
   </data>
   <data name="ConnectorName.Text" xml:space="preserve">
-    <value>Google Analytics Core Connector</value>
+    <value>Google Analytics (Legacy UA) Connector</value>
   </data>
   <data name="TrackAdministrators.Text" xml:space="preserve">
     <value>Track for Administrators:</value>

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.cs
@@ -16,7 +16,7 @@ namespace DNN.Connectors.GoogleAnalytics
     /// <summary>Connector to provide configuration for Google Analytics support.</summary>
     public class GoogleAnalyticsConnector : IConnector
     {
-        private const string DefaultDisplayName = "Google Analytics";
+        private const string DefaultDisplayName = "Google Analytics (Legacy UA)";
 
         private string displayName;
 

--- a/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.dnn
+++ b/DNN Platform/Connectors/GoogleAnalytics/GoogleAnalyticsConnector.dnn
@@ -1,8 +1,8 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
         <package name="DNN.Connectors.GoogleAnalytics" type="Connector" isSystem="false" version="09.12.00">
-            <friendlyName>Google Analytics Connector</friendlyName>
-            <description>Configure your site's Google Analytics settings.</description>
+            <friendlyName>Google Analytics (Legacy UA) Connector</friendlyName>
+            <description>Configure your site's Google Analytics settings using Universal Analytics.</description>
             <iconFile>~/DesktopModules/Connectors/GoogleAnalytics/Images/GoogleAnalytics_32X32_Standard.png</iconFile>
           <dependencies>
             <dependency type="CoreVersion">09.02.00</dependency>


### PR DESCRIPTION
- Fixes #5700 

Updated the name to consistently reference (Legacy UA) to help identify it as universal analytics.

This allows 9.12.x to be properly named, with a new ticket to be created to remove the legacy package in 10.x