### PR TITLE
Fixed module cache

### DIFF
--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -164,7 +164,13 @@ namespace DotNetNuke.Entities.Modules.Settings
                     }
                 }
             });
-            DataCache.SetCache(this.CacheKey(portalId, moduleContext?.TabModuleID ?? -1), settings);
+
+            DataCache.ClearCache(this.CacheKeyPortalPrefix(portalId));
+            DataCache.SetCache(this.CacheKey(portalId, -1), settings);
+            if (moduleContext is not null)
+            {
+                DataCache.SetCache(this.CacheKey(portalId, moduleContext.TabModuleID), settings);
+            }
         }
 
         private T Load(CacheItemArgs args)
@@ -225,7 +231,12 @@ namespace DotNetNuke.Entities.Modules.Settings
         /// <param name="tabModuleId">The tab module ID.</param>
         /// <remarks>When <paramref name="tabModuleId"/> is -1, the cache key is for portal settings instead.</remarks>
         /// <returns>The cache key.</returns>
-        private string CacheKey(int portalId, int tabModuleId) => $"Settings{this.MappingCacheKey}_{portalId}_{tabModuleId}";
+        private string CacheKey(int portalId, int tabModuleId) => $"{this.CacheKeyPortalPrefix(portalId)}{tabModuleId}";
+
+        /// <summary>Gets the prefix of the cache key for the given portal.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <returns>The cache key prefix.</returns>
+        private string CacheKeyPortalPrefix(int portalId) => $"Settings{this.MappingCacheKey}_{portalId}_";
 
         /// <summary>Deserializes the property.</summary>
         /// <param name="settings">The settings.</param>

--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -166,11 +166,7 @@ namespace DotNetNuke.Entities.Modules.Settings
             });
 
             DataCache.ClearCache(this.CacheKeyPortalPrefix(portalId));
-            DataCache.SetCache(this.CacheKey(portalId, -1), settings);
-            if (moduleContext is not null)
-            {
-                DataCache.SetCache(this.CacheKey(portalId, moduleContext.TabModuleID), settings);
-            }
+            DataCache.SetCache(this.CacheKey(portalId, moduleContext?.TabModuleID ?? -1), settings);
         }
 
         private T Load(CacheItemArgs args)

--- a/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
+++ b/DNN Platform/Library/Entities/Modules/Settings/SettingsRepository.cs
@@ -50,13 +50,13 @@ namespace DotNetNuke.Entities.Modules.Settings
         /// <inheritdoc/>
         public T GetSettings(ModuleInfo moduleContext)
         {
-            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(moduleContext.PortalID), 20, CacheItemPriority.AboveNormal, moduleContext), this.Load, false);
+            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(moduleContext.PortalID, moduleContext.TabModuleID), 20, CacheItemPriority.AboveNormal, moduleContext), this.Load, false);
         }
 
         /// <inheritdoc/>
         public T GetSettings(int portalId)
         {
-            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(portalId), 20, CacheItemPriority.AboveNormal, null, portalId), this.Load, false);
+            return CBO.GetCachedObject<T>(new CacheItemArgs(this.CacheKey(portalId, -1), 20, CacheItemPriority.AboveNormal, null, portalId), this.Load, false);
         }
 
         /// <inheritdoc/>
@@ -164,7 +164,7 @@ namespace DotNetNuke.Entities.Modules.Settings
                     }
                 }
             });
-            DataCache.SetCache(this.CacheKey(portalId), settings);
+            DataCache.SetCache(this.CacheKey(portalId, moduleContext?.TabModuleID ?? -1), settings);
         }
 
         private T Load(CacheItemArgs args)
@@ -220,7 +220,12 @@ namespace DotNetNuke.Entities.Modules.Settings
             return settings;
         }
 
-        private string CacheKey(int id) => $"Settings{this.MappingCacheKey}_{id}";
+        /// <summary>Gets the cache key for the given portal and tab module.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabModuleId">The tab module ID.</param>
+        /// <remarks>When <paramref name="tabModuleId"/> is -1, the cache key is for portal settings instead.</remarks>
+        /// <returns>The cache key.</returns>
+        private string CacheKey(int portalId, int tabModuleId) => $"Settings{this.MappingCacheKey}_{portalId}_{tabModuleId}";
 
         /// <summary>Deserializes the property.</summary>
         /// <param name="settings">The settings.</param>


### PR DESCRIPTION
Fixes #5844

## Summary
Currently the module cache is being retrieved from the portal cache because we're only using the portal ID as key. Now we're using both the portal and module ID to generate a key.

If there is no module, then we use -1 as module ID; which is the null-value.