### PR TITLE
Use Cake Frosting optimized addins

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="Cake.BuildSystems.Module" Version="7.0.0" />
     <PackageReference Include="Cake.FileHelpers" Version="7.0.0" />
     <PackageReference Include="Cake.Frosting" Version="4.0.0" />
-    <PackageReference Include="Cake.Git" Version="3.0.0" />
-    <PackageReference Include="Cake.Issues" Version="4.1.0" />
-    <PackageReference Include="Cake.Issues.MsBuild" Version="4.1.0" />
+    <PackageReference Include="Cake.Frosting.Git" Version="4.0.0" />
+    <PackageReference Include="Cake.Issues" Version="4.3.0" />
+    <PackageReference Include="Cake.Frosting.Issues.MsBuild" Version="4.3.0" />
     <PackageReference Include="Cake.Json" Version="7.0.1" />
     <PackageReference Include="Cake.XdtTransform" Version="2.0.0" />
     <PackageReference Include="Dnn.CakeUtils" Version="2.0.2" />


### PR DESCRIPTION
## Summary
Updates build to make use of addins optimized to be used with Cake Frosting. Compared to the previously used addins, these addins contain NuGet dependencies instead of shipping them as part of the package. 

In case of Cake.Git this fixes some issues with native LibGit2Sharp DLLs. Beside that it gives you control about the version of dependencies which should be used in your build, which can be useful for example for Cake.Issues.MsBuild and MsBuild.StructuredLogger if a newer binlog version should be supported and Cake.Issues.MsBuild is not available yet.

Also updates addins to latest version. For Cake.Git to a version which support Cake Frosting 4.x, and for Cake Issues addins to the latest versions, which also brings support for binlog format version 20.