### PR TITLE
Fixed a serialization issue with PermissionInfo

### DIFF
--- a/DNN Platform/Library/Security/Permissions/PermissionInfo.cs
+++ b/DNN Platform/Library/Security/Permissions/PermissionInfo.cs
@@ -19,27 +19,32 @@ namespace DotNetNuke.Security.Permissions
     [Serializable]
     public class PermissionInfo : BaseEntityInfo, IPermissionDefinitionInfo
     {
-        /// <inheritdoc cref="IPermissionDefinitionInfo.ModuleDefId" />
+        private int moduleDefId;
+        private int permissionId;
+
+        /// <inheritdoc cref="ModuleDefId" />
         [XmlIgnore]
         [JsonIgnore]
-        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(IPermissionDefinitionInfo)}.{nameof(IPermissionDefinitionInfo.ModuleDefId)} instead. Scheduled for removal in v11.0.0.")]
+        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(ModuleDefId)} instead. Scheduled for removal in v11.0.0.")]
+        [CLSCompliant(false)]
         public int ModuleDefID
         {
-            get => ((IPermissionDefinitionInfo)this).ModuleDefId;
-            set => ((IPermissionDefinitionInfo)this).ModuleDefId = value;
+            get => this.moduleDefId;
+            set => this.moduleDefId = value;
         }
 
         /// <inheritdoc />
         [XmlElement("permissioncode")]
         public string PermissionCode { get; set; }
 
-        /// <inheritdoc cref="IPermissionDefinitionInfo.PermissionID" />
-        [XmlElement("permissionid")]
-        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(IPermissionDefinitionInfo)}.{nameof(IPermissionDefinitionInfo.PermissionId)} instead. Scheduled for removal in v11.0.0.")]
+        /// <inheritdoc cref="PermissionId" />
+        [XmlIgnore]
+        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(PermissionId)} instead. Scheduled for removal in v11.0.0.")]
+        [CLSCompliant(false)]
         public int PermissionID
         {
-            get => ((IPermissionDefinitionInfo)this).PermissionId;
-            set => ((IPermissionDefinitionInfo)this).PermissionId = value;
+            get => this.permissionId;
+            set => this.permissionId = value;
         }
 
         /// <inheritdoc />
@@ -54,12 +59,19 @@ namespace DotNetNuke.Security.Permissions
         /// <inheritdoc />
         [XmlIgnore]
         [JsonIgnore]
-        int IPermissionDefinitionInfo.ModuleDefId { get; set; }
+        public int ModuleDefId
+        {
+            get => this.moduleDefId;
+            set => this.moduleDefId = value;
+        }
 
         /// <inheritdoc />
-        [XmlIgnore]
-        [JsonIgnore]
-        int IPermissionDefinitionInfo.PermissionId { get; set; }
+        [XmlElement("permissionid")]
+        public int PermissionId
+        {
+            get => this.permissionId;
+            set => this.permissionId = value;
+        }
 
         /// <summary>FillInternal fills a PermissionInfo from a Data Reader.</summary>
         /// <param name="dr">The Data Reader to use.</param>
@@ -67,12 +79,11 @@ namespace DotNetNuke.Security.Permissions
         {
             base.FillInternal(dr);
 
-            var @this = (IPermissionDefinitionInfo)this;
-            @this.PermissionId = Null.SetNullInteger(dr["PermissionID"]);
-            @this.ModuleDefId = Null.SetNullInteger(dr["ModuleDefID"]);
-            @this.PermissionCode = Null.SetNullString(dr["PermissionCode"]);
-            @this.PermissionKey = Null.SetNullString(dr["PermissionKey"]);
-            @this.PermissionName = Null.SetNullString(dr["PermissionName"]);
+            this.permissionId = Null.SetNullInteger(dr["PermissionID"]);
+            this.moduleDefId = Null.SetNullInteger(dr["ModuleDefID"]);
+            this.PermissionCode = Null.SetNullString(dr["PermissionCode"]);
+            this.PermissionKey = Null.SetNullString(dr["PermissionKey"]);
+            this.PermissionName = Null.SetNullString(dr["PermissionName"]);
         }
     }
 }

