### PR TITLE
Aperture theme - refine various styles and utility classes

### DIFF
--- a/DNN Platform/Skins/Aperture/src/scss/_base.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/_base.scss
@@ -28,30 +28,37 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 {
   @include font-baseline(48, calc(48 * 1.15));
+  margin-bottom: 1rem;
 }
 
 h2 {
   @include font-baseline(48, calc(48 * 1.15));
+  margin-bottom: 1rem;
 }
 
 h3 {
   @include font-baseline(42, calc(42 * 1.15));
+  margin-bottom: 1rem;
 }
 
 h4 {
   @include font-baseline(36, calc(36 * 1.15));
+  margin-bottom: 1.5rem;
 }
 
 h5 {
   @include font-baseline(30, calc(30 * 1.15));
+  margin-bottom: 1.5rem;
 }
 
 h6 {
   @include font-baseline(24, calc(24 * 1.15));
+  margin-bottom: 1.5rem;
 }
 
 .lead {
   @include font-baseline(22, calc(22 * 1.5));
+  margin-bottom: 2rem;
 }
 
 p {

--- a/DNN Platform/Skins/Aperture/src/scss/utilities/_dividers.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/utilities/_dividers.scss
@@ -1,0 +1,9 @@
+.aperture-divider {
+    background-image: url(/portals/0/images/banner-bottom.png);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: 3rem;
+    object-fit: cover;
+    width:100%;
+}

--- a/DNN Platform/Skins/Aperture/src/scss/utilities/_flex.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/utilities/_flex.scss
@@ -29,61 +29,61 @@
 
 // Mixin for generating other flex properties
 // usage: @include flex-property('flex-wrap', 'flex-wrap', 'wrap');
-@mixin flex-property($property, $class, $value) {
+@mixin flex-property($property, $class-prefix, $class-suffix, $value) {
     @each $breakpoint, $min-width in $breakpoints {
         @media (min-width: $min-width) {
-            .aperture-#{$class}-#{$breakpoint} {
+            .aperture-#{$class-prefix}-#{$breakpoint}-#{$class-suffix} {
                 #{$property}: #{$value} !important;
             }
         }
     }
-    .aperture-#{$class} {
+    .aperture-#{$class-prefix}-#{$class-suffix} {
         #{$property}: #{$value};
     }
 }
 
 // Generate flex-wrap classes
-@include flex-property('flex-wrap', 'flex-wrap', 'wrap');
-@include flex-property('flex-wrap', 'flex-nowrap', 'nowrap');
-@include flex-property('flex-wrap', 'flex-wrap-reverse', 'wrap-reverse');
+@include flex-property('flex-wrap', 'flex', 'wrap', 'wrap');
+@include flex-property('flex-wrap', 'flex', 'nowrap', 'nowrap');
+@include flex-property('flex-wrap', 'flex-wrap', 'reverse', 'wrap-reverse');
 
 // Generate flex-grow classes
-@include flex-property('flex-grow', 'flex-grow-0', 0);
-@include flex-property('flex-grow', 'flex-grow-1', 1);
+@include flex-property('flex-grow', 'flex-grow', '0', 0);
+@include flex-property('flex-grow', 'flex-grow', '1', 1);
 
 // Generate flex-shrink classes
-@include flex-property('flex-shrink', 'flex-shrink-0', 0);
-@include flex-property('flex-shrink', 'flex-shrink-1', 1);
+@include flex-property('flex-shrink', 'flex-shrink', '0', 0);
+@include flex-property('flex-shrink', 'flex-shrink', '1', 1);
 
 // Generate flex-fill classes
-@include flex-property('flex', 'flex-fill', '1 1 auto');
+@include flex-property('flex', 'flex', 'fill', '1 1 auto');
 
 // Generate justify-content classes
-@include flex-property('justify-content', 'justify-content-start', 'flex-start');
-@include flex-property('justify-content', 'justify-content-end', 'flex-end');
-@include flex-property('justify-content', 'justify-content-center', 'center');
-@include flex-property('justify-content', 'justify-content-between', 'space-between');
-@include flex-property('justify-content', 'justify-content-around', 'space-around');
+@include flex-property('justify-content', 'justify-content', 'start', 'flex-start');
+@include flex-property('justify-content', 'justify-content', 'end', 'flex-end');
+@include flex-property('justify-content', 'justify-content', 'center', 'center');
+@include flex-property('justify-content', 'justify-content', 'between', 'space-between');
+@include flex-property('justify-content', 'justify-content', 'around', 'space-around');
 
 // Generate align-items classes
