### PR TITLE
Fixed the retry fequency if un-changed for the WebServerMonitor

### DIFF
--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
@@ -53,6 +53,23 @@ AS
 			WHERE   (PT.IsActive = 1)
 GO
 
+
+/* Fix Scheduler Frequency for Server Monitor #5634 */
+
+IF EXISTS (SELECT * 
+            FROM {databaseOwner}[{objectQualifier}Schedule] 
+            WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke' 
+            AND TimeLapse = 5 
+            AND RetryTimeLapse = 10
+            AND TimeLapseMeasurement = 'm'
+            AND RetryTimeLapseMeasurement = 'm')
+BEGIN
+    --Update the retry timelapse to 2 minutes, similar to other standard jobs
+    UPDATE {databaseOwner}[{objectQualifier}Schedule]
+    SET RetryTimeLapse = 2
+    WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke'
+END
+GO
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
@@ -56,19 +56,14 @@ GO
 
 /* Fix Scheduler Frequency for Server Monitor #5634 */
 
-IF EXISTS (SELECT * 
-            FROM {databaseOwner}[{objectQualifier}Schedule] 
-            WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke' 
-            AND TimeLapse = 5 
-            AND RetryTimeLapse = 10
-            AND TimeLapseMeasurement = 'm'
-            AND RetryTimeLapseMeasurement = 'm')
-BEGIN
-    --Update the retry timelapse to 2 minutes, similar to other standard jobs
-    UPDATE {databaseOwner}[{objectQualifier}Schedule]
-    SET RetryTimeLapse = 2
-    WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke'
-END
+--Update the retry timelapse to 2 minutes, similar to other standard jobs
+UPDATE {databaseOwner}[{objectQualifier}Schedule]
+SET RetryTimeLapse = 2
+WHERE TypeFullName = 'DotNetNuke.Services.SystemHealth.WebServerMonitor, DotNetNuke'
+AND TimeLapse = 5 
+AND RetryTimeLapse = 10
+AND TimeLapseMeasurement = 'm'
+AND RetryTimeLapseMeasurement = 'm';
 GO
 /************************************************************/
 /*****              SqlDataProvider                     *****/


### PR DESCRIPTION
- Fixes #5634 

Given the nature of the default configurations, this change looks for a default configuration still existing; if found, it updates the configuration to be proper.  If the settings do not match the defaults no changes are made.