### PR TITLE
resourceManager bad url using Azure

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-copy-url/dnn-action-copy-url.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/actions/dnn-action-copy-url/dnn-action-copy-url.tsx
@@ -14,7 +14,7 @@ export class DnnActionCopyUrl {
   private handleClick(): void {
     let t;
     if (this.items[0].path.includes(":")) {
-      t = `${this.items[0].path}`;
+      t = this.items[0].path;
     } else {
       t = `${window.location.protocol}//${window.location.host}${this.items[0].path}`;
     }   


### PR DESCRIPTION
Closes https://github.com/dnnsoftware/Dnn.Platform/issues/5797


Summary

Add check before copying the url of a file because if the file is in an azure storage account you will get the url of the page and the storage together