### PR TITLE
Fix server info error on .NET 4.8

### DIFF
--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -478,6 +478,10 @@ namespace DotNetNuke.Common
         /// </value>
         public static Version NETFrameworkVersion { get; set; }
 
+        /// <summary>Gets the .Net framework version text.</summary>
+        /// <value>The .Net framework version text.</value>
+        public static string FormattedNetFrameworkVersion => FormatVersion(NETFrameworkVersion, "0", 3, ".");
+
         /// <summary>Gets or sets the database engine version.</summary>
         /// <value>
         /// The database engine version.

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Common/GlobalsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Common/GlobalsTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Common;
+
+using System;
+
+using DotNetNuke.Common;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class GlobalsTests
+{
+    [Test]
+    public void FormatVersion_WhenTwoDigitVersionFormattedWithThreeParts_UsesZeroForThirdPart()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8"), "0", 3, "."), Is.EqualTo("4.8.0"));
+    }
+
+    [Test]
+    public void FormatVersion_WhenThreeDigitVersionFormattedWithThreeParts_DisplaysThirdPart()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8.1"), "0", 3, "."), Is.EqualTo("4.8.1"));
+    }
+
+    [Test]
+    public void FormatVersion_WhenFourDigitVersionFormattedWithThreeParts_DoesNotDisplayFourthPart()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8.1.7"), "0", 3, "."), Is.EqualTo("4.8.1"));
+    }
+
+    [Test]
+    public void FormatVersion_WhenTwoDigitVersion_DisplaysThreePartsWithLeadingZeroes_InABrokenWay()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8")), Is.EqualTo("04.00.-01"));
+    }
+
+    [Test]
+    public void FormatVersion_WhenThreeDigitVersion_DisplaysThirdPartWithLeadingZeroes()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8.1")), Is.EqualTo("04.08.01"));
+    }
+
+    [Test]
+    public void FormatVersion_WhenFourDigitVersion_DisplaysThreePartsWithLeadingZeroes()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8.1.7")), Is.EqualTo("04.08.01"));
+    }
+
+    [Test]
+    public void FormatVersion_WhenFourDigitVersionWithRevision_DisplaysThreePartsWithLeadingZeroes()
+    {
+        Assert.That(Globals.FormatVersion(new Version("4.8.1.7"), true), Is.EqualTo("04.08.01 (7)"));
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Collections\ReaderWriterSlimLockTests.cs" />
     <Compile Include="Collections\SharedDictionaryTests.cs" />
     <Compile Include="Collections\SharedListTests.cs" />
+    <Compile Include="Common\GlobalsTests.cs" />
     <Compile Include="Common\NavigationManagerTests.cs" />
     <Compile Include="Common\UrlUtilsTests.cs" />
     <Compile Include="ComponentModel\ComponentFactoryTests.cs" />

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Models/HostModel.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Prompt/Models/HostModel.cs
@@ -63,7 +63,7 @@ namespace Dnn.PersonaBar.Prompt.Components.Models
                 Version = "v." + Globals.FormatVersion(application.Version, true),
                 Product = application.Description,
                 UpgradeAvailable = upgradeIndicator != null,
-                Framework = isHost ? Globals.NETFrameworkVersion.ToString(3) : string.Empty,
+                Framework = isHost ? Globals.FormattedNetFrameworkVersion : string.Empty,
                 IpAddress = System.Net.Dns.GetHostEntry(hostName).AddressList[0].ToString(),
                 Permissions = DotNetNuke.Framework.SecurityPolicy.Permissions,
                 Site = hostPortal.PortalName,

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Servers/WebServer/ServerInfo.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Servers/WebServer/ServerInfo.cs
@@ -15,7 +15,7 @@ namespace Dnn.PersonaBar.Servers.Components.WebServer
     {
         public string Framework => Environment.Version.ToString();
 
-        public string NetFrameworkVersion => Globals.NETFrameworkVersion.ToString(3);
+        public string NetFrameworkVersion => Globals.FormattedNetFrameworkVersion;
 
         public string HostName => Dns.GetHostName();
 

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/ServerSummaryController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/ServerSummaryController.cs
@@ -51,7 +51,7 @@ namespace Dnn.PersonaBar.UI.Services
                 {
                     ProductName = DotNetNukeContext.Current.Application.Description,
                     ProductVersion = "v. " + Globals.FormatVersion(DotNetNukeContext.Current.Application.Version, true),
-                    FrameworkVersion = isHost ? Globals.NETFrameworkVersion.ToString(3) : string.Empty,
+                    FrameworkVersion = isHost ? Globals.FormattedNetFrameworkVersion : string.Empty,
                     ServerName = isHost ? Globals.ServerName : string.Empty,
                     LicenseVisible = isHost && this.GetVisibleSetting("LicenseVisible"),
                     DocCenterVisible = this.GetVisibleSetting("DocCenterVisible"),


### PR DESCRIPTION
When a `Version` only has two parts (e.g. `new Version("4.8")`), it throws an exception when calling `.ToString(3)`. This PR adds a `string` `FormattedNetFrameworkVersion` property to `Globals` (to complement `Version Globals.NETFrameworkVersion`) and replaces all usages of `Globals.NETFrameworkVersion.ToString` with `Globals.FormattedNetFrameworkVersion`. This property uses `Globals.FormatVersion` to do the formatting, which has logic to replace a `-1` from a two-digit version with a `0` to make a three-digit version.

I also added a few tests for `Globals.FormatVersion` to verify its behavior and documented that only the verbose overload has that logic and that `Globals.FormatVersion(new Version("4.8"))` will output `"04.00.-01"`.

Fixes #6200