### PR TITLE
Refactored upgrade code after rollup of sql scripts

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -8,7 +8,6 @@ namespace DotNetNuke.Services.Upgrade
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Security.Cryptography;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -1392,54 +1391,11 @@ namespace DotNetNuke.Services.Upgrade
 
             try
             {
-                if (version.Revision == -1)
+                switch (version.ToString(3))
                 {
-                    switch (version.ToString(3))
-                    {
-                        case "9.1.0":
-                            UpgradeToVersion910();
-                            break;
-                        case "9.2.0":
-                            UpgradeToVersion920();
-                            break;
-                        case "9.2.1":
-                            UpgradeToVersion921();
-                            break;
-                        case "9.3.0":
-                            UpgradeToVersion930();
-                            break;
-                        case "9.4.1":
-                            UpgradeToVersion941();
-                            break;
-                        case "9.6.0":
-                            UpgradeToVersion960();
-                            break;
-                    }
-                }
-                else
-                {
-                    // Incremental
-                    switch (version.ToString(4))
-                    {
-                        case "8.0.0.6":
-                            UpgradeToVersion8006();
-                            break;
-                        case "8.0.0.7":
-                            UpgradeToVersion8007();
-                            break;
-                        case "8.0.0.13":
-                            UpgradeToVersion80013();
-                            break;
-                        case "8.0.0.16":
-                            UpgradeToVersion80016();
-                            break;
-                        case "8.0.0.26":
-                            UpgradeToVersion80026();
-                            break;
-                        case "8.0.0.27":
-                            UpgradeToVersion80027();
-                            break;
-                    }
+                    case "10.0.0":
+                        UpgradeToVersion10_0_0();
+                        break;
                 }
             }
             catch (Exception ex)
@@ -2568,146 +2524,8 @@ namespace DotNetNuke.Services.Upgrade
             }
         }
 
