### PR TITLE
Force Telerik uninstall

### DIFF
--- a/Build/Build.csproj
+++ b/Build/Build.csproj
@@ -9,6 +9,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS0618</WarningsNotAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />

--- a/DNN Platform/DotNetNuke.Maintenance/Constants.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Constants.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Maintenance;
+
+/// <summary>Constant values used for the maintenance project.</summary>
+public static class Constants
+{
+    /// <summary>Key of the Telerik uninstall option in the host settings.</summary>
+    public static readonly string TelerikUninstallOptionSettingKey = "telerikUninstallOption";
+
+    /// <summary>Value of the Telerik uninstall option in the host settings to indicate the uninstallation should occur.</summary>
+    public static readonly string TelerikUninstallYesValue = "Y";
+
+    /// <summary>Value of the Telerik uninstall option in the host settings to indicate the uninstallation should not occur.</summary>
+    public static readonly string TelerikUninstallNoValue = "N";
+}

--- a/DNN Platform/DotNetNuke.Maintenance/DotNetNuke.Maintenance.csproj
+++ b/DNN Platform/DotNetNuke.Maintenance/DotNetNuke.Maintenance.csproj
@@ -6,6 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
     <DocumentationFile>bin/$(Configuration)/$(TargetFramework)/DotNetNuke.Maintenance.xml</DocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.Maintenance/Telerik/ITelerikUtils.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Telerik/ITelerikUtils.cs
@@ -19,7 +19,7 @@ namespace DotNetNuke.Maintenance.Telerik
         IEnumerable<string> GetAssembliesThatDependOnTelerik();
 
         /// <summary>Checks whether Telerik is installed on this site or not.</summary>
-        /// <returns><c>True</c> if Telerik is found in this site, or <c>False</c> otherwise.</returns>
+        /// <returns><see langword="true"/> if Telerik is found in this site, or <see langword="false"/> otherwise.</returns>
         bool TelerikIsInstalled();
 
         /// <summary>Loads the Telerik assembly and returns its version number.</summary>
@@ -30,5 +30,10 @@ namespace DotNetNuke.Maintenance.Telerik
         /// The <see cref="Exception.InnerException"/> property contains the cause of the error.
         /// </exception>
         Version GetTelerikVersion();
+
+        /// <summary>Checks whether the version number of the Telerik assembly is older than a known-safe version.</summary>
+        /// <param name="version">The version number to validate.</param>
+        /// <returns><see langword="true"/> if the version is known to be vulnerable, otherwise <see langword="false"/>.</returns>
+        bool IsTelerikVersionVulnerable(Version version);
     }
 }

--- a/DNN Platform/DotNetNuke.Maintenance/Telerik/Removal/TelerikUninstaller.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Telerik/Removal/TelerikUninstaller.cs
@@ -40,6 +40,8 @@ namespace DotNetNuke.Maintenance.Telerik.Removal
                 this.RemoveUninstalledExtensionFiles("App_Data/ExtensionPackages", "Library_DotNetNuke.Web.Deprecated_*"),
                 this.RemoveUninstalledExtensionFiles("App_Data/ExtensionPackages", "Library_DotNetNuke.Website.Deprecated_*"),
                 this.RemoveUninstalledExtensionFiles("App_Data/ExtensionPackages", "Module_DNNSecurityHotFix*"),
+                this.RemoveFile("bin", "Telerik.Web.UI.dll"),
+                this.RemoveFile("bin", "Telerik.Web.UI.Skins.dll"),
             };
 
             var skip = false;

--- a/DNN Platform/DotNetNuke.Maintenance/Telerik/TelerikUtils.cs
+++ b/DNN Platform/DotNetNuke.Maintenance/Telerik/TelerikUtils.cs
@@ -93,6 +93,12 @@ namespace DotNetNuke.Maintenance.Telerik
             }
         }
 
