### PR TITLE
Bulk Install: Remove CSS var typo now that dnn-elements has been updated

### DIFF
--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/dnn-bulk-install/dnn-bulk-install.scss
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/dnn-bulk-install/dnn-bulk-install.scss
@@ -12,8 +12,6 @@
   dnn-tabs {
     --color-background: var(--dnn-color-neutral, #ededee);
     --color-visible: var(--dnn-color-tertiary-light, #1aaee3);
-    // TODO: This should be renamed when this fix is merged into dnn-elements
-    --color-bisible-text: var(--dnn-color-tertiary-contrast, #ffffff);
     --color-visible-text: var(--dnn-color-tertiary-contrast, #ffffff);
     --color-text: var(--dnn-color-neutral-contrast, #000000);
 


### PR DESCRIPTION
## Summary
This PR takes care of a TODO to correct a CSS variable name once the correction was made in `dnn-elements` (which it now has been).

This is part of the ongoing effort related to #5920.