### PR TITLE
Update release and development configs to reflect API Tokens auth addition

### DIFF
--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -409,6 +409,7 @@
         <clear />
         <add name="BasicAuth" type="DotNetNuke.Web.Api.Auth.BasicAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="false" />
         <add name="DigestAuth" type="DotNetNuke.Web.Api.Auth.DigestAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="false" />
+        <add name="ApiTokenAuth" type="DotNetNuke.Web.Api.Auth.ApiTokenAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="true" />
       </messageHandlers>
     </authServices>
     <cryptography defaultProvider="FipsCompilanceCryptographyProvider">

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -406,6 +406,7 @@
         <clear />
         <add name="BasicAuth" type="DotNetNuke.Web.Api.Auth.BasicAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="false" />
         <add name="DigestAuth" type="DotNetNuke.Web.Api.Auth.DigestAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="false" />
+        <add name="ApiTokenAuth" type="DotNetNuke.Web.Api.Auth.ApiTokenAuthMessageHandler, DotNetNuke.Web" enabled="false" defaultInclude="true" forceSSL="true" />
       </messageHandlers>
     </authServices>
     <cryptography defaultProvider="FipsCompilanceCryptographyProvider">


### PR DESCRIPTION
This PR repairs the fact that new DNN 10 installations do not have the necessary entry in the web.config to enable API tokens.