### PR TITLE
Updated Initialize.cs to show modern dotnet4+ versions

### DIFF
--- a/DNN Platform/Library/Common/Initialize.cs
+++ b/DNN Platform/Library/Common/Initialize.cs
@@ -383,14 +383,20 @@ namespace DotNetNuke.Common
             // Otherwise utilize release DWORD from registry to determine version
             // Reference List: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies
             var release = GetDotNet4ReleaseNumberFromRegistry();
+            if (release >= 533320)
+            {
+                version = "4.8.1 or later";
+            }
             if (release >= 528040)
             {
                 version = "4.8";
             }
-            else
+            if (release >= 461808)
             {
                 version = "4.7.2";
             }
+            // This code should never execute
+            version = "No 4.5 or later version detected (or unexpected result)";
 
             return new Version(version);
         }


### PR DESCRIPTION
Fixes #6127 

## Summary
Quick update so that the .NET Framework version shown (e.g. in the PersonaBar) is accurate up to v4.8.1.

Also updated the code style (no more `else`) making it easy to added new versions in the future.
