### PR TITLE
Changed some default styles

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_type.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_type.scss
@@ -13,7 +13,6 @@ body{
 h1, h2, h3, h4, h5, h6{
     font-family: Arial, Helvetica, sans-serif;
     font-weight: bold;
-    color: var(--dnn-color-foreground-light, #333);
     font-weight: inherit;
     line-height: 1.4;
     margin-top: 1rem;

--- a/DNN Platform/Library/Entities/Portals/PortalStyles.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalStyles.cs
@@ -102,15 +102,15 @@ namespace DotNetNuke.Entities.Portals
 
         /// <inheritdoc/>
         [PortalSetting(Prefix = Prefix)]
-        public string ColorForeground { get; set; } = "323232";
+        public string ColorForeground { get; set; } = "472A2B";
 
         /// <inheritdoc/>
         [PortalSetting(Prefix = Prefix)]
-        public string ColorForegroundLight { get; set; } = "A2A2A2";
+        public string ColorForegroundLight { get; set; } = "673D3E";
 
         /// <inheritdoc/>
         [PortalSetting(Prefix = Prefix)]
-        public string ColorForegroundDark { get; set; } = "000000";
+        public string ColorForegroundDark { get; set; } = "231717";
 
         /// <inheritdoc/>
         [PortalSetting(Prefix = Prefix)]


### PR DESCRIPTION
default.css was too opiniated on the color of heading, we should just use the ambiant foreground color at that level and leave it to theme developers to override if they want and how they want.

We did not have the DNN dark brown in the color system, this is now our foreground color which makes foreground text the DNN brown color and looks almost black on smaller text and keeps a soft not 100% contrast that feels nice to me.

![image](https://github.com/user-attachments/assets/4e6c30ba-1134-4918-ae2c-35a7b7b5f943)

![image](https://github.com/user-attachments/assets/b296f525-2618-41cd-a5c5-1f048c1f219c)
