### PR TITLE
Added sub-dependencies of AspNetWebApi to package

### DIFF
--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -43,7 +43,11 @@
     "/bin/WebMatrix.Data.dll",
     "/bin/WebMatrix.WebData.dll",
     "/Install/Module/DNNCE_Website.Deprecated_*_Install.zip",
-    "/bin/WebFormsMvp.dll"
+    "/bin/WebFormsMvp.dll",
+    "/bin/Newtonsoft.Json.Bson.dll",
+    "/bin/System.Memory.dll",
+    "/bin/System.Threading.Tasks.Extensions",
+    "/bin/System.Runtime.CompilerServices.Unsafe.dll"
   ],
   "installInclude": ["/Install/InstallWizard.aspx.cs"],
   "upgradeExclude": [
@@ -56,7 +60,10 @@
     "/bin/Newtonsoft.Json.dll",
     "/Config/DotNetNuke.config",
     "/Install/InstallWizard.aspx",
-    "/bin/WebFormsMvp.dll"
+    "/bin/WebFormsMvp.dll",
+    "/bin/System.Memory.dll",
+    "/bin/System.Threading.Tasks.Extensions.dll",
+    "/bin/System.Runtime.CompilerServices.Unsafe.dll"
   ],
   "symbolsInclude": [
     "/bin/*.pdb",

--- a/DNN Platform/Components/Microsoft.AspNetWebApi/Microsoft.AspNetWebApi.dnn
+++ b/DNN Platform/Components/Microsoft.AspNetWebApi/Microsoft.AspNetWebApi.dnn
@@ -30,6 +30,26 @@
               <name>System.Web.Http.WebHost.dll</name>
               <version>5.2.8</version>
             </assembly>
+            <assembly>
+              <path>bin</path>
+              <name>Newtonsoft.Json.Bson.dll</name>
+              <version>5.2.8</version>
+            </assembly>
+            <assembly>
+              <path>bin</path>
+              <name>Newtonsoft.Json.dll</name>
+              <version>13.0.1</version>
+            </assembly>
+            <assembly>
+              <path>bin</path>
+              <name>System.Memory.dll</name>
+              <version>4.5.5</version>
+            </assembly>
+            <assembly>
+              <path>bin</path>
+              <name>System.Threading.Tasks.Extensions.dll</name>
+              <version>4.5.4</version>
+            </assembly>
           </assemblies>
         </component>
       </components>


### PR DESCRIPTION
This may fix #6222 but I ran out of time to test, a clean install did work fine and that's all I had time to test for now.

I think there are a couple other dlls in the issue we could handle here or elsewhere and we need to test upgrade scenarios from 9.13.4,5,6 to be sure.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
