### PR TITLE
Removed hard-coded text for Terms and Privacy theme objects

### DIFF
--- a/DNN Platform/Skins/Aperture/partials/_footer.ascx
+++ b/DNN Platform/Skins/Aperture/partials/_footer.ascx
@@ -5,7 +5,7 @@
             <dnn:MENU id="menu_footer" CssClass="aperture-d-none aperture-d-md-block" MenuStyle="menus/footer" runat="server" NodeSelector="*,0,0"></dnn:MENU>
           </div>
           <div class="footer-terms-privacy">
-            <dnn:TERMS id="dnnTerms" Text="Terms" runat="server" CssClass="aperture-terms" /><dnn:PRIVACY id="dnnPrivacy" Text="Privacy" runat="server" />
+            <dnn:TERMS id="dnnTerms" runat="server" CssClass="aperture-terms" /><dnn:PRIVACY id="dnnPrivacy" runat="server" />
           </div>
           <div class="footer-copyright">
             <dnn:COPYRIGHT id="dnnCopyright" runat="server" />


### PR DESCRIPTION
## Summary
Resolves #5941 

These values were hard-coded before and not localized.  These should use the default localized values within DNN:

![image](https://github.com/dnnsoftware/Dnn.Platform/assets/4568451/80271bf6-9a10-4e1e-8c32-8b0ce0bc146e)

Using this `appSetting` in the `web.config` you can now see the values are localized.  Thanks again @valadas for showing me this!

```xml
  <appSettings>
    <add key="ShowMissingKeys" value="true" />
  </appSettings>
```

![image](https://github.com/dnnsoftware/Dnn.Platform/assets/4568451/b533e1be-dec4-41c1-a980-ede0cada4e6f)
