### PR TITLE
Update component style helpers to set the stage for template content dev

### DIFF
--- a/DNN Platform/Skins/Aperture/src/scss/components/_backgrounds.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_backgrounds.scss
@@ -1,6 +1,6 @@
 // bg classes from current color scheme
 @each $color, $value in $colors {
-    .bg-#{$color}{
+    .aperture-bg-#{$color}{
         background-color: color($color) !important;
     }
 }

--- a/DNN Platform/Skins/Aperture/src/scss/components/_backgrounds.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_backgrounds.scss
@@ -1,6 +1,6 @@
 // bg classes from current color scheme
 @each $color, $value in $colors {
     .aperture-bg-#{$color}{
-        background-color: color($color) !important;
+        background-color: color($color);
     }
 }

--- a/DNN Platform/Skins/Aperture/src/scss/components/_borders.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_borders.scss
@@ -1,0 +1,6 @@
+// border classes from current color scheme
+@each $color, $value in $colors {
+    .aperture-border-#{$color} {
+        border-color: color($color) !important;
+    }
+}

--- a/DNN Platform/Skins/Aperture/src/scss/components/_borders.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_borders.scss
@@ -1,6 +1,6 @@
 // border classes from current color scheme
 @each $color, $value in $colors {
     .aperture-border-#{$color} {
-        border-color: color($color) !important;
+        border-color: color($color);
     }
 }

--- a/DNN Platform/Skins/Aperture/src/scss/components/_buttons.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_buttons.scss
@@ -1,15 +1,15 @@
 // button iterations for each color
 @each $color, $value in $colors {
-  .btn-#{$color} {
+  .aperture-btn-#{$color} {
     @include button-variant($color,.8);
   }
-  .btn-outline-#{$color} {
+  .aperture-btn-outline-#{$color} {
     @include button-outline-variant($color);
   }
-  .btn-reverse-outline-#{$color} {
+  .aperture-btn-reverse-outline-#{$color} {
     @include button-reverse-outline-variant($color);
   }
-  .btn-inverse-#{$color} {
+  .aperture-btn-inverse-#{$color} {
     @include button-inverse-variant($color,.9);
   }
 }

--- a/DNN Platform/Skins/Aperture/src/scss/components/_components.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_components.scss
@@ -1,7 +1,9 @@
 @import 'dnn';
 @import 'login';
 @import 'backgrounds';
+@import 'borders';
 @import 'buttons';
 @import 'helpers';
 @import 'nav';
 @import 'search';
+@import 'text';

--- a/DNN Platform/Skins/Aperture/src/scss/components/_dnn.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_dnn.scss
@@ -353,7 +353,7 @@ a.dnnPrimaryAction {
 .dnnPrimaryAction[disabled],
 .dnnPrimaryAction[disabled]:hover,
 .dnnPrimaryAction[disabled]:active {
-    @extend .aperture-btn-disabled !optional;
+    @extend .aperture-btn-neutral !optional;
 }
 
 /* Secondary Action */
@@ -420,7 +420,7 @@ a.dnnTertiaryAction {
 /* Re-set default cursor for disabled elements */
 .dnnFormItem button[disabled],
 .dnnFormItem input[disabled] {
-    @extend .aperture-btn-disabled !optional;
+    @extend .aperture-btn-neutral !optional;
 }
 
 

--- a/DNN Platform/Skins/Aperture/src/scss/components/_dnn.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_dnn.scss
@@ -347,13 +347,13 @@ ul.dnnAdminTabNav li a,
 .dnnPrimaryAction,
 .dnnFormItem input[type="submit"],
 a.dnnPrimaryAction {
-    @extend .btn-primary !optional;
+    @extend .aperture-btn-primary !optional;
 }
 
 .dnnPrimaryAction[disabled],
 .dnnPrimaryAction[disabled]:hover,
 .dnnPrimaryAction[disabled]:active {
-    @extend .btn-disabled !optional;
+    @extend .aperture-btn-disabled !optional;
 }
 
 /* Secondary Action */
@@ -364,7 +364,7 @@ a.dnnPrimaryAction {
 a.dnnSecondaryAction,
 ul.dnnAdminTabNav li a,
 .dnnLogin .LoginTabGroup span {
-    @extend .btn-secondary !optional;
+    @extend .aperture-btn-secondary !optional;
 }
 
 .dnnFormItem button:active,
@@ -394,7 +394,7 @@ span.dnnSecondaryAction>a.dnnSecondaryAction {
 /* Tertiary Action */
 .dnnTertiaryAction,
 a.dnnTertiaryAction {
-    @extend .btn-tertiary !optional;
+    @extend .aperture-btn-tertiary !optional;
 }
 
 /* Action Button behind input */
@@ -420,7 +420,7 @@ a.dnnTertiaryAction {
 /* Re-set default cursor for disabled elements */
 .dnnFormItem button[disabled],
 .dnnFormItem input[disabled] {
-    @extend .btn-disabled !optional;
+    @extend .aperture-btn-disabled !optional;
 }
 
 

--- a/DNN Platform/Skins/Aperture/src/scss/components/_helpers.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_helpers.scss
@@ -1,13 +1,3 @@
-// text classes from current color scheme
-@each $color, $value in $colors {
-    .text-#{$color} {
-        color: color($color) !important;
-    }
-    .border-#{$color} {
-        border-color: color($color) !important;
-    }
-}
-
 .dnn-d-none {
     display: none;
 }

--- a/DNN Platform/Skins/Aperture/src/scss/components/_text.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_text.scss
@@ -1,6 +1,6 @@
 // text classes from current color scheme
 @each $color, $value in $colors {
     .aperture-text-#{$color} {
-        color: color($color) !important;
+        color: color($color);
     }
 }

--- a/DNN Platform/Skins/Aperture/src/scss/components/_text.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_text.scss
@@ -1,0 +1,6 @@
+// text classes from current color scheme
+@each $color, $value in $colors {
+    .aperture-text-#{$color} {
+        color: color($color) !important;
+    }
+}


### PR DESCRIPTION
## Summary
This PR adjusts component style helpers to follow a unique naming system for the Aperture theme.  These styles will be utilized for content within the `Default`/`Blank` templates.

Example Background Classes
* aperture-bg-primary
* aperture-bg-secondary
* aperture-bg-tertiary
* aperture-bg-info
* _aperture-bg-****_

Example Border Classes
* aperture-border-primary
* aperture-border-secondary
* aperture-border-tertiary
* aperture-border-info
* _aperture-border-****_

Example Button Classes
* aperture-btn-primary
* aperture-btn-secondary
* aperture-btn-tertiary
* aperture-btn-info
* _aperture-btn-****_

Example Text Classes
* aperture-text-primary
* aperture-text-secondary
* aperture-text-tertiary
* aperture-text-info
* _aperture-text-****_
