### PR TITLE
Update Cake-Issues Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,7 @@ updates:
       Cake-Issues:
         patterns:
           - "Cake.Issues*"
+          - "Cake.Frosting.Issues*"
       DependencyInjection:
         patterns:
           - "Microsoft.Extensions.DependencyInjection*"


### PR DESCRIPTION
## Summary
Dependabot opened #6064 and #6065, which are both updates to Cake Issues packages, and should be grouped together. This PR updates the Cake-Issues Dependabot group to include the Cake.Frosting.Issues packages.