### PR TITLE
Fixed an issue where ServerSummary would not hide

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
@@ -2062,9 +2062,9 @@ div.ui-dialog-titlebar>.ui-dialog-titlebar-close:hover {
     top: 0;
     opacity: 0;
     display: none;
+    visibility: hidden;
     box-sizing: border-box;
-    animation: summarymenu 200ms linear;
-    animation-fill-mode: forwards;
+    animation: summarymenu 200ms linear forwards;
     text-align: left;
     cursor: default;
 }
@@ -2080,15 +2080,11 @@ div.ui-dialog-titlebar>.ui-dialog-titlebar-close:hover {
 @keyframes summarymenu {
     0% {
         opacity: 0;
-        display: none;
-    }
-    1% {
-        opacity: 0;
-        display: block;
+        visibility: hidden;
     }
     100% {
         opacity: 1;
-        display: block;
+        visibility: visible;
     }
 }
 

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/serversummary.js
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/serversummary.js
@@ -27,16 +27,19 @@ define(['jquery', 'knockout', 'jquery.hoverIntent.min'], function ($, ko) {
     return $summary;
   }
   var showServerSummary = function () {
-    mainFrame.style.width = '100%';
-    $('.hoverSummaryMenu, .hovermenu').hide();
-    getSummaryContainer().addClass('shown');
+      mainFrame.style.width = '100%';
+      var container = getSummaryContainer();
+      container.show();
+      container.addClass('shown');
   }
 
   var hideServerSummary = function () {
     if (!$('.hovermenu:visible').length && !$('.socialpanel:visible').length) {
       mainFrame.style.width = personaBarWidth + "px";
     }
-    getSummaryContainer().removeClass('shown');
+      var container = getSummaryContainer();
+      container.removeClass('shown');
+      container.hide();
   }
 
   var getServerInfo = function (callback) {


### PR DESCRIPTION
Closes #5771

Some browser change (affecting most Chromium based browsers) made it so that the Server Summary panel would no longer hide after showing. This simplifies the css and improves the javascript to circumvent the issue.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
