### PR TITLE
Feature/5819 improvements fixes

### DIFF
--- a/DNN Platform/Library/Services/Mail/Mail.cs
+++ b/DNN Platform/Library/Services/Mail/Mail.cs
@@ -131,7 +131,7 @@ namespace DotNetNuke.Services.Mail
             // Send Notification to User
             var user = UserController.Instance.GetUserById(portalId, userId);
             int toUser = user.UserID;
-            string locale = user.Profile.PreferredLocale;
+            string locale = user.Profile.PreferredLocale ?? settings.DefaultLanguage;
             string subject;
             string body;
             ArrayList custom = null;
@@ -142,7 +142,7 @@ namespace DotNetNuke.Services.Mail
                     body = "EMAIL_USER_REGISTRATION_ADMINISTRATOR_BODY";
                     toUser = settings.AdministratorId;
                     UserInfo admin = UserController.GetUserById(settings.PortalId, settings.AdministratorId);
-                    locale = admin.Profile.PreferredLocale;
+                    locale = admin?.Profile.PreferredLocale;
                     break;
                 case MessageType.UserRegistrationPrivate:
                     subject = "EMAIL_USER_REGISTRATION_PRIVATE_SUBJECT";
@@ -199,7 +199,7 @@ namespace DotNetNuke.Services.Mail
                     body = "EMAIL_PASSWORD_REMINDER_USER_ISNOT_APPROVED_ADMINISTRATOR_BODY";
                     toUser = settings.AdministratorId;
                     admin = UserController.GetUserById(settings.PortalId, settings.AdministratorId);
-                    locale = admin.Profile.PreferredLocale;
+                    locale = admin?.Profile.PreferredLocale;
                     break;
                 case MessageType.UserAuthorized:
                     subject = "EMAIL_USER_AUTHORIZED_SUBJECT";
@@ -220,7 +220,12 @@ namespace DotNetNuke.Services.Mail
 
             var fromUser = (UserController.GetUserByEmail(settings.PortalId, settings.Email) != null) ?
                 string.Format("{0} < {1} >", UserController.GetUserByEmail(settings.PortalId, settings.Email).DisplayName, settings.Email) : settings.Email;
-            SendEmail(fromUser, UserController.GetUserById(settings.PortalId, toUser).Email, subject, body);
+
+            var toUserInfo = UserController.GetUserById(settings.PortalId, toUser);
+            if (toUserInfo != null)
+            {
+                SendEmail(fromUser, toUserInfo.Email, subject, body);
+            }
 
             return Null.NullString;
         }

--- a/DNN Platform/Library/Services/Scheduling/Scheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/Scheduler.cs
@@ -128,6 +128,12 @@ namespace DotNetNuke.Services.Scheduling
                 // Get the enabled servers with recent activity.
                 var enabledServers = ServerController.GetEnabledServersWithActivity();
 
+                if (!enabledServers.Any())
+                {
+                    // No enabled servers with activity, so just return true to indicate the scheduled item was not updated.
+                    return true;
+                }
+
                 // Validate that any server in the scheduled item is in the enabled server list with activity in the last 10 minutes.
                 bool serverHasRecentActivity = enabledServers.Any(i => servers.Contains(i.ServerName.ToLowerInvariant()));
 

--- a/DNN Platform/Modules/DDRMenu/MenuBase.cs
+++ b/DNN Platform/Modules/DDRMenu/MenuBase.cs
@@ -280,7 +280,9 @@ namespace DotNetNuke.Web.DDRMenu
                     n =>
                     {
                         var tab = TabController.Instance.GetTab(n.TabId, portalSettings.PortalId);
-                        return tab == null || !tab.IsVisible;
+                        // Node added through NodeManipulator would have tab==null
+                        // and should not be filtered out
+                        return !(tab?.IsVisible ?? true);
                     }));
 
             parentNode.Children.RemoveAll(n => filteredNodes.Contains(n));

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/09.12.01.SqlDataProvider
@@ -79,6 +79,146 @@ AND TimeLapseMeasurement = 'm'
 AND RetryTimeLapseMeasurement = 'm';
 GO
 
