### PR TITLE
Change the string format of the NETFramework ToString(3) in PersonaBar

### DIFF
--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Models/HostModel.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Models/HostModel.cs
@@ -63,7 +63,7 @@ namespace Dnn.PersonaBar.Prompt.Components.Models
                 Version = "v." + Globals.FormatVersion(application.Version, true),
                 Product = application.Description,
                 UpgradeAvailable = upgradeIndicator != null,
-                Framework = isHost ? Globals.NETFrameworkVersion.ToString(2) : string.Empty,
+                Framework = isHost ? Globals.NETFrameworkVersion.ToString(3) : string.Empty,
                 IpAddress = System.Net.Dns.GetHostEntry(hostName).AddressList[0].ToString(),
                 Permissions = DotNetNuke.Framework.SecurityPolicy.Permissions,
                 Site = hostPortal.PortalName,

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/ServerSummaryController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/ServerSummaryController.cs
@@ -51,7 +51,7 @@ namespace Dnn.PersonaBar.UI.Services
                 {
                     ProductName = DotNetNukeContext.Current.Application.Description,
                     ProductVersion = "v. " + Globals.FormatVersion(DotNetNukeContext.Current.Application.Version, true),
-                    FrameworkVersion = isHost ? Globals.NETFrameworkVersion.ToString(2) : string.Empty,
+                    FrameworkVersion = isHost ? Globals.NETFrameworkVersion.ToString(3) : string.Empty,
                     ServerName = isHost ? Globals.ServerName : string.Empty,
                     LicenseVisible = isHost && this.GetVisibleSetting("LicenseVisible"),
                     DocCenterVisible = this.GetVisibleSetting("DocCenterVisible"),


### PR DESCRIPTION
Change the string format of the NETFramework version from ToString(2) to ToString(3) to show the full 3 part .NET Framework version number in the PersonaBar.

Fixes #6143. 

## Summary

Changed `.ToString(2)` to `.ToString(3)` and we now get the improve output showing the full 3 part .NET Framework version.

![image](https://github.com/user-attachments/assets/27d14afc-0eeb-4913-8269-bc2048523acb)

