### PR TITLE
Improve API tokens

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Api/Auth/ApiTokens/ApiTokenController.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Auth/ApiTokens/ApiTokenController.cs
@@ -102,6 +102,11 @@ namespace DotNetNuke.Web.Api.Auth.ApiTokens
                 if (!res.ContainsKey(k))
                 {
                     var name = DotNetNuke.Services.Localization.Localization.GetString(attr.Key + ".Text", attr.ResourceFile, locale);
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        name = attr.Key;
+                    }
+
                     var description = DotNetNuke.Services.Localization.Localization.GetString(attr.Key + ".Help", attr.ResourceFile, locale);
                     res.Add(k, new ApiTokenAttribute((int)attr.Scope, key, name, description));
                 }

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/apiTokenSettings/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/apiTokenSettings/index.jsx
@@ -140,6 +140,7 @@ class ApiTokenSettingsPanelBody extends Component {
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
                                 value={state.apiTokenSettings.AllowApiTokens}
+                                readOnly={!state.apiTokenSettings.ApiTokensEnabled}
                                 onChange={this.onSettingChange.bind(this, "AllowApiTokens")}
                             />
                         </div>
@@ -161,7 +162,7 @@ class ApiTokenSettingsPanelBody extends Component {
                                 onSelect={(newVal) => {
                                     this.onSettingChange("MaximumSiteTimespan", newVal.value);
                                 }}
-                                enabled={true}
+                                enabled={state.apiTokenSettings.ApiTokensEnabled}
                             />
                         </InputGroup>
                     )}

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/apiTokens/CreateApiToken/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/apiTokens/CreateApiToken/index.jsx
@@ -13,11 +13,12 @@ class CreateApiToken extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            currentScope: 0,
+            currentScope: 2,
             apiTokenKeysFiltered: [],
             selectedKeys: [],
             selectedTimespan: props.timespanOptions.length > 0 ? props.timespanOptions[0].value : 0,
             tokenName: "",
+            scopeOptions: (props.apiTokenSettings && props.apiTokenSettings.AllowApiTokens) ? props.scopeOptions : props.scopeOptions.slice(2)
         };
         isHost = util.settings.isHost;
         isAdmin = util.settings.isAdmin;
@@ -66,7 +67,7 @@ class CreateApiToken extends Component {
                             <Dropdown
                                 value={this.state.currentScope}
                                 style={{ width: "100%" }}
-                                options={this.props.scopeOptions}
+                                options={this.state.scopeOptions}
                                 withBorder={false}
                                 onSelect={(value) => {
                                     this.setState({


### PR DESCRIPTION
During a Demo of the new DNN 10 API Tokens feature, a few things struck me that needed improvement:

- Fallback for when a resourcefile cannot be found so that API keys will show up with some text
- Do not show or allow users to create things when it's switched off

This PR addresses these issues