### PR TITLE
CKE Provider fixes

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -790,7 +790,7 @@ namespace DNNConnect.CKEditorProvider.Browser
                 this.portalSettings,
                 this.currentSettings,
                 settingsDictionary,
-                "DNNCKP#-1#",
+                SettingConstants.HostKey,
                 null);
 
             switch (this.currentSettings.SettingMode)
@@ -808,7 +808,7 @@ namespace DNNConnect.CKEditorProvider.Browser
                         this.portalSettings,
                         this.currentSettings,
                         settingsDictionary,
-                        "DNNCKH#",
+                        SettingConstants.HostKey,
                         null);
                     break;
                 case SettingsMode.Portal:
@@ -816,7 +816,7 @@ namespace DNNConnect.CKEditorProvider.Browser
                         this.portalSettings,
                         this.currentSettings,
                         settingsDictionary,
-                        $"DNNCKP#{this.request.QueryString["PortalID"]}#",
+                        SettingConstants.PortalKey(this.request.QueryString["PortalID"]),
                         portalRoles);
                     break;
                 case SettingsMode.Page:

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx.cs
@@ -192,7 +192,7 @@ namespace DNNConnect.CKEditorProvider.Browser
                         this.portalSettings,
                         currentSettings,
                         settingsDictionary,
-                        "DNNCKH#",
+                        SettingConstants.HostKey,
                         portalRoles);
                     break;
                 case SettingsMode.Portal:
@@ -200,7 +200,7 @@ namespace DNNConnect.CKEditorProvider.Browser
                         this.portalSettings,
                         currentSettings,
                         settingsDictionary,
-                        $"DNNCKP#{portalId}#",
+                        SettingConstants.PortalKey(portalId),
                         portalRoles);
                     break;
                 case SettingsMode.Page:

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.cs
@@ -769,7 +769,7 @@ namespace DNNConnect.CKEditorProvider
             // get the all-sites settings to be able to to show overridden values
             // when we're not in all-sites mode
             var allPortalsSettings = SettingsUtil.LoadEditorSettingsByKey(
-                this.portalSettings, this.currentSettings, EditorController.GetEditorHostSettings(), "DNNCKP#-1#", new List<RoleInfo>());
+                this.portalSettings, this.currentSettings, EditorController.GetEditorHostSettings(), SettingConstants.HostKey, new List<RoleInfo>());
 
             this.HostBrowserRootDir.ReadOnly = !this.IsHostMode || this.CurrentPortalOnly;
             this.HostBrowserRootDir.Text = this.HostBrowserRootDir.ReadOnly ? allPortalsSettings.HostBrowserRootDir : importedSettings.HostBrowserRootDir;

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/CKEditorOptions.ascx.cs
@@ -1839,8 +1839,8 @@ namespace DNNConnect.CKEditorProvider
             var settingsDictionary = EditorController.GetEditorHostSettings();
             var portalRoles = RoleController.Instance.GetRoles(this.portalSettings?.PortalId ?? Host.HostPortalID);
 
-            var hostKey = "DNNCKH#";
-            var portalKey = $"DNNCKP#{this.portalSettings?.PortalId ?? Host.HostPortalID}#";
+            var hostKey = SettingConstants.HostKey;
+            var portalKey = SettingConstants.PortalKey(this.portalSettings?.PortalId ?? Host.HostPortalID);
             var pageKey = $"DNNCKT#{this.CurrentOrSelectedTabId}#";
             var moduleKey = $"DNNCKMI#{this.ModuleId}#INS#{this.moduleInstanceName}#";
 