-        private static void UpgradeToVersion8006()
+        private static void UpgradeToVersion10_0_0()
         {
-            RemoveAdminPages("//Admin//Languages");
-            RemoveAdminPages("//Admin//Lists");
-            RemoveAdminPages("//Admin//LogViewer");
-            RemoveAdminPages("//Admin//Newsletters");
-            RemoveAdminPages("//Admin//Pages");
-            RemoveAdminPages("//Admin//RecycleBin");
-            RemoveAdminPages("//Admin//SiteLog");
-            RemoveAdminPages("//Admin//SiteWizard");
-            RemoveAdminPages("//Admin//Vendors");
-            RemoveHostPage("Lists");
-            RemoveHostPage("Vendors");
-
-            var package = PackageController.Instance.GetExtensionPackage(-1, p => p.Name == "DotNetNuke.Vendors");
-            if (package != null)
-            {
-                PackageController.Instance.DeleteExtensionPackage(package);
-            }
-
-            package = PackageController.Instance.GetExtensionPackage(-1, p => p.Name == "DotNetNuke.SiteLog");
-            if (package != null)
-            {
-                PackageController.Instance.DeleteExtensionPackage(package);
-            }
-        }
-
-        private static void UpgradeToVersion8007()
-        {
-            RemoveHostPage("Dashboard");
-            RemoveHostPage("SQL");
-            RemoveHostPage("Configuration Manager");
-
-            UninstallPackage("DotNetNuke.ProfessionalPreview", "Module");
-            UninstallPackage("DotNetNuke.Dashboard", "Module");
-            UninstallPackage("DotNetNuke.Configuration Manager", "Module");
-        }
-
-        private static void UpgradeToVersion80013()
-        {
-            UninstallPackage("DotNetNuke.Newsletters", "Module");
-        }
-
-        private static void UpgradeToVersion80016()
-        {
-            UninstallPackage("Solutions", "Module");
-
-            RemoveAdminPages("//Admin//GoogleAnalytics");
-            UninstallPackage("DotNetNuke.Google Analytics", "Module");
-
-            RemoveAdminPages("//Admin//AdvancedSettings");
-            UninstallPackage("DotNetNuke.AdvancedSettings", "Module");
-            UninstallPackage("DotNetNuke.ContentList", "Module");
-
-            RemoveAdminPages("//Admin//Skins");
-            UninstallPackage("DotNetNuke.Skins", "Module");
-            UninstallPackage("DotNetNuke.Skin Designer", "Module");
-            UninstallPackage("DotNetNuke.Banners", "Module");
-
-            RemoveGettingStartedPages();
-        }
-
-        private static void UpgradeToVersion80026()
-        {
-            FixTabsMissingLocalizedFields();
-        }
-
-        private static void UpgradeToVersion80027()
-        {
-            RemoveAdminPages("//Admin//DynamicContentTypeManager");
-            UninstallPackage("Dnn.DynamicContentManager", "Module");
-            UninstallPackage("Dnn.DynamicContentViewer", "Module");
-        }
-
-        private static void UpgradeToVersion910()
-        {
-            RemoveHostPage("Host Settings");
-            RemoveHostPage("Site Management");
-            RemoveHostPage("Schedule");
-            RemoveHostPage("Superuser Accounts");
-            RemoveHostPage("Extensions");
-            RemoveHostPage("Device Detection Management");
-
-            RemoveAdminPages("//Admin//Extensions");
-            RemoveAdminPages("//Admin//SiteSettings");
-            RemoveAdminPages("//Admin//SecurityRoles");
-            RemoveAdminPages("//Admin//Taxonomy");
-            RemoveAdminPages("//Admin//SiteRedirectionManagement");
-            RemoveAdminPages("//Admin//DevicePreviewManagement");
-            RemoveAdminPages("//Admin//SearchAdmin");
-
-            // Normal Modules
-            UninstallPackage("DotNetNuke.MobileManagement", "Module");
-            UninstallPackage("DotNetNuke.Modules.PreviewProfileManagement", "Module");
-
-            UninstallPackage("DotNetNuke.Dashboard.WebServer", "DashboardControl");
-            UninstallPackage("DotNetNuke.Dashboard.Database", "DashboardControl");
-            UninstallPackage("DotNetNuke.Dashboard.Host", "DashboardControl");
-            UninstallPackage("DotNetNuke.Dashboard.Portals", "DashboardControl");
-            UninstallPackage("DotNetNuke.Dashboard.Modules", "DashboardControl");
-            UninstallPackage("DotNetNuke.Dashboard.Skins", "DashboardControl");
-
-            // Admin Modules
-            UninstallPackage("DotNetNuke.HostSettings", "Module");
-            UninstallPackage("DotNetNuke.Languages", "Module");
-            UninstallPackage("DotNetNuke.Lists", "Module");
-            UninstallPackage("DotNetNuke.LogViewer", "Module");
-            UninstallPackage("DotNetNuke.RecycleBin", "Module");
-            UninstallPackage("DotNetNuke.Sitemap", "Module");
-            UninstallPackage("DotNetNuke.SiteWizard", "Module");
-            UninstallPackage("Dnn.Themes", "Module"); // aka. Skin Management
-            UninstallPackage("DotNetNuke.Tabs", "Module");
-
-            // at last remove "/Admin" / "/Host" pages
-            UninstallPackage("DotNetNuke.Portals", "Module");
-            UninstallPackage("DotNetNuke.Scheduler", "Module");
-            UninstallPackage("DotNetNuke.SearchAdmin", "Module");
-            UninstallPackage("DotNetNuke.SQL", "Module");
-            UninstallPackage("DotNetNuke.Extensions", "Module");
-            UninstallPackage("DotNetNuke.Configuration Manager", "Module");
-            UninstallPackage("DotNetNuke.Dashboard", "Module");
-            UninstallPackage("DotNetNuke.Google Analytics", "Module");
-            UninstallPackage("DotNetNuke.Taxonomy", "Module");
-
-            UninstallPackage("UrlManagement", "Library", false);
-        }
-
-        private static void UpgradeToVersion920()
-        {
-            DataProvider.Instance().UnRegisterAssembly(Null.NullInteger, "SharpZipLib.dll");
-            DataProvider.Instance().RegisterAssembly(Null.NullInteger, "ICSharpCode.SharpZipLib.dll", "0.86.0");
-
-            RemoveAdminPages("//Admin//SearchEngineSiteMap");
-            RemoveAdminPages("//Admin//Solutions");
-            RemoveAdminPages("//Admin//BulkEmail");
-
-            RemoveHostPage("Marketplace");
-            RemoveHostPage("Module Definitions");
-            RemoveHostPage("Portals");
-
             if (!HostTabExists("Superuser Accounts"))
             {
                 // add SuperUser Accounts module and tab
@@ -2729,125 +2547,6 @@ namespace DotNetNuke.Services.Upgrade
                     AddModuleToPage(newPage, moduleDefId, "SuperUser Accounts", "~/Icons/Sigma/Users_32X32_Standard.png");
                 }
             }
