### PR TITLE
Fixed an issue where filenames of downloads would get mangled

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-download-item/dnn-action-download-item.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-download-item/dnn-action-download-item.tsx
@@ -18,7 +18,7 @@ export class DnnActionDownloadItem {
   }
 
   private handleClick(): void {
-    this.itemsClient.download(this.item.itemId, true);
+    this.itemsClient.download(this.item.itemId, false);
   }
 
   render() {

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -169,7 +169,6 @@ export class ItemsClient{
                 signal: this.abortController.signal,
             })
             .then(response => {
-                debugger;
                 if (response.status == 200) {
                     var filename = response.headers.get("Content-Disposition").split("filename=")[1];
                     filename = this.decodeRFC5987ContentDisposition(filename);

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -169,8 +169,10 @@ export class ItemsClient{
                 signal: this.abortController.signal,
             })
             .then(response => {
+                debugger;
                 if (response.status == 200) {
                     var filename = response.headers.get("Content-Disposition").split("filename=")[1];
+                    filename = this.decodeRFC5987ContentDisposition(filename);
                     response.blob().then(blob => {
                         var oldDownloadLink = document.querySelector("#downloadLink");
                         if (oldDownloadLink) {
@@ -188,6 +190,20 @@ export class ItemsClient{
             })
             .catch(error => reject(error));
         });
+    }
+    private decodeRFC5987ContentDisposition(filename: string): string {
+        filename = filename.replace(/(^")|("$)/g, '');
+
+        if (filename.startsWith("=?utf-8?B?") && filename.endsWith("?=")) {
+            const encoded = filename.slice(10, -2);
+            return decodeURIComponent(
+              atob(encoded)
+                .split('')
+                .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+                .join('')
+            );
+          }
+          return filename;
     }
 
     public search(
@@ -741,3 +757,4 @@ export interface DeleteFolderRequest{
 export interface DeleteFileRequest{
     FileId: number;
 }
+


### PR DESCRIPTION
Closes #5551

The string is in quotes when there are spaces in the filename and Chrome replaced those with underscores. Filenames with special characters are encoded in the response. This adds a function to convert all those special cases back into a plain string that matches the actual filename in the front end.

<!-- 
  Please read the contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
