### PR TITLE
Aperture: Resolve page description issue in mobile menu

### DIFF
--- a/DNN Platform/Skins/Aperture/menus/mobile/RazorMenu.cshtml
+++ b/DNN Platform/Skins/Aperture/menus/mobile/RazorMenu.cshtml
@@ -27,17 +27,16 @@
     foreach (var page in pages)
     {
         var hasChildren = page.HasChildren();
-        var pageDesc = Html.Raw(!string.IsNullOrEmpty(page.Description) ? ("<br/><span class=\"link-description\">" + @page.Description + "</span>") :string.Empty);
         var attrTarget = !string.IsNullOrEmpty(page.Target) ? ("target=\"" + page.Target + "\"") :string.Empty;
 
         <li class="nav-item @(hasChildren ? "nav-expand aperture-d-flex aperture-align-items-center" : string.Empty)@(page.Selected ? "selected" : string.Empty)">
             @if (page.Enabled)
             {
-                <a class="nav-link" href="@page.Url" @attrTarget>@page.Text @pageDesc</a>
+                <a class="nav-link" href="@page.Url" @attrTarget>@page.Text</a>
             }
             else
             {
-                <a href="javascript:void(0);" @attrTarget>@page.Text @pageDesc</a>
+                <a href="javascript:void(0);" @attrTarget>@page.Text</a>
             }
 
             @if (hasChildren)


### PR DESCRIPTION
## Summary
The page description should not show in the mobile menu.  This PR removes it.  

Resolves #6425
