### PR TITLE
Enable corepack for browserslist action

### DIFF
--- a/.github/workflows/browserslist-update-db.yml
+++ b/.github/workflows/browserslist-update-db.yml
@@ -20,7 +20,8 @@ jobs:
         run: |
           # Setup for commiting using built-in token. See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"         
+      - run: corepack enable
       - name: Update Browserslist database and create PR if applies
         uses: c2corg/browserslist-update-action@v2
         with:


### PR DESCRIPTION
## Summary
The Browserslist update GitHub action has been failing since it was introduced in #6256, with an error about needing to enable `corepack`. This PR adds that step to the workflow.