### PR TITLE
Bump GitVersion from 5.12.0 to 6.1.0

### DIFF
--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Build
                 .UseLifetime<Lifetime>()
                 .UseWorkingDirectory("..")
                 .UseModule<AzurePipelinesModule>()
-                .InstallTool(new Uri("dotnet:?package=GitVersion.Tool&version=5.12.0"))
+                .InstallTool(new Uri("dotnet:?package=GitVersion.Tool&version=6.1.0"))
                 .InstallTool(new Uri("nuget:?package=Microsoft.TestPlatform&version=" + MicrosoftTestPlatformVersion))
                 .InstallTool(new Uri("nuget:?package=NUnit3TestAdapter&version=" + NUnit3TestAdapterVersion))
                 .InstallTool(new Uri("nuget:?package=NuGet.CommandLine&version=6.5.0"))

--- a/Build/Tasks/SetVersion.cs
+++ b/Build/Tasks/SetVersion.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Build.Tasks
             if (context.Settings.Version == "auto")
             {
                 context.Version = context.GitVersion();
-                context.BuildNumber = context.Version.LegacySemVerPadded;
+                context.BuildNumber = context.Version.FullSemVer;
             }
             else
             {

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -7,36 +7,38 @@ ignore:
 branches:
   future:
     regex: ^future?[/-]
-    tag: 'alpha'
+    label: 'alpha'
     increment: Major
     source-branches: []
   development:
     regex: ^development$
-    tag: 'alpha'
+    label: 'alpha'
     increment: Major
     source-branches: []
   develop:
     regex: ^develop$
-    tag: 'alpha'
+    label: 'alpha'
     increment: Patch
-    is-mainline: true
+    is-main-branch: true
     source-branches: []
     tracks-release-branches: false
   release:
     regex: ^release?[/-]
     mode: ContinuousDelivery
-    tag: 'rc'
+    label: 'rc'
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+        of-merged-branch: true
     track-merge-target: false
     tracks-release-branches: false
     is-release-branch: true
     source-branches: []
   pull-request:
     regex: (pull|pull\-requests|pr)[/-]
-    tag: 'pr'
-    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    label: 'pr'
+    label-number-pattern: '[/-](?<number>\d+)[-/]'
     increment: Patch
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+        of-merged-branch: true
     is-release-branch: false
     source-branches: []


### PR DESCRIPTION
## Summary
This PR bumps GitVersion from 5.x to 6.x. This involves adjusting the configuration and removing usage of legacy variables.

With the most straightforward conversion from the 5.x config to 6.x, the output from the tool is a bit different. As an example, here's output for this PR branch:

<details>
<summary>5.x output</summary>
<pre><code>
{
  "Major": 10,
  "Minor": 0,
  "Patch": 0,
  "PreReleaseTag": "gitversion-6.993",
  "PreReleaseTagWithDash": "-gitversion-6.993",
  "PreReleaseLabel": "gitversion-6",
  "PreReleaseLabelWithDash": "-gitversion-6",
  "PreReleaseNumber": 993,
  "WeightedPreReleaseNumber": 993,
  "BuildMetaData": null,
  "BuildMetaDataPadded": "",
  "FullBuildMetaData": "Branch.gitversion-6.Sha.2719998965ea595ecd1c9a6bda0fb6d57ce41a0d",
  "MajorMinorPatch": "10.0.0",
  "SemVer": "10.0.0-gitversion-6.993",
  "LegacySemVer": "10.0.0-gitversion-6-993",
  "LegacySemVerPadded": "10.0.0-gitversion-6-0993",
  "AssemblySemVer": "10.0.0.0",
  "AssemblySemFileVer": "10.0.0.993",
  "FullSemVer": "10.0.0-gitversion-6.993",
  "InformationalVersion": "10.0.0-gitversion-6.993+Branch.gitversion-6.Sha.2719998965ea595ecd1c9a6bda0fb6d57ce41a0d",
  "BranchName": "gitversion-6",
  "EscapedBranchName": "gitversion-6",
  "Sha": "2719998965ea595ecd1c9a6bda0fb6d57ce41a0d",
  "ShortSha": "2719998",
  "NuGetVersionV2": "10.0.0-gitversion-6-0993",
  "NuGetVersion": "10.0.0-gitversion-6-0993",
  "NuGetPreReleaseTagV2": "gitversion-6-0993",
  "NuGetPreReleaseTag": "gitversion-6-0993",
  "VersionSourceSha": "e69f3dbc5a08e0afb93638990246c60c1993d5a9",
  "CommitsSinceVersionSource": 993,
  "CommitsSinceVersionSourcePadded": "0993",
  "UncommittedChanges": 0,
  "CommitDate": "20250204"
}
</code></pre>
<blockquote>
<ul>
<li>Informational Version : 10.0.0-gitversion-6.993+Branch.gitversion-6.Sha.2719998965ea595ecd1c9a6bda0fb6d57ce41a0d</li>
<li>Product Version : 10.0.0</li>
<li>Build Number : 10.0.0-gitversion-6-0993</li>
<li>The build Id is : 0</li>
</ul>
</details>
<details>
<summary>6.x output</summary>
<pre><code>
{
  "Major": 10,
  "Minor": 0,
  "Patch": 1,
  "PreReleaseTag": "gitversion-6.1",
  "PreReleaseTagWithDash": "-gitversion-6.1",
  "PreReleaseLabel": "gitversion-6",
  "PreReleaseLabelWithDash": "-gitversion-6",
  "PreReleaseNumber": 1,
  "WeightedPreReleaseNumber": 1,
  "BuildMetaData": "556",
  "BuildMetaDataPadded": null,
  "FullBuildMetaData": "556.Branch.gitversion-6.Sha.653cdb94ca7e8ea1af57776535d24e3a39c37b65",
  "MajorMinorPatch": "10.0.1",
  "SemVer": "10.0.1-gitversion-6.1",
  "LegacySemVer": null,
  "LegacySemVerPadded": null,
  "AssemblySemVer": "10.0.1.0",
  "AssemblySemFileVer": "10.0.1.556",
  "FullSemVer": "10.0.1-gitversion-6.1+556",
  "InformationalVersion": "10.0.1-gitversion-6.1+556.Branch.gitversion-6.Sha.653cdb94ca7e8ea1af57776535d24e3a39c37b65",
  "BranchName": "gitversion-6",
  "EscapedBranchName": "gitversion-6",
  "Sha": "653cdb94ca7e8ea1af57776535d24e3a39c37b65",
  "ShortSha": "653cdb9",
  "NuGetVersionV2": null,
  "NuGetVersion": null,
  "NuGetPreReleaseTagV2": null,
  "NuGetPreReleaseTag": null,
  "VersionSourceSha": "eef6b1ce197be22fc33427e6f764377f8ebc588e",
  "CommitsSinceVersionSource": 556,
  "CommitsSinceVersionSourcePadded": null,
  "UncommittedChanges": 0,
  "CommitDate": "20250204"
}
</code></pre>
<blockquote>
<ul>
<li>Informational Version : 10.0.1-gitversion-6.1+556.Branch.gitversion-6.Sha.653cdb94ca7e8ea1af57776535d24e3a39c37b65</li>
<li>Product Version : 10.0.1</li>
<li>Build Number : 10.0.1-gitversion-6.1+556</li>
<li>The build Id is : 0</li>
</ul>
</details>

```diff
 {
   "Major": 10,
   "Minor": 0,
-  "Patch": 0,
-  "PreReleaseTag": "gitversion-6.993",
-  "PreReleaseTagWithDash": "-gitversion-6.993",
+  "Patch": 1,
+  "PreReleaseTag": "gitversion-6.1",
+  "PreReleaseTagWithDash": "-gitversion-6.1",
   "PreReleaseLabel": "gitversion-6",
   "PreReleaseLabelWithDash": "-gitversion-6",
-  "PreReleaseNumber": 993,
-  "WeightedPreReleaseNumber": 993,
-  "BuildMetaData": null,
-  "BuildMetaDataPadded": "",
-  "FullBuildMetaData": "Branch.gitversion-6.Sha.2719998965ea595ecd1c9a6bda0fb6d57ce41a0d",
-  "MajorMinorPatch": "10.0.0",
-  "SemVer": "10.0.0-gitversion-6.993",
-  "LegacySemVer": "10.0.0-gitversion-6-993",
-  "LegacySemVerPadded": "10.0.0-gitversion-6-0993",
-  "AssemblySemVer": "10.0.0.0",
-  "AssemblySemFileVer": "10.0.0.993",
-  "FullSemVer": "10.0.0-gitversion-6.993",
-  "InformationalVersion": "10.0.0-gitversion-6.993+Branch.gitversion-6.Sha.2719998965ea595ecd1c9a6bda0fb6d57ce41a0d",
+  "PreReleaseNumber": 1,
+  "WeightedPreReleaseNumber": 1,
+  "BuildMetaData": "557",
+  "BuildMetaDataPadded": null,
+  "FullBuildMetaData": "557.Branch.gitversion-6.Sha.25089eaa68614064f25bf7728872068d6dd2bcb5",
+  "MajorMinorPatch": "10.0.1",
+  "SemVer": "10.0.1-gitversion-6.1",
+  "LegacySemVer": null,
+  "LegacySemVerPadded": null,
+  "AssemblySemVer": "10.0.1.0",
+  "AssemblySemFileVer": "10.0.1.557",
+  "FullSemVer": "10.0.1-gitversion-6.1+557",
+  "InformationalVersion": "10.0.1-gitversion-6.1+557.Branch.gitversion-6.Sha.25089eaa68614064f25bf7728872068d6dd2bcb5",
   "BranchName": "gitversion-6",
   "EscapedBranchName": "gitversion-6",
-  "Sha": "2719998965ea595ecd1c9a6bda0fb6d57ce41a0d",
-  "ShortSha": "2719998",
-  "NuGetVersionV2": "10.0.0-gitversion-6-0993",
-  "NuGetVersion": "10.0.0-gitversion-6-0993",
-  "NuGetPreReleaseTagV2": "gitversion-6-0993",
-  "NuGetPreReleaseTag": "gitversion-6-0993",
-  "VersionSourceSha": "e69f3dbc5a08e0afb93638990246c60c1993d5a9",
-  "CommitsSinceVersionSource": 993,
-  "CommitsSinceVersionSourcePadded": "0993",
+  "Sha": "25089eaa68614064f25bf7728872068d6dd2bcb5",
+  "ShortSha": "25089ea",
+  "NuGetVersionV2": null,
+  "NuGetVersion": null,
+  "NuGetPreReleaseTagV2": null,
+  "NuGetPreReleaseTag": null,
+  "VersionSourceSha": "eef6b1ce197be22fc33427e6f764377f8ebc588e",
+  "CommitsSinceVersionSource": 557,
+  "CommitsSinceVersionSourcePadded": null,
   "UncommittedChanges": 0,
   "CommitDate": "20250204"
 }
-Informational Version : 10.0.0-gitversion-6.993+Branch.gitversion-6.Sha.2719998965ea595ecd1c9a6bda0fb6d57ce41a0d
-Product Version : 10.0.0
-Build Number : 10.0.0-gitversion-6-0993
+Informational Version : 10.0.1-gitversion-6.1+556.Branch.gitversion-6.Sha.653cdb94ca7e8ea1af57776535d24e3a39c37b65
+Product Version : 10.0.1
+Build Number : 10.0.1-gitversion-6.1+556
 The build Id is : 0
```

However, there is not a significant difference when building the release/10.0.0 branch with these changes, so maybe this is fine.