### PR TITLE
Feature/5819 improvements logging

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/StandardTabAndModuleInfoProvider.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/StandardTabAndModuleInfoProvider.cs
@@ -153,11 +153,11 @@ namespace DotNetNuke.Web.Mvc
                 {
                     return ids.First();
                 }
-            }
 
-            if (Logger.IsWarnEnabled)
-            {
-                Logger.WarnFormat("The specified moniker ({0}) is not defined in the system", monikerValue);
+                if (Logger.IsWarnEnabled)
+                {
+                    Logger.WarnFormat("The specified moniker ({0}) is not defined in the system", monikerValue);
+                }
             }
 
             return Null.NullInteger;

--- a/DNN Platform/DotNetNuke.Web/Api/StandardTabAndModuleInfoProvider.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/StandardTabAndModuleInfoProvider.cs
@@ -166,11 +166,11 @@ namespace DotNetNuke.Web.Api
                 {
                     return ids.First();
                 }
-            }
 
-            if (Logger.IsWarnEnabled)
-            {
-                Logger.WarnFormat("The specified moniker ({0}) is not defined in the system", monikerValue);
+                if (Logger.IsWarnEnabled)
+                {
+                    Logger.WarnFormat("The specified moniker ({0}) is not defined in the system", monikerValue);
+                }
             }
 
             return Null.NullInteger;

--- a/DNN Platform/HttpModules/UrlRewrite/BasicUrlRewriter.cs
+++ b/DNN Platform/HttpModules/UrlRewrite/BasicUrlRewriter.cs
@@ -223,10 +223,9 @@ namespace DotNetNuke.HttpModules.UrlRewrite
                     }
                 }
             }
-            catch (ThreadAbortException exc)
+            catch (ThreadAbortException)
             {
                 // Do nothing if Thread is being aborted - there are two response.redirect calls in the Try block
-                Logger.Debug(exc);
             }
             catch (Exception ex)
             {

--- a/DNN Platform/Modules/DDRMenu/MenuBase.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuBase.cs
@@ -222,7 +222,6 @@ namespace DotNetNuke.Web.DDRMenu
                                     return false;
                                 }
 
-
                                 var tab = TabController.Instance.GetTab(n.TabId, Null.NullInteger, false);
                                 foreach (TabPermissionInfo perm in tab.TabPermissions)
                                 {

--- a/DNN Platform/Modules/DDRMenu/MenuBase.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuBase.cs
@@ -217,7 +217,11 @@ namespace DotNetNuke.Web.DDRMenu
                             n =>
                             {
                                 // no need to check when the node is not a page
-                                if (n.TabId <= 0) return false;
+                                if (n.TabId <= 0)
+                                {
+                                    return false;
+                                }
+
 
                                 var tab = TabController.Instance.GetTab(n.TabId, Null.NullInteger, false);
                                 foreach (TabPermissionInfo perm in tab.TabPermissions)

--- a/DNN Platform/Modules/DDRMenu/MenuBase.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuBase.cs
@@ -216,6 +216,9 @@ namespace DotNetNuke.Web.DDRMenu
                         this.RootNode.Children.FindAll(
                             n =>
                             {
+                                // no need to check when the node is not a page
+                                if (n.TabId <= 0) return false;
+
                                 var tab = TabController.Instance.GetTab(n.TabId, Null.NullInteger, false);
                                 foreach (TabPermissionInfo perm in tab.TabPermissions)
                                 {


### PR DESCRIPTION
This PR relats to #5819 and covers the logging-related changes:
- Skip warning for moniker not found, when moniker value is empty
- In DDRMenu.FilterNodes only do GetTab when tabId > 0
- DDRMenu: Don't GetTab when we already know TabId <= 0
- BasicUrlRewriter: no log after redirect
