### PR TITLE
Add module id information.

### DIFF
--- a/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.js
+++ b/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.js
@@ -313,7 +313,7 @@
             if (!rootText || rootText.length == 0) {
                 return;                
             }
-            root.append("<li class=\"" + rootClass + "\"><div>" + rootText + "</div>");
+            root.append("<li class=\"" + rootClass + "\"><div>" + moduleId + ":" + rootText + "</div>");
         }
 
         function buildQuickSettings(root, rootText, rootClass, rootIcon) {

--- a/DNN Platform/Website/admin/Modules/App_LocalResources/ModuleSettings.ascx.resx
+++ b/DNN Platform/Website/admin/Modules/App_LocalResources/ModuleSettings.ascx.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -399,5 +399,11 @@
   </data>
   <data name="MonikerExists.Text" xml:space="preserve">
     <value>The new value of the moniker already exists; it must be unique in the portal.</value>
+  </data>
+  <data name="plModuleId.Help" xml:space="preserve">
+    <value>Displays the id of the module.</value>
+  </data>
+  <data name="plModuleId.Text" xml:space="preserve">
+    <value>Module Id</value>
   </data>
 </root>

--- a/DNN Platform/Website/admin/Modules/Modulesettings.ascx
+++ b/DNN Platform/Website/admin/Modules/Modulesettings.ascx
@@ -23,6 +23,10 @@
         <div class="msmsContent dnnClear">
             <h2 id="dnnPanel-ModuleGeneralDetails" class="dnnFormSectionHead"><a href="" class="dnnSectionExpanded"><%=LocalizeString("GeneralDetails")%></a></h2>
             <fieldset>
+                <div class="dnnFormItem">
+                    <dnn:label id="plModuleId" runat="server" controlname="ltModuleId" />
+                    <span><asp:Literal ID="ltModuleId" runat="server"></asp:Literal></span>
+                </div>
                 <div class="dnnFormItem" id="cultureRow" runat="server">
                     <dnn:label id="cultureLabel" runat="server" controlname="cultureLanguageLabel" />
                     <dnnweb:dnnlanguagelabel id="cultureLanguageLabel" runat="server" />

--- a/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
@@ -612,6 +612,7 @@ namespace DotNetNuke.Modules.Admin.Modules
                     this.dgPermissions.InheritViewPermissionsFromTab = this.Module.InheritViewPermissions;
                 }
 
+                this.ltModuleId.Text = this.module.ModuleID.ToString();
                 this.txtFriendlyName.Text = this.Module.DesktopModule.FriendlyName;
                 this.txtTitle.Text = this.Module.ModuleTitle;
                 this.ctlIcon.Url = this.Module.IconFile;

--- a/DNN Platform/Website/admin/Modules/Modulesettings.ascx.designer.cs
+++ b/DNN Platform/Website/admin/Modules/Modulesettings.ascx.designer.cs
@@ -27,6 +27,18 @@ namespace DotNetNuke.Modules.Admin.Modules {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HyperLink hlSpecificSettings;
+        /// <summary>plModuleId control.</summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::DotNetNuke.UI.UserControls.LabelControl plModuleId;
+        /// <summary>ltModuleId control.</summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Literal ltModuleId;
         /// <summary>cultureRow control.</summary>
         /// <remarks>
         /// Auto-generated field.


### PR DESCRIPTION
This PR add module id information to module settings and module label.

Sometimes, module id information is needed to add an as an anchor link, or simply to locate this module.

This code add a new row in module settings to show a label and a text with module id.

<img width="367" alt="Captura de pantalla 2024-05-24 a la(s) 6 27 20 a  m" src="https://github.com/dnnsoftware/Dnn.Platform/assets/1165122/18ccc7ff-3336-44b4-8c06-7bb30fc721e5">

Additionally module id was added in module actions script, to show it next to de module label.

<img width="211" alt="Captura de pantalla 2024-05-24 a la(s) 6 23 55 a  m" src="https://github.com/dnnsoftware/Dnn.Platform/assets/1165122/d5776563-31db-4aa1-9f11-b1c057edb80f">

I hope this code can be helpful for the platform.

Sorry if im skipping something for the PR, but is my first time pushing code for the solution.