-
-            var portalController = PortalController.Instance;
-            foreach (PortalInfo portal in portalController.GetPortals())
-            {
-                if (!string.IsNullOrEmpty(portal.ProcessorPassword))
-                {
-                    portalController.UpdatePortalInfo(portal);
-                }
-            }
-        }
-
-        private static void UpgradeToVersion921()
-        {
-            UninstallPackage("jQuery", "Javascript_Library", true, "1.9.1");
-            UninstallPackage("jQuery-UI", "Javascript_Library", true, "1.11.3");
-            UninstallPackage("jQuery-Migrate", "Javascript_Library", true, "1.2.1");
-        }
-
-        private static void UpgradeToVersion930()
-        {
-            var applicationName = System.Web.Security.Membership.ApplicationName;
-            if (string.IsNullOrWhiteSpace(applicationName))
-            {
-                Logger.Warn("Unable to run orphaned user check. Application name is missing or not defined.");
-                return;
-            }
-
-            using (var reader = DataProvider.Instance().ExecuteReader("DeleteOrphanedAspNetUsers", applicationName))
-            {
-                while (reader.Read())
-                {
-                    var errorMsg = reader["ErrorMessage"];
-                    if (errorMsg != null)
-                    {
-                        Logger.Error("Failed to remove orphaned aspnet users. Error: " +
-                            errorMsg.ToString());
-                    }
-                }
-            }
-        }
-
-        private static void UpgradeToVersion941()
-        {
-            // It's possible previous versions of DNN created invalid binding redirects with <dependentAssembly xmlns="">, which are ignored
-            // This finds these and removes them, adding a correct binding redirect if one doesn't exist
-            var webConfig = Config.Load();
-
-            var ns = new XmlNamespaceManager(webConfig.NameTable);
-            ns.AddNamespace("ab", "urn:schemas-microsoft-com:asm.v1");
-
-            var invalidDependentAssemblies = webConfig.SelectNodes("/configuration/runtime/ab:assemblyBinding/dependentAssembly", ns);
-            foreach (XmlNode dependentAssembly in invalidDependentAssemblies)
-            {
-                var assemblyBindingElement = dependentAssembly.ParentNode;
-                var assemblyIdentity = dependentAssembly.ChildNodes.Cast<XmlNode>().SingleOrDefault(n => n.LocalName.Equals("assemblyIdentity", StringComparison.Ordinal));
-                if (assemblyIdentity == null)
-                {
-                    assemblyBindingElement.RemoveChild(dependentAssembly);
-                    continue;
-                }
-
-                var name = assemblyIdentity.Attributes["name"]?.Value;
-                var publicKeyToken = assemblyIdentity.Attributes["publicKeyToken"]?.Value;
-                if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(publicKeyToken))
-                {
-                    assemblyBindingElement.RemoveChild(dependentAssembly);
-                    continue;
-                }
-
-                var dependentAssemblyXPath = $"/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='{name}'][ab:assemblyIdentity/@publicKeyToken='{publicKeyToken}']";
-                var validDependentAssembly = webConfig.SelectSingleNode(dependentAssemblyXPath, ns);
-                if (validDependentAssembly != null)
-                {
-                    // a valid dependentAssembly exists for this assembly, just remove the invalid element
-                    assemblyBindingElement.RemoveChild(dependentAssembly);
-                    continue;
-                }
-
-                // otherwise, replace the invalid dependentAssembly with a valid version of it
-                AssemblyName assemblyName;
-                try
-                {
-                    assemblyName = AssemblyName.GetAssemblyName(Path.Combine(Globals.ApplicationMapPath, "bin", name + ".dll"));
-                }
-                catch
-                {
-                    assemblyBindingElement.RemoveChild(dependentAssembly);
-                    continue;
-                }
-
-                var validAssemblyIdentity = webConfig.CreateElement("assemblyIdentity", "urn:schemas-microsoft-com:asm.v1");
-                validAssemblyIdentity.AddAttribute("name", name);
-                validAssemblyIdentity.AddAttribute("publicKeyToken", publicKeyToken);
-
-                var validBindingRedirect = webConfig.CreateElement("bindingRedirect", "urn:schemas-microsoft-com:asm.v1");
-                validBindingRedirect.AddAttribute("oldVersion", "0.0.0.0-32767.32767.32767.32767");
-                validBindingRedirect.AddAttribute("newVersion", assemblyName.Version.ToString());
-
-                validDependentAssembly = webConfig.CreateElement("dependentAssembly", "urn:schemas-microsoft-com:asm.v1");
-                validDependentAssembly.AppendChild(validAssemblyIdentity);
-                validDependentAssembly.AppendChild(validBindingRedirect);
-
-                assemblyBindingElement.ReplaceChild(validDependentAssembly, dependentAssembly);
-            }
-
-            if (invalidDependentAssemblies.Count > 0)
-            {
-                Config.Save(webConfig);
-            }
-        }
-
-        private static void UpgradeToVersion960()
-        {
-            // Set default end user upload extension whitelist - ensure we don't add extensions that were not in the master list before
-            var toAdd = new List<string> { ".export" };
-            HostController.Instance.Update("FileExtensions", Host.AllowedExtensionWhitelist.ToStorageString(toAdd));
-            var exts = new FileExtensionWhitelist("jpg,jpeg,jpe,gif,bmp,png,svg,doc,docx,xls,xlsx,ppt,pptx,pdf,txt,zip,rar,ico,avi,mpg,mpeg,mp3,wmv,mov,wav,mp4,webm,ogv,export");
-            exts.RestrictBy(Host.AllowedExtensionWhitelist);
-            HostController.Instance.Update("DefaultEndUserExtensionWhitelist", exts.ToStorageString());
         }
 
         private static void FixFipsCompilanceAssembly(string filePath)

