### PR TITLE
Sometimes we need to get additional keyFound variable to know if ResourceKey does not exist or exists but empty value

### DIFF
--- a/DNN Platform/Library/Services/Localization/ILocalizationProvider.cs
+++ b/DNN Platform/Library/Services/Localization/ILocalizationProvider.cs
@@ -22,6 +22,8 @@ namespace DotNetNuke.Services.Localization
 
         string GetString(string key, string resourceFileRoot, string language, PortalSettings portalSettings, bool disableShowMissingKeys);
 
+        string GetString(string key, string resourceFileRoot, string language, PortalSettings portalSettings, bool disableShowMissingKeys, out bool keyFound);
+
         /// <summary>Saves a string to a resource file.</summary>
         /// <param name="key">The key to save (e.g. "MyWidget.Text").</param>
         /// <param name="value">The text value for the key.</param>

--- a/DNN Platform/Library/Services/Localization/Localization.cs
+++ b/DNN Platform/Library/Services/Localization/Localization.cs
@@ -780,6 +780,20 @@ namespace DotNetNuke.Services.Localization
             return LocalizationProvider.Instance.GetString(key, resourceFileRoot, language, portalSettings, disableShowMissingKeys);
         }
 
+        /// <overloads>One of six overloads.</overloads>
+        /// <summary>GetString gets the localized string corresponding to the <paramref name="key"/>.</summary>
+        /// <param name="key">The resource key to find.</param>
+        /// <param name="resourceFileRoot">The Local Resource root.</param>
+        /// <param name="portalSettings">The current portals Portal Settings.</param>
+        /// <param name="language">A specific language to lookup the string.</param>
+        /// <param name="disableShowMissingKeys">Disables the show missing keys flag.</param>
+        /// <param name="keyFound">Returns whether a ResourceKey exists in the ResourceFile.</param>
+        /// <returns>The localized Text.</returns>
+        public static string GetString(string key, string resourceFileRoot, PortalSettings portalSettings, string language, bool disableShowMissingKeys, out bool keyFound)
+        {
+            return LocalizationProvider.Instance.GetString(key, resourceFileRoot, language, portalSettings, disableShowMissingKeys, out keyFound);
+        }
+
         /// <summary>GetStringUrl gets the localized string corresponding to the <paramref name="key"/>.</summary>
         /// <param name="key">The resource key to find.</param>
         /// <param name="resourceFileRoot">The Local Resource root.</param>

--- a/DNN Platform/Library/Services/Localization/LocalizationProvider.cs
+++ b/DNN Platform/Library/Services/Localization/LocalizationProvider.cs
@@ -53,6 +53,11 @@ namespace DotNetNuke.Services.Localization
         /// <inheritdoc/>
         public string GetString(string key, string resourceFileRoot, string language, PortalSettings portalSettings, bool disableShowMissingKeys)
         {
+            return this.GetString(key, resourceFileRoot, language, portalSettings, disableShowMissingKeys, out _);
+        }
+
+        public string GetString(string key, string resourceFileRoot, string language, PortalSettings portalSettings, bool disableShowMissingKeys, out bool keyFound)
+        {
             // make the default translation property ".Text"
             if (key.IndexOf(".", StringComparison.Ordinal) < 1)
             {
@@ -60,7 +65,7 @@ namespace DotNetNuke.Services.Localization
             }
 
             string resourceValue = Null.NullString;
-            bool keyFound = TryGetStringInternal(key, language, resourceFileRoot, portalSettings, ref resourceValue);
+            keyFound = TryGetStringInternal(key, language, resourceFileRoot, portalSettings, ref resourceValue);
 
             // If the key can't be found then it doesn't exist in the Localization Resources
             if (Localization.ShowMissingKeys && !disableShowMissingKeys)

--- a/DNN Platform/Library/Services/Localization/LocalizationProvider.cs
+++ b/DNN Platform/Library/Services/Localization/LocalizationProvider.cs
@@ -56,6 +56,7 @@ namespace DotNetNuke.Services.Localization
             return this.GetString(key, resourceFileRoot, language, portalSettings, disableShowMissingKeys, out _);
         }
 
+        /// <inheritdoc/>
         public string GetString(string key, string resourceFileRoot, string language, PortalSettings portalSettings, bool disableShowMissingKeys, out bool keyFound)
         {
             // make the default translation property ".Text"


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Sometimes we need to get additional keyFound variable to know if ResourceKey does not exist or exists but empty value

```
bool keyFound;
string strLocalization = Localization.GetString(ResourceKey, LocalResourceFile,  PortalSettings, null, false, out keyFound);
if(string.IsNullOrEmpty(strLocalization)){
  if(!keyFound)
  {
      strLocalization = "Key not found, click here to create....";
  }
  else {
      strLocalization = "Key found but empty value";
  }
}
return strLocalization;
```