### PR TITLE
Fixed an issue with distribution path of Aperture

### DIFF
--- a/DNN Platform/Skins/Aperture/build.ts
+++ b/DNN Platform/Skins/Aperture/build.ts
@@ -341,11 +341,13 @@ async function packageFiles(): Promise<void> {
 
   // Copy package to Install/Skin
   console.log("Copying package to Install/Skin...");
-  var skinInstallPath = "../../../Website/Install/Skin";
+  var skinInstallPath = "../../../Website/Install/Skin/";
   console.log(`Copying ${packageName} to ${skinInstallPath}`);
+  var destinationPath = `${skinInstallPath}/${packageName}`
+  ensureDirectoryExists(destinationPath);
   fs.copyFileSync(
       packagePath,
-      `${skinInstallPath}/${packageName}`);
+      destinationPath);
   deleteDirectoryWithRetry(artifactsDir);
   console.log(`Package copied to ${skinInstallPath}/${packageName}.`);
 }


### PR DESCRIPTION
The destination path for Aperture could not exist on a clean clone (or in this case in CI). This PR ensures the directory exists before the copy.

