### PR TITLE
Add Dependabot groups for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,31 @@ updates:
     labels:
       - ".NET"
       - "Type: Maintenance"
+    groups:
+      MailKit:
+        patterns:
+          - "MailKit"
+          - "MimeKit"
+          - "BouncyCastle.Cryptography"
+      Google-Apis:
+        patterns:
+          - "Google.Apis*"
+      AspNet:
+        patterns:
+          - "Microsoft.AspNet.*"
+      SourceLink:
+        patterns:
+          - "Microsoft.SourceLink.*"
+      TestStack-Dossier:
+        patterns:
+          - "TestStack.Dossier"
+          - "AutoFixture"
+          - "Fare"
+          - "NSubstitute"
+          - "Castle.Core"
+      Cake-Issues:
+        patterns:
+          - "Cake.Issues*"
+      DependencyInjection:
+        patterns:
+          - "Microsoft.Extensions.DependencyInjection*"


### PR DESCRIPTION
## Summary
This PR updates the Dependabot config so that it will open on PR for multiple related dependencies. I've added a handful of NuGet dependencies that appeared to be directly connected, though others can be added in the future.