### PR TITLE
Fix #6448 enhance Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dnn to avoid potential compilation errors

### DIFF
--- a/DNN Platform/Components/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dnn
+++ b/DNN Platform/Components/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dnn
@@ -13,6 +13,166 @@
       <license/>
       <releaseNotes src="releaseNotes.txt"></releaseNotes>
       <components>
+        <component type="Config">
+          <config>
+            <configFile>web.config</configFile>
+            <install>
+              <configuration>
+                <nodes>
+                  <!-- Prevents Roslyn from running to avoid potential compilation errors
+                       when a newer version of Roslyn is installed in the next steps.-->
+                  <node path="/configuration/system.codedom/compilers/compiler[@extension='.cs']" action="remove" />
+                  <node path="/configuration/system.codedom/compilers/compiler[@extension='.vb']" action="remove" />
+                </nodes>
+              </configuration>
+            </install>
+            <uninstall>
+              <configuration>
+                <nodes/>
+              </configuration>
+            </uninstall>
+          </config>
+        </component>
+        <component type="Assembly">
+          <assemblies>
+            <assembly Action="UnRegister">
+              <path>bin</path>
+              <name>Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</name>
+            </assembly>
+          </assemblies>
+        </component>
+        <component type="Cleanup" version="10.00.00">
+          <files>
+            <file>
+              <path>bin</path>
+              <name>Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>csc.exe</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>csc.exe.config</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>csc.rsp</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>csi.exe</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>csi.exe.config</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>csi.rsp</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.Build.Tasks.CodeAnalysis.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.CodeAnalysis.CSharp.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.CodeAnalysis.CSharp.Scripting.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.CodeAnalysis.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.CodeAnalysis.Scripting.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.CodeAnalysis.VisualBasic.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.CSharp.Core.targets</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.DiaSymReader.Native.amd64.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.DiaSymReader.Native.x86.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.Managed.Core.targets</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>Microsoft.VisualBasic.Core.targets</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>roslyn.zip.manifest</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Buffers.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Collections.Immutable.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Memory.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Numerics.Vectors.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Reflection.Metadata.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Runtime.CompilerServices.Unsafe.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Text.Encoding.CodePages.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>System.Threading.Tasks.Extensions.dll</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>vbc.exe</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>vbc.exe.config</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>vbc.rsp</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>VBCSCompiler.exe</name>
+            </file>
+            <file>
+              <path>bin\roslyn</path>
+              <name>VBCSCompiler.exe.config</name>
+            </file>
+          </files>
+        </component>
         <component type="Assembly">
           <assemblies>
             <assembly>
@@ -25,10 +185,10 @@
         <component type="ResourceFile">
           <resourceFiles>
             <basePath>bin/roslyn</basePath>
-              <resourceFile>
-                <name>roslyn.zip</name>
-              </resourceFile>
-            </resourceFiles>
+            <resourceFile>
+              <name>roslyn.zip</name>
+            </resourceFile>
+          </resourceFiles>
         </component>
         <component type="Config">
           <config>

--- a/DNN Platform/Website/Install/Config/10.00.00.config
+++ b/DNN Platform/Website/Install/Config/10.00.00.config
@@ -10,11 +10,5 @@
     <node path="/configuration/dotnetnuke/permissions/providers" action="update" key="name" collision="overwrite">
       <add name="AdvancedPermissionProvider" type="DotNetNuke.Security.Permissions.AdvancedPermissionProvider, DotNetNuke" providerPath="~\Providers\PermissionProviders\AdvancedPermissionProvider\" />
     </node>
-    
-    <!-- Prevents Roslyn from running to avoid potential compilation errors
-         when a newer version of Roslyn is installed in the next steps.-->
-    <node path="/configuration/system.codedom/compilers/compiler[@extension='.cs']" action="remove" />
-    <node path="/configuration/system.codedom/compilers/compiler[@extension='.vb']" action="remove" />
-    
   </nodes>
 </configuration>


### PR DESCRIPTION
Fixes #6448

## Summary  
This fix is now self-contained in the most logical place—`Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dnn`—and no longer modifies `10.00.00.config`.  

This fix effectively uninstalls Roslyn by:  
- Making necessary changes in `web.config`.  
- Unregistering the assembly.  
- Removing all files from `bin\roslyn`.  

### Verification Scenarios
I verified the fix across multiple test scenarios, all of which executed successfully without issues:
1. Clean install of `DNN_Platform_10.0.0-rc.15_Install.zip`.  
2. Clean install of DNN `9.13.8`, followed by an upgrade using `DNN_Platform_10.0.0-rc.15_Upgrade.zip`.  
3. Clean install of DNN `9.13.8`, then installation of `Microsoft.CodeDom.Providers.DotNetCompilerPlatform (v3.6)`, followed by an upgrade using `DNN_Platform_10.0.0-rc.15_Upgrade.zip`.  
4. Clean install of DNN `9.13.8`, then installation of `Microsoft.CodeDom.Providers.DotNetCompilerPlatform (v3.6)`, followed by `2sxc 19.03.02 LTS` (including all content and app templates), then an upgrade using `DNN_Platform_10.0.0-rc.15_Upgrade.zip`.  

### Conclusion
Since all tests were successful, I am confident that this improved fix is ready for a PR review and merge.