### PR TITLE
Min height of Page Content #6402

### DIFF
--- a/DNN Platform/Skins/Aperture/default.ascx
+++ b/DNN Platform/Skins/Aperture/default.ascx
@@ -6,7 +6,7 @@
   <!--#include file="partials/_header.ascx" -->
   
   <!-- Main Content -->
-  <main>
+  <main class="aperture-main">
     <div id="BannerPane" runat="server"></div>
     <div id="ContentPane" class="aperture-content-pane" runat="server"></div> 
     <div id="FluidPane" runat="server"></div>

--- a/DNN Platform/Skins/Aperture/src/scss/sections/_sections.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/sections/_sections.scss
@@ -11,8 +11,12 @@
         max-width: 1280px;
     }
 	
-	// Edit mode: Content Minimum height even if there are no Modules on the Page.
-    @at-root .personabar-visible & .aperture-main{
-        min-height: 20vh;
+    // Sticky footer
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    
+    .aperture-main{
+        flex-grow: 1;
     }
 }

--- a/DNN Platform/Skins/Aperture/src/scss/sections/_sections.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/sections/_sections.scss
@@ -10,4 +10,9 @@
         width: 100%;
         max-width: 1280px;
     }
+	
+	// Edit mode: Content Minimum height even if there are no Modules on the Page.
+    @at-root .personabar-visible & .aperture-main{
+        min-height: 20vh;
+    }
 }


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
This PR makes sure the content has a minimum height of 20vh even when there are no module son the page.
This is only the case when the PersonaBar is visible.

![image](https://github.com/user-attachments/assets/34da3f8c-69f0-4a97-81eb-c1ac51075c25)


I did wonder if we should add a _dnn-edit.scss file for this?
What do you think @valadas / @david-poindexter ?

fixes #6402 