--- a/DNN Platform/Library/Security/Permissions/PermissionInfoBase.cs
+++ b/DNN Platform/Library/Security/Permissions/PermissionInfoBase.cs
@@ -76,19 +76,20 @@ namespace DotNetNuke.Security.Permissions
             }
         }
 
-        /// <inheritdoc cref="IPermissionInfo.RoleId" />
-        [XmlElement("roleid")]
-        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(IPermissionInfo)}.{nameof(IPermissionInfo.RoleId)} instead. Scheduled for removal in v11.0.0.")]
+        /// <inheritdoc cref="RoleId" />
+        [XmlIgnore]
+        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(RoleId)} instead. Scheduled for removal in v11.0.0.")]
+        [CLSCompliant(false)]
         public int RoleID
         {
             get
             {
-                return ((IPermissionInfo)this).RoleId;
+                return this.roleId;
             }
 
             set
             {
-                ((IPermissionInfo)this).RoleId = value;
+                this.roleId = value;
             }
         }
 
@@ -107,19 +108,20 @@ namespace DotNetNuke.Security.Permissions
             }
         }
 
-        /// <inheritdoc cref="IPermissionInfo.UserId" />
-        [XmlElement("userid")]
-        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(IPermissionInfo)}.{nameof(IPermissionInfo.UserId)} instead. Scheduled for removal in v11.0.0.")]
+        /// <inheritdoc cref="UserId"/>
+        [XmlIgnore]
+        [Obsolete($"Deprecated in DotNetNuke 9.13.1. Use {nameof(UserId)} instead. Scheduled for removal in v11.0.0.")]
+        [CLSCompliant(false)]
         public int UserID
         {
             get
             {
-                return ((IPermissionInfo)this).UserId;
+                return this.userId;
             }
 
             set
             {
-                ((IPermissionInfo)this).UserId = value;
+                this.userId = value;
             }
         }
 
@@ -139,14 +141,16 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <inheritdoc />
-        int IPermissionInfo.RoleId
+        [XmlElement("roleid")]
+        public int RoleId
         {
             get => this.roleId;
             set => this.roleId = value;
         }
 
         /// <inheritdoc />
