### PR TITLE
Fix SharpZipLib issues

### DIFF
--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -60,7 +60,8 @@
     "/bin/Newtonsoft.Json.dll",
     "/Config/DotNetNuke.config",
     "/Install/InstallWizard.aspx",
-    "/bin/WebFormsMvp.dll"
+    "/bin/WebFormsMvp.dll",
+    "/bin/ICSharpCode.SharpZipLib.dll"
   ],
   "symbolsInclude": [
     "/bin/*.pdb",

--- a/DNN Platform/Admin Modules/Dnn.Modules.Console/web.config
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Console/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Connectors/Azure/app.config
+++ b/DNN Platform/Connectors/Azure/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Connectors/GoogleAnalytics/app.config
+++ b/DNN Platform/Connectors/GoogleAnalytics/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Connectors/GoogleAnalytics4/app.config
+++ b/DNN Platform/Connectors/GoogleAnalytics4/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Connectors/GoogleTagManager/app.config
+++ b/DNN Platform/Connectors/GoogleTagManager/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Dnn.AuthServices.Jwt/app.config
+++ b/DNN Platform/Dnn.AuthServices.Jwt/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/DotNetNuke.Web.Mvc/app.config
+++ b/DNN Platform/DotNetNuke.Web.Mvc/app.config
@@ -11,10 +11,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/DotNetNuke.Web/app.config
+++ b/DNN Platform/DotNetNuke.Web/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/CoreMessaging/web.config
+++ b/DNN Platform/Modules/CoreMessaging/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/DnnExportImport/app.config
+++ b/DNN Platform/Modules/DnnExportImport/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/Groups/web.config
+++ b/DNN Platform/Modules/Groups/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/HTML/web.config
+++ b/DNN Platform/Modules/HTML/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/HtmlEditorManager/web.config
+++ b/DNN Platform/Modules/HtmlEditorManager/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/Journal/web.config
+++ b/DNN Platform/Modules/Journal/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/MemberDirectory/web.config
+++ b/DNN Platform/Modules/MemberDirectory/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/RazorHost/web.config
+++ b/DNN Platform/Modules/RazorHost/web.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/ResourceManager/web.config
+++ b/DNN Platform/Modules/ResourceManager/web.config
@@ -19,10 +19,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Modules/TelerikRemoval/Web.config
+++ b/DNN Platform/Modules/TelerikRemoval/Web.config
@@ -43,10 +43,6 @@
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="MimeKit" publicKeyToken="bede1c8a46c66814" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/web.config
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/web.config
@@ -19,10 +19,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -236,10 +236,6 @@
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/App.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/App.config
@@ -11,10 +11,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/DotNetNuke.Tests.AspNetCCP.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/DotNetNuke.Tests.AspNetCCP.csproj
@@ -47,9 +47,6 @@
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.4.2.13, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SharpZipLib.1.4.2\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Moq, Version=4.20.70.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Moq.4.20.70\lib\net462\Moq.dll</HintPath>
     </Reference>

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/packages.config
@@ -4,7 +4,6 @@
   <package id="Moq" version="4.20.70" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net48" />
-  <package id="SharpZipLib" version="1.4.2" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net48" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/app.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/app.config
@@ -23,10 +23,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/DotNetNuke.Tests.Data.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/DotNetNuke.Tests.Data.csproj
@@ -68,9 +68,6 @@
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.4.2.13, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\SharpZipLib.1.4.2\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.ApplicationBlocks.Data">
       <HintPath>..\..\Components\DataAccessBlock\bin\Microsoft.ApplicationBlocks.Data.dll</HintPath>
     </Reference>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
@@ -8,7 +8,6 @@
   <package id="Moq" version="4.20.70" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net48" />
-  <package id="SharpZipLib" version="1.4.2" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net48" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.UI/app.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.UI/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/app.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/app.config
@@ -7,10 +7,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/app.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/app.config
@@ -27,10 +27,6 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
       </dependentAssembly>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/App.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/App.config
@@ -19,10 +19,6 @@
                 <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
             </dependentAssembly>
             <dependentAssembly>
-                <assemblyIdentity name="ICSharpCode.SharpZipLib" publicKeyToken="1b03e6acf1164f73" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-1.4.2.13" newVersion="1.4.2.13" />
-            </dependentAssembly>
-            <dependentAssembly>
                 <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-1.9.0.0" newVersion="1.9.0.0" />
             </dependentAssembly>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -717,9 +717,6 @@
     <Content Include="SqlDataProvider\09.04.01.SqlDataProvider" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.4.2.13, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SharpZipLib.1.4.2\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>


### PR DESCRIPTION
This PR removes a few unnecessary SharpZipLib references and ensures the library is not included in the bin folder of the main Upgrade zip. The latter ensures DNN will still upgrade as the references in the web.config during upgrade are still pointing to the old version.

This follows up issues mentioned in #2735 