+        /// <inheritdoc />
+        public bool IsTelerikVersionVulnerable(Version version)
+        {
+            return version < new Version(2014, 0);
+        }
+
         private bool AssemblyDependsOnTelerik(string path, AppDomain domain)
         {
             try

--- a/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
+++ b/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RootDirectory>$(MSBuildProjectDirectory)\..\..</RootDirectory>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <Import Project="..\..\DNN_Platform.build" />
   <PropertyGroup>

--- a/DNN Platform/Modules/TelerikRemoval/Dnn.Modules.TelerikRemoval.csproj
+++ b/DNN Platform/Modules/TelerikRemoval/Dnn.Modules.TelerikRemoval.csproj
@@ -23,6 +23,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DNN Platform/Modules/TelerikRemoval/TelerikRemoval.dnn
+++ b/DNN Platform/Modules/TelerikRemoval/TelerikRemoval.dnn
@@ -62,7 +62,7 @@
                 <processorCommand>UpgradeModule</processorCommand>
                 <attributes>
                     <businessControllerClass>Dnn.Modules.TelerikRemoval.UpgradeController, Dnn.Modules.TelerikRemoval</businessControllerClass>
-                    <upgradeVersionsList>install</upgradeVersionsList>
+                    <upgradeVersionsList>install,upgrade</upgradeVersionsList>
                 </attributes>
             </eventMessage>
         </package>

--- a/DNN Platform/Modules/TelerikRemoval/UpgradeController.cs
+++ b/DNN Platform/Modules/TelerikRemoval/UpgradeController.cs
@@ -22,9 +22,6 @@ namespace Dnn.Modules.TelerikRemoval
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(UpgradeController));
 
-        /// <summary>Key of the Telerik unintall option in the host settings.</summary>
-        private static readonly string TelerikUninstallOptionSettingKey = "telerikUninstallOption";
-
         private readonly IServiceProvider serviceProvider = GetServiceProvider();
 
         /// <inheritdoc/>
@@ -49,7 +46,7 @@ namespace Dnn.Modules.TelerikRemoval
                 Logger.Info("Added Telerik Removal host menu item.");
             }
 
-            var option = this.GetHostSetting(TelerikUninstallOptionSettingKey);
+            var option = this.GetHostSetting(DotNetNuke.Maintenance.Constants.TelerikUninstallOptionSettingKey);
 
             // we have read the value, and now we need to delete the setting
             // to prevent this process from getting triggered if the user
@@ -58,9 +55,9 @@ namespace Dnn.Modules.TelerikRemoval
             // this is an upgrade or a manual installation because this
             // method is executed during Application startup, after the
             // upgrade process has already finished.
-            this.DeleteHostSetting(TelerikUninstallOptionSettingKey);
+            this.DeleteHostSetting(DotNetNuke.Maintenance.Constants.TelerikUninstallOptionSettingKey);
 
-            if ("Y".Equals(option, StringComparison.OrdinalIgnoreCase))
+            if (DotNetNuke.Maintenance.Constants.TelerikUninstallYesValue.Equals(option, StringComparison.OrdinalIgnoreCase))
             {
                 this.GetService<ITelerikUninstaller>().Execute();
             }

