### PR TITLE
Fixed an issue where develop was publishing wrong version

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -3,7 +3,7 @@ commit-date-format: 'yyyyMMdd'
 assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{CommitsSinceVersionSource}'
 mode: ContinuousDeployment
 ignore:
-  commits-before: 2020-01-01T00:00:00
+  commits-before: 2023-01-01T00:00:00
 branches:
   future:
     regex: future?[/-]
@@ -21,6 +21,7 @@ branches:
     increment: Patch
     is-mainline: true
     source-branches: []
+    tracks-release-branches: false
   release:
     regex: release?[/-]
     mode: ContinuousDelivery


### PR DESCRIPTION
Closes #5871

Also further limits how far back GitVersion looks at commits for versioning purposes which makes it way quicker to run.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
