### PR TITLE
Use valid syntax for CSS gradients

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/dnn-jquery/_dnn-progressbar.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/dnn-jquery/_dnn-progressbar.scss
@@ -23,6 +23,6 @@ because it is used in the installer and rarely visible in the module injection.
         background: -moz-linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, right top, color-stop(0%,#2b7fda), color-stop(100%,#3fbdff)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* W3C */
+        background: linear-gradient(to right, #2b7fda 0%, #3fbdff 100%); /* W3C */
     }
 }

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/jquery-ui/_spinner.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/jquery-ui/_spinner.scss
@@ -7,7 +7,7 @@
     overflow: visible;
     border: 1px solid #c9c9c9;
     background: #fff;
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     border-radius: 3px;
     color: #333;
     text-decoration: none;

--- a/DNN Platform/Modules/CoreMessaging/module.css
+++ b/DNN Platform/Modules/CoreMessaging/module.css
@@ -129,7 +129,7 @@ button, input[type="button"], input[type="reset"], input[type="submit"], .dnnPri
 	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,152,241,1)), color-stop(100%,rgba(2,111,196,1))); /* Chrome,Safari4+ */
 	background: -webkit-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Chrome10+,Safari5.1+ */
 	background: -o-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Opera 11.10+ */
-	background: linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
+	background: linear-gradient(to bottom, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
 	
 	-webkit-border-radius: 	3px;
 	-moz-border-radius: 	3px;
@@ -314,7 +314,7 @@ button, input[type="button"], input[type="reset"], input[type="submit"], .dnnPri
 		background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,152,241,1)), color-stop(100%,rgba(2,111,196,1))); /* Chrome,Safari4+ */
 		background: -webkit-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Opera 11.10+ */
-		background: linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
+		background: linear-gradient(t bottom, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
 		
 		-webkit-border-radius: 	3px;
 		-moz-border-radius: 	3px;
@@ -338,7 +338,7 @@ button, input[type="button"], input[type="reset"], input[type="submit"], .dnnPri
 		background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(227,227,227,1)), color-stop(100%,rgba(199,200,202,1))); /* Chrome,Safari4+ */
 		background: -webkit-linear-gradient(top, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* Opera 11.10+ */
-		background: linear-gradient(top, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* W3C */
+		background: linear-gradient(to bottom, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* W3C */
 		
 		-webkit-border-radius: 	3px;
 		-moz-border-radius: 	3px;
@@ -376,7 +376,7 @@ button, input[type="button"], input[type="reset"], input[type="submit"], .dnnPri
 		background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,152,241,1)), color-stop(100%,rgba(2,111,196,1))); /* Chrome,Safari4+ */
 		background: -webkit-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Opera 11.10+ */