--- a/DNN Platform/Modules/TelerikRemoval/UpgradeController.cs
+++ b/DNN Platform/Modules/TelerikRemoval/UpgradeController.cs
@@ -5,6 +5,7 @@
 namespace Dnn.Modules.TelerikRemoval
 {
     using System;
+    using System.Linq;
 
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Common;
@@ -59,7 +60,20 @@ namespace Dnn.Modules.TelerikRemoval
 
             if (DotNetNuke.Maintenance.Constants.TelerikUninstallYesValue.Equals(option, StringComparison.OrdinalIgnoreCase))
             {
-                this.GetService<ITelerikUninstaller>().Execute();
+                var uninstaller = this.GetService<ITelerikUninstaller>();
+                uninstaller.Execute();
+                return string.Join(
+                    Environment.NewLine,
+                    uninstaller.Progress.Select((step, i) =>
+                    {
+                        var status = "🔲";
+                        if (step.Success.HasValue)
+                        {
+                            status = step.Success.Value ? "✅" : "🚨";
+                        }
+
+                        return $"{i}. {step.StepName} {status} - {step.Notes}";
+                    }));
             }
 
             return "Success";

--- a/DNN Platform/Skins/Aperture/Dnn.Skins.Aperture.csproj
+++ b/DNN Platform/Skins/Aperture/Dnn.Skins.Aperture.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules.DDRMenu/DotNetNuke.Tests.Modules.DDRMenu.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules.DDRMenu/DotNetNuke.Tests.Modules.DDRMenu.csproj
@@ -22,6 +22,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DNN Platform/Website/Install/App_LocalResources/UpgradeWizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/UpgradeWizard.aspx.resx
@@ -226,7 +226,7 @@
     <value>Your installation is utilizing Telerik in the following assemblies:</value>
   </data>
   <data name="TelerikInstalledAndUsedWarning.Text" xml:space="preserve">
-    <value>It appears that you have extensions that depended on Telerik. We are unable to remove the dependencies we've detected and listed above for you. However, this upgrade process &lt;em&gt;will&lt;/em&gt; remove the known-vulnerable Telerik components. Please ensure you have a backup of the site before continuing with the upgrade process.</value>
+    <value>It appears that you have extensions that depended on Telerik. We are unable to remove the dependencies we've detected and listed above for you. However, this upgrade process &lt;em&gt;will&lt;/em&gt; remove the known-vulnerable Telerik components. Please ensure you have a backup of the site before continuing with the upgrade process.  After the upgrade completes, it is possible that your website will stop functioning, manually restoring the &lt;code&gt;Telerik.Web.UI.dll&lt;/code&gt; may allow you to restore operation until you can uninstall the impacted extensions.</value>
   </data>
   <data name="TelerikInstalledButNotUsedInfo.Text" xml:space="preserve">
     <value>Your installation does NOT appear to be utilizing any of these components, the Telerik component will automatically be uninstalled. Please ensure you have a backup of the site before continuing with the upgrade process.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/UpgradeWizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/UpgradeWizard.aspx.resx
@@ -226,34 +226,28 @@
     <value>Your installation is utilizing Telerik in the following assemblies:</value>
   </data>
   <data name="TelerikInstalledAndUsedWarning.Text" xml:space="preserve">
-    <value>It appears that you have extensions that depended on Telerik. We are unable to remove the dependencies we've detected and listed above for you. However, please ensure that you have in fact properly patched Telerik and removed all DNN Platform distributed Telerik components per the guidance found &lt;a href="https://docs.dnncommunity.org/content/getting-started/setup/telerik-removal/index.html" target="_blank"&gt;here&lt;/a&gt;. Note you will NOT be able to upgrade to DNN 10 with those dependencies unless they are distributed with their own copy of Telerik.</value>
+    <value>It appears that you have extensions that depended on Telerik. We are unable to remove the dependencies we've detected and listed above for you. However, this upgrade process &lt;em&gt;will&lt;/em&gt; remove the known-vulnerable Telerik components. Please ensure you have a backup of the site before continuing with the upgrade process.</value>
   </data>
   <data name="TelerikInstalledButNotUsedInfo.Text" xml:space="preserve">
-    <value>Since your installation does NOT appear to be utilizing any of these components, you may elect to have them removed as part of this upgrade to improve the security of your application.</value>
+    <value>Your installation does NOT appear to be utilizing any of these components, the Telerik component will automatically be uninstalled. Please ensure you have a backup of the site before continuing with the upgrade process.</value>
   </data>
   <data name="TelerikInstalledHeading.Text" xml:space="preserve">
-    <value>Security Alert</value>
+    <value>Telerik Install Detected</value>
   </data>
   <data name="TelerikInstalledDetected.Text" xml:space="preserve">
-    <value>We have detected the presence of the previously distributed Telerik developer components. Detected Telerik version is:</value>
+    <value>We have detected the presence of the Telerik components. Detected Telerik version is:</value>
   </data>
   <data name="TelerikInstalledBulletin.Text" xml:space="preserve">
     <value>A Security Bulletin was released in August of 2021 that recommends immediate removal of this component due to the high-level security vulnerabilities present. You can read more about this on the &lt;a href="https://dnncommunity.org/security" target="_blank"&gt;DNN Security Center&lt;/a&gt;.</value>
   </data>
   <data name="TelerikNotInstalledHeading.Text" xml:space="preserve">
-    <value>Ready for Future Upgrades</value>
+    <value>Security Check: Success</value>
   </data>
   <data name="TelerikNotInstalledInfo.Text" xml:space="preserve">
-    <value>We have confirmed that you have removed Telerik, which makes your site ready for DNN 10.0.0.</value>
+    <value>We have confirmed that your site does not include the vulnerable Telerik component previously distributed with DNN.</value>
   </data>
   <data name="TelerikUninstallInfo.Text" xml:space="preserve">
     <value>Please note that selecting "Yes" from below will complete &lt;a href="https://docs.dnncommunity.org/content/getting-started/setup/telerik-removal/index.html" target="_blank"&gt;these steps&lt;/a&gt; for you automatically.</value>
-  </data>
-  <data name="TelerikUninstallNo.Text" xml:space="preserve">
-    <value>No, Leave my Site Insecure</value>
-  </data>
-  <data name="TelerikUninstallYes.Text" xml:space="preserve">
-    <value>Yes, Improve my Security &amp; Remove Telerik Now</value>
   </data>
   <data name="TelerikInvalidAntiForgeryToken.Text" xml:space="preserve">
     <value>Invalid Telerik anti-forgery token.</value>
@@ -264,7 +258,7 @@
   <data name="CheckingSecurity.Text" xml:space="preserve">
     <value>Checking security aspects of this installation</value>
   </data>
-  <data name="TelerikInstalledButNotUsedInfoAutoInstall.Text" xml:space="preserve">
-    <value>Since your installation does NOT appear to be utilizing any of these components, you can safely remove them. Please use the Telerik Removal Tool on the Personabar menu to remove these components.</value>
+  <data name="TelerikVersionNotKnownToBeVulnerableInfo.Text" xml:space="preserve">
+    <value>Your installation appears to be using a version of the Telerik components which is newer than the known-vulnerable version previously distributed. An uninstall will not occur automatically, however please review the &lt;a href="https://docs.dnncommunity.org/content/getting-started/setup/telerik-removal/index.html" target="_blank"&gt;removal steps&lt;/a&gt; to ensure all vulnerable components are removed or replaced. In addition, review &lt;a href="https://www.telerik.com/products/aspnet-ajax/documentation/security/security-information#telerik-ajax-control-specific-security-guidelines"&gt;Telerik's security guidance&lt;a&gt; to ensure any usage is using a version without known vulnerabilities and is configured correctly.</value>
   </data>
 </root>

--- a/DNN Platform/Website/Install/Install.aspx.cs
+++ b/DNN Platform/Website/Install/Install.aspx.cs
@@ -471,6 +471,7 @@ namespace DotNetNuke.Services.Install
                                     this.Response.Write($"{a}<br/>");
                                 }
 
