### PR TITLE
Move DnnDeprecatedAttribute to Abstractions

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/DnnDeprecatedAttribute.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/DnnDeprecatedAttribute.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+public class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
+++ b/DNN Platform/DotNetNuke.Abstractions/DotNetNuke.Abstractions.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
+++ b/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
@@ -36,7 +36,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </ProjectReference>
     <ProjectReference Include="..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj" />
   </ItemGroup>
 

--- a/DNN Platform/DotNetNuke.Instrumentation/DotNetNuke.Instrumentation.csproj
+++ b/DNN Platform/DotNetNuke.Instrumentation/DotNetNuke.Instrumentation.csproj
@@ -82,9 +82,13 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj
+++ b/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj
@@ -104,9 +104,13 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
@@ -210,7 +210,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5fe5d021-9c8d-47a6-bd34-f328ba3e709c}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNuke.Web.Razor.csproj
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNuke.Web.Razor.csproj
@@ -137,7 +137,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5fe5d021-9c8d-47a6-bd34-f328ba3e709c}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -438,7 +438,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5fe5d021-9c8d-47a6-bd34-f328ba3e709c}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
+++ b/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
@@ -99,7 +99,7 @@
     <Compile Include="Users Online\UsersOnlineModule.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -1918,7 +1918,7 @@
     <Folder Include="UI\Internal\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5fe5d021-9c8d-47a6-bd34-f328ba3e709c}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
+++ b/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
@@ -227,7 +227,7 @@
     <Folder Include="Packages\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Modules/DnnExportImport/DnnExportImport.csproj
+++ b/DNN Platform/Modules/DnnExportImport/DnnExportImport.csproj
@@ -145,9 +145,13 @@
     <Content Include="Module.build" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\DotNetNuke.Instrumentation\DotNetNuke.Instrumentation.csproj">
       <Project>{3cd5f6b8-8360-4862-80b6-f402892db7dd}</Project>

--- a/DNN Platform/Modules/HTML/DotNetNuke.Modules.Html.csproj
+++ b/DNN Platform/Modules/HTML/DotNetNuke.Modules.Html.csproj
@@ -219,7 +219,7 @@
     <Content Include="web.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Modules/HtmlEditorManager/DotNetNuke.Modules.HtmlEditorManager.csproj
+++ b/DNN Platform/Modules/HtmlEditorManager/DotNetNuke.Modules.HtmlEditorManager.csproj
@@ -146,7 +146,7 @@
     <Content Include="App_LocalResources\ProviderConfiguration.ascx.resx" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
+++ b/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
@@ -174,7 +174,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Modules/RazorHost/DotNetNuke.Modules.RazorHost.csproj
+++ b/DNN Platform/Modules/RazorHost/DotNetNuke.Modules.RazorHost.csproj
@@ -195,7 +195,7 @@
     <Content Include="web.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.csproj
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.csproj
@@ -408,7 +408,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Tests/DNN.Integration.Test.Framework/DNN.Integration.Test.Framework.csproj
+++ b/DNN Platform/Tests/DNN.Integration.Test.Framework/DNN.Integration.Test.Framework.csproj
@@ -115,9 +115,13 @@
     <Compile Include="WebApiException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DotNetNuke.Abstractions\DotNetNuke.Abstractions.csproj">
+      <Project>{6928a9b1-f88a-4581-a132-d3eb38669bb0}</Project>
+      <Name>DotNetNuke.Abstractions</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Library\DotNetNuke.Library.csproj">
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/DnnDeprecatedGeneratorTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/DnnDeprecatedGeneratorTests.cs
@@ -318,7 +318,7 @@ partial class Page
             AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
                 .Select(a => MetadataReference.CreateFromFile(a.Location))
