### PR TITLE
Feature/5819 improvements caching

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -1394,9 +1394,9 @@ namespace DotNetNuke.Entities.Tabs
                     // correctly, this may occurred when install is set up in web farm.
                     tab = CBO.FillObject<TabInfo>(this.dataProvider.GetTab(tabId));
 
-                    // if tab is not null means that the cache doesn't update correctly, we need clear the cache
-                    // and let it rebuild cache when request next time.
-                    if (tab != null)
+                    // if tab is not null, and it is for "portalId", that means that the cache doesn't update correctly,
+                    // we need to clear the cache and let it rebuild cache when request next time.
+                    if (tab != null && tab.PortalID == portalId)
                     {
                         this.ClearCache(tab.PortalID);
                     }

--- a/DNN Platform/Modules/HTML/Components/WorkflowStateController.cs
+++ b/DNN Platform/Modules/HTML/Components/WorkflowStateController.cs
@@ -13,16 +13,31 @@ namespace DotNetNuke.Modules.Html
     public class WorkflowStateController
     {
         private const string WORKFLOWCACHEKEY = "Workflow{0}";
+        private const string WORKFLOWS_CACHE_KEY = "Workflows{0}";
         private const int WORKFLOWCACHETIMEOUT = 20;
 
         private const CacheItemPriority WORKFLOWCACHEPRIORITY = CacheItemPriority.Normal;
 
-        /// <summary>GetWorkFlows retrieves a collection of workflows for the portal.</summary>
+        /// <summary>GetWorkFlows retrieves a collection of workflows for the portal from the cache.</summary>
         /// <param name="portalID">The ID of the Portal.</param>
         /// <returns>An <see cref="ArrayList"/> of <see cref="WorkflowStateInfo"/> instances.</returns>
         public ArrayList GetWorkflows(int portalID)
         {
-            return CBO.FillCollection(DataProvider.Instance().GetWorkflows(portalID), typeof(WorkflowStateInfo));
+            var cacheKey = string.Format(WORKFLOWS_CACHE_KEY, portalID);
+            return CBO.GetCachedObject<ArrayList>(new CacheItemArgs(cacheKey, WORKFLOWCACHETIMEOUT, WORKFLOWCACHEPRIORITY, portalID), this.GetWorkflowsCallBack);
+        }
+
+        /// -----------------------------------------------------------------------------
+        /// <summary>
+        ///   GetWorkflowsCallBack retrieves a collection of WorkflowStateInfo objects for the Portal from the database.
+        /// </summary>
+        /// <param name = "cacheItemArgs">Arguments passed by the GetWorkflowStates method.</param>
+        /// <returns>WorkflowStateInfo List.</returns>
+        /// -----------------------------------------------------------------------------
+        public object GetWorkflowsCallBack(CacheItemArgs cacheItemArgs)
+        {
+            var portalId = (int)cacheItemArgs.ParamList[0];
+            return CBO.FillCollection(DataProvider.Instance().GetWorkflows(portalId), typeof(WorkflowStateInfo));
         }
 
         /// <summary>GetWorkFlowStates retrieves a collection of WorkflowStateInfo objects for the Workflow from the cache.</summary>

--- a/DNN Platform/Modules/HTML/Components/WorkflowStateController.cs
+++ b/DNN Platform/Modules/HTML/Components/WorkflowStateController.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Modules.Html
     public class WorkflowStateController
     {
         private const string WORKFLOWCACHEKEY = "Workflow{0}";
-        private const string WORKFLOWS_CACHE_KEY = "Workflows{0}";
+        private const string WORKFLOWSCACHEKEY = "Workflows{0}";
         private const int WORKFLOWCACHETIMEOUT = 20;
 
         private const CacheItemPriority WORKFLOWCACHEPRIORITY = CacheItemPriority.Normal;
@@ -23,7 +23,7 @@ namespace DotNetNuke.Modules.Html
         /// <returns>An <see cref="ArrayList"/> of <see cref="WorkflowStateInfo"/> instances.</returns>
         public ArrayList GetWorkflows(int portalID)
         {
-            var cacheKey = string.Format(WORKFLOWS_CACHE_KEY, portalID);
+            var cacheKey = string.Format(WORKFLOWSCACHEKEY, portalID);
             return CBO.GetCachedObject<ArrayList>(new CacheItemArgs(cacheKey, WORKFLOWCACHETIMEOUT, WORKFLOWCACHEPRIORITY, portalID), this.GetWorkflowsCallBack);
         }
 
@@ -34,7 +34,7 @@ namespace DotNetNuke.Modules.Html
         /// <param name = "cacheItemArgs">Arguments passed by the GetWorkflowStates method.</param>
         /// <returns>WorkflowStateInfo List.</returns>
         /// -----------------------------------------------------------------------------
-        public object GetWorkflowsCallBack(CacheItemArgs cacheItemArgs)
+        public ArrayList GetWorkflowsCallBack(CacheItemArgs cacheItemArgs)
         {
             var portalId = (int)cacheItemArgs.ParamList[0];
             return CBO.FillCollection(DataProvider.Instance().GetWorkflows(portalId), typeof(WorkflowStateInfo));

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/Dto/FrameworkQueryDTO.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/Dto/FrameworkQueryDTO.cs
@@ -8,6 +8,7 @@ namespace Dnn.PersonaBar.UI.Services.DTO
     using System.Runtime.Serialization;
 
     [DataContract]
+    [Serializable]
     public class FrameworkQueryDTO
     {
         [DataMember(Name = "UpToDate")]

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/Dto/RoleGroupDto.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/Dto/RoleGroupDto.cs
@@ -5,14 +5,12 @@
 namespace Dnn.PersonaBar.UI.Services.DTO
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.Serialization;
-    using System.Web;
 
     using DotNetNuke.Security.Roles;
 
     [DataContract]
+    [Serializable]
     public class RoleGroupDto
     {
         /// <summary>Initializes a new instance of the <see cref="RoleGroupDto"/> class.</summary>

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/Dto/SuggestionDto.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/Dto/SuggestionDto.cs
@@ -4,9 +4,11 @@
 
 namespace Dnn.PersonaBar.UI.Services.DTO
 {
+    using System;
     using System.Runtime.Serialization;
 
     [DataContract]
+    [Serializable]
     public class SuggestionDto
     {
         [DataMember(Name = "value")]


### PR DESCRIPTION
This PR relats to #5819 and covers the caching-related changes:
- Fix serialization errors when using external cache
- HTML/Text: implement caching for GetWorkflows
- Only do a clearcache when unknown tab belongs to the portal whose cache is being flushed.
- TabController: only clear cache when tab is for the current portal