### PR TITLE
Mark unused CoreCacheType enum as obsolete

### DIFF
--- a/DNN Platform/Library/Common/Utilities/DataCache.cs
+++ b/DNN Platform/Library/Common/Utilities/DataCache.cs
@@ -20,6 +20,7 @@ namespace DotNetNuke.Common.Utilities
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Services.OutputCache;
 
+    [Obsolete("Deprecated in DotNetNuke 9.13.8. This type has no known use. Scheduled for removal in v11.0.0.")]
     public enum CoreCacheType
     {
         Host = 1,


### PR DESCRIPTION
## Summary
`CoreCacheType` is never used within DNN. Ideally, we could mark the type as deprecated in 9.x so it can be removed in 11.0.0.