### PR TITLE
Improved permissions grid (React one)

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/Grid.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/Grid.jsx
@@ -107,25 +107,27 @@ class Grid extends Component {
         return (
             <GridCell style={{"display":"table"}} className={props.type + "-permissions-grid"}>
                 <GridCaption service={props.service} localization={props.localization} type={props.type} onSuggestion={this.onSuggestion.bind(this) } />
-                <GridHeader type={props.type} definitions={props.definitions}
-                    roleColumnWidth={roleColumnWidth}
-                    columnWidth={columnWidth}
-                    actionsWidth={actionsWidth}
-                    localization={props.localization}  />
-                {props.permissions.map((permission) => {
-                    return (
-                        <GridRow
-                            key={permission}
-                            type={props.type}
-                            definitions={props.definitions}
-                            permission={permission}
-                            onChange={self.onPermissionChange.bind(self) }
-                            onDeletePermisson={self.onPermissionDeleted.bind(self) }
-                            roleColumnWidth={roleColumnWidth}
-                            columnWidth={columnWidth}
-                            actionsWidth={actionsWidth} />);
-                }) }
-                {props.permissions.length === 0 && <GridCell className="empty-row">{props.type === "role" ? props.localization.emptyRole : props.localization.emptyUser}</GridCell>}
+                <table>
+                    <GridHeader type={props.type} definitions={props.definitions}
+                        roleColumnWidth={roleColumnWidth}
+                        columnWidth={columnWidth}
+                        actionsWidth={actionsWidth}
+                        localization={props.localization}  />
+                    {props.permissions.map((permission) => {
+                        return (
+                            <GridRow
+                                key={permission}
+                                type={props.type}
+                                definitions={props.definitions}
+                                permission={permission}
+                                onChange={self.onPermissionChange.bind(self) }
+                                onDeletePermisson={self.onPermissionDeleted.bind(self) }
+                                roleColumnWidth={roleColumnWidth}
+                                columnWidth={columnWidth}
+                                actionsWidth={actionsWidth} />);
+                    }) }
+                    {props.permissions.length === 0 && <GridCell className="empty-row">{props.type === "role" ? props.localization.emptyRole : props.localization.emptyUser}</GridCell>}
+                </table>
             </GridCell>);
     }
 

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/GridCaption.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/GridCaption.jsx
@@ -5,9 +5,6 @@ import Label from "../Label";
 import RoleGroupFilter from "./RoleGroupFilter";
 import Suggestion from "./Suggestion";
 