+                                this.Response.Write("<br>");
                                 this.Response.Write(this.LocalizeString("TelerikInstalledAndUsedWarning"));
                                 this.Response.Write("<br>");
                             }

--- a/DNN Platform/Website/Install/Install.aspx.cs
+++ b/DNN Platform/Website/Install/Install.aspx.cs
@@ -14,10 +14,12 @@ namespace DotNetNuke.Services.Install
     using System.Web.UI;
     using System.Xml;
 
+    using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Application;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
+    using DotNetNuke.Entities;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Maintenance.Telerik;
     using DotNetNuke.Maintenance.Telerik.Removal;
@@ -141,6 +143,20 @@ namespace DotNetNuke.Services.Install
         private static ITelerikUtils CreateTelerikUtils()
         {
             return Globals.GetCurrentServiceProvider().GetRequiredService<ITelerikUtils>();
+        }
+
+        private static void SetHostSetting(string key, string value, bool isSecure = false)
+        {
+            var setting = new ConfigurationSetting
+            {
+                IsSecure = isSecure,
+                Key = key,
+                Value = value,
+            };
+
+            Globals.GetCurrentServiceProvider()
+                .GetRequiredService<IHostSettingsService>()
+                .Update(setting);
         }
 
         private void ExecuteScripts()
@@ -411,44 +427,54 @@ namespace DotNetNuke.Services.Install
                     this.Response.Write("<br>");
                     this.Response.Write("<h2>Checking Security Aspects</h2>");
                     var telerikUtils = CreateTelerikUtils();
