### PR TITLE
DNNImageHandler - Add Option to prevent URL text from appearing as co…

### DIFF
--- a/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/DnnImageHandler.cs
@@ -17,6 +17,7 @@ namespace DotNetNuke.Services.GeneratedImage
     using System.Web;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.GeneratedImage.FilterTransform;
@@ -177,7 +178,12 @@ namespace DotNetNuke.Services.GeneratedImage
 
                         if (!string.IsNullOrEmpty(parameters["Text"]))
                         {
-                            placeHolderTrans.Text = text;
+                            bool dnnImagePlaceholder;
+                            bool.TryParse(Config.GetSetting("DnnImagePlaceholder"), out dnnImagePlaceholder);
+                            if (dnnImagePlaceholder)
+                            {
+                                placeHolderTrans.Text = text;
+                            }
                         }
 
                         if (!string.IsNullOrEmpty(parameters["BackColor"]))


### PR DESCRIPTION


Fixes: https://github.com/dnnsoftware/Dnn.Platform/security/advisories/GHSA-2rrc-g594-rhqw


## Summary
The code change adds a security feature to prevent public URL adding content to the Page.
The DnnImageThumbnailer has been changed to stop it accepting a URL parameter to display text onto the content of the page.
By default the text parameter will not be allowed.  An additional setting in the web.config can be added to allow the original functionality. 

In the web.config a settings in "configuration/appSettings" can be created.

<!-- DnnImagePlaceholder controls URL text option in the DnnImageHandler.ashx -->
 <add key="DnnImagePlaceholder" value="false" />	

### Values 
true = Text allowed.
false = Text not allowed to be displayed.
<not in web.config> = Text not allowed to be displayed.

By default the settings should be set to false or not included in the web.config.