### PR TITLE
Fixed missing css for dialogs

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/jquery-ui/jquery-ui.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/jquery-ui/jquery-ui.scss
@@ -1,6 +1,7 @@
 @use "resizable";
 @use "spinner";
 @use "tabs";
+@use "dialog";
 
 /* jQuery UI overrides. */
 /* We may be able to remove the dnnForm scope if tested to work good with a single jQuery UI theme. */


### PR DESCRIPTION
The dialog css was not included in the sass compilation. Closes #6374

![image](https://github.com/user-attachments/assets/8475ce33-d0ca-4be6-b91e-995346dc6667)