-                    if (telerikUtils.TelerikIsInstalled())
+                    if (!telerikUtils.TelerikIsInstalled())
                     {
-                        var version = telerikUtils.GetTelerikVersion().ToString();
-                        var assemblies = telerikUtils.GetAssembliesThatDependOnTelerik()
-                                        .Select(a => Path.GetFileName(a));
-
+                        this.Response.Write(this.LocalizeString("TelerikNotInstalledInfo"));
+                        this.Response.Write("<br>");
+                    }
+                    else
+                    {
+                        var version = telerikUtils.GetTelerikVersion();
                         this.Response.Write("<strong>");
                         this.Response.Write(this.LocalizeString("TelerikInstalledHeading"));
                         this.Response.Write("</strong><br>");
                         this.Response.Write(this.LocalizeString("TelerikInstalledDetected"));
                         this.Response.Write(" ");
-                        this.Response.Write(version);
-                        this.Response.Write("<br>");
-                        this.Response.Write(this.LocalizeString("TelerikInstalledBulletin"));
+                        this.Response.Write(version.ToString());
                         this.Response.Write("<br>");
 
-                        if (!assemblies.Any())
+                        if (!telerikUtils.IsTelerikVersionVulnerable(version))
                         {
-                            this.Response.Write(this.LocalizeString("TelerikInstalledButNotUsedInfoAutoInstall"));
+                            this.Response.Write(this.LocalizeString("TelerikVersionNotKnownToBeVulnerableInfo"));
                             this.Response.Write("<br>");
                         }
                         else
                         {
-                            this.Response.Write(this.LocalizeString("TelerikInstalledAndUsedInfo"));
-                            this.Response.Write("<br>");
-                            foreach (var a in assemblies)
-                            {
-                                this.Response.Write($"{a}<br/>");
-                            }
+                            SetHostSetting(DotNetNuke.Maintenance.Constants.TelerikUninstallOptionSettingKey, DotNetNuke.Maintenance.Constants.TelerikUninstallYesValue);
+                            var assemblies = telerikUtils.GetAssembliesThatDependOnTelerik()
+                                .Select(a => Path.GetFileName(a));
 
-                            this.Response.Write(this.LocalizeString("TelerikInstalledAndUsedWarning"));
+                            this.Response.Write(this.LocalizeString("TelerikInstalledBulletin"));
                             this.Response.Write("<br>");
+
+                            if (!assemblies.Any())
+                            {
+                                this.Response.Write(this.LocalizeString("TelerikInstalledButNotUsedInfo"));
+                                this.Response.Write("<br>");
+                            }
+                            else
+                            {
+                                this.Response.Write(this.LocalizeString("TelerikInstalledAndUsedInfo"));
+                                this.Response.Write("<br>");
+                                foreach (var a in assemblies)
+                                {
+                                    this.Response.Write($"{a}<br/>");
+                                }
+
+                                this.Response.Write(this.LocalizeString("TelerikInstalledAndUsedWarning"));
+                                this.Response.Write("<br>");
+                            }
                         }
-                    }
-                    else
-                    {
-                        this.Response.Write(this.LocalizeString("TelerikNotInstalledInfo"));
-                        this.Response.Write("<br>");
                     }
 
                     this.Response.Write("<br>");

