### PR TITLE
Add sorting functionality to recycle bin items

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Recyclebin/IRecyclebinController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Recyclebin/IRecyclebinController.cs
@@ -36,10 +36,10 @@ namespace Dnn.PersonaBar.Recyclebin.Components
 
         bool RestoreUser(UserInfo user, out string resultmessage);
 
-        List<TabInfo> GetDeletedTabs(out int totalRecords, int pageIndex = -1, int pageSize = -1);
+        List<TabInfo> GetDeletedTabs(out int totalRecords, int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "");
 
-        List<ModuleInfo> GetDeletedModules(out int totalRecords, int pageIndex = -1, int pageSize = -1);
+        List<ModuleInfo> GetDeletedModules(out int totalRecords, int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "");
 
-        List<UserInfo> GetDeletedUsers(out int totalRecords, int pageIndex = -1, int pageSize = -1);
+        List<UserInfo> GetDeletedUsers(out int totalRecords, int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "");
     }
 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Recyclebin/RecyclebinController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Recyclebin/RecyclebinController.cs
@@ -214,24 +214,49 @@ namespace Dnn.PersonaBar.Recyclebin.Components
         }
 
         /// <inheritdoc/>
-        public List<TabInfo> GetDeletedTabs(out int totalRecords, int pageIndex = -1, int pageSize = -1)
+        public List<TabInfo> GetDeletedTabs(out int totalRecords, int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "")
         {
             var adminTabId = PortalSettings.AdminTabId;
             var tabs = TabController.GetPortalTabs(PortalSettings.PortalId, adminTabId, true, true, true, true);
             var deletedtabs =
                 tabs.Where(t => t.ParentId != adminTabId && t.IsDeleted && TabPermissionController.CanDeletePage(t));
+            if (sortType == "tab")
+            {
+                deletedtabs = sortDirection == "asc" ? deletedtabs = deletedtabs.OrderBy(tab => tab.TabName) : deletedtabs = deletedtabs.OrderByDescending(tab => tab.TabName);
+            }
+
+            if (sortType == "date")
+            {
+                deletedtabs = sortDirection == "asc" ? deletedtabs = deletedtabs.OrderBy(tab => tab.LastModifiedOnDate) : deletedtabs = deletedtabs.OrderByDescending(tab => tab.LastModifiedOnDate);
+            }
+
             totalRecords = deletedtabs.Count();
             return pageIndex == -1 || pageSize == -1 ? deletedtabs.ToList() : deletedtabs.Skip(pageIndex * pageSize).Take(pageSize).ToList();
         }
 
         /// <inheritdoc/>
-        public List<ModuleInfo> GetDeletedModules(out int totalRecords, int pageIndex = -1, int pageSize = -1)
+        public List<ModuleInfo> GetDeletedModules(out int totalRecords, int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "")
         {
             var deletedModules = this.moduleController.GetModules(PortalSettings.PortalId)
                 .Cast<ModuleInfo>()
                 .Where(module => module.IsDeleted && (
                     TabPermissionController.CanAddContentToPage(TabController.Instance.GetTab(module.TabID, module.PortalID)) ||
                     ModulePermissionController.CanDeleteModule(module)));
+            if (sortType == "title")
+            {
+                deletedModules = sortDirection == "asc" ? deletedModules = deletedModules.OrderBy(module => module.ModuleTitle) : deletedModules = deletedModules.OrderByDescending(module => module.ModuleTitle);
+            }
+
+            if (sortType == "tab")
+            {
+                deletedModules = sortDirection == "asc" ? deletedModules = deletedModules.OrderBy(module => module.ParentTab.TabName) : deletedModules = deletedModules.OrderByDescending(module => module.ParentTab.TabName);
+            }
+
+            if (sortType == "date")
+            {
+                deletedModules = sortDirection == "asc" ? deletedModules = deletedModules.OrderBy(module => module.LastModifiedOnDate) : deletedModules = deletedModules.OrderByDescending(module => module.LastModifiedOnDate);
+            }
+
             totalRecords = deletedModules.Count();
             return pageIndex == -1 || pageSize == -1 ? deletedModules.ToList() : deletedModules.Skip(pageIndex * pageSize).Take(pageSize).ToList();
         }