-		background: linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
+		background: linear-gradient(to bottom, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
 		
 		-webkit-border-radius: 	3px;
 		-moz-border-radius: 	3px;
@@ -400,7 +400,7 @@ button, input[type="button"], input[type="reset"], input[type="submit"], .dnnPri
 		background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(227,227,227,1)), color-stop(100%,rgba(199,200,202,1))); /* Chrome,Safari4+ */
 		background: -webkit-linear-gradient(top, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* Opera 11.10+ */
-		background: linear-gradient(top, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* W3C */
+		background: linear-gradient(to bottom, rgba(227,227,227,1) 0%,rgba(199,200,202,1) 100%); /* W3C */
 		
 		-webkit-border-radius: 	3px;
 		-moz-border-radius: 	3px;
@@ -472,7 +472,7 @@ ul.dnnButtonGroup {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: 0px 1px 0px 0px #bbb;

--- a/DNN Platform/Modules/CoreMessaging/module.css
+++ b/DNN Platform/Modules/CoreMessaging/module.css
@@ -314,7 +314,8 @@ button, input[type="button"], input[type="reset"], input[type="submit"], .dnnPri
 		background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,152,241,1)), color-stop(100%,rgba(2,111,196,1))); /* Chrome,Safari4+ */
 		background: -webkit-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Chrome10+,Safari5.1+ */
 		background: -o-linear-gradient(top, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* Opera 11.10+ */
-		background: linear-gradient(t bottom, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
+		background: linear-gradient(to bottom, rgba(31,152,241,1) 0%,rgba(2,111,196,1) 100%); /* W3C */
+
 		
 		-webkit-border-radius: 	3px;
 		-moz-border-radius: 	3px;

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.18.0/plugins/balloonpanel/skins/moono/balloonpanel.css
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.18.0/plugins/balloonpanel/skins/moono/balloonpanel.css
@@ -52,7 +52,7 @@ For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
 	background-image: -webkit-linear-gradient(top, #f5f5f5, #cfd1cf);
 	background-image: -o-linear-gradient(top, #f5f5f5, #cfd1cf);
 	background-image: -ms-linear-gradient(top, #f5f5f5, #cfd1cf);
-	background-image: linear-gradient(top, #f5f5f5, #cfd1cf);
+	background-image: linear-gradient(to bottom, #f5f5f5, #cfd1cf);
 	filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#f5f5f5', endColorstr='#cfd1cf');
 }
 

--- a/DNN Platform/Website/DesktopModules/Admin/SearchResults/module.css
+++ b/DNN Platform/Website/DesktopModules/Admin/SearchResults/module.css
@@ -66,7 +66,7 @@
                 background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
                 background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
                 background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-                background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+                background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
             }
 
             .dnnSearchResultPanel .dnnSearchResultSortOptions > li.active > a,
@@ -75,7 +75,7 @@
                 background: -moz-linear-gradient(top, #ccc 0%, #fff 100%); /* FF3.6+ */
                 background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ccc), color-stop(100%,#fff)); /* Chrome,Safari4+ */
                 background: -webkit-linear-gradient(top, #ccc 0%,#fff 100%); /* Chrome10+,Safari5.1+ */
-                background: linear-gradient(top, #ccc 0%,#fff 100%); /* W3C */
+                background: linear-gradient(to bottom, #ccc 0%,#fff 100%); /* W3C */
                 color: #333;
             }
 
@@ -205,7 +205,7 @@
         background: -webkit-linear-gradient(top, #fff 0%, #eee6e5 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #fff 0%, #eee6e5 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #fff 0%,#eee6e5 100%); /* IE10+ */
-        background: linear-gradient(top, #fff 0%,#eee6e5 100%); /* W3C */
+        background: linear-gradient(to bottom, #fff 0%,#eee6e5 100%); /* W3C */
         border: 1px solid #dddddd;
         box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
         color: #555;

--- a/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/ComboBox.Default.css
+++ b/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/ComboBox.Default.css
@@ -66,7 +66,7 @@ div.RadComboBox_Default .rcbArrowCell a {
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%) !important; /* Chrome10+,Safari5.1+ */
 	background: -o-linear-gradient(top,  #fff 1%,#f0f2f1 100%); /* Opera 11.10+ */
 	background: -ms-linear-gradient(top, #fff 0%,#f0f2f1 100%) !important; /* IE10+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%) !important; /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%) !important; /* W3C */
     color: #999;
     text-decoration: none;
     margin: 0 !important;
@@ -114,7 +114,7 @@ div.RadComboBox_Default .rcbArrowCell a {
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%) !important; /* Chrome10+,Safari5.1+ */
 	background: -o-linear-gradient(top,  #fff 1%,#f0f2f1 100%); /* Opera 11.10+ */
 	background: -ms-linear-gradient(top, #fff 0%,#f0f2f1 100%) !important; /* IE10+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%) !important; /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%) !important; /* W3C */
     color: #333;
     text-decoration: none;
     vertical-align: middle !important;

--- a/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/DatePicker.Default.css
+++ b/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/DatePicker.Default.css
@@ -735,7 +735,7 @@ body > .RadCalendarPopupShadows {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     color: rgba(0,0,0,0.75);
 }
 
@@ -781,7 +781,7 @@ body > .RadCalendarPopupShadows {
     background: -webkit-linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* Chrome10+,Safari5.1+ */
     background: -o-linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* IE10+ */
-    background: linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* W3C */
+    background: linear-gradient(to bottom, #d9d9d9 0%,#c7c7c7 100%); /* W3C */
 }
 
 .RadCalendar_Default .rcMainTable .rcWeek th {
@@ -816,7 +816,7 @@ body > .RadCalendarPopupShadows {
     background: -webkit-linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* Chrome10+,Safari5.1+ */
     background: -o-linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* IE10+ */
-    background: linear-gradient(top, #d9d9d9 0%,#c7c7c7 100%); /* W3C */
+    background: linear-gradient(to bottom, #d9d9d9 0%,#c7c7c7 100%); /* W3C */
 }
 
 /* hover on day */
@@ -859,7 +859,7 @@ body > .RadCalendarPopupShadows {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     color: rgba(0,0,0,0.75);
     font-size: 12px !important;
     font-weight: bold;

--- a/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/Grid.Default.css
+++ b/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/Grid.Default.css
@@ -413,7 +413,7 @@
 	background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
 	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
 	background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-	background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+	background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
 }
 
 .RadGrid_Default .rgHeader:last-child, .RadGrid_Default th.rgResizeCol:last-child{

--- a/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/GridView.Default.css
+++ b/DNN Platform/Website/Portals/_default/Skins/_default/WebControlSkin/Default/GridView.Default.css
@@ -23,7 +23,7 @@
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1));
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%);
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%);
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%);
 }
 .dnn-grid tr td {
     border-style: solid;

--- a/DNN Platform/Website/Resources/Shared/components/DropDownList/dnn.DropDownList.css
+++ b/DNN Platform/Website/Resources/Shared/components/DropDownList/dnn.DropDownList.css
@@ -16,7 +16,7 @@
     background: -webkit-linear-gradient(top, #fff 0%, #f0f2f1 100%);
     background: -o-linear-gradient(top, #fff 1%, #f0f2f1 100%);
     background: -ms-linear-gradient(top, #fff 0%, #f0f2f1 100%);
-    background: linear-gradient(top, #fff 0%, #f0f2f1 100%);
+    background: linear-gradient(to bottom, #fff 0%, #f0f2f1 100%);
     color: #999;
     text-decoration: none;
     margin: 0;
@@ -195,7 +195,7 @@
     background: -moz-linear-gradient(top, #fff 0%, #eee6e5 100%);
     background: -ms-linear-gradient(top, #fff 0%,#eee6e5 100%);
     background: -o-linear-gradient(top, #fff 0%,#eee6e5 100%);
-    background: linear-gradient(top, #fff 0%,#eee6e5 100%);
+    background: linear-gradient(to bottom, #fff 0%,#eee6e5 100%);
     background-repeat: no-repeat;
     border: 1px solid #ccc;
     margin: 0 15px 0 0;

--- a/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/7.0.0/default.css
+++ b/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/7.0.0/default.css
@@ -451,7 +451,7 @@ li p {
         background: -webkit-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* IE10+ */
-        background: linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
+        background: linear-gradient(to bottom, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
         text-align: left;
         text-shadow: 1px 1px 0px rgba(255,255,255,0.8);
         color: #333;
@@ -474,7 +474,7 @@ li p {
                 background: -webkit-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Chrome10+,Safari5.1+ */
                 background: -o-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Opera 11.10+ */
                 background: -ms-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* IE10+ */
-                background: linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* W3C */
+                background: linear-gradient(to bottom, #fefefe 0%,#e8e8e8 100%); /* W3C */
                 color: #333;
             }
 
@@ -486,7 +486,7 @@ li p {
                 background: -webkit-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Chrome10+,Safari5.1+ */
                 background: -o-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Opera 11.10+ */
                 background: -ms-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* IE10+ */
-                background: linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
+                background: linear-gradient(to bottom, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
                 -webkit-box-shadow: inset 0px 2px 3px 0px rgba(0, 0, 0, 0.3);
                 box-shadow: inset 0px 2px 3px 0px rgba(0, 0, 0, 0.3);
             }
@@ -715,7 +715,7 @@ ul.dnnAdminTabNav li a,
     background: -moz-linear-gradient(top, #358eea 0%, #2170cd 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#358eea), color-stop(100%,#2170cd)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #358eea 0%,#2170cd 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #358eea 0%,#2170cd 100%); /* W3C */
+    background: linear-gradient(to bottom, #358eea 0%,#2170cd 100%); /* W3C */
     -webkit-box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.6), inset 0px 1px 0px 0px rgba(255, 255, 255, 0.4);
     box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.6), inset 0px 1px 0px 0px rgba(255, 255, 255, 0.4);
     color: #efefef;
@@ -728,7 +728,7 @@ ul.dnnAdminTabNav li a,
         background: -moz-linear-gradient(top, #6cb6f3 0%, #4387d2 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6cb6f3), color-stop(100%,#4387d2)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(top, #6cb6f3 0%,#4387d2 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(top, #6cb6f3 0%,#4387d2 100%); /* W3C */
+        background: linear-gradient(to bottom, #6cb6f3 0%,#4387d2 100%); /* W3C */
         color: #fff;
     }
 
@@ -738,7 +738,7 @@ ul.dnnAdminTabNav li a,
         background: -moz-linear-gradient(top, #1f66be 0%, #3085e0 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#1f66be), color-stop(100%,#3085e0)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(top, #1f66be 0%,#3085e0 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(top, #1f66be 0%,#3085e0 100%); /* W3C */
+        background: linear-gradient(to bottom, #1f66be 0%,#3085e0 100%); /* W3C */
         -webkit-box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
         box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
         color: #fff;
@@ -766,7 +766,7 @@ ul.dnnAdminTabNav li a,
     background: -webkit-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Chrome10+,Safari5.1+ */
     background: -o-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* IE10+ */
-    background: linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
+    background: linear-gradient(to bottom, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
     -webkit-box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
     box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
     text-shadow: 0px 1px 0px #ffffff;
@@ -785,7 +785,7 @@ ul.dnnAdminTabNav li a,
         background: -webkit-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* IE10+ */
-        background: linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* W3C */
+        background: linear-gradient(to bottom, #fefefe 0%,#e8e8e8 100%); /* W3C */
         color: #555;
     }
 
@@ -803,7 +803,7 @@ ul.dnnAdminTabNav li a,
         background: -webkit-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* IE10+ */
-        background: linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
+        background: linear-gradient(to bottom, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
         -webkit-box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
         box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
     }
@@ -1532,7 +1532,7 @@ div.dnnFormGroup {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     color: #333;
@@ -1836,7 +1836,7 @@ div.dnnTagsInput > div > input.dnnTagsInvalid {
     background: -moz-linear-gradient(top, #f0f2f1 0%, #fff 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f0f2f1), color-stop(100%,#fff)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #f0f2f1 0%,#fff 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #f0f2f1 0%,#fff 100%); /* W3C */
+    background: linear-gradient(to bottom, #f0f2f1 0%,#fff 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: inset 0px 1px 3px 0px rgba(0,0,0,0.25), 0px 1px 0px 0px #fff;
@@ -1859,7 +1859,7 @@ div.dnnTagsInput > div > input.dnnTagsInvalid {
         background: -moz-linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, right top, color-stop(0%,#2b7fda), color-stop(100%,#3fbdff)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* W3C */
+        background: linear-gradient(to right, #2b7fda 0%, #3fbdff 100%); /* W3C */
     }
 
 /* Button Dropdown */
@@ -1875,7 +1875,7 @@ div.dnnTagsInput > div > input.dnnTagsInvalid {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: 0px 1px 0px 0px #bbb;
@@ -1959,7 +1959,7 @@ ul.dnnButtonGroup {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: 0px 1px 0px 0px #bbb;
@@ -2734,7 +2734,7 @@ table.dnnASPGrid {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
 }
 
 .dnnGridItem td, .dnnGridAltItem td {

--- a/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/8.0.0/default.css
+++ b/DNN Platform/Website/Resources/Shared/stylesheets/dnndefault/8.0.0/default.css
@@ -185,7 +185,7 @@ img {
         background: -webkit-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* IE10+ */
-        background: linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
+        background: linear-gradient(to bottom, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
         text-align: left;
         text-shadow: 1px 1px 0px rgba(255,255,255,0.8);
         color: #333;
@@ -208,7 +208,7 @@ img {
                 background: -webkit-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Chrome10+,Safari5.1+ */
                 background: -o-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Opera 11.10+ */
                 background: -ms-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* IE10+ */
-                background: linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* W3C */
+                background: linear-gradient(to bottom, #fefefe 0%,#e8e8e8 100%); /* W3C */
                 color: #333;
             }
 
@@ -220,7 +220,7 @@ img {
                 background: -webkit-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Chrome10+,Safari5.1+ */
                 background: -o-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Opera 11.10+ */
                 background: -ms-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* IE10+ */
-                background: linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
+                background: linear-gradient(to bottom, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
                 -webkit-box-shadow: inset 0px 2px 3px 0px rgba(0, 0, 0, 0.3);
                 box-shadow: inset 0px 2px 3px 0px rgba(0, 0, 0, 0.3);
             }
@@ -449,7 +449,7 @@ ul.dnnAdminTabNav li a,
     background: -moz-linear-gradient(top, #358eea 0%, #2170cd 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#358eea), color-stop(100%,#2170cd)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #358eea 0%,#2170cd 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #358eea 0%,#2170cd 100%); /* W3C */
+    background: linear-gradient(to bottom, #358eea 0%,#2170cd 100%); /* W3C */
     -webkit-box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.6), inset 0px 1px 0px 0px rgba(255, 255, 255, 0.4);
     box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.6), inset 0px 1px 0px 0px rgba(255, 255, 255, 0.4);
     color: #efefef;
@@ -462,7 +462,7 @@ ul.dnnAdminTabNav li a,
         background: -moz-linear-gradient(top, #6cb6f3 0%, #4387d2 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#6cb6f3), color-stop(100%,#4387d2)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(top, #6cb6f3 0%,#4387d2 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(top, #6cb6f3 0%,#4387d2 100%); /* W3C */
+        background: linear-gradient(to bottom, #6cb6f3 0%,#4387d2 100%); /* W3C */
         color: #fff;
     }
 
@@ -472,7 +472,7 @@ ul.dnnAdminTabNav li a,
         background: -moz-linear-gradient(top, #1f66be 0%, #3085e0 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#1f66be), color-stop(100%,#3085e0)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(top, #1f66be 0%,#3085e0 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(top, #1f66be 0%,#3085e0 100%); /* W3C */
+        background: linear-gradient(to bottom, #1f66be 0%,#3085e0 100%); /* W3C */
         -webkit-box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
         box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
         color: #fff;
@@ -500,7 +500,7 @@ ul.dnnAdminTabNav li a,
     background: -webkit-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Chrome10+,Safari5.1+ */
     background: -o-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* IE10+ */
-    background: linear-gradient(top, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
+    background: linear-gradient(to bottom, #f5f5f5 0%,#dfdfdf 100%); /* W3C */
     -webkit-box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
     box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
     text-shadow: 0px 1px 0px #ffffff;
@@ -519,7 +519,7 @@ ul.dnnAdminTabNav li a,
         background: -webkit-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* IE10+ */
-        background: linear-gradient(top, #fefefe 0%,#e8e8e8 100%); /* W3C */
+        background: linear-gradient(to bottom, #fefefe 0%,#e8e8e8 100%); /* W3C */
         color: #555;
     }
 
@@ -537,7 +537,7 @@ ul.dnnAdminTabNav li a,
         background: -webkit-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Chrome10+,Safari5.1+ */
         background: -o-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* Opera 11.10+ */
         background: -ms-linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* IE10+ */
-        background: linear-gradient(top, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
+        background: linear-gradient(to bottom, #c6c6c6 0%,#f3f3f3 100%); /* W3C */
         -webkit-box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
         box-shadow: inset 0px 1px 5px 0px rgba(0, 0, 0, 0.4);
     }
@@ -1273,7 +1273,7 @@ div.dnnFormGroup {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     color: #333;
@@ -1582,7 +1582,7 @@ div.dnnTagsInput > div > input.dnnTagsInvalid {
     background: -moz-linear-gradient(top, #f0f2f1 0%, #fff 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f0f2f1), color-stop(100%,#fff)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #f0f2f1 0%,#fff 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #f0f2f1 0%,#fff 100%); /* W3C */
+    background: linear-gradient(to bottom, #f0f2f1 0%,#fff 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: inset 0px 1px 3px 0px rgba(0,0,0,0.25), 0px 1px 0px 0px #fff;
@@ -1605,7 +1605,7 @@ div.dnnTagsInput > div > input.dnnTagsInvalid {
         background: -moz-linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* FF3.6+ */
         background: -webkit-gradient(linear, left top, right top, color-stop(0%,#2b7fda), color-stop(100%,#3fbdff)); /* Chrome,Safari4+ */
         background: -webkit-linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* Chrome10+,Safari5.1+ */
-        background: linear-gradient(left, #2b7fda 0%, #3fbdff 100%); /* W3C */
+        background: linear-gradient(to right, #2b7fda 0%, #3fbdff 100%); /* W3C */
     }
 
 /* Button Dropdown */
@@ -1621,7 +1621,7 @@ div.dnnTagsInput > div > input.dnnTagsInvalid {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: 0px 1px 0px 0px #bbb;
@@ -1708,7 +1708,7 @@ ul.dnnButtonGroup {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
     -webkit-border-radius: 3px;
     border-radius: 3px;
     -webkit-box-shadow: 0px 1px 0px 0px #bbb;
@@ -1747,7 +1747,7 @@ ul.dnnButtonGroup {
             background: -webkit-linear-gradient(top, #f5f5f5 0%, #dfdfdf 100%);
             background: -o-linear-gradient(top, #f5f5f5 0%, #dfdfdf 100%);
             background: -ms-linear-gradient(top, #f5f5f5 0%, #dfdfdf 100%);
-            background: linear-gradient(top, #f5f5f5 0%, #dfdfdf 100%);
+            background: linear-gradient(to bottom, #f5f5f5 0%, #dfdfdf 100%);
             -webkit-box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
             box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.4), inset 0px 1px 0px 0px rgba(255, 255, 255, 1);
             text-shadow: 0px 1px 0px #ffffff;
@@ -2497,7 +2497,7 @@ table.dnnASPGrid {
     background: -moz-linear-gradient(top, #fff 0%, #f0f2f1 100%); /* FF3.6+ */
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fff), color-stop(100%,#f0f2f1)); /* Chrome,Safari4+ */
     background: -webkit-linear-gradient(top, #fff 0%,#f0f2f1 100%); /* Chrome10+,Safari5.1+ */
-    background: linear-gradient(top, #fff 0%,#f0f2f1 100%); /* W3C */
+    background: linear-gradient(to bottom, #fff 0%,#f0f2f1 100%); /* W3C */
 }
 
 .dnnGridItem td, .dnnGridAltItem td {


### PR DESCRIPTION
## Summary
Many of the CSS gradients defined in the platform used the outdated syntax which specified the direction the gradient comes _from_, whereas the final approved syntax uses the keyword `to` along with the direction that the gradient _goes to_. This PR adjusts those usages.