### PR TITLE
Deprecate DnnLogger

### DIFF
--- a/DNN Platform/DotNetNuke.Instrumentation/DnnLog.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/DnnLog.cs
@@ -5,7 +5,6 @@ namespace DotNetNuke.Instrumentation
 {
     using System;
     using System.Diagnostics;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Web.Compilation;

--- a/DNN Platform/DotNetNuke.Instrumentation/DnnLogger.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/DnnLogger.cs
@@ -10,13 +10,15 @@ namespace DotNetNuke.Instrumentation
     using System.Web.Compilation;
     using System.Web.UI;
 
+    using DotNetNuke.Internal.SourceGenerators;
     using log4net;
     using log4net.Core;
     using log4net.Repository;
     using log4net.Util;
 
-    /// <summary>Please use LoggerSource.Instance as a more unit testable way to create loggers.</summary>
-    public sealed class DnnLogger : LoggerWrapperImpl
+    /// <summary>Obsolete, use <see cref="LoggerSource"/> instead.</summary>
+    [DnnDeprecated(9, 13, 7, "Use LoggerSource.Instance", RemovalVersion = 11)]
+    public sealed partial class DnnLogger : LoggerWrapperImpl
     {
         // add custom logging levels (below trace value of 20000)
         private static Level levelLogInfo = new Level(10001, "LogInfo");

--- a/DNN Platform/DotNetNuke.Instrumentation/LoggerSourceImpl.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/LoggerSourceImpl.cs
@@ -5,12 +5,10 @@
 namespace DotNetNuke.Instrumentation
 {
     using System;
-    using System.Diagnostics;
     using System.Globalization;
     using System.IO;
-    using System.Security;
-    using System.Web;
 
+    using DotNetNuke.Internal.SourceGenerators;
     using log4net;
     using log4net.Config;
     using log4net.Core;
@@ -32,6 +30,7 @@ namespace DotNetNuke.Instrumentation
             return new Logger(LogManager.GetLogger(name).Logger, null);
         }
 
+        [DnnDeprecated(9, 13, 7, "Use LoggerSource.Instance", RemovalVersion = 11)]
         private class Logger : LoggerWrapperImpl, ILog
         {
             private const string ConfigFile = "DotNetNuke.log4net.config";
@@ -47,7 +46,7 @@ namespace DotNetNuke.Instrumentation
             // add custom logging levels (below trace value of 20000)
             //            internal static Level LevelLogInfo = new Level(10001, "LogInfo");
             //            internal static Level LevelLogError = new Level(10002, "LogError");
-            private readonly Type stackBoundary = typeof(DnnLogger);
+            private readonly Type stackBoundary = typeof(Logger);
 
             internal Logger(ILogger logger, Type type)
                 : base(logger)

--- a/DNN Platform/DotNetNuke.Instrumentation/LoggerSourceImpl.cs
+++ b/DNN Platform/DotNetNuke.Instrumentation/LoggerSourceImpl.cs
@@ -30,7 +30,6 @@ namespace DotNetNuke.Instrumentation
             return new Logger(LogManager.GetLogger(name).Logger, null);
         }
 
-        [DnnDeprecated(9, 13, 7, "Use LoggerSource.Instance", RemovalVersion = 11)]
         private class Logger : LoggerWrapperImpl, ILog
         {
             private const string ConfigFile = "DotNetNuke.log4net.config";

--- a/DNN Platform/Library/Entities/Tabs/TabWorkflowTracker.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabWorkflowTracker.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Entities.Tabs
 
     internal class TabWorkflowTracker : ServiceLocator<ITabChangeTracker, TabWorkflowTracker>, ITabChangeTracker
     {
-        private static readonly DnnLogger Logger = DnnLogger.GetClassLogger(typeof(TabWorkflowTracker));
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(TabWorkflowTracker));
         private readonly ITabController tabController;
         private readonly IWorkflowEngine workflowEngine;
         private readonly IWorkflowManager workflowManager;

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Components/BusinessController.cs
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Components/BusinessController.cs
@@ -4,15 +4,10 @@
 
 namespace Dnn.EditBar.UI.Components
 {
-    using System;
-
     using DotNetNuke.Entities.Modules;
-    using DotNetNuke.Instrumentation;
 
     public class BusinessController : IUpgradeable
     {
-        private static readonly DnnLogger Logger = DnnLogger.GetClassLogger(typeof(BusinessController));
-
         /// <inheritdoc/>
         public string UpgradeModule(string version)
         {

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Controllers/PersonaBarController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Controllers/PersonaBarController.cs
@@ -22,7 +22,7 @@ namespace Dnn.PersonaBar.Library.Controllers
 
     public class PersonaBarController : ServiceLocator<IPersonaBarController, PersonaBarController>, IPersonaBarController
     {
-        private static readonly DnnLogger Logger = DnnLogger.GetClassLogger(typeof(PersonaBarController));
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(PersonaBarController));
 
         private readonly IPersonaBarRepository personaBarRepository;
 

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Permissions/MenuPermissionController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Permissions/MenuPermissionController.cs
@@ -29,7 +29,7 @@ namespace Dnn.PersonaBar.Library.Permissions
 
         private const string ViewPermissionKey = "VIEW";
 
-        private static readonly ILog Logger = LoggerSource.Instance.GetClassLogger(typeof(MenuPermissionController));
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(MenuPermissionController));
 
         private static readonly IDataService DataService = new DataService();
         private static readonly object ThreadLocker = new object();

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Permissions/MenuPermissionController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Permissions/MenuPermissionController.cs
@@ -29,7 +29,7 @@ namespace Dnn.PersonaBar.Library.Permissions
 
         private const string ViewPermissionKey = "VIEW";
 
-        private static readonly DnnLogger Logger = DnnLogger.GetClassLogger(typeof(MenuPermissionController));
+        private static readonly ILog Logger = LoggerSource.Instance.GetClassLogger(typeof(MenuPermissionController));
 
         private static readonly IDataService DataService = new DataService();
         private static readonly object ThreadLocker = new object();

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/MenuExtensionsController.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Services/MenuExtensionsController.cs
@@ -25,7 +25,7 @@ namespace Dnn.PersonaBar.UI.Services
     [MenuPermission(Scope = ServiceScope.Regular)]
     public class MenuExtensionsController : PersonaBarApiController
     {
-        private static readonly DnnLogger Logger = DnnLogger.GetClassLogger(typeof(MenuExtensionsController));
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(MenuExtensionsController));
 
         /// <summary>Retrieve a list of extensions for menu.</summary>
         /// <returns>A response with a collection of extension info.</returns>


### PR DESCRIPTION
If we wish to move away from Log4net in the future we must begin to eliminate any exposure of its classes through our API.

The DnnLogger class inherits from and exposes log4net classes. We have an alternative in LoggerSource. Deprecating this now means we can remove log4net if needed by DNN 11.


