### PR TITLE
Prevents Roslyn Compilation Errors During DNN v10 Upgrade

### DIFF
--- a/DNN Platform/Website/Install/Config/10.00.00.config
+++ b/DNN Platform/Website/Install/Config/10.00.00.config
@@ -10,5 +10,11 @@
     <node path="/configuration/dotnetnuke/permissions/providers" action="update" key="name" collision="overwrite">
       <add name="AdvancedPermissionProvider" type="DotNetNuke.Security.Permissions.AdvancedPermissionProvider, DotNetNuke" providerPath="~\Providers\PermissionProviders\AdvancedPermissionProvider\" />
     </node>
+    
+    <!-- Prevents Roslyn from running to avoid potential compilation errors
+         when a newer version of Roslyn is installed in the next steps.-->
+    <node path="/configuration/system.codedom/compilers/compiler[@extension='.cs']" action="remove" />
+    <node path="/configuration/system.codedom/compilers/compiler[@extension='.vb']" action="remove" />
+    
   </nodes>
 </configuration>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #6448

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Prevents Roslyn from running to avoid potential compilation errors when a newer version of Roslyn is installed in the next steps with `Microsoft.CodeDom.Providers.DotNetCompilerPlatform_04.01.00_Install.zip`.