+/* Fix error updating PortalLocalization when no en-US exists for portal */
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}UpdatePortalInfo]') AND type in (N'P', N'PC'))
+	DROP PROCEDURE {databaseOwner}[{objectQualifier}UpdatePortalInfo]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}UpdatePortalInfo]
+	@PortalID				INT,
+	@PortalGroupID			INT,
+	@PortalName				NVARCHAR(128),
+	@LogoFile				NVARCHAR(50),
+	@FooterText				NVARCHAR(100),
+	@ExpiryDate				DATETIME,
+	@UserRegistration		INT,
+	@BannerAdvertising		INT,
+	@Currency				CHAR(3),
+	@AdministratorId		INT,
+	@HostFee				MONEY,
+	@HostSpace				INT,
+	@PageQuota				INT,
+	@UserQuota				INT,
+	@PaymentProcessor		NVARCHAR(50),
+	@ProcessorUserId		NVARCHAR(50),
+	@ProcessorPassword		NVARCHAR(50),
+	@Description			NVARCHAR(500),
+	@KeyWords				NVARCHAR(500),
+	@BackgroundFile			NVARCHAR(50),
+	@SiteLogHistory			INT,
+	@SplashTabId			INT,
+	@HomeTabId				INT,
+	@LoginTabId				INT,
+	@RegisterTabId			INT,
+	@UserTabId				INT,
+	@SearchTabId			INT,
+    @Custom404TabId			INT,
+    @Custom500TabId			INT,
+	@DefaultLanguage		NVARCHAR(10),
+	@HomeDirectory			VARCHAR(100),
+	@LastModifiedByUserID	INT,
+	@CultureCode			NVARCHAR(50)
+
+AS
+
+	UPDATE {databaseOwner}{objectQualifier}Portals
+		SET    
+		   PortalGroupID		= @PortalGroupID,
+		   ExpiryDate			= @ExpiryDate,
+		   UserRegistration		= @UserRegistration,
+		   BannerAdvertising	= @BannerAdvertising,
+		   Currency				= @Currency,
+		   AdministratorId		= @AdministratorId,
+		   HostFee				= @HostFee,
+		   HostSpace			= @HostSpace,
+		   PageQuota			= @PageQuota,
+		   UserQuota			= @UserQuota,
+		   PaymentProcessor		= @PaymentProcessor,
+		   ProcessorUserId		= @ProcessorUserId,
+		   ProcessorPassword	= @ProcessorPassword,
+		   SiteLogHistory		= @SiteLogHistory,
+		   DefaultLanguage		= @DefaultLanguage,
+		   HomeDirectory		= @HomeDirectory,
+		   LastModifiedByUserID = @LastModifiedByUserID,
+		   LastModifiedOnDate	= GETDATE()
+	WHERE  PortalId = @PortalID
+
+    IF EXISTS (SELECT * FROM {databaseOwner}{objectQualifier}PortalLocalization WHERE PortalId = @PortalID AND CultureCode = @CultureCode)
+	BEGIN 
+		UPDATE {databaseOwner}{objectQualifier}PortalLocalization
+			SET
+				PortalName				= @PortalName,
+				LogoFile				= @LogoFile,
+				FooterText				= @FooterText,
+				Description				= @Description,
+				KeyWords				= @KeyWords,
+				BackgroundFile			= @BackgroundFile,
+				HomeTabId				= @HomeTabId,
+				LoginTabId				= @LoginTabId,
+				RegisterTabId			= @RegisterTabId,
+				UserTabId				= @UserTabId,
+				SplashTabId				= @SplashTabId,
+				SearchTabId				= @SearchTabId,
+                Custom404TabId			= @Custom404TabId,
+                Custom500TabId			= @Custom500TabId,
+				LastModifiedByUserID	= @LastModifiedByUserID,
+				LastModifiedOnDate		= GETDATE()
+		WHERE	PortalId = @PortalID 
+			AND CultureCode = @CultureCode
+	END 
+    ELSE
+	BEGIN 
+		DECLARE @AdminTabId int
+		SET @AdminTabId = (SELECT TOP 1 AdminTabId 
+								FROM {databaseOwner}{objectQualifier}PortalLocalization 
+								WHERE PortalID = @PortalID)
+
+		INSERT INTO {databaseOwner}{objectQualifier}PortalLocalization (
+			[PortalID],
+			[CultureCode],
+			[PortalName],
+			[LogoFile],
+			[FooterText],
+			[Description],
+			[KeyWords],
+			[BackgroundFile],
+			[HomeTabId],
+			[LoginTabId],
+			[UserTabId],
+			[AdminTabId],
+			[SplashTabId],
+			[SearchTabId],
+            [Custom404TabId],
+            [Custom500TabId],
+			[CreatedByUserID],
+			[CreatedOnDate],
+			[LastModifiedByUserID],
+			[LastModifiedOnDate]
+		)
+		VALUES (
+			@PortalID,
+			@CultureCode,
+			@PortalName,
+			@LogoFile, 
+			@FooterText,
+			@Description,
+			@KeyWords,
+			@BackgroundFile,
+			@HomeTabId ,
+			@LoginTabId ,
+			@UserTabId,
+			@AdminTabid,
+			@SplashTabId,
+			@SearchTabId,
+            @Custom404TabId,
+            @Custom500TabId,
+			-1,
+			GETDATE(),
+			-1,
+			GETDATE()
+		)
+	END
+GO
 
 /************************************************************/
 /*****              SqlDataProvider                     *****/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Schema.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/DotNetNuke.Schema.SqlDataProvider
@@ -3359,9 +3359,9 @@ AS
 ELSE
 	BEGIN 
 		DECLARE @AdminTabId int
-		SET @AdminTabId = (SELECT AdminTabId 
+		SET @AdminTabId = (SELECT TOP 1 AdminTabId 
 								FROM {databaseOwner}{objectQualifier}PortalLocalization 
-								WHERE PortalID = @PortalID AND CultureCode='en-US')
+								WHERE PortalID = @PortalID)
 
 		INSERT INTO {databaseOwner}{objectQualifier}PortalLocalization (
 			[PortalID],

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
@@ -346,7 +346,7 @@ namespace Dnn.PersonaBar.SiteSettings.Services
                         RedirectAfterLogoutTabName = this.TabSanitizer(redirectAfterLogoutTabId, pid)?.TabName,
                         RedirectAfterRegistrationTabId = this.TabSanitizer(redirectAfterRegistrationTabId, pid)?.TabID,
                         RedirectAfterRegistrationTabName = this.TabSanitizer(redirectAfterRegistrationTabId, pid)?.TabName,
-                        PageHeadText = localizedPortalSettings["PageHeadText"],
+                        PageHeadText = localizedPortalSettings.GetValue("PageHeadText", ""),
                     },
                 });
             }


### PR DESCRIPTION
This PR relats to #5819 and covers the fixes:
- Prevent exception for missing PortalSetting PageHeadText
- Fix UpdatePortalInfo for new language when en-US not present
- Fix mail Null Reference exception in SendMail found in upgraded portals
- When NodeManipulator adds items they have no tabid, do not filter on null.
- Scheduler Fix for error thrown when no servers active
