### PR TITLE
Replace legacy System.IdentityModel.Tokens.Jwt

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Dnn.AuthServices.Jwt.csproj
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Dnn.AuthServices.Jwt.csproj
@@ -86,9 +86,6 @@
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.9.0.2\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=8.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.8.4.0\lib\net472\System.IdentityModel.Tokens.Jwt.dll</HintPath>
-    </Reference>
     <Reference Include="System.IO.Pipelines, Version=9.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Pipelines.9.0.2\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>

--- a/DNN Platform/Dnn.AuthServices.Jwt/Dnn.Jwt.dnn
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Dnn.Jwt.dnn
@@ -25,10 +25,6 @@
             </assembly>
             <assembly>
               <path>bin</path>
-              <name>System.IdentityModel.Tokens.Jwt.dll</name>
-            </assembly>
-            <assembly>
-              <path>bin</path>
               <name>Microsoft.IdentityModel.Abstractions.dll</name>
             </assembly>
             <assembly>
@@ -134,6 +130,14 @@
               </configuration>
             </uninstall>
           </config>
+        </component>
+        <component type="Cleanup">
+          <files>
+            <file>
+              <path>bin</path>
+              <name>System.IdentityModel.Tokens.Jwt.dll</name>
+            </file>
+          </files>
         </component>
       </components>
     </package>

--- a/DNN Platform/Dnn.AuthServices.Jwt/Library.build
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Library.build
@@ -16,7 +16,6 @@
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\$(AssemblyName).dll" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\$(AssemblyName).pdb" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\$(AssemblyName).xml" DestinationFolder="$(WebsitePath)/bin" />
-    <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\System.IdentityModel.Tokens.Jwt.dll" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Microsoft.IdentityModel.Tokens.dll" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Microsoft.IdentityModel.JsonWebTokens.dll" DestinationFolder="$(WebsitePath)/bin" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Microsoft.IdentityModel.Logging.dll" DestinationFolder="$(WebsitePath)/bin" />

--- a/DNN Platform/Dnn.AuthServices.Jwt/packages.config
+++ b/DNN Platform/Dnn.AuthServices.Jwt/packages.config
@@ -18,7 +18,6 @@
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net48" developmentDependency="true" />
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="9.0.2" targetFramework="net48" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="8.4.0" targetFramework="net48" />
   <package id="System.IO.Pipelines" version="9.0.2" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />


### PR DESCRIPTION
This PR builds on top of #6350, which upgrades the System.IdentityModel.Tokens.Jwt NuGet package. That package is now [marked as "legacy"](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/e5272528a608b903e321223dd05f132d1d31a5dd/src/System.IdentityModel.Tokens.Jwt/System.IdentityModel.Tokens.Jwt.csproj#L7), so this follow-on PR replaces its usage with the recommended Microsoft.IdentityModel.JsonWebTokens package (which was already referenced). This was mostly straightforward, other than the header validation check that needed to be moved around a bit.