@@ -2793,10 +2793,10 @@ namespace DNNConnect.CKEditorProvider
             switch (this.CurrentSettingsMode)
             {
                 case SettingsMode.Host:
-                    this.SaveSettingsByKey("DNNCKH#");
+                    this.SaveSettingsByKey(SettingConstants.HostKey);
                     break;
                 case SettingsMode.Portal:
-                    this.SaveSettingsByKey($"DNNCKP#{this.portalSettings?.PortalId ?? Host.HostPortalID}#");
+                    this.SaveSettingsByKey(SettingConstants.PortalKey(this.portalSettings?.PortalId ?? Host.HostPortalID));
                     break;
                 case SettingsMode.Page:
                     this.SaveSettingsByKey($"DNNCKT#{this.CurrentOrSelectedTabId}#");
@@ -3287,6 +3287,7 @@ namespace DNNConnect.CKEditorProvider
             exportSettings.Config.Skin = this.ddlSkin.SelectedValue;
             exportSettings.Config.CodeMirror.Theme = this.CodeMirrorTheme.SelectedValue;
             exportSettings.Browser = this.ddlBrowser.SelectedValue;
+            exportSettings.BrowserAllowFollowFolderPerms = this.BrowAllowFollowPerms.Checked;
             exportSettings.ImageButton = this.ddlImageButton.SelectedValue;
             exportSettings.FileListViewMode =
                 (FileListView)Enum.Parse(typeof(FileListView), this.FileListViewMode.SelectedValue);

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Constants/SettingConstants.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Constants/SettingConstants.cs
@@ -4,6 +4,7 @@
 namespace DNNConnect.CKEditorProvider.Constants
 {
     using System;
+    using System.Dynamic;
 
     /// <summary>Provider Constants.</summary>
     public static class SettingConstants
@@ -128,5 +129,19 @@ namespace DNNConnect.CKEditorProvider.Constants
 
         /// <summary>The resize Upload height setting name.</summary>
         public const string RESIZEHEIGHTUPLOAD = "resizeheightupload";
+
+        /// <summary>Gets the prefix key for host level settings.</summary>
+        /// <returns>Host Key.</returns>
+        public static string HostKey => PortalKey(-1);
+
+        /// <summary>Gets the prefix key for portal level settings.</summary>
+        /// <param name="portalId">The portal id.</param>
+        /// <returns>Portal Key.</returns>
+        public static string PortalKey(int portalId) => PortalKey(portalId.ToString());
+
+        /// <summary>Gets the prefix key for portal level settings.</summary>
+        /// <param name="portalId">The portal id as a string.</param>
+        /// <returns>Portal Key.</returns>
+        public static string PortalKey(string portalId) => $"DNNCKP#{portalId}#";
     }
 }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Constants/SettingConstants.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Constants/SettingConstants.cs
@@ -4,7 +4,7 @@
 namespace DNNConnect.CKEditorProvider.Constants
 {
     using System;
-    using System.Dynamic;
+    using System.Globalization;
 
     /// <summary>Provider Constants.</summary>
     public static class SettingConstants
@@ -137,7 +137,7 @@ namespace DNNConnect.CKEditorProvider.Constants
         /// <summary>Gets the prefix key for portal level settings.</summary>
         /// <param name="portalId">The portal id.</param>
         /// <returns>Portal Key.</returns>
-        public static string PortalKey(int portalId) => PortalKey(portalId.ToString());
+        public static string PortalKey(int portalId) => PortalKey(portalId.ToString(CultureInfo.InvariantCulture));
 
         /// <summary>Gets the prefix key for portal level settings.</summary>
         /// <param name="portalId">The portal id as a string.</param>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.dnn
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.dnn
@@ -1,5 +1,5 @@
 ﻿<dotnetnuke type="Package" version="5.0">
-  <packages><package name="DNNConnect.CKEditorProvider" type="Provider" version="09.12.00">
+  <packages><package name="DNNConnect.CKEditorProvider" type="Provider" version="09.12.01">
             <friendlyName>CKEditor Provider</friendlyName>
             <description>CKEditor Provider for DNN</description>
             <iconFile>~/Providers/HtmlEditorProviders/DNNConnect.CKE/LogoCKEditor.png</iconFile>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.dnn
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.dnn
@@ -1,5 +1,5 @@
 ﻿<dotnetnuke type="Package" version="5.0">
-  <packages><package name="DNNConnect.CKEditorProvider" type="Provider" version="09.12.01">
+  <packages><package name="DNNConnect.CKEditorProvider" type="Provider" version="09.12.00">
             <friendlyName>CKEditor Provider</friendlyName>
             <description>CKEditor Provider for DNN</description>
             <iconFile>~/Providers/HtmlEditorProviders/DNNConnect.CKE/LogoCKEditor.png</iconFile>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Module/EditorConfigManager.ascx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Module/EditorConfigManager.ascx.cs
@@ -11,6 +11,7 @@ namespace DNNConnect.CKEditorProvider.Module
     using System.Linq;
     using System.Web.UI.WebControls;
 
+    using DNNConnect.CKEditorProvider.Constants;
     using DNNConnect.CKEditorProvider.Helper;
     using DNNConnect.CKEditorProvider.Objects;
     using DNNConnect.CKEditorProvider.Utilities;
@@ -332,7 +333,7 @@ namespace DNNConnect.CKEditorProvider.Module
 
         private void RenderHostNode(IEnumerable<PortalInfo> portals, ModuleController moduleController, List<EditorHostSetting> editorHostSettings)
         {
-            const string hostKey = "DNNCKH#";
+            var hostKey = SettingConstants.HostKey;
             var hostSettingsExist = SettingsUtil.CheckSettingsExistByKey(editorHostSettings, hostKey);
 
             var hostNode = new TreeNode()

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Module/EditorConfigManager.ascx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Module/EditorConfigManager.ascx.cs
@@ -362,7 +362,7 @@ namespace DNNConnect.CKEditorProvider.Module
         /// <param name="parentNode">The parent node.</param>
         private void RenderPortalNode(PortalInfo portal, ModuleController moduleController, List<EditorHostSetting> editorHostSettings, TreeNode parentNode = null)
         {
-            var portalKey = $"DNNCKP#{portal.PortalID}#";
+            var portalKey = SettingConstants.PortalKey(portal.PortalID);
 
             var portalSettingsExists = SettingsUtil.CheckSettingsExistByKey(editorHostSettings, portalKey);
 

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/SettingsUtil.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/SettingsUtil.cs
@@ -386,23 +386,6 @@ namespace DNNConnect.CKEditorProvider.Utilities
 
                 if (
                     filteredSettings.Any(
-                        setting => setting.Name.Equals($"{key}{SettingConstants.BROWSERALLOWFOLLOWFOLDERPERMS}")))
-                {
-                    var settingValue =
-                        filteredSettings.FirstOrDefault(
-                            s => s.Name.Equals($"{key}{SettingConstants.BROWSERALLOWFOLLOWFOLDERPERMS}")).Value;
-
-                    if (!string.IsNullOrEmpty(settingValue))
-                    {
-                        if (bool.TryParse(settingValue, out var bResult))
-                        {
-                            currentSettings.BrowserAllowFollowFolderPerms = bResult;
-                        }
-                    }
-                }
-
-                if (
-                    filteredSettings.Any(
                         setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.ROLES))))
                 {
                     var settingValue =
@@ -436,6 +419,26 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                 roles.Add(sRoleName);
                             }
                         }
