### PR TITLE
Fixed a font weight issue

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/modules.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/modules.scss
@@ -18,7 +18,6 @@ td.SubHead{
 .NormalDeleted {
     color: var(--dnn-color-foreground, #444);
     font-size: 1rem;
-    font-weight: normal;
     line-height: 1.125rem;
     word-wrap: break-word;
 }


### PR DESCRIPTION
default.css and Aperture were having a bit of a fight for a font weight that made the theme not look as designed initially. default.css should not try to be too opiniated, so I removed the font weight from it to let the theme win that fight.
![image](https://github.com/user-attachments/assets/29728a07-0ae7-4fac-95b5-94d5b73ba868)
