### PR TITLE
Updates issue template as per having released `v9.13.0`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -72,8 +72,8 @@ body:
         **NOTE:** _If your version is not listed, please upgrade to the latest version. If you cannot upgrade at this time, please open a [Discussion](https://github.com/dnnsoftware/Dnn.Platform/discussions) instead._
       multiple: true
       options:
-        - 9.12.0 (latest release)
-        - 9.13.0 (release candidate)
+        - 9.13.0 (latest release)
+        - 9.13.1 (alpha)
         - 10.0.0 (alpha)
     validations:
       required: true


### PR DESCRIPTION
Updates issue template as per having released `v9.13.0`

This is a release management task, as per our policy, we are self-approving it. 