@@ -248,9 +273,24 @@ namespace Dnn.PersonaBar.Recyclebin.Components
         }
 
         /// <inheritdoc/>
-        public List<UserInfo> GetDeletedUsers(out int totalRecords, int pageIndex = -1, int pageSize = -1)
+        public List<UserInfo> GetDeletedUsers(out int totalRecords, int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "")
         {
             var deletedusers = UserController.GetDeletedUsers(PortalSettings.PortalId).Cast<UserInfo>().Where(this.CanManageUser);
+            if (sortType == "username")
+            {
+                deletedusers = sortDirection == "asc" ? deletedusers = deletedusers.OrderBy(user => user.Username) : deletedusers = deletedusers.OrderByDescending(user => user.Username);
+            }
+
+            if (sortType == "displayname")
+            {
+                deletedusers = sortDirection == "asc" ? deletedusers = deletedusers.OrderBy(user => user.DisplayName) : deletedusers = deletedusers.OrderByDescending(user => user.DisplayName);
+            }
+
+            if (sortType == "date")
+            {
+                deletedusers = sortDirection == "asc" ? deletedusers = deletedusers.OrderBy(user => user.LastModifiedOnDate) : deletedusers = deletedusers.OrderByDescending(user => user.LastModifiedOnDate);
+            }
+
             totalRecords = deletedusers.Count();
             return pageIndex == -1 || pageSize == -1 ? deletedusers.ToList() : deletedusers.Skip(pageIndex * pageSize).Take(pageSize).ToList();
         }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/RecyclebinController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/RecyclebinController.cs
@@ -34,10 +34,10 @@ namespace Dnn.PersonaBar.Recyclebin.Services
         [HttpGet]
         [AdvancedPermission(MenuName = Components.Constants.MenuName, Permission = Components.Constants.RecycleBinPagesView)]
 
