### PR TITLE
Fix two tab deletion issues

### DIFF
--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -2903,7 +2903,10 @@ namespace DotNetNuke.Entities.Tabs
                 contentController.DeleteContentItem(tab);
             }
 
-            EventManager.Instance.OnTabDeleted(new TabEventArgs { Tab = tab });
+            if (tab != null)
+            {
+                EventManager.Instance.OnTabDeleted(new TabEventArgs { Tab = tab });
+            }
         }
 
         private bool SoftDeleteChildTabs(int intTabid, PortalSettings portalSettings)

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -1221,7 +1221,8 @@ namespace DotNetNuke.Entities.Tabs
                 }
             }
 
-            this.DeleteTab(tabId, portalId);
+            this.HardDeleteTabInternal(tabId, portalId);
+            this.ClearCache(portalId);
         }
 
         /// <summary>Delete a Setting of a tab instance.</summary>


### PR DESCRIPTION
## Summary
This PR fixes two bugs with deleting tabs. The first is described in #6438. The second comes when calling `DeleteTab` on a tab that has already been deleted (perhaps related to a workaround for the first issue 😉).

Fixes #6438 