-@include flex-property('align-items', 'align-items-start', 'flex-start');
-@include flex-property('align-items', 'align-items-end', 'flex-end');
-@include flex-property('align-items', 'align-items-center', 'center');
-@include flex-property('align-items', 'align-items-baseline', 'baseline');
-@include flex-property('align-items', 'align-items-stretch', 'stretch');
+@include flex-property('align-items', 'align-items', 'start', 'flex-start');
+@include flex-property('align-items', 'align-items', 'end', 'flex-end');
+@include flex-property('align-items', 'align-items', 'center', 'center');
+@include flex-property('align-items', 'align-items', 'baseline', 'baseline');
+@include flex-property('align-items', 'align-items', 'stretch', 'stretch');
 
 // Generate align-content classes
-@include flex-property('align-content', 'align-content-start', 'flex-start');
-@include flex-property('align-content', 'align-content-end', 'flex-end');
-@include flex-property('align-content', 'align-content-center', 'center');
-@include flex-property('align-content', 'align-content-between', 'space-between');
-@include flex-property('align-content', 'align-content-around', 'space-around');
-@include flex-property('align-content', 'align-content-stretch', 'stretch');
+@include flex-property('align-content', 'align-content', 'start', 'flex-start');
+@include flex-property('align-content', 'align-content', 'end', 'flex-end');
+@include flex-property('align-content', 'align-content', 'center', 'center');
+@include flex-property('align-content', 'align-content', 'between', 'space-between');
+@include flex-property('align-content', 'align-content', 'around', 'space-around');
+@include flex-property('align-content', 'align-content', 'stretch', 'stretch');
 
 // Generate align-self classes
-@include flex-property('align-self', 'align-self-auto', 'auto');
-@include flex-property('align-self', 'align-self-start', 'flex-start');
-@include flex-property('align-self', 'align-self-end', 'flex-end');
-@include flex-property('align-self', 'align-self-center', 'center');
-@include flex-property('align-self', 'align-self-baseline', 'baseline');
-@include flex-property('align-self', 'align-self-stretch', 'stretch');
+@include flex-property('align-self', 'align-self', 'auto', 'auto');
+@include flex-property('align-self', 'align-self', 'start', 'flex-start');
+@include flex-property('align-self', 'align-self', 'end', 'flex-end');
+@include flex-property('align-self', 'align-self', 'center', 'center');
+@include flex-property('align-self', 'align-self', 'baseline', 'baseline');
+@include flex-property('align-self', 'align-self', 'stretch', 'stretch');

--- a/DNN Platform/Skins/Aperture/src/scss/utilities/_margin.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/utilities/_margin.scss
@@ -5,7 +5,8 @@ $margin-sizes: (
     2: 0.5rem,
     3: 1rem,
     4: 2.5rem,
-    5: 5rem
+    5: 5rem,
+    auto: auto
 );
 
 // Margin Mixin

--- a/DNN Platform/Skins/Aperture/src/scss/utilities/_utilities.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/utilities/_utilities.scss
@@ -4,6 +4,7 @@
 @import 'containers';
 @import 'dimension';
 @import 'display';
+@import 'dividers';
 @import 'flex';
 @import 'fonts';
 @import 'gap';

--- a/DNN Platform/Skins/Aperture/themeReleaseNotes.txt
+++ b/DNN Platform/Skins/Aperture/themeReleaseNotes.txt
@@ -1,12 +1,5 @@
 <h2>Aperture Theme</h2>
 <div><em>Default theme for DNN 10.</em></div>
-<div>&nbsp;</div>
-<h3>Release History</h3>
 <hr />
 <div>&nbsp;</div>
-<div>
-	<h4>Version 1.0.0</h4>
-	<ul>
-		<li style="margin-left:20px;">Initial Release</li>
-	</ul>
-</div>
+<div>Release notes are available on the <a href="https://github.com/dnnsoftware/Dnn.Platform" target="_blank">DNN Platform GitHub repo</a>.</div>


### PR DESCRIPTION
## Summary
This PR:
* Updates margins on base styles.
* Adds a utility class for `aperture-divider`.
* Resolves an issue with the `flex` utility class naming convention to bring it more in line with what people coming from Bootstrap would expect.
* Add support to `margin` utility classes for `auto`.
* Update release notes to remove version to avoid an ongoing maintenance nightmare.