### PR TITLE
Prevent control characters in username

### DIFF
--- a/DNN Platform/Library/Security/PortalSecurity.cs
+++ b/DNN Platform/Library/Security/PortalSecurity.cs
@@ -38,6 +38,7 @@ namespace DotNetNuke.Security
         private static readonly Regex StripTagsRegex = new Regex("<[^<>]*>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
         private static readonly Regex BadStatementRegex = new Regex(BadStatementExpression, RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex ControlCharactersRegex = new Regex(@"\p{C}+", RegexOptions.Compiled);
+        private static readonly Regex ControlCharacterToWhitespaceRegex = new Regex(@"\r\n|\r|\n|\t", RegexOptions.Compiled);
 
         private static readonly Regex[] RxListStrings = new[]
         {
@@ -114,6 +115,9 @@ namespace DotNetNuke.Security
             /// <summary>
             /// Removes all unicode control characters (like \0, \t, \n, \r, etc.) from the string.
             /// </summary>
+            /// <remarks>
+            /// The control characters \r\n, \r, \n, and \t are replaced with a single space instead of being removed.
+            /// </remarks>
             NoControlCharacters = 64,
         }
 
@@ -1035,7 +1039,7 @@ namespace DotNetNuke.Security
         /// <remarks>This is a private function that is used internally by the <see cref="InputFilter"/> function.</remarks>
         private static string FormatRemoveControlCharacters(string str)
         {
-            return ControlCharactersRegex.Replace(str.Replace('\t', ' '), string.Empty);
+            return ControlCharactersRegex.Replace(ControlCharacterToWhitespaceRegex.Replace(str, " "), string.Empty);
         }
 
         /// <summary>This function determines if the Input string contains any markup.</summary>

--- a/DNN Platform/Library/Security/PortalSecurity.cs
+++ b/DNN Platform/Library/Security/PortalSecurity.cs
@@ -1029,7 +1029,7 @@ namespace DotNetNuke.Security
             return BadStatementRegex.Replace(strSQL, " ").Replace("'", "''");
         }
 
-        /// <summary> This function removes control characters from the string.</summary>
+        /// <summary>This function removes control characters from the string.</summary>
         /// <param name="str">This is the string to be filtered.</param>
         /// <returns>Filtered UserInput.</returns>
         /// <remarks>This is a private function that is used internally by the <see cref="InputFilter"/> function.</remarks>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/PortalSecurity/PortalSecurityTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/PortalSecurity/PortalSecurityTest.cs
@@ -127,5 +127,27 @@ namespace DotNetNuke.Tests.Core.Security.PortalSecurity
             // Assert
             Assert.AreEqual(filterOutput, expectedOutput);
         }
+
+        [TestCase("User\0name", "Username",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+        [TestCase("O'\0Example", "O'Example",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+        [TestCase("My\nUsername", "MyUsername",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+        [TestCase("My\tUsername", "My Username",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+
+        public void Control_Character_Should_Not_Be_Allowed(string html, string expectedOutput,
+            DotNetNuke.Security.PortalSecurity.FilterFlag markup)
+        {
+            // Arrange
+            var portalSecurity = new DotNetNuke.Security.PortalSecurity();
+
+            // Act
+            var filterOutput = portalSecurity.InputFilter(html, markup);
+
+            // Assert
+            Assert.AreEqual(filterOutput, expectedOutput);
+        }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/PortalSecurity/PortalSecurityTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/PortalSecurity/PortalSecurityTest.cs
@@ -136,6 +136,8 @@ namespace DotNetNuke.Tests.Core.Security.PortalSecurity
             DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
         [TestCase("My\tUsername", "My Username",
             DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+        [TestCase("mail@example.com", "mail@example.com",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
 
         public void Control_Character_Should_Not_Be_Allowed(string html, string expectedOutput,
             DotNetNuke.Security.PortalSecurity.FilterFlag markup)

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/PortalSecurity/PortalSecurityTest.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/PortalSecurity/PortalSecurityTest.cs
@@ -132,7 +132,11 @@ namespace DotNetNuke.Tests.Core.Security.PortalSecurity
             DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
         [TestCase("O'\0Example", "O'Example",
             DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
-        [TestCase("My\nUsername", "MyUsername",
+        [TestCase("My\r\nUsername", "My Username",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+        [TestCase("My\rUsername", "My Username",
+            DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
+        [TestCase("My\nUsername", "My Username",
             DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]
         [TestCase("My\tUsername", "My Username",
             DotNetNuke.Security.PortalSecurity.FilterFlag.NoControlCharacters)]

--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -178,7 +178,11 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
                     {
                         if (this.Request.QueryString["username"] != null)
                         {
-                            this.txtUsername.Text = this.Request.QueryString["username"];
+                            string userName = PortalSecurity.Instance.InputFilter(
+                                this.Request.QueryString["username"],
+                                PortalSecurity.FilterFlag.NoScripting | PortalSecurity.FilterFlag.NoAngleBrackets | PortalSecurity.FilterFlag.NoMarkup | PortalSecurity.FilterFlag.NoControlCharacters);
+
+                            this.txtUsername.Text = userName;
                         }
                     }
                     catch (Exception ex)
@@ -265,7 +269,7 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
                 var loginStatus = UserLoginStatus.LOGIN_FAILURE;
                 string userName = PortalSecurity.Instance.InputFilter(
                     this.txtUsername.Text,
-                    PortalSecurity.FilterFlag.NoScripting | PortalSecurity.FilterFlag.NoAngleBrackets | PortalSecurity.FilterFlag.NoMarkup);
+                    PortalSecurity.FilterFlag.NoScripting | PortalSecurity.FilterFlag.NoAngleBrackets | PortalSecurity.FilterFlag.NoMarkup | PortalSecurity.FilterFlag.NoControlCharacters);
 
                 // DNN-6093
                 // check if we use email address here rather than username


### PR DESCRIPTION
Fixes #5834

## Summary
Prevents control characters to be inserted in the username field.

Before (http://localhost/Login?username=User%00name):
![image](https://github.com/dnnsoftware/Dnn.Platform/assets/2109929/7d04ede2-9a81-43d5-a2cd-b91482444718)

After (http://localhost/Login?username=User%00name):
![image](https://github.com/dnnsoftware/Dnn.Platform/assets/2109929/ed29d4b9-3055-40c5-bd16-73fdbc6ec111)

Noteworthy, this blocks _all_ control characters, including `\n` or `\r`. Instead of removing `\t` I've added a replacement of a space, but I don't think anyone uses a tab (since this switches the input field in the browser) or new lines (since this isn't a textarea) in their username.