+                    }
+                }
+            }
+
+            // check the BrowserAllowFollowFolderPerms setting before the browser mode, because it depends on it
+            // skip if the setting already is true, to let the host setting go before the site level setting
+            if (currentSettings.BrowserAllowFollowFolderPerms == false &&
+                filteredSettings.Any(
+                    setting => setting.Name.Equals($"{key}{SettingConstants.BROWSERALLOWFOLLOWFOLDERPERMS}")))
+            {
+                var settingValue =
+                    filteredSettings.FirstOrDefault(
+                        s => s.Name.Equals($"{key}{SettingConstants.BROWSERALLOWFOLLOWFOLDERPERMS}")).Value;
+
+                if (!string.IsNullOrEmpty(settingValue))
+                {
+                    bool bResult;
+                    if (bool.TryParse(settingValue, out bResult))
+                    {
+                        currentSettings.BrowserAllowFollowFolderPerms = bResult;
                     }
                 }
             }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Web/EditorControl.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Web/EditorControl.cs
@@ -928,10 +928,10 @@ namespace DNNConnect.CKEditorProvider.Web
             // Set Current Mode to Default
             this.currentEditorSettings.SettingMode = SettingsMode.Default;
 
-            const string hostKey = "DNNCKH#";
-            var portalKey = string.Format("DNNCKP#{0}#", this.portalSettings.PortalId);
-            var pageKey = string.Format("DNNCKT#{0}#", this.portalSettings.ActiveTab.TabID);
-            var moduleKey = string.Format("DNNCKMI#{0}#INS#{1}#", this.parentModulId, this.ID);
+            var hostKey = SettingConstants.HostKey;
+            var portalKey = SettingConstants.PortalKey(this.portalSettings.PortalId);
+            var pageKey = $"DNNCKT#{this.portalSettings.ActiveTab.TabID}#";
+            var moduleKey = $"DNNCKMI#{this.parentModulId}#INS#{this.ID}#";
 
             // Load Host Settings ?!
             if (SettingsUtil.CheckSettingsExistByKey(settingsDictionary, hostKey))


### PR DESCRIPTION
This PR closes 2 issues:
Closes #5811 
Closes #5812 

## Summary
for #5811 :
Since I have not been able to find any site with a settingname starting with the host level prefix of DNNCKH#, I changed the host level prefix to be the one that's actually being used: DNNCKP#-1#
For obvious reasons I also changed the occurences of strings DNNCHP# to use SettingConstants.

for #5812 :
I had to move the part that reads the setting value outside of an if-block, and stop it from overriding the host level setting with the site level setting, when set on host level.
