### PR TITLE
Fixed a tab position issue in install/upgrade wizard

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/install/install.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/install/install.scss
@@ -28,6 +28,7 @@ body {
                 display: flex;
                 list-style-type: none;
                 width: 100%;
+                padding: 0;
                 >li{
                     &:last-child{
                         flex-grow: 1;


### PR DESCRIPTION
I did something in our default `ul` styles that messed up the tabs in install/upgrade wizards.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
