### PR TITLE
Fix build Project file does not exist.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,2 @@
-dotnet run --project build/Build.csproj -- $args
+dotnet run --project Build/Build.csproj -- $args
 exit $LASTEXITCODE;

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-dotnet run --project ./build/Build.csproj -- "$@"
+dotnet run --project ./Build/Build.csproj -- "$@"


### PR DESCRIPTION
Fix
MSBUILD : error MSB1009: Project file does not exist.
Switch: ./build/Build.csproj

