### PR TITLE
Include JWT Auth by default

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Library.build
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Library.build
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <Import Project="..\..\DNN_Platform.build" />
   <PropertyGroup>
-    <Extension>resources</Extension>
+    <Extension>zip</Extension>
     <DNNFileName>Dnn.Jwt</DNNFileName>
     <PackageName>DnnJwtAuth</PackageName>
     <ModuleFolderName>$(WebsitePath)\DesktopModules\AuthenticationServices\JWTAuth</ModuleFolderName>


### PR DESCRIPTION
## Summary
I believe the @dnnsoftware/approvers had decided at some point that the JWT auth package should be included by default starting in DNN 10.