-                .Append(MetadataReference.CreateFromFile(typeof(DnnDeprecatedAttribute).Assembly.Location));
+                .Append(MetadataReference.CreateFromFile(typeof(DnnDeprecatedGenerator).Assembly.Location));
         var compilation = CSharpCompilation.Create(
             "AnAssemblyName",
             new[] { CSharpSyntaxTree.ParseText(source), },

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedExtensionMethod_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedExtensionMethod_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,13 +1,12 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information
+﻿//HintName: DnnDeprecatedAttribute.g.cs
 namespace DotNetNuke.Internal.SourceGenerators;
 
+using System;
 using System.Diagnostics;
 
 /// <summary>Marks a type or member as deprecated.</summary>
 [Conditional("DNN_SOURCE_GENERATOR")]
-public class DnnDeprecatedAttribute : Attribute
+internal class DnnDeprecatedAttribute : Attribute
 {
     /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
     /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedGenericPartialClass_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedGenericPartialClass_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedMethodWithOptionalParameters_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedMethodWithOptionalParameters_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedMethodWithParamsParameter_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedMethodWithParamsParameter_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedMethods_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedMethods_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedNestedGenericPartialClass_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedNestedGenericPartialClass_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedNestedPartialRecord_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedNestedPartialRecord_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedNonPartialClass_ReportsAnErrorDiagnostic#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedNonPartialClass_ReportsAnErrorDiagnostic#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialClass_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialClass_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialGenericInterface_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialGenericInterface_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialInterface_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialInterface_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialRecord_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialRecord_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialStruct_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedPartialStruct_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedWithSpecialCharacters_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.DeprecatedWithSpecialCharacters_AddsPartialWithObsoleteAttribute#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.NotDeprecatedClass_DoesNotGenerateAnything#DnnDeprecatedAttribute.g.verified.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.SourceGenerators/Snapshots/DnnDeprecatedGeneratorTests.NotDeprecatedClass_DoesNotGenerateAnything#DnnDeprecatedAttribute.g.verified.cs
@@ -1,0 +1,39 @@
+﻿//HintName: DnnDeprecatedAttribute.g.cs
+namespace DotNetNuke.Internal.SourceGenerators;
+
+using System;
+using System.Diagnostics;
+
+/// <summary>Marks a type or member as deprecated.</summary>
+[Conditional("DNN_SOURCE_GENERATOR")]
+internal class DnnDeprecatedAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="DnnDeprecatedAttribute"/> class.</summary>
+    /// <param name="majorVersion">The major version in which the type or member was deprecated.</param>
+    /// <param name="minorVersion">The minor version in which the type or member was deprecated.</param>
+    /// <param name="patchVersion">The patch version in which the type or member was deprecated.</param>
+    /// <param name="replacement">The suggested replacement or alternative.</param>
+    public DnnDeprecatedAttribute(int majorVersion, int minorVersion, int patchVersion, string replacement)
+    {
+        this.MajorVersion = majorVersion;
+        this.MinorVersion = minorVersion;
+        this.PatchVersion = patchVersion;
+        this.Replacement = replacement;
+        this.RemovalVersion = majorVersion + 2;
+    }
+
+    /// <summary>Gets the major version in which the type or member was deprecated.</summary>
+    public int MajorVersion { get; }
+
+    /// <summary>Gets the minor version in which the type or member was deprecated.</summary>
+    public int MinorVersion { get; }
+
+    /// <summary>Gets the patch version in which the type or member was deprecated.</summary>
+    public int PatchVersion { get; }
+
+    /// <summary>Gets the suggested replacement or alternative.</summary>
+    public string Replacement { get; }
+
+    /// <summary>Gets or sets the major version in which the type or member will be removed.</summary>
+    public int RemovalVersion { get; set; }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
@@ -136,7 +136,7 @@
     <Compile Include="Util.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -3413,7 +3413,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5fe5d021-9c8d-47a6-bd34-f328ba3e709c}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -627,7 +627,7 @@
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
       <Name>DotNetNuke.Library</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5FE5D021-9C8D-47A6-BD34-F328BA3E709C}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
@@ -145,7 +145,7 @@
       <Project>{6b29aded-7b56-4484-bea5-c0e09079535b}</Project>
       <Name>DotNetNuke.Library</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" OutputItemType="Analyzer">
+    <ProjectReference Include="..\..\..\DotNetNuke.Internal.SourceGenerators\DotNetNuke.Internal.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer">
       <Project>{5fe5d021-9c8d-47a6-bd34-f328ba3e709c}</Project>
       <Name>DotNetNuke.Internal.SourceGenerators</Name>
     </ProjectReference>

--- a/DotNetNuke.Internal.SourceGenerators/DnnDeprecatedGenerator.cs
+++ b/DotNetNuke.Internal.SourceGenerators/DnnDeprecatedGenerator.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-/// <summary>A source generator which turns <see cref="DnnDeprecatedAttribute"/> into <see cref="ObsoleteAttribute"/>.</summary>
+/// <summary>A source generator which turns <c>DnnDeprecatedAttribute</c> into <see cref="ObsoleteAttribute"/>.</summary>
 [Generator]
 public class DnnDeprecatedGenerator : IIncrementalGenerator
 {
@@ -461,7 +461,7 @@ public class DnnDeprecatedGenerator : IIncrementalGenerator
         return true;
     }
 
-    private static DnnDeprecatedAttribute? GetDeprecation(ISymbol typeSymbol, ISymbol dnnDeprecatedType)
+    private static DnnDeprecation? GetDeprecation(ISymbol typeSymbol, ISymbol dnnDeprecatedType)
     {
         foreach (var attribute in typeSymbol.GetAttributes())
         {
@@ -479,7 +479,7 @@ public class DnnDeprecatedGenerator : IIncrementalGenerator
                 }
             }
 
-            var deprecation = new DnnDeprecatedAttribute(
+            var deprecation = new DnnDeprecation(
                 (int)args[0].Value!,
                 (int)args[1].Value!,
                 (int)args[2].Value!,
@@ -487,7 +487,7 @@ public class DnnDeprecatedGenerator : IIncrementalGenerator
 
             foreach (var arg in attribute.NamedArguments)
             {
-                if (!arg.Key.Equals(nameof(DnnDeprecatedAttribute.RemovalVersion), StringComparison.Ordinal))
+                if (!arg.Key.Equals("RemovalVersion", StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -567,5 +567,27 @@ public class DnnDeprecatedGenerator : IIncrementalGenerator
         }
 
         return null;
+    }
+
+    private class DnnDeprecation
+    {
+        public DnnDeprecation(int majorVersion, int minorVersion, int patchVersion, string replacement)
+        {
+            this.MajorVersion = majorVersion;
+            this.MinorVersion = minorVersion;
+            this.PatchVersion = patchVersion;
+            this.Replacement = replacement;
+            this.RemovalVersion = majorVersion + 2;
+        }
+
+        public int MajorVersion { get; }
+
+        public int MinorVersion { get; }
+
+        public int PatchVersion { get; }
+
+        public string Replacement { get; }
+
+        public int RemovalVersion { get; set; }
     }
 }


### PR DESCRIPTION
In order for projects to not require a full reference to the source generator project, the attribute cannot be defined in the project. The first attempt to resolve this was to generate the attribute via the source generator itself, but since the Library project exposes its internals to other projects (e.g. DotNetNuke.HttpModules), this resulted in ambiguous references. As a result, moving the type to a project that all other projects can reference seemed to be the best compromise. Since the attribute is conditional, it doesn't affect the public API of that project.

Fixes #5815