### PR TITLE
Add .NET SDK to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
       - "javascript"
       - "Type: Maintenance"
 
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - ".NET"
+      - "Type: Maintenance"
+
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:


### PR DESCRIPTION
See https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/