### PR TITLE
Fix #6004: get role for current site

### DIFF
--- a/DNN Platform/Library/Entities/Users/UserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/UserInfo.cs
@@ -230,6 +230,7 @@ namespace DotNetNuke.Entities.Users
 
             set
             {
+                this.roles = value;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dnnsoftware/Dnn.Platform/issues/6004

## Summary
Role is now updated when user moves from one portal to another.

## Test
[DEMO - Site_Role_Test]( https://drive.google.com/file/d/1b3WyisKtB8KYw3Hh4bsoTk3Ws_UaYh_-/view?usp=sharing)

### Test 1
Created two sites [portal1](http://engage-9-13-3-184-308.qa.evoqondemand.com/portal1/) and [portal2](http://engage-9-13-3-184-308.qa.evoqondemand.com/portal2/):
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/7d589174-c1e1-4686-875d-3543c3e667e5)

Created a new user as `user1`
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/2f479385-0cfb-421a-98a5-186d30c7f895)

`Content Editor` permission granted to `user1` in `portal1` as below:
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/a9841f51-41a8-4850-bd41-3c4139779fbd)

`Content Editor` permission `NOT` granted to `user1` in `portal2` as below:
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/52debb8c-f458-4c50-8b3a-0ce8e5541b21)

Logged in to `portal1` as `user1` and can see edit option:
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/6b8d88b3-d975-4800-b619-e775c39794e5)

Logged in to `portal2` as `user1` (using active session from portal1) and `NO` edit option:
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/0aa8c598-8f42-41d4-b14d-8df3c93ac0dd)

THIS IS WORKING AS EXPECTED !!!!

### Test 2
Did a new/fresh login in to `portal2` as `user1` and `NO` edit option:
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/0aa8c598-8f42-41d4-b14d-8df3c93ac0dd)

Logged in to `portal1` as `user1` (using active session from portal2) and and can see edit option:
![image](https://github.com/trilogy-group/eng-maintenance/assets/38633444/6b8d88b3-d975-4800-b619-e775c39794e5)

THIS IS WORKING AS EXPECTED !!!!