--- a/DNN Platform/Website/Install/UpgradeWizard.aspx.cs
+++ b/DNN Platform/Website/Install/UpgradeWizard.aspx.cs
@@ -374,6 +374,7 @@ namespace DotNetNuke.Services.Install
                     CreateParagraph("TelerikInstalledBulletin"),
                     CreateParagraph("TelerikInstalledAndUsedInfo"),
                     CreateTable(assemblies, maxRows: 3, maxColumns: 4),
+                    new Literal { Text = "<br />" },
                     CreateParagraph("TelerikInstalledAndUsedWarning")),
             };
         }

--- a/DNN Platform/Website/Install/UpgradeWizard.aspx.cs
+++ b/DNN Platform/Website/Install/UpgradeWizard.aspx.cs
@@ -46,8 +46,8 @@ namespace DotNetNuke.Services.Install
         /// <summary>Client ID of the hidden input containing the Telerik anti-forgery token.</summary>
         protected static readonly string TelerikAntiForgeryTokenClientID = "telerikAntiForgeryToken";
 
-        /// <summary>Client Id of the Telerik unintall radio buttons.</summary>
-        protected static readonly string TelerikUninstallOptionClientID = "telerikUninstallOption";
+        /// <summary>Client Id of the Telerik uninstall radio buttons.</summary>
+        protected static readonly string TelerikUninstallOptionClientID = DotNetNuke.Maintenance.Constants.TelerikUninstallOptionSettingKey;
 
         /// <summary>Form value when user selects Yes.</summary>
         protected static readonly string OptionYes = "Y";
@@ -142,10 +142,7 @@ namespace DotNetNuke.Services.Install
 
         public static Tuple<bool, string, SecurityTabResult> GetSecurityTab(Dictionary<string, string> accountInfo)
         {
-            string errorMsg;
-            var result = VerifyHostUser(accountInfo, out errorMsg);
-
-            if (!result)
+            if (!VerifyHostUser(accountInfo, out var errorMsg))
             {
                 return Tuple.Create(false, errorMsg, default(SecurityTabResult));
             }
@@ -160,7 +157,14 @@ namespace DotNetNuke.Services.Install
                     GetTelerikNotInstalledResult());
             }
 
-            var version = telerikUtils.GetTelerikVersion().ToString();
+            var version = telerikUtils.GetTelerikVersion();
+            if (!telerikUtils.IsTelerikVersionVulnerable(version))
+            {
+                return Tuple.Create(
+                    true,
+                    default(string),
+                    GetTelerikInstalledWithVersionNotKnownToBeVulnerable(version));
+            }
 
             var assemblies = telerikUtils.GetAssembliesThatDependOnTelerik()
                 .Select(a => Path.GetFileName(a));
@@ -199,7 +203,7 @@ namespace DotNetNuke.Services.Install
                 }
 
                 var option = accountInfo[TelerikUninstallOptionClientID];
-                SetHostSetting(TelerikUninstallOptionClientID, option);
+                SetHostSetting(DotNetNuke.Maintenance.Constants.TelerikUninstallOptionSettingKey, option);
 
                 upgradeRunning = false;
                 LaunchUpgrade();
@@ -329,56 +333,62 @@ namespace DotNetNuke.Services.Install
             };
         }
 