--- a/DNN Platform/Website/Portals/_default/Blank Website.template
+++ b/DNN Platform/Website/Portals/_default/Blank Website.template
@@ -2956,6 +2956,98 @@
       </panes>
       <tabUrls />
     </tab>
+      <tab>
+          <content>User Accounts</content>
+          <contentKey />
+          <containersrc />
+          <cultureCode />
+          <description>Manage user accounts for the portal.</description>
+          <disabled>false</disabled>
+          <enddate>0001-01-01T00:00:00</enddate>
+          <issecure>false</issecure>
+          <visible>false</visible>
+          <issystem>false</issystem>
+          <keywords />
+          <pageheadtext />
+          <permanentredirect>false</permanentredirect>
+          <refreshinterval>-1</refreshinterval>
+          <sitemappriority>0.5</sitemappriority>
+          <skinsrc />
+          <startdate>0001-01-01T00:00:00</startdate>
+          <name>User Accounts</name>
+          <title>User Accounts</title>
+          <iconfile>~/Icons/Sigma/Users_16X16_Standard.png</iconfile>
+          <iconfilelarge>~/Icons/Sigma/Users_32X32_Standard.png</iconfilelarge>
+          <url type="Normal" />
+          <tabpermissions>
+              <permission>
+                  <permissioncode>SYSTEM_TAB</permissioncode>
+                  <permissionkey>VIEW</permissionkey>
+                  <allowaccess>true</allowaccess>
+                  <rolename>Administrators</rolename>
+              </permission>
+              <permission>
+                  <permissioncode>SYSTEM_TAB</permissioncode>
+                  <permissionkey>EDIT</permissionkey>
+                  <allowaccess>true</allowaccess>
+                  <rolename>Administrators</rolename>
+              </permission>
+          </tabpermissions>
+          <tabsettings />
+          <parent>Admin</parent>
+          <panes>
+              <pane>
+                  <name>ContentPane</name>
+                  <modules>
+                      <module>
+                          <contentKey />
+                          <moduleID>439</moduleID>
+                          <alignment />
+                          <alltabs>false</alltabs>
+                          <border />
+                          <cachemethod />
+                          <cachetime>0</cachetime>
+                          <color />
+                          <containersrc />
+                          <displayprint>true</displayprint>
+                          <displaysyndicate>false</displaysyndicate>
+                          <displaytitle>true</displaytitle>
+                          <enddate>0001-01-01T00:00:00</enddate>
+                          <footer />
+                          <header />
+                          <iconfile>~/Icons/Sigma/Users_32X32_Standard.png</iconfile>
+                          <inheritviewpermissions>true</inheritviewpermissions>
+                          <iswebslice>false</iswebslice>
+                          <modulepermissions>
+                              <permission>
+                                  <permissioncode>SYSTEM_MODULE_DEFINITION</permissioncode>
+                                  <permissionkey>EDIT</permissionkey>
+                                  <allowaccess>true</allowaccess>
+                                  <rolename>Administrators</rolename>
+                              </permission>
+                          </modulepermissions>
+                          <title>User Accounts</title>
+                          <startdate>0001-01-01T00:00:00</startdate>
+                          <uniqueId>22bb2d49-d123-430f-8883-a9d40c1e03ec</uniqueId>
+                          <visibility>Maximized</visibility>
+                          <websliceexpirydate>0001-01-01T00:00:00</websliceexpirydate>
+                          <webslicettl>0</webslicettl>
+                          <cultureCode />
+                          <modulesettings />
+                          <tabmodulesettings>
+                              <tabmodulesetting>
+                                  <settingname>hideadminborder</settingname>
+                                  <settingvalue>True</settingvalue>
+                              </tabmodulesetting>
+                          </tabmodulesettings>
+                          <definition>Security</definition>
+                          <moduledefinition>User Accounts</moduledefinition>
+                      </module>
+                  </modules>
+              </pane>
+          </panes>
+          <tabUrls />
+      </tab>
   </tabs>
   <folders>
     <folder>

