### PR TITLE
Partial solution for #5552 to remove a stored procedure 

### DIFF
--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
@@ -53,6 +53,11 @@ AS
 			WHERE   (PT.IsActive = 1)
 GO
 
+
+/* Fix Invalid Objects #5552 */
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}DeleteSearchWord]') AND type in (N'P', N'PC'))
+    DROP PROCEDURE {databaseOwner}[{objectQualifier}DeleteSearchWord]
+GO
 /************************************************************/
 /*****              SqlDataProvider                     *****/
 /************************************************************/


### PR DESCRIPTION
This is a partial fix for #5552 

A stored procedure that should have been remove a long time ago, back in 7.2.2, was still in the DNN Data model.  This change removes it.