-        private static SecurityTabResult GetTelerikInstalledButNotUsedResult(string version)
+        private static SecurityTabResult GetTelerikInstalledWithVersionNotKnownToBeVulnerable(Version version)
         {
-            var yesButton = new ListItem(LocalizeStringStatic("TelerikUninstallYes"), OptionYes);
-            var noButton = new ListItem(LocalizeStringStatic("TelerikUninstallNo"), OptionNo);
-
             return new SecurityTabResult
             {
                 CanProceed = true,
                 View = RenderControls(
                     CreateTelerikAntiForgeryTokenField(),
+                    CreateHiddenField(TelerikUninstallOptionClientID, DotNetNuke.Maintenance.Constants.TelerikUninstallNoValue),
                     CreateTelerikInstalledHeader(version),
+                    CreateParagraph("TelerikVersionNotKnownToBeVulnerableInfo")),
+            };
+        }
+
+        private static SecurityTabResult GetTelerikInstalledButNotUsedResult(Version version)
+        {
+            return new SecurityTabResult
+            {
+                CanProceed = true,
+                View = RenderControls(
+                    CreateTelerikAntiForgeryTokenField(),
+                    CreateHiddenField(TelerikUninstallOptionClientID, DotNetNuke.Maintenance.Constants.TelerikUninstallYesValue),
+                    CreateTelerikInstalledHeader(version),
+                    CreateParagraph("TelerikInstalledBulletin"),
                     CreateParagraph("TelerikInstalledButNotUsedInfo"),
-                    CreateParagraph("TelerikUninstallInfo"),
-                    new RadioButtonList
-                    {
-                        ID = TelerikUninstallOptionClientID,
-                        Items = { yesButton, noButton },
-                        SelectedValue = OptionYes,
-                    }),
+                    CreateParagraph("TelerikUninstallInfo")),
             };
         }
 
         private static SecurityTabResult GetTelerikInstalledAndUsedResult(
-            IEnumerable<string> assemblies, string version)
+            IEnumerable<string> assemblies, Version version)
         {
             return new SecurityTabResult
             {
                 CanProceed = true,
                 View = RenderControls(
                     CreateTelerikAntiForgeryTokenField(),
-                    CreateHiddenField(TelerikUninstallOptionClientID, OptionNo),
+                    CreateHiddenField(TelerikUninstallOptionClientID, DotNetNuke.Maintenance.Constants.TelerikUninstallYesValue),
                     CreateTelerikInstalledHeader(version),
-                    CreateParagraph($"TelerikInstalledAndUsedInfo"),
+                    CreateParagraph("TelerikInstalledBulletin"),
+                    CreateParagraph("TelerikInstalledAndUsedInfo"),
                     CreateTable(assemblies, maxRows: 3, maxColumns: 4),
-                    CreateParagraph($"TelerikInstalledAndUsedWarning")),
+                    CreateParagraph("TelerikInstalledAndUsedWarning")),
             };
         }
 
         private static Control CreateTelerikAntiForgeryTokenField() =>
             CreateHiddenField(TelerikAntiForgeryTokenClientID, CreateTelerikAntiForgeryToken());
 
-        private static Control CreateTelerikInstalledHeader(string version)
+        private static Control CreateTelerikInstalledHeader(Version version)
         {
             return CreateBundle(
                 CreateHeading("TelerikInstalledHeading"),
-                CreateTelerikInstalledDetectedParagraph(version),
-                CreateParagraph("TelerikInstalledBulletin"));
+                CreateTelerikInstalledDetectedParagraph(version));
         }
 
-        private static Control CreateTelerikInstalledDetectedParagraph(string version)
+        private static Control CreateTelerikInstalledDetectedParagraph(Version version)
         {
             return new HtmlGenericControl("p")
             {
@@ -386,7 +396,7 @@ namespace DotNetNuke.Services.Install
                 {
                     new Label { Text = LocalizeStringStatic("TelerikInstalledDetected") },
                     new Literal { Text = " " },
-                    new Label { Text = version, CssClass = "telerikVersion" },
+                    new Label { Text = version.ToString(), CssClass = "telerikVersion" },
                 },
             };
         }


### PR DESCRIPTION
## Summary
This PR updates the upgrade wizard and auto-upgrade pages to trigger an uninstall of Telerik, if installed, unless the version that is present is newer than the known-vulnerable version previously distributed.

This PR has not been tested yet b/c of build issues related to #6326.