### PR TITLE
Fixed an issue that cause wrong size of + icon in SEO module

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/Table.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Seo/PageUrls/Table.jsx
@@ -50,7 +50,7 @@ class Table extends Component {
         /* eslint-disable react/no-danger */
         return (
             <div>
-                <div className={styles.AddItemRow}>
+                <div className={styles.addItemRow}>
                     <div className="link-icon" dangerouslySetInnerHTML={{ __html: SvgIcons.LinkIcon }} />
                     <div className="sectionTitle">{Localization.get("UrlsForThisPage")}</div>
                     <div className={"AddItemBox" + (newFormOpened ? " active" : "")} onClick={onOpenNewForm}>


### PR DESCRIPTION
Fixes #6116 - Huge Add (+) Icon in Pages SEO tab

Details in the issue's comments.

## Lowercased the first letter of the styles attribute

```
styles.addItemRow
      ^^
```