--- a/DNN Platform/Website/Portals/_default/Default Website.template
+++ b/DNN Platform/Website/Portals/_default/Default Website.template
@@ -3366,6 +3366,98 @@
       </panes>
       <tabUrls />
     </tab>
+      <tab>
+          <content>User Accounts</content>
+          <contentKey />
+          <containersrc />
+          <cultureCode />
+          <description>Manage user accounts for the portal.</description>
+          <disabled>false</disabled>
+          <enddate>0001-01-01T00:00:00</enddate>
+          <issecure>false</issecure>
+          <visible>false</visible>
+          <issystem>false</issystem>
+          <keywords />
+          <pageheadtext />
+          <permanentredirect>false</permanentredirect>
+          <refreshinterval>-1</refreshinterval>
+          <sitemappriority>0.5</sitemappriority>
+          <skinsrc />
+          <startdate>0001-01-01T00:00:00</startdate>
+          <name>User Accounts</name>
+          <title>User Accounts</title>
+          <iconfile>~/Icons/Sigma/Users_16X16_Standard.png</iconfile>
+          <iconfilelarge>~/Icons/Sigma/Users_32X32_Standard.png</iconfilelarge>
+          <url type="Normal" />
+          <tabpermissions>
+              <permission>
+                  <permissioncode>SYSTEM_TAB</permissioncode>
+                  <permissionkey>VIEW</permissionkey>
+                  <allowaccess>true</allowaccess>
+                  <rolename>Administrators</rolename>
+              </permission>
+              <permission>
+                  <permissioncode>SYSTEM_TAB</permissioncode>
+                  <permissionkey>EDIT</permissionkey>
+                  <allowaccess>true</allowaccess>
+                  <rolename>Administrators</rolename>
+              </permission>
+          </tabpermissions>
+          <tabsettings />
+          <parent>Admin</parent>
+          <panes>
+              <pane>
+                  <name>ContentPane</name>
+                  <modules>
+                      <module>
+                          <contentKey />
+                          <moduleID>439</moduleID>
+                          <alignment />
+                          <alltabs>false</alltabs>
+                          <border />
+                          <cachemethod />
+                          <cachetime>0</cachetime>
+                          <color />
+                          <containersrc />
+                          <displayprint>true</displayprint>
+                          <displaysyndicate>false</displaysyndicate>
+                          <displaytitle>true</displaytitle>
+                          <enddate>0001-01-01T00:00:00</enddate>
+                          <footer />
+                          <header />
+                          <iconfile>~/Icons/Sigma/Users_32X32_Standard.png</iconfile>
+                          <inheritviewpermissions>true</inheritviewpermissions>
+                          <iswebslice>false</iswebslice>
+                          <modulepermissions>
+                              <permission>
+                                  <permissioncode>SYSTEM_MODULE_DEFINITION</permissioncode>
+                                  <permissionkey>EDIT</permissionkey>
+                                  <allowaccess>true</allowaccess>
+                                  <rolename>Administrators</rolename>
+                              </permission>
+                          </modulepermissions>
+                          <title>User Accounts</title>
+                          <startdate>0001-01-01T00:00:00</startdate>
+                          <uniqueId>22bb2d49-d123-430f-8883-a9d40c1e03ec</uniqueId>
+                          <visibility>Maximized</visibility>
+                          <websliceexpirydate>0001-01-01T00:00:00</websliceexpirydate>
+                          <webslicettl>0</webslicettl>
+                          <cultureCode />
+                          <modulesettings />
+                          <tabmodulesettings>
+                              <tabmodulesetting>
+                                  <settingname>hideadminborder</settingname>
+                                  <settingvalue>True</settingvalue>
+                              </tabmodulesetting>
+                          </tabmodulesettings>
+                          <definition>Security</definition>
+                          <moduledefinition>User Accounts</moduledefinition>
+                      </module>
+                  </modules>
+              </pane>
+          </panes>
+          <tabUrls />
+      </tab>
   </tabs>
   <folders>
     <folder>


### PR DESCRIPTION
In #6038 a rollup script was put in place to revamp our clean installation logic, get rid of some upgrade logic and potentially speed up installs, etc.

In RC1 issue #6364 was reported. I spent quite a lot of time trying to figure it out. Had to do a `git bisect` and it identified the commit of the rollup script as being the first commit to cause that issue. After a lot of head scratching I realized that the code in upgrade.cs was the one creating the virtual host page that should hold the module that allows editing user profiles from the Persona Bar. This solved the issue for HOST users but not for admins. For admins, this lives in the portal templates, it was cleaned up from modules we don't want, but this one needed to be brought back as the Persona Bar needs it for admins.

As I was in upgrade.cs I though since we will document in our upgrade steps to upgrade to latest v9 before going to v10, we can get rid of all the other upgrade logic for all versions <10 in there.

Closes #6364 