-const nameColumnSpace = 15;
-const actionColumnSpace = 10;
-
 class GridCaption extends Component {
 
     constructor() {

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/GridHeader.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/GridHeader.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import GridCell from "../GridCell";
 
 class GridHeader extends Component {
     constructor(props) {
@@ -10,27 +9,41 @@ class GridHeader extends Component {
         };
     }
 
-    getLocaliztion(key) {
+    getLocalization(key) {
         let localized = this.props.localization[key.replace(" ", "")];
         return localized || key;
     }
 
+    getName(type) {
+        const key = `Permission${type.replace(" ", "")}`;
+        const localized = this.props.localization[key];
+        return localized || type;
+    }
+
+    getDescription(type) {
+        const key = `Permission${type.replace(" ", "")}Description`;
+        const localized = this.props.localization[key];
+        return localized || type;
+    }
+
     renderHeader() {
         const {props} = this;
-        const {roleColumnWidth, columnWidth, actionsWidth} = props;
+        const {roleColumnWidth, actionsWidth} = props;
 
-        return <GridCell className="grid-header">
-            <GridCell columnSize={roleColumnWidth}><span title={props.type}>{this.getLocaliztion(props.type)}</span></GridCell>
+        return <tr className="grid-header">
+            <th columnSize={roleColumnWidth}><span title={props.type}>{this.getLocalization(props.type)}</span></th>
             {props.definitions.map((def) => {
-                return <GridCell key={def.permissionName} columnSize={columnWidth}><span title={def.permissionName}>{this.getLocaliztion(def.permissionName)}</span></GridCell>;
+                return <th key={def.permissionName}>
+                    <span title={this.getDescription(def.permissionName)}>
+                        {this.getName(def.permissionName)}
+                    </span>
+                </th>;
             }) }
-            <GridCell columnSize={actionsWidth} />
-        </GridCell>;
+            <th columnSize={actionsWidth} />
+        </tr>;
     }
 
     render() {
-        const {props, state} = this;
-
         return (
             this.renderHeader()
         );

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/GridRow.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/GridRow.jsx
@@ -164,8 +164,8 @@ class GridRow extends Component {
         let self = this;
        
         return (
-            <GridCell className="grid-row" ref={node => this.node = node}>
-                <GridCell columnSize={roleColumnWidth}><span title={this.getHeaderColumnText() }>{this.getHeaderColumnText() }</span></GridCell>
+            <tr className="grid-row" ref={node => this.node = node}>
+                <td columnSize={roleColumnWidth}><span title={this.getHeaderColumnText() }>{this.getHeaderColumnText() }</span></td>
                 {props.definitions.map(function (def) {
                     let permission = props.permission.permissions.filter(p => {
                         return p.permissionId === def.permissionId;
@@ -182,15 +182,15 @@ class GridRow extends Component {
 
                     return (
                         
-                        <GridCell style={{"height":self.columnHeight+"px"}} columnSize={columnWidth} key={def.permissionId} >
+                        <td style={{"height":self.columnHeight+"px"}} key={def.permissionId} >
                             <StatusSwitch permission={permission} status={status} onChange={self.onStatusChanged.bind(self, def) } />
-                        </GridCell>
+                        </td>
                     );
                 }) }
-                <GridCell style={{"height":self.columnHeight+"px"}} columnSize={actionsWidth} className="col-actions">
+                <td style={{"height":self.columnHeight+"px"}} className="col-actions">
                     {!props.permission.default && <IconButton type="trash" onClick={this.onDelete.bind(this) } />}
-                </GridCell>
-            </GridCell>
+                </td>
+            </tr>
         );
     }
 

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/index.jsx
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import GridCell from "../GridCell";
-import Button from "../Button";
-import Label from "../Label";
 import Grid from "./Grid";
 import "./style.less";
 

--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/style.less
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/PermissionGrid/style.less
@@ -1,5 +1,8 @@
 @import "../../styles/index";
 .permissions-grid {
+    >div{
+        overflow-x: auto;
+    }
     .grid-caption {
         border-bottom: 1px solid var(--dnn-color-foreground-light, @alto);
         padding: 0;
@@ -112,5 +115,44 @@
         color: var(--dnn-color-foreground-light, @alto);
         font-weight: bold;
         text-align: center;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        border-spacing: 0;
+        border: 1px solid var(--dnn-color-foreground-light, #666);
+        tr{
+            th{
+                writing-mode: vertical-rl;
+                min-width: 2rem;
+                span{
+                    display: block;
+                    transform: translate(50%, 0) rotate(-135deg);
+                    text-align: left;
+                }
+                &:first-child {
+                    writing-mode: horizontal-tb;
+                    padding-left: 1rem;
+                    padding-bottom: 0.75rem;
+                    vertical-align: bottom;
+                    span{
+                        transform: none;
+                    }
+                }
+            }
+            td{
+                border-right: 1px solid var(--dnn-color-foreground-light, #666);
+                text-align: center;
+                a{
+                    svg{
+                        width: 2rem;
+                    }
+                }
+                &:first-child {
+                    text-align: left;
+                    padding-left: 1rem;
+                }
+            }
+        }
     }
 }

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PermissionGrid/PermissionGrid.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/PermissionGrid/PermissionGrid.jsx
@@ -37,8 +37,26 @@ class PermissionGrid extends Component {
                         allGroupsText: Localization.get("AllGroups"),
                         roleText: Localization.get("Role"),
                         userText: Localization.get("User"),
-                        ViewTab: Localization.get("ViewTab"),
-                        EditTab: Localization.get("EditTab")
+                        PermissionViewTab: Localization.get("PermissionViewTab"),
+                        PermissionViewTabDescription: Localization.get("PermissionViewTabDescription"),
+                        PermissionAdd: Localization.get("PermissionAdd"),
+                        PermissionAddDescription: Localization.get("PermissionAddDescription"),
+                        PermissionContent: Localization.get("PermissionContent"),
+                        PermissionContentDescription: Localization.get("PermissionContentDescription"),
+                        PermissionCopy: Localization.get("PermissionCopy"),
+                        PermissionCopyDescription: Localization.get("PermissionCopyDescription"),
+                        PermissionDelete: Localization.get("PermissionDelete"),
+                        PermissionDeleteDescription: Localization.get("PermissionDeleteDescription"),
+                        PermissionExport: Localization.get("PermissionExport"),
+                        PermissionExportDescription: Localization.get("PermissionExportDescription"),
+                        PermissionImport: Localization.get("PermissionImport"),
+                        PermissionImportDescription: Localization.get("PermissionImportDescription"),
+                        PermissionManage: Localization.get("PermissionManage"),
+                        PermissionManageDescription: Localization.get("PermissionManageDescription"),
+                        PermissionNavigate: Localization.get("PermissionNavigate"),
+                        PermissionNavigateDescription: Localization.get("PermissionNavigateDescription"),
+                        PermissionEditTag: Localization.get("PermissionEditTab"),
+                        PermissionEditTabDescription: Localization.get("PermissionEditTabDescription"),
                     }}
                     permissions={cloneDeep(this.props.permissions)} 
                     onPermissionsChanged={this.onPermissionsChanged.bind(this)}

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -810,9 +810,6 @@
   <data name="User.Text" xml:space="preserve">
     <value>User</value>
   </data>
-  <data name="ViewTab.Text" xml:space="preserve">
-    <value>View</value>
-  </data>
   <data name="SiteDefault.Text" xml:space="preserve">
     <value>Site Default</value>
   </data>
@@ -1791,5 +1788,65 @@
   </data>
   <data name="WorkflowEnabled_tooltip" xml:space="preserve">
     <value>When enabled, DNN will enforce the selected content workflow during the publishing process of page edits.</value>
+  </data>
+  <data name="PermissionViewTab.Text" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="PermissionViewTabDescription.Text" xml:space="preserve">
+    <value>Allows viewing the page.</value>
+  </data>
+  <data name="PermissionAdd.Text" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="PermissionAddDescription.Text" xml:space="preserve">
+    <value>Allows adding child pages.</value>
+  </data>
+  <data name="PermissionContent.Text" xml:space="preserve">
+    <value>Content</value>
+  </data>
+  <data name="PermissionContentDescription.Text" xml:space="preserve">
+    <value>Allows editing the content of the page.</value>
+  </data>
+  <data name="PermissionCopy.Text" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="PermissionCopyDescription.Text" xml:space="preserve">
+    <value>Allows copying the page.</value>
+  </data>
+  <data name="PermissionDelete.Text" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="PermissionDeleteDescription.Text" xml:space="preserve">
+    <value>Allows deleting the page.</value>
+  </data>
+  <data name="PermissionExport.Text" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="PermissionExportDescription.Text" xml:space="preserve">
+    <value>Allows exporting the page.</value>
+  </data>
+  <data name="PermissionImport.Text" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="PermissionImportDescription.Text" xml:space="preserve">
+    <value>Allows importing the page.</value>
+  </data>
+  <data name="PermissionManage.Text" xml:space="preserve">
+    <value>Manage</value>
+  </data>
+  <data name="PermissionManageDescription.Text" xml:space="preserve">
+    <value>Allows managing the page settings except permissions.</value>
+  </data>
+  <data name="PermissionNavigate.Text" xml:space="preserve">
+    <value>Navigate</value>
+  </data>
+  <data name="PermissionNavigateDescription.Text" xml:space="preserve">
+    <value>Allows viewing the page in navigation menus.</value>
+  </data>
+  <data name="PermissionEditTab.Text" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="PermissionEditTabDescription.Text" xml:space="preserve">
+    <value>Allows full control including adding modules and changing permissions.</value>
   </data>
 </root>


### PR DESCRIPTION
- Turns the label to have more room
- Should there be more permissions than the width allows, the table gets a slider for the overflow instead of cutting into the text
- Adds localized label names and descriptions (tooltips) to better explain what each permission does.

![image](https://github.com/user-attachments/assets/73c5a539-79cc-4884-bb01-6d1d3aab5769)
