### PR TITLE
Fixed a typo (missing prefix) for variation-opacity

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalStyles.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStyles.cs
@@ -314,7 +314,7 @@ namespace DotNetNuke.Entities.Portals
                     --dnn-controls-radius: {{this.ControlsRadius}}px;
                     --dnn-controls-padding: {{this.ControlsPadding}}px;
                     --dnn-base-font-size: {{this.BaseFontSize}}px;
-                    --variation-opacity: {{this.VariationOpacity}};
+                    --dnn-variation-opacity: {{this.VariationOpacity}};
                 }
              """;
         }


### PR DESCRIPTION
This css variable was missing it's dnn- prefix that all others have.

Closes #6274

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