-        public HttpResponseMessage GetDeletedPageList(int pageIndex = -1, int pageSize = -1)
+        public HttpResponseMessage GetDeletedPageList(int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "")
         {
             var totalRecords = 0;
-            var tabs = Components.RecyclebinController.Instance.GetDeletedTabs(out totalRecords, pageIndex, pageSize);
+            var tabs = Components.RecyclebinController.Instance.GetDeletedTabs(out totalRecords, pageIndex, pageSize, sortType, sortDirection);
             var deletedtabs = from t in tabs
                               select this.ConvertToPageItem(t, tabs);
             var response = new
@@ -52,10 +52,10 @@ namespace Dnn.PersonaBar.Recyclebin.Services
         [HttpGet]
         [AdvancedPermission(MenuName = Components.Constants.MenuName, Permission = Components.Constants.RecycleBinModulesView)]
 
-        public HttpResponseMessage GetDeletedModuleList(int pageIndex = -1, int pageSize = -1)
+        public HttpResponseMessage GetDeletedModuleList(int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "")
         {
             var totalRecords = 0;
-            var mods = Components.RecyclebinController.Instance.GetDeletedModules(out totalRecords, pageIndex, pageSize);
+            var mods = Components.RecyclebinController.Instance.GetDeletedModules(out totalRecords, pageIndex, pageSize, sortType, sortDirection);
             var deletedmodules = from t in mods select this.ConvertToModuleItem(t);
             var response = new
             {
@@ -69,10 +69,10 @@ namespace Dnn.PersonaBar.Recyclebin.Services
         [HttpGet]
         [AdvancedPermission(MenuName = Components.Constants.MenuName, Permission = Components.Constants.RecycleBinUsersView)]
 
-        public HttpResponseMessage GetDeletedUserList(int pageIndex = -1, int pageSize = -1)
+        public HttpResponseMessage GetDeletedUserList(int pageIndex = -1, int pageSize = -1, string sortType = "", string sortDirection = "")
         {
             var totalRecords = 0;
-            var users = Components.RecyclebinController.Instance.GetDeletedUsers(out totalRecords, pageIndex, pageSize);
+            var users = Components.RecyclebinController.Instance.GetDeletedUsers(out totalRecords, pageIndex, pageSize, sortType, sortDirection);
             var deletedusers = from t in users select this.ConvertToUserItem(t);
             var response = new
             {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Recyclebin/App_LocalResources/Recyclebin.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Recyclebin/App_LocalResources/Recyclebin.resx
@@ -133,7 +133,7 @@
     <value>Yes</value>
   </data>
   <data name="recyclebin_DeletedDate.Text" xml:space="preserve">
-    <value>Date</value>
+    <value>Deletion Date</value>
   </data>
   <data name="recyclebin_EmptyRecycleBin.Text" xml:space="preserve">
     <value>Empty Recycle Bin</value>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Recyclebin/Recyclebin.html
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Recyclebin/Recyclebin.html
@@ -32,8 +32,8 @@
             <table class="dnnRBGrid">
                 <tr class="dnnRBGridHeader">
                     <td class="first" data-bind="visible:settings.canViewPages && settings.canManagePages"><input type="checkbox" class="page-item" data-bind="checked: selectAllPages" aria-label="Check" /></td>
-                    <td class="thumbnail pagename" data-bind="html: $root.resx.recyclebin_Page"></td>
-                    <td class="deleteddate" data-bind="html: $root.resx.recyclebin_DeletedDate"></td>
+                    <td class="thumbnail pagename" data-bind="html: $root.resx.recyclebin_Page, click: sortDirection() == 'asc' ? sortBy.bind($data,'pages', 'tab', 'desc') : sortBy.bind($data,'pages', 'tab', 'asc')"></td>
+                    <td class="deleteddate" data-bind="html: $root.resx.recyclebin_DeletedDate, click: sortDirection() == 'asc' ? sortBy.bind($data,'pages', 'date', 'desc') : sortBy.bind($data,'pages', 'date', 'asc')"></td>
                     <td class="actions" data-bind="visible:settings.canViewPages && settings.canManagePages, html: $root.resx.recyclebin_Actions"></td>
                 </tr>
                 <tbody class="pages-list-container" data-bind="template: { name: 'pages-list-recyclebin', foreach: deletedpagesList }"></tbody>
@@ -54,9 +54,9 @@
             <table class="dnnRBGrid">
                 <tr class="dnnRBGridHeader">
                     <td class="first" data-bind="visible:settings.canViewModules && settings.canManageModules"><input type="checkbox" class="page-item" data-bind="checked: selectAllModules" aria-label="Check" /></td>
-                    <td class="mtitle" data-bind="html: $root.resx.recyclebin_ModuleTitle"></td>
-                    <td class="mpage" data-bind="html: $root.resx.recyclebin_Page"></td>
-                    <td class="deleteddate" data-bind="html: $root.resx.recyclebin_DeletedDate"></td>
+                    <td class="mtitle" data-bind="html: $root.resx.recyclebin_ModuleTitle, click: sortDirection() == 'asc' ? sortBy.bind($data,'modules', 'title', 'desc') : sortBy.bind($data,'modules', 'title', 'asc')"></td>
+                    <td class="mpage" data-bind="html: $root.resx.recyclebin_Page, click: sortDirection() == 'asc' ? sortBy.bind($data,'modules', 'tab', 'desc') : sortBy.bind($data,'modules', 'tab', 'asc')"></td>
+                    <td class="deleteddate" data-bind="html: $root.resx.recyclebin_DeletedDate, click: sortDirection() == 'asc' ? sortBy.bind($data,'modules', 'date', 'desc') : sortBy.bind($data,'modules', 'date', 'asc')"></td>
                     <td class="actions" data-bind="visible:settings.canViewModules && settings.canManageModules, html: $root.resx.recyclebin_Actions"></td>
                 </tr>
                 <tbody class="pages-list-container" data-bind="template: { name: 'modules-list-recyclebin', foreach: deletedmodulesList }"></tbody>
@@ -77,9 +77,9 @@
             <table class="dnnRBGrid">
                 <tr class="dnnRBGridHeader">
                     <td class="first" data-bind="visible:settings.canViewUsers && settings.canManageUsers"><input type="checkbox" class="page-item" data-bind="checked: selectAllUsers" aria-label="Check" /></td>
-                    <td class="username" data-bind="html: $root.resx.recyclebin_Username"></td>
-                    <td class="displayname" data-bind="html: $root.resx.recyclebin_UserDisplayName"></td>
-                    <td class="deleteddate" data-bind="html: $root.resx.recyclebin_DeletedDate"></td>
+                    <td class="username" data-bind="html: $root.resx.recyclebin_Username, click: sortDirection() == 'asc' ? sortBy.bind($data,'users', 'username', 'desc') : sortBy.bind($data,'users', 'username', 'asc')"></td>
+                    <td class="displayname" data-bind="html: $root.resx.recyclebin_UserDisplayName, click: sortDirection() == 'asc' ? sortBy.bind($data,'users', 'displayname', 'desc') : sortBy.bind($data,'users', 'displayname', 'asc')"></td>
+                    <td class="deleteddate" data-bind="html: $root.resx.recyclebin_DeletedDate, click: sortDirection() == 'asc' ? sortBy.bind($data,'users', 'date', 'desc') : sortBy.bind($data,'users', 'date', 'asc')"></td>
                     <td class="actions" data-bind="visible:settings.canViewUsers && settings.canManageUsers, html: $root.resx.recyclebin_Actions"></td>
                 </tr>
                 <tbody class="pages-list-container" data-bind="template: { name: 'users-list-recyclebin', foreach: deletedusersList }"></tbody>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Recyclebin/css/RecycleBin.css
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Recyclebin/css/RecycleBin.css
@@ -457,6 +457,23 @@ div#recycleBin-header.socialpanelheader .actions {
     background: #F2F2F2;
 }
 
+    .recycleBinContainer #pages table.dnnRBGrid tr.dnnRBGridHeader td.pagename,
+    .recycleBinContainer #pages table.dnnRBGrid tr.dnnRBGridHeader td.deleteddate {
+        cursor: pointer;
+    }
+
+    .recycleBinContainer #modules table.dnnRBGrid tr.dnnRBGridHeader td.mtitle,
+    .recycleBinContainer #modules table.dnnRBGrid tr.dnnRBGridHeader td.mpage,
+    .recycleBinContainer #modules table.dnnRBGrid tr.dnnRBGridHeader td.deleteddate {
+        cursor: pointer;
+    }
+
+    .recycleBinContainer #users table.dnnRBGrid tr.dnnRBGridHeader td.username,
+    .recycleBinContainer #users table.dnnRBGrid tr.dnnRBGridHeader td.displayname,
+    .recycleBinContainer #users table.dnnRBGrid tr.dnnRBGridHeader td.deleteddate {
+        cursor: pointer;
+    }
+
 .recycleBinContainer table.dnnRBGrid tr.dnnRBGridBody td.thumbnail,
 .recycleBinContainer table.dnnRBGrid tr.dnnRBGridBody td.title,
 .recycleBinContainer table.dnnRBGrid tr.dnnRBGridBody td.pagename,


### PR DESCRIPTION
This PR Closes #6075

Recycle bin section, for now is ordering items according ids (TabId, ModuleId, UserId), but when you have a lot of deleted information, is a little bit hard to locate information.

I added an option to sort pages, modules or users according to main fields as name, alias or deletion date. Additionally i have changed Date column name to Deletion Date, to be more specific about what that field means.