### PR TITLE
Improvements for Dnn.ClientSide project

### DIFF
--- a/DNN Platform/Dnn.ClientSide/Dnn.ClientSide.esproj
+++ b/DNN Platform/Dnn.ClientSide/Dnn.ClientSide.esproj
@@ -1,3 +1,8 @@
 <Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.1738743">
-
+	<PropertyGroup>
+	  <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
+	</PropertyGroup>
+	<Target Name="YarnInstall" BeforeTargets="BeforeRestore">
+	  <Exec Command="yarn install" />
+	</Target>
 </Project>

--- a/DNN Platform/Dnn.ClientSide/Dnn.ClientSide.esproj
+++ b/DNN Platform/Dnn.ClientSide/Dnn.ClientSide.esproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.1738743">
 	<PropertyGroup>
 	  <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
+	  <ResolveNuGetPackages>false</ResolveNuGetPackages>
 	</PropertyGroup>
 	<Target Name="YarnInstall" BeforeTargets="BeforeRestore">
 	  <Exec Command="yarn install" />


### PR DESCRIPTION
## Summary
Since the addition of the Dnn.ClientSide project in #6316, when building the project, `package-lock.json` files are created. This is because the JSPS/esproj build system runs `npm install` automatically during build. This PR disables that and runs `yarn install` instead.

I also ran into the following build error:
>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\NuGet\17.0\Microsoft.NuGet.targets(198,5): Your project does not reference ".NETCoreApp,Version=v6.0" framework. Add a reference to ".NETCoreApp,Version=v6.0" in the "TargetFrameworks" property of your project file and then re-run NuGet restore. [D:\code\Dnn.Platform\DNN Platform\Dnn.ClientSide\Dnn.ClientSide.esproj]

I'm not sure what the underlying issue is, but it does appear to be coming from a NuGet Restore task, so disabling NuGet restore for the project seems to resolve the issue.