### PR TITLE
Fix #5994: Sorting (A-Z) members of roles in PersonaBar

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/RolesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/RolesController.cs
@@ -246,7 +246,7 @@ namespace Dnn.PersonaBar.Roles.Services
                         Localization.GetString("InvalidRequest", Components.Constants.LocalResourcesFile));
                 }
 
-                var users = RoleController.Instance.GetUserRoles(this.PortalId, Null.NullString, role.RoleName);
+                var users = RoleController.Instance.GetUserRoles(this.PortalId, Null.NullString, role.RoleName).ToList();
                 if (!string.IsNullOrEmpty(keyword))
                 {
                     users =
@@ -257,7 +257,7 @@ namespace Dnn.PersonaBar.Roles.Services
                 var totalRecords = users.Count;
                 var startIndex = pageIndex * pageSize;
                 var portal = PortalController.Instance.GetPortal(this.PortalId);
-                var pagedData = users.Skip(startIndex).Take(pageSize).Select(u => new UserRoleDto()
+                var pagedData = users.OrderBy(x => x.FullName).Skip(startIndex).Take(pageSize).Select(u => new UserRoleDto()
                 {
                     UserId = u.UserID,
                     RoleId = u.RoleID,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/RolesController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/RolesController.cs
@@ -246,7 +246,7 @@ namespace Dnn.PersonaBar.Roles.Services
                         Localization.GetString("InvalidRequest", Components.Constants.LocalResourcesFile));
                 }
 
-                var users = RoleController.Instance.GetUserRoles(this.PortalId, Null.NullString, role.RoleName).ToList();
+                var users = RoleController.Instance.GetUserRoles(this.PortalId, Null.NullString, role.RoleName);
                 if (!string.IsNullOrEmpty(keyword))
                 {
                     users =


### PR DESCRIPTION
Fix #5994: Sorting (A-Z) members of roles in PersonaBar
