### PR TITLE
Fix #5912: Resource Manger Context Menu Doesn't reposition after scroll.

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list-item/dnn-rm-folder-list-item.scss
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list-item/dnn-rm-folder-list-item.scss
@@ -3,6 +3,7 @@
   font-weight: normal;
   color: black;
   transition: all 300ms ease-in-out;
+  position: relative;
 }
 :host(.selected){
   .item-name{
@@ -22,7 +23,7 @@ button{
   cursor: pointer;
 }
 dnn-collapsible{
-  position: fixed;
+  position: absolute;
   display: none;
   border: 1px solid lightgray;
   box-shadow: 2px 2px 4px -2px;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list-item/dnn-rm-folder-list-item.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list-item/dnn-rm-folder-list-item.tsx
@@ -94,14 +94,17 @@ export class DnnRmFolderListItem {
 
   private handleContextMenu(e: MouseEvent): void {
     e.preventDefault();
+    this.dismissContextMenu();
+
     this.itemsClient.getFolderItem(Number.parseInt(this.folder.data.key))
     .then(item => {
       const collapsible = document.createElement("dnn-collapsible");
       const folderContextMenu = document.createElement("dnn-rm-folder-context-menu");
       collapsible.appendChild(folderContextMenu);
       folderContextMenu.item = item;
-      collapsible.style.left = `${e.pageX}px`;
-      collapsible.style.top = `${e.pageY}px`;
+      const parentPosition = this.el.getBoundingClientRect();
+      collapsible.style.left = `${e.clientX - parentPosition.left}px`;
+      collapsible.style.top = `${e.clientY - parentPosition.top}px`;
       collapsible.style.display = "block";
       this.el.shadowRoot.appendChild(collapsible);
       setTimeout(() => {

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.scss
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.scss
@@ -1,6 +1,7 @@
 :host {
   display: block;
   margin-left: 1em;
+  position: relative;
 }
 
 button{
@@ -12,7 +13,7 @@ button{
 }
 
 dnn-collapsible{
-  position: fixed;
+  position: absolute;
   display: none;
   border: 1px solid lightgray;
   box-shadow: 2px 2px 4px -2px;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
@@ -97,14 +97,17 @@ export class DnnRmFolderList {
 
   private handleContextMenu(e: MouseEvent): void {
     e.preventDefault();
+    this.dismissContextMenu();
+
     this.itemsClient.getFolderItem(state.settings.HomeFolderId)
     .then(item => {
       const collapsible = document.createElement("dnn-collapsible");
       const folderContextMenu = document.createElement("dnn-rm-folder-context-menu");
       collapsible.appendChild(folderContextMenu);
       folderContextMenu.item = item;
-      collapsible.style.left = `${e.pageX}px`;
-      collapsible.style.top = `${e.pageY}px`;
+      const parentPosition = this.el.getBoundingClientRect();
+      collapsible.style.left = `${e.clientX - parentPosition.left}px`;
+      collapsible.style.top = `${e.clientY - parentPosition.top}px`;
       collapsible.style.display = "block";
       this.el.shadowRoot.appendChild(collapsible);
       setTimeout(() => {


### PR DESCRIPTION
## Summary
Calculate the menu's position based on the parent element.