### PR TITLE
Fixed an issue that kept rm items selected after changing folders

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-left-pane/dnn-rm-left-pane.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-left-pane/dnn-rm-left-pane.tsx
@@ -17,6 +17,7 @@ export class DnnRmLeftPane {
   }
 
   private handleFolderClicked(e: CustomEvent<FolderTreeItem>): void {
+    state.selectedItems = [];
     this.itemsClient.getFolderContent(
       Number.parseInt(e.detail.data.key),
       0,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,19 @@ pr:
 
 steps:
 
+- task: PowerShell@2
+  displayName: 'Create Yarn Cache Folder'
+  inputs:
+    targetType: 'inline'
+    script: |
+      $yarnCacheFolder = "$(YARN_CACHE_FOLDER)"
+      if (-not (Test-Path $yarnCacheFolder)) {
+        Write-Host "Creating Yarn cache folder at $yarnCacheFolder"
+        New-Item -ItemType Directory -Path $yarnCacheFolder -Force
+      } else {
+        Write-Host "Yarn cache folder already exists."
+      }
+
 - task: Cache@2
   displayName: Cache Yarn packages
   inputs:


### PR DESCRIPTION
This could cause confusion and users to accidently perform batch operations (like deletions) by accident on items they were not expecting to be selected.

Closes #5758
