### PR TITLE
Fix reflection calls in Client Resources

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceSettings.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceSettings.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Web.Client
     using System.Reflection;
     using System.Web;
 
+    using DotNetNuke.Instrumentation;
     using DotNetNuke.Internal.SourceGenerators;
 
     // note: this class is duplicated in ClientDependency.Core.Config.DnnConfiguration, any updates need to be synced between the two.
@@ -43,9 +44,9 @@ namespace DotNetNuke.Web.Client
                 PortalAliasControllerType = Type.GetType("DotNetNuke.Entities.Portals.PortalAliasController, DotNetNuke");
                 HostControllerType = Type.GetType("DotNetNuke.Entities.Controllers.HostController, DotNetNuke");
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                // ignore
+                LoggerSource.Instance.GetLogger(typeof(ClientResourceSettings)).Warn("Failed to get get types for reflection", exception);
             }
         }
 
@@ -214,9 +215,9 @@ namespace DotNetNuke.Web.Client
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                // ignore
+                LoggerSource.Instance.GetLogger(typeof(ClientResourceSettings)).Warn("Failed to Get Portal Setting Through Reflection", exception);
             }
 
             return null;
@@ -234,9 +235,9 @@ namespace DotNetNuke.Web.Client
                     return (int)portalId;
                 }
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                // ignore
+                LoggerSource.Instance.GetLogger(typeof(ClientResourceSettings)).Warn("Failed to Get Portal ID Through Reflection", exception);
             }
 
             return null;
@@ -256,9 +257,9 @@ namespace DotNetNuke.Web.Client
                     return value;
                 }
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                // ignore
+                LoggerSource.Instance.GetLogger(typeof(ClientResourceSettings)).Warn("Failed to Get Host Setting Through Reflection", exception);
             }
 
             return null;
@@ -300,8 +301,9 @@ namespace DotNetNuke.Web.Client
                 var status = (UpgradeStatus)property.GetValue(null, null);
                 return status;
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                LoggerSource.Instance.GetLogger(typeof(ClientResourceSettings)).Warn("Failed to Get Status By Reflection", exception);
                 return UpgradeStatus.Unknown;
             }
         }

--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceSettings.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceSettings.cs
@@ -197,10 +197,12 @@ namespace DotNetNuke.Web.Client
 
             try
             {
-                var method = PortalControllerType.GetMethod("GetPortalSettingsDictionary", BindingFlags.NonPublic | BindingFlags.Static);
-                var dictionary = (Dictionary<string, string>)method.Invoke(null, new object[] { portalId.Value });
-                string value;
-                if (dictionary.TryGetValue(settingKey, out value))
+                using var scope = GetServiceScope();
+                var portalController = ActivatorUtilities.GetServiceOrCreateInstance(scope.ServiceProvider, PortalControllerType);
+                var method = PortalControllerType.GetMethod("GetPortalSettings", BindingFlags.Public | BindingFlags.Instance);
+                var dictionary = (Dictionary<string, string>)method.Invoke(portalController, new object[] { portalId.Value, });
+
+                if (dictionary.TryGetValue(settingKey, out var value))
                 {
                     return value;
                 }

--- a/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj
+++ b/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj
@@ -57,9 +57,21 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\DotNetNuke.Instrumentation\bin\DotNetNuke.Instrumentation.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Extensions" />
@@ -97,6 +109,7 @@
     <AdditionalFiles Include="..\..\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.Web.Client/app.config
+++ b/DNN Platform/DotNetNuke.Web.Client/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.2" newVersion="9.0.0.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/DNN Platform/DotNetNuke.Web.Client/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Client/packages.config
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dnn.ClientDependency" version="1.9.10" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Build.Tasks.Git" version="8.0.0" targetFramework="net48" developmentDependency="true" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.SourceLink.Common" version="8.0.0" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="8.0.0" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net48" developmentDependency="true" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
## Summary
DotNetNuke.Web.Client calls DNN methods via reflection. However, the methods it calls were removed in DNN 10, so those calls are failing. This means that configuring client resources by portal does not work in DNN 10 anymore b/c it can't find which portal the request is for.

I've fixed the worst offending method, but I think there are more.