### PR TITLE
Updated Quick Settings Performance

### DIFF
--- a/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -113,7 +113,12 @@ namespace DotNetNuke.Admin.Containers
                     this.quickSettings.Controls.Add(control);
 
                     this.DisplayQuickSettings = this.ModuleContext.Configuration.ModuleSettings.GetValueOrDefault("QS_FirstLoad", true);
-                    ModuleController.Instance.UpdateModuleSetting(this.ModuleContext.ModuleId, "QS_FirstLoad", "False");
+
+                    // If we are displaying settings due to first load, then we need to update the setting to false, this WILL trigger a cache clear for the tab
+                    if (this.DisplayQuickSettings)
+                    {
+                        ModuleController.Instance.UpdateModuleSetting(this.ModuleContext.ModuleId, "QS_FirstLoad", "False");
+                    }
 
                     ClientResourceManager.RegisterScript(this.Page, "~/admin/menus/ModuleActions/dnnQuickSettings.js");
                 }


### PR DESCRIPTION
- Fixes #6241

Given the reported issue in #6239, each time a module setting is updated the cache is cleared.  The current code, was always updating the first load to be false, even if the first load value was already set to false.

This change utilizes the retreived setting value to ensure that we are ONLY updateing the module to flip the quick settings flag to false if it is currently set to true.  This has a substantial impact to performance for modules using Quick Settings.