### PR TITLE
DNN 10 Theme: Add title container (mainly for Resource Manager module use in templates)

### DIFF
--- a/DNN Platform/Skins/Aperture/containers/title.ascx
+++ b/DNN Platform/Skins/Aperture/containers/title.ascx
@@ -1,0 +1,6 @@
+<%@ Control AutoEventWireup="false" Explicit="True" Inherits="DotNetNuke.UI.Containers.Container" %>
+<%@ Register TagPrefix="dnn" TagName="TITLE" Src="~/Admin/Containers/Title.ascx" %>
+<div class="aperture-title-wrapper">
+    <h5><dnn:TITLE runat="server" id="apertureTitle" /></h5>
+    <div id="ContentPane" runat="server"></div>
+</div>

--- a/DNN Platform/Skins/Aperture/default.ascx
+++ b/DNN Platform/Skins/Aperture/default.ascx
@@ -8,7 +8,7 @@
   <!-- Main Content -->
   <main>
     <div id="BannerPane" runat="server"></div>
-    <div id="ContentPane" class="aperture-container" runat="server"></div> 
+    <div id="ContentPane" class="aperture-content-pane" runat="server"></div> 
     <div id="FluidPane" runat="server"></div>
   </main>
 

--- a/DNN Platform/Skins/Aperture/src/scss/components/_components.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_components.scss
@@ -1,4 +1,6 @@
 @import 'dnn';
+@import 'panes';
+@import 'containers';
 @import 'login';
 @import 'backgrounds';
 @import 'borders';

--- a/DNN Platform/Skins/Aperture/src/scss/components/_containers.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_containers.scss
@@ -1,0 +1,14 @@
+.aperture-title-wrapper {
+    margin-top: 1rem;
+    h5 {
+        margin-left: 2rem;
+    }
+}
+
+.aperture-content-pane {
+    .aperture-title-wrapper {
+        h5 {
+            margin-left: 0;
+        }
+    }
+}

--- a/DNN Platform/Skins/Aperture/src/scss/components/_panes.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/components/_panes.scss
@@ -1,0 +1,6 @@
+.aperture-content-pane {
+    margin: 0 auto;
+    padding: 0 2rem;
+    width: 100%;
+    max-width: 1280px;
+}


### PR DESCRIPTION
## Summary
This PR adds a `title` container to the `Aperture` theme.  It also makes an adjustment to styles for the `ContentPane` to ensure `display: block` instead of `display: flex`.