### PR TITLE
Bulk Install: Implemented initial UI for Event Logs

### DIFF
--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components.d.ts
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components.d.ts
@@ -10,6 +10,8 @@ export namespace Components {
     }
     interface DnnBulkInstall {
     }
+    interface EventLog {
+    }
     interface IpSafelist {
     }
 }
@@ -26,6 +28,12 @@ declare global {
         prototype: HTMLDnnBulkInstallElement;
         new (): HTMLDnnBulkInstallElement;
     };
+    interface HTMLEventLogElement extends Components.EventLog, HTMLStencilElement {
+    }
+    var HTMLEventLogElement: {
+        prototype: HTMLEventLogElement;
+        new (): HTMLEventLogElement;
+    };
     interface HTMLIpSafelistElement extends Components.IpSafelist, HTMLStencilElement {
     }
     var HTMLIpSafelistElement: {
@@ -35,6 +43,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "api-users": HTMLApiUsersElement;
         "dnn-bulk-install": HTMLDnnBulkInstallElement;
+        "event-log": HTMLEventLogElement;
         "ip-safelist": HTMLIpSafelistElement;
     }
 }
@@ -43,11 +52,14 @@ declare namespace LocalJSX {
     }
     interface DnnBulkInstall {
     }
+    interface EventLog {
+    }
     interface IpSafelist {
     }
     interface IntrinsicElements {
         "api-users": ApiUsers;
         "dnn-bulk-install": DnnBulkInstall;
+        "event-log": EventLog;
         "ip-safelist": IpSafelist;
     }
 }
@@ -57,6 +69,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "api-users": LocalJSX.ApiUsers & JSXBase.HTMLAttributes<HTMLApiUsersElement>;
             "dnn-bulk-install": LocalJSX.DnnBulkInstall & JSXBase.HTMLAttributes<HTMLDnnBulkInstallElement>;
+            "event-log": LocalJSX.EventLog & JSXBase.HTMLAttributes<HTMLEventLogElement>;
             "ip-safelist": LocalJSX.IpSafelist & JSXBase.HTMLAttributes<HTMLIpSafelistElement>;
         }
     }

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/dnn-bulk-install/dnn-bulk-install.tsx
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/dnn-bulk-install/dnn-bulk-install.tsx
@@ -15,7 +15,7 @@ export class DnnBulkInstall {
               <div class="tab-content">Install UI goes here.</div>
             </dnn-tab>
             <dnn-tab tabTitle="Event Log">
-              <div class="tab-content">Event Log UI goes here.</div>
+              <event-log></event-log>
             </dnn-tab>
             <dnn-tab tabTitle="API Users">
               <div class="tab-content">

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/dnn-bulk-install/readme.md
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/dnn-bulk-install/readme.md
@@ -11,14 +11,16 @@
 
 - dnn-tabs
 - dnn-tab
-- [api-users](../api-users)
-- [ip-safelist](../ip-safelist)
+- [event-log](../tabs/event-log)
+- [api-users](../tabs/api-users)
+- [ip-safelist](../tabs/ip-safelist)
 
 ### Graph
 ```mermaid
 graph TD;
   dnn-bulk-install --> dnn-tabs
   dnn-bulk-install --> dnn-tab
+  dnn-bulk-install --> event-log
   dnn-bulk-install --> api-users
   dnn-bulk-install --> ip-safelist
   api-users --> dnn-input

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/api-users/readme.md
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/api-users/readme.md
@@ -9,7 +9,7 @@
 
 ### Used by
 
- - [dnn-bulk-install](../dnn-bulk-install)
+ - [dnn-bulk-install](../../dnn-bulk-install)
 
 ### Depends on
 

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/event-log.model.ts
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/event-log.model.ts
@@ -1,0 +1,5 @@
+export interface Event {
+    date: string;
+    type: string;
+    message: string;
+}

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/event-log.scss
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/event-log.scss
@@ -1,0 +1,85 @@
+:host {
+  display: block;
+
+  /* Grid layout */
+  .row {
+    display: block;
+    margin: 0;
+  }
+
+  .col {
+    max-width: 100%;
+    padding: 1em 0;
+  }
+
+  /* Panel styling */
+  .panel {
+    border: 1px solid var(--dnn-color-neutral, #ededee);
+    border-radius: .5em;
+  }
+
+  .panel-heading {
+    padding: .3em .5em;
+    border-bottom: 1px solid var(--dnn-color-neutral, #ededee);
+    background-color: var(--dnn-color-neutral, #ededee);
+  }
+
+  .panel-title {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 16px;
+  }
+
+  .panel-body {
+  }
+
+  /* Form styling */
+  .form-horizontal {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    width: fit-content;
+    padding: 1em;
+  }
+
+  label {
+    display: flex;
+    gap: .5em;
+    align-items: center;
+  }
+
+  dnn-button {
+    width: fit-content;
+  }
+
+  /* Table styling */
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .table th,
+  .table td {
+    padding: .3em .5em;
+    text-align: left;
+    border: 1px solid var(--dnn-color-neutral, #ededee);
+  }
+
+  .table th {
+    background-color: var(--dnn-color-neutral-dark, #999999);
+    color: var(--dnn-color-neutral, #ededee);
+  }
+
+  /* Utility */
+  .clearfix::after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+
+}

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/event-log.tsx
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/event-log.tsx
@@ -1,0 +1,49 @@
+import { Component, Host, h } from '@stencil/core';
+import { Event } from './event-log.model';
+
+@Component({
+  tag: 'event-log',
+  styleUrl: 'event-log.scss',
+  shadow: true,
+})
+export class EventLog {
+
+  private events: Event[] = [];
+
+  render() {
+    return (
+      <Host>
+
+        <div class="row">
+          <div class="col">
+            <div class="panel">
+              <div class="panel-heading">
+                <h3 class="panel-title">Events</h3>
+              </div>
+              <div class="panel-body">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Type</th>
+                      <th>Message</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {this.events.map((event) => (
+                      <tr>
+                        <td>{event.date}</td>
+                        <td>{event.type}</td>
+                        <td>{event.message}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/readme.md
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/event-log/readme.md
@@ -1,0 +1,23 @@
+# api-users
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Dependencies
+
+### Used by
+
+ - [dnn-bulk-install](../../dnn-bulk-install)
+
+### Graph
+```mermaid
+graph TD;
+  dnn-bulk-install --> event-log
+  style event-log fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/ip-safelist/readme.md
+++ b/DNN Platform/Modules/BulkInstall/BulkInstall.Web/src/components/tabs/ip-safelist/readme.md
@@ -9,7 +9,7 @@
 
 ### Used by
 
- - [dnn-bulk-install](../dnn-bulk-install)
+ - [dnn-bulk-install](../../dnn-bulk-install)
 
 ### Depends on
 


### PR DESCRIPTION
## Summary
This PR adds the initial UI for the `Event Logs` tab of Bulk Install.  It is part of ongoing work for #5920.

![image](https://github.com/user-attachments/assets/b800f117-726e-4df9-805b-c4cc83973fc0)
