### PR TITLE
Made dnn.cookieconsent not require jQuery

### DIFF
--- a/DNN Platform/Website/js/Debug/dnn.cookieconsent.js
+++ b/DNN Platform/Website/js/Debug/dnn.cookieconsent.js
@@ -1,14 +1,5 @@
-﻿$(window).on('load', function () {
-    window.cookieconsentoptions = window.cookieconsentoptions || {
-        "palette": {
-            "popup": {
-                "background": "#000"
-            },
-            "button": {
-                "background": "#f1d600"
-            }
-        }
-    }
+﻿document.addEventListener('DOMContentLoaded', function () {
+    window.cookieconsentoptions = window.cookieconsentoptions || {};
     window.cookieconsentoptions.content = {
         message: window.dnn.getVar('cc_message'),
         dismiss: window.dnn.getVar('cc_dismiss'),
@@ -17,5 +8,15 @@
     if (window.dnn.getVar('cc_morelink') != '') {
         window.cookieconsentoptions.content.href = window.dnn.getVar('cc_morelink')
     }
+    if (!window.cookieconsentoptions.palette) {
+        window.cookieconsentoptions.palette = {
+            "popup": {
+                "background": "#000"
+            },
+            "button": {
+                "background": "#f1d600"
+            }
+        }
+    }
     window.cookieconsent.initialise(window.cookieconsentoptions);
-});    
+});

--- a/DNN Platform/Website/js/dnn.cookieconsent.js
+++ b/DNN Platform/Website/js/dnn.cookieconsent.js
@@ -1,4 +1,4 @@
-﻿$(window).on('load', function () {
+﻿document.addEventListener('DOMContentLoaded', function () {
     window.cookieconsentoptions = window.cookieconsentoptions || {};
     window.cookieconsentoptions.content = {
         message: window.dnn.getVar('cc_message'),
@@ -8,15 +8,15 @@
     if (window.dnn.getVar('cc_morelink') != '') {
         window.cookieconsentoptions.content.href = window.dnn.getVar('cc_morelink')
     }
-	if (!window.cookieconsentoptions.palette) {
-		window.cookieconsentoptions.palette = {
-			"popup": {
-      "background": "#000"
-    },
-    "button": {
-      "background": "#f1d600"
+    if (!window.cookieconsentoptions.palette) {
+        window.cookieconsentoptions.palette = {
+            "popup": {
+                "background": "#000"
+            },
+            "button": {
+                "background": "#f1d600"
+            }
+        }
     }
-		}
-	}
     window.cookieconsent.initialise(window.cookieconsentoptions);
-});    
+});


### PR DESCRIPTION
Our new default theme does not have dependencies on jQuery and the cookie consent feature just assumed jQuery was loaded which is not the case. This makes it no longer depend on jQuery.

Closes #6353

