### PR TITLE
Update PersonaBar Manage/Roles to show Role ID

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleEditor/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleEditor/index.jsx
@@ -196,8 +196,7 @@ class RolesEditor extends Component {
         const columnOne = <div key="editor-container-columnOne" className="editor-container">
             <div className="editor-row divider" style={{marginTop:"-3rem"}}>
                 <Label
-                    label={resx.get("RoleId") + ": " + state.roleDetails.id}
-                    style={{ fontWeight: "bolder" }} />
+                    label={resx.get("RoleId") + ": " + state.roleDetails.id} />
             </div>
             <div className="editor-row divider">
                 <SingleLineInputWithError

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleEditor/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleEditor/index.jsx
@@ -194,6 +194,11 @@ class RolesEditor extends Component {
     render() {
         let { state, props } = this;
         const columnOne = <div key="editor-container-columnOne" className="editor-container">
+            <div className="editor-row divider" style={{marginTop:"-3rem"}}>
+                <Label
+                    label={resx.get("RoleId") + ": " + state.roleDetails.id}
+                    style={{ fontWeight: "bolder" }} />
+            </div>
             <div className="editor-row divider">
                 <SingleLineInputWithError
                     value={state.roleDetails.name}

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleRow/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/RoleRow/index.jsx
@@ -119,7 +119,9 @@ RoleRow.propTypes = {
     openId: PropTypes.string,
     currentIndex: PropTypes.number,
     visible: PropTypes.bool,
-    roleIsApproved: PropTypes.bool
+    roleIsApproved: PropTypes.bool,
+    addIsClosed: PropTypes.bool,
+    children: PropTypes.node
 };
 RoleRow.defaultProps = {
     collapsed: true,

--- a/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/UsersInRole/UserRow/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Roles.Web/src/components/roles/UsersInRole/UserRow/index.jsx
@@ -138,7 +138,9 @@ UserRow.propTypes = {
     userDetails: PropTypes.object.isRequired,
     index: PropTypes.number,
     saveUser: PropTypes.func.isRequired,
-    deleteUser: PropTypes.func.isRequired
+    deleteUser: PropTypes.func.isRequired,
+    roleName: PropTypes.string.isRequired,
+    dispatch: PropTypes.func.isRequired
 };
 UserRow.defaultProps = {
     roleUsersList: []

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Roles/App_LocalResources/Roles.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Roles/App_LocalResources/Roles.resx
@@ -189,6 +189,9 @@
   <data name="RoleName.Text" xml:space="preserve">
     <value>Role Name</value>
   </data>
+  <data name="RoleId.Text" xml:space="preserve">
+    <value>Role ID</value>
+  </data>
   <data name="securityModeListLabel.Text" xml:space="preserve">
     <value>Security Mode</value>
   </data>


### PR DESCRIPTION
Fixes Issue #6153

## [Enhancement]: PersonaBar, Manage Roles - Add Role ID to Visible Information

This screenshot shows the result of these changes.
![image](https://github.com/user-attachments/assets/2c4dc462-a374-49fa-b967-6ec4dd71de11)
