### PR TITLE
Update `web.config` max upload size defaults, correct backend calcs, and fix validation issue preventing increasing

### DIFF
--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -318,8 +318,7 @@ namespace DotNetNuke.Common.Utilities
 
             if (httpNode != null)
             {
-                var maxAllowedContentLength = XmlUtils.GetAttributeValueAsLong(httpNode.CreateNavigator(), "maxAllowedContentLength", 30000000);
-                return maxAllowedContentLength / 1024 / 1024;
+                return 4294967295 / 1024 / 1024; // 4GB (max allowedContentLength supported in IIS7)
             }
 
             return DefaultRequestFilter;
@@ -352,7 +351,6 @@ namespace DotNetNuke.Common.Utilities
             if (httpNode != null)
             {
                 httpNode.Attributes["maxRequestLength"].InnerText = (newSize / 1024).ToString("#");
-                httpNode.Attributes["requestLengthDiskThreshold"].InnerText = (newSize / 1024).ToString("#");
             }
 
             httpNode = configNav.SelectSingleNode("configuration//system.webServer//security//requestFiltering//requestLimits") ??

--- a/DNN Platform/Library/Common/Utilities/Config.cs
+++ b/DNN Platform/Library/Common/Utilities/Config.cs
@@ -318,7 +318,8 @@ namespace DotNetNuke.Common.Utilities
 
             if (httpNode != null)
             {
-                return 4294967295 / 1024 / 1024; // 4GB (max allowedContentLength supported in IIS7)
+                var maxAllowedContentLength = XmlUtils.GetAttributeValueAsLong(httpNode.CreateNavigator(), "maxAllowedContentLength", 30000000);
+                return maxAllowedContentLength / 1024 / 1024;
             }
 
             return DefaultRequestFilter;
@@ -351,6 +352,7 @@ namespace DotNetNuke.Common.Utilities
             if (httpNode != null)
             {
                 httpNode.Attributes["maxRequestLength"].InnerText = (newSize / 1024).ToString("#");
+                httpNode.Attributes["requestLengthDiskThreshold"].InnerText = (newSize / 1024).ToString("#");
             }
 
             httpNode = configNav.SelectSingleNode("configuration//system.webServer//security//requestFiltering//requestLimits") ??

--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -114,7 +114,7 @@
       <forms name=".DOTNETNUKE" protection="All" timeout="60" cookieless="UseCookies" />
     </authentication>
     <!-- allow large file uploads -->
-    <httpRuntime shutdownTimeout="120" executionTimeout="900" useFullyQualifiedRedirectUrl="true" maxRequestLength="12288" requestLengthDiskThreshold="12288" />
+    <httpRuntime shutdownTimeout="120" executionTimeout="900" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="81920" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain="" />
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application. 

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -117,6 +117,11 @@
         <add name="X-Frame-Options" value="SAMEORIGIN" />
       </customHeaders>
     </httpProtocol>
+    <security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="29360128" />
+      </requestFiltering>
+    </security>
   </system.webServer>
 
   <system.web>
@@ -149,7 +154,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -117,6 +117,11 @@
         <add name="X-Frame-Options" value="SAMEORIGIN" />
       </customHeaders>
     </httpProtocol>
+    <security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="29360128" />
+      </requestFiltering>
+    </security>
   </system.webServer>
 
   <system.web>
@@ -150,7 +155,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="29296" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
@@ -710,7 +710,7 @@ namespace Dnn.PersonaBar.Security.Services
                             Host.AutoAccountUnlockDuration,
                             Host.AsyncTimeout,
                             MaxUploadSize = Config.GetMaxUploadSize() / 1024 / 1024,
-                            RangeUploadSize = Config.GetRequestFilterSize(),
+                            RangeUploadSize = 4294967295 / 1024 / 1024, // 4GB (max allowedContentLength supported in IIS7)
                             AllowedExtensionWhitelist = Host.AllowedExtensionWhitelist.ToStorageString(),
                             DefaultEndUserExtensionWhitelist = Host.DefaultEndUserExtensionWhitelist.ToStorageString(),
                         },

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SecurityController.cs
@@ -709,7 +709,7 @@ namespace Dnn.PersonaBar.Security.Services
                             Host.RememberCheckbox,
                             Host.AutoAccountUnlockDuration,
                             Host.AsyncTimeout,
-                            MaxUploadSize = Config.GetMaxUploadSize() / (1024 * 1024),
+                            MaxUploadSize = Config.GetMaxUploadSize() / 1024 / 1024,
                             RangeUploadSize = Config.GetRequestFilterSize(),
                             AllowedExtensionWhitelist = Host.AllowedExtensionWhitelist.ToStorageString(),
                             DefaultEndUserExtensionWhitelist = Host.DefaultEndUserExtensionWhitelist.ToStorageString(),


### PR DESCRIPTION
## Summary
Resolves #5778 

The following was done in this PR:
* Updated default values for `maxRequestLength` in `development.config` and `release.config`.
* Added section for IIS7 support of `maxAllowedContentLength`
```xml
<system.webServer>
    <security>
      <requestFiltering>
        <requestLimits maxAllowedContentLength="28672000" />
      </requestFiltering>
    </security>
</system.webServer>
```
* Resolved backend calculation issues resulting in confusing values (by default and when saving)
* Resolved validation issue that was preventing an admin from increasing the Max Upload Size in the UI.  Now it validates against the max supported value of 4GB (minus one byte) for IIS.

Lastly, we decided it best to not add a new field in the UI to control `requestLengthDiskThreshold`.  Since this is not something DNN admins would typically know/understand, it is best to leave this to manual `web.config` changes by server admins wanting to optimize performance for specific scenarios/environments.