### PR TITLE
Fix nuspec dependencies

### DIFF
--- a/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.Mvc.nuspec
@@ -18,9 +18,9 @@
       <dependency id="DotNetNuke.Web" version="$version$" />
       <dependency id="DotNetNuke.Web.Client" version="$version$" />
       <dependency id="DotNetNuke.WebApi" version="$version$" />
-      <dependency id="Microsoft.AspNet.Mvc" version="5.2.9" />
-      <dependency id="Microsoft.AspNet.Razor" version="3.2.9" />
-      <dependency id="Microsoft.AspNet.WebPages" version="3.2.9" />
+      <dependency id="Microsoft.AspNet.Mvc" version="5.3.0" />
+      <dependency id="Microsoft.AspNet.Razor" version="3.3.0" />
+      <dependency id="Microsoft.AspNet.WebPages" version="3.3.0" />
       <dependency id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
     </dependencies>
   </metadata>

--- a/Build/Tools/NuGet/DotNetNuke.Web.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.Web.nuspec
@@ -16,7 +16,7 @@
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>
     <dependencies>
       <dependency id="DotNetNuke.Core" version="$version$" />
-      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.9" />
+      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.3.0" />
     </dependencies>
   </metadata>
   <files>

--- a/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
+++ b/Build/Tools/NuGet/DotNetNuke.WebApi.nuspec
@@ -15,8 +15,8 @@
     </description>
     <copyright>Copyright (c) .NET Foundation and Contributors, All Rights Reserved.</copyright>
     <dependencies>
-      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.9" />
-      <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.9" />
+      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.3.0" />
+      <dependency id="Microsoft.AspNet.WebApi.Client" version="6.0.0" />
       <dependency id="NewtonSoft.Json" version="13.0.3" />
       <dependency id="DotNetNuke.Web" version="$version$" />
     </dependencies>


### PR DESCRIPTION
The AspNet NuGet packages were bumped in #6146, but the dependency versions weren't bumped in the `nuspec` files