### PR TITLE
Fixed JavaScript error

### DIFF
--- a/DNN Platform/JavaScript Libraries/DnnPlugins/dnn.jquery.js
+++ b/DNN Platform/JavaScript Libraries/DnnPlugins/dnn.jquery.js
@@ -4314,10 +4314,14 @@
         });
     };
 
+    function registerEvents() {
+        Sys.WebForms.PageRequestManager.getInstance().add_beginRequest(saveRgDataDivScrollTop);
+        Sys.WebForms.PageRequestManager.getInstance().add_endRequest(dnnInitCustomisedCtrls);
+    }
+
     window.__rgDataDivScrollTopPersistArray = [];
     $(document).ajaxComplete(dnnInitCustomisedCtrls);
-    Sys.WebForms.PageRequestManager.getInstance().add_beginRequest(saveRgDataDivScrollTop);
-    Sys.WebForms.PageRequestManager.getInstance().add_endRequest(dnnInitCustomisedCtrls);
     $(dnnInitCustomisedCtrls);
+    $(registerEvents);
     handlerSendVerificationMailLink();
 })(jQuery);


### PR DESCRIPTION
Fixes #5818
Fixes #5839

## Summary
I'm not sure what caused this issue, maybe this is introduced in #5724. 

The problem is that "dnn.jquery.js" was loaded before "ScriptResource.axd" that includes the WebForms classes (with `Sys.WebForms.PageRequestManager`). To resolve this issue the events are now being registered after the DOM has been loaded. In this case the classes are loaded.