### PR TITLE
Fixed a performance issue while navigating folders for providers

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -23,6 +23,7 @@ namespace DotNetNuke.Services.FileSystem
     using DotNetNuke.ComponentModel;
     using DotNetNuke.Data;
     using DotNetNuke.Entities;
+    using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Instrumentation;
@@ -945,7 +946,10 @@ namespace DotNetNuke.Services.FileSystem
             {
                 var folderProvider = FolderProvider.Instance(folderMapping.FolderProviderType);
 
-                if (folderMapping.MappingName != "Standard" && folderMapping.MappingName != "Secure" && folderMapping.MappingName != "Database")
+                if (folderMapping.MappingName != "Standard" &&
+                    folderMapping.MappingName != "Secure" &&
+                    folderMapping.MappingName != "Database" &&
+                    Host.EnableFileAutoSync)
                 {
                     var type = folderProvider.GetType();
                     MethodInfo method = type.GetMethod("ClearCache");


### PR DESCRIPTION
When navigating folders using a Folder Provider, this code would refresh the whole provider even though we are not making changes.

This PR avoids doing so if EnableFileAutoSync is off, thus improving navigation performance. Users can use the Refresh button to do so manually as needed instead.

This is related to #5969 but does not solve it completely, it improves the navigation of folders experience but there is still the performance issue uploading.