-        int IPermissionInfo.UserId
+        [XmlElement("userid")]
+        public int UserId
         {
             get => this.userId;
             set => this.userId = value;
@@ -159,22 +163,21 @@ namespace DotNetNuke.Security.Permissions
             // Call the base classes fill method to populate base class properties
             base.FillInternal(dr);
 
-            var @this = (IPermissionInfo)this;
-            @this.UserId = Null.SetNullInteger(dr["UserID"]);
-            @this.Username = Null.SetNullString(dr["Username"]);
-            @this.DisplayName = Null.SetNullString(dr["DisplayName"]);
-            if (@this.UserId == Null.NullInteger)
+            this.userId = Null.SetNullInteger(dr["UserID"]);
+            this.username = Null.SetNullString(dr["Username"]);
+            this.displayName = Null.SetNullString(dr["DisplayName"]);
+            if (this.userId == Null.NullInteger)
             {
-                @this.RoleId = Null.SetNullInteger(dr["RoleID"]);
-                @this.RoleName = Null.SetNullString(dr["RoleName"]);
+                this.roleId = Null.SetNullInteger(dr["RoleID"]);
+                this.roleName = Null.SetNullString(dr["RoleName"]);
             }
             else
             {
-                @this.RoleId = int.Parse(Globals.glbRoleNothing);
-                @this.RoleName = string.Empty;
+                this.roleId = int.Parse(Globals.glbRoleNothing);
+                this.roleName = string.Empty;
             }
 
-            @this.AllowAccess = Null.SetNullBoolean(dr["AllowAccess"]);
+            this.allowAccess = Null.SetNullBoolean(dr["AllowAccess"]);
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -209,6 +209,8 @@
     <Compile Include="Providers\Membership\MembershipProviderTests.cs" />
     <Compile Include="Providers\Permissions\PermissionTests.cs" />
     <Compile Include="RetryableActionTests.cs" />
+    <Compile Include="Security\Permissions\PermissionInfoBaseTests.cs" />
+    <Compile Include="Security\Permissions\PermissionInfoTests.cs" />
     <Compile Include="Security\Permissions\PermissionProviderTests.cs" />
     <Compile Include="Security\PortalSecurity\PortalSecurityTest.cs" />
     <Compile Include="Services\ClientCapability\FacebookRequestControllerTests.cs" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Permissions/PermissionInfoBaseTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Permissions/PermissionInfoBaseTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Security.Permissions
+{
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Security.Permissions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PermissionInfoBaseTests
+    {
+        [Test]
+        public void SerializesXMLProperly()
+        {
+            // Arrange
+            var derived = new DerivedPermissionInfo
+            {
+                AllowAccess = true,
+                DisplayName = "Test Name",
+                RoleID = 123,
+                RoleName = "Test Role",
+                UserID = 234,
+                Username = "Test User",
+            };
+
+            // Act
+            var xml = XmlUtils.Serialize(derived);
+
+            // Assert
+            Assert.IsNotNull(xml);
+            Assert.True(xml.Contains("allowaccess"));
+            Assert.True(xml.Contains("displayname"));
+            Assert.True(xml.Contains("roleid"));
+            Assert.True(xml.Contains("rolename"));
+            Assert.True(xml.Contains("userid"));
+            Assert.True(xml.Contains("username"));
+        }
+    }
+
+    public class DerivedPermissionInfo : PermissionInfoBase
+    {
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Permissions/PermissionInfoTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Permissions/PermissionInfoTests.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Security.Permissions
+{
+    using System;
+    using System.IO;
+    using System.Text;
+
+    using DotNetNuke.Abstractions.Security.Permissions;
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Security.Permissions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PermissionInfoTests
+    {
+        [Test]
+        public void SerializesJson_IncluddingObsoleteProperties()
+        {
+            // Arrange
+            var permissionInfo = new PermissionInfo
+            {
+                ModuleDefID = 123,
+                PermissionCode = "test",
+                PermissionID = 456,
+                PermissionKey = "testKey",
+                PermissionName = "testName",
+            };
+
+            // Act
+            var json = Json.Serialize(permissionInfo);
+
+            // Assert
+            Assert.NotNull(json);
+            Assert.False(json.Contains(nameof(permissionInfo.ModuleDefId)));
+            Assert.True(json.Contains(nameof(permissionInfo.PermissionCode)));
+            Assert.True(json.Contains(nameof(permissionInfo.PermissionID))); // old obsolete casing.
+            Assert.True(json.Contains(nameof(permissionInfo.PermissionId))); // new casing.
+            Assert.True(json.Contains(nameof(permissionInfo.PermissionKey)));
+            Assert.False(json.Contains(nameof(permissionInfo.PermissionName)));
+        }
+
+        [Test]
+        public void DeserializesJson_Properly()
+        {
+            // Arrange
+            var json = "{\"PermissionCode\":\"test\",\"PermissionID\":456,\"PermissionKey\":\"testKey\"}";
+
+            // Act
+            var permissionInfo = Json.Deserialize<PermissionInfo>(json);
+
+            // Assert
+            Assert.NotNull(permissionInfo);
+            Assert.AreEqual("test", permissionInfo.PermissionCode);
+            Assert.AreEqual(456, permissionInfo.PermissionID);
+            Assert.AreEqual(456, ((IPermissionDefinitionInfo)permissionInfo).PermissionId);
+            Assert.AreEqual("testKey", permissionInfo.PermissionKey);
+        }
+
+        [Test]
+        public void SerializesXml_IncludesObsoleteProperties()
+        {
+            // Arrange
+            var permissionInfo = new PermissionInfo
+            {
+                ModuleDefID = 123,
+                PermissionCode = "test",
+                PermissionID = 456,
+                PermissionKey = "testKey",
+                PermissionName = "testName",
+            };
+            // Act
+            var xml = XmlUtils.Serialize(permissionInfo);
+
+            // Assert
+            Assert.NotNull(xml);
+            Assert.False(xml.IndexOf("moduledefid", StringComparison.OrdinalIgnoreCase) >= 0);
+            Assert.True(xml.Contains("permissioncode"));
+            Assert.True(xml.Contains("permissionid"));
+            Assert.True(xml.Contains("permissionkey"));
+            Assert.False(xml.IndexOf("permissionname", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        [Test]
+        public void Deserializes_Properly()
+        {
+            // Arrange
+            var xml = "<PermissionInfo><permissioncode>test</permissioncode><permissionid>456</permissionid><permissionkey>testKey</permissionkey></PermissionInfo>";
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream, Encoding.UTF8);
+            writer.Write(xml);
+            writer.Flush();
+            stream.Position = 0;
+
+            // Act
+            var permissionInfo = (PermissionInfo)XmlUtils.Deserialize(stream, typeof(PermissionInfo));
+
+            // Assert
+            Assert.NotNull(permissionInfo);
+            Assert.AreEqual("test", permissionInfo.PermissionCode);
+            Assert.AreEqual(456, permissionInfo.PermissionID);
+            Assert.AreEqual(456, ((IPermissionDefinitionInfo)permissionInfo).PermissionId);
+            Assert.AreEqual("testKey", permissionInfo.PermissionKey);
+        }
+    }
+}


### PR DESCRIPTION
This is a work in progress

This way appears to work for serializing as before the changes in #5841

But now I am bumping into an installation issue where Activator.CreateInstance inside CBO.CreateObject inside DTO.FillCollection (don't quote me on the exacts here) but it returns a null instead of an instance which causes this error during installation:

```
1/29/2024 07:12:44 [ERROR] DotNetNuke.Services.Upgrade.Upgrade Error: Value cannot be null.
Parameter name: source   at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
   at DotNetNuke.Security.Permissions.PermissionController.GetPermissionByCodeAndKeyEnumerable(String permissionCode, String permissionKey) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Security\Permissions\PermissionController.cs:line 306
   at DotNetNuke.Security.Permissions.PermissionController.GetPermissionByCodeAndKey(String permissionCode, String permissionKey) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Security\Permissions\PermissionController.cs:line 137
   at DotNetNuke.Entities.Modules.ModuleController.InitialModulePermission(ModuleInfo module, Int32 tabId, Int32 permissionType) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Entities\Modules\ModuleController.cs:line 1138
   at DotNetNuke.Services.Upgrade.Upgrade.AddModuleToPage(TabInfo page, Int32 moduleDefId, String moduleTitle, String moduleIconFile, Boolean inheritPermissions, Boolean displayTitle, String paneName) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Services\Upgrade\Upgrade.cs:line 290
   at DotNetNuke.Services.Upgrade.Upgrade.AddModuleToPage(TabInfo page, Int32 moduleDefId, String moduleTitle, String moduleIconFile, Boolean inheritPermissions) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Services\Upgrade\Upgrade.cs:line 242
   at DotNetNuke.Services.Upgrade.Upgrade.AddModuleToPage(TabInfo page, Int32 moduleDefId, String moduleTitle, String moduleIconFile) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Services\Upgrade\Upgrade.cs:line 2248
   at DotNetNuke.Services.Upgrade.Upgrade.UpgradeToVersion920() in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Services\Upgrade\Upgrade.cs:line 2750
   at DotNetNuke.Services.Upgrade.Upgrade.UpgradeApplication(String providerPath, Version version, Boolean writeFeedback) in C:\dnnvaladas\Dnn.Platform\DNN Platform\Library\Services\Upgrade\Upgrade.cs:line 1394
```

I am creating this WIP PR to probe your minds about some sort of pattern for the furue ID renamings for Id (which will happen in may other places" I'd like to see what people think about simply having both casisings during the deprecation phase and bypassing the CLSCompliance on only the wrong one.

I also needed some code to be here to refer to it in comments of other issues :)