### PR TITLE
Fixed a menu collapsion issue in Firefox

### DIFF
--- a/DNN Platform/Skins/Aperture/src/scripts/menu.ts
+++ b/DNN Platform/Skins/Aperture/src/scripts/menu.ts
@@ -62,3 +62,9 @@ export const navFunctions = (() => {
 		bodyOverlay.classList.toggle('aperture-d-none');
 	});
 });
+
+// Reset menu state for firefox
+window.addEventListener("pageshow", () => {
+	const hamburgerMenu: HTMLInputElement = document.querySelector('#menuToggle input[type="checkbox"]')!;
+	hamburgerMenu.checked = false;
+});


### PR DESCRIPTION
Firefox restores fields values upon going back and the mobile menu expand/collapse control is a checkbox restyled. This made it so upon reloading or going back in history in firefox, the menu would be collapsed but could show the icon as if it was expanded. This PR solves that.

Closes #6360

