### PR TITLE
Make GitVersion config less ambiguous

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -6,24 +6,24 @@ ignore:
   commits-before: 2023-01-01T00:00:00
 branches:
   future:
-    regex: future?[/-]
+    regex: ^future?[/-]
     tag: 'alpha'
     increment: Major
     source-branches: []
   development:
-    regex: development
+    regex: ^development$
     tag: 'alpha'
     increment: Major
     source-branches: []
   develop:
-    regex: develop
+    regex: ^develop$
     tag: 'alpha'
     increment: Patch
     is-mainline: true
     source-branches: []
     tracks-release-branches: false
   release:
-    regex: release?[/-]
+    regex: ^release?[/-]
     mode: ContinuousDelivery
     tag: 'rc'
     increment: Patch


### PR DESCRIPTION
## Summary
Some of our builds have failed due to Cake being unable to parse the GitVersion output. Running locally with Diagnostic verbosity, I receive the following error message at the top of the output:
```
Multiple branch configurations match the current branch branchName of 'bdukes/merge-develop-to-release-10.0.0'. Using the first matching configuration, 'develop'. Matching configurations include:'
 - develop
 - release'
```

I've deleted any branches that I can see with both `develop` and `release` in the name for the short-term.

This PR updates the `regex` field for the branches to include `^` (starts with) and `$` (ends with) tokens, so that the match is exact (i.e. the `develop` rule only matches the `develop` branch, not other branches that have `develop` in the name).