### PR TITLE
Fixed an issue with wrong localization detection

### DIFF
--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -59,9 +59,9 @@
         <add key="UsePortNumber" value="true" /> -->
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
-	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+    <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
     <add key="PreserveLoginUrl" value="true" />
-	  <add key="loginUrl" value="~/Login.aspx" />
+    <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />
@@ -85,6 +85,7 @@
     <modules>
       <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
+      <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
@@ -138,7 +139,7 @@
       </buildProviders>
       <assemblies>
         <add assembly="Microsoft.VisualBasic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
-		<add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+    <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       </assemblies>
       <expressionBuilders >
         <add expressionPrefix="dnnLoc" type="DotNetNuke.Services.Localization.LocalizationExpressionBuilder, DotNetNuke"/>

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -59,9 +59,9 @@
         <add key="UsePortNumber" value="true" /> -->
     <!-- Services Framework Tracing is primarily useful for developing and debugging -->
     <add key="EnableServicesFrameworkTracing" value="false" />
-	  <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
+    <add key="UpdateServiceUrl" value="https://dnnplatform.io" />
     <add key="PreserveLoginUrl" value="true" />
-	  <add key="loginUrl" value="~/Login.aspx" />
+    <add key="loginUrl" value="~/Login.aspx" />
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />
     <add key="MobileViewSiteCookieName" value="dnn_IsMobile" />
     <add key="DisableMobileViewSiteCookieName" value="dnn_NoMobile" />
@@ -85,6 +85,7 @@
     <modules>
       <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
+      <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="MobileRedirect" type="DotNetNuke.HttpModules.MobileRedirectModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="Exception" type="DotNetNuke.HttpModules.Exceptions.ExceptionModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="DNNMembership" type="DotNetNuke.HttpModules.Membership.MembershipModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
@@ -139,7 +140,7 @@
       </buildProviders>
       <assemblies>
         <add assembly="Microsoft.VisualBasic, Version=10.0.0.0, Culture=neutral, PublicKeyToken=B03F5F7F11D50A3A" />
-		<add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+    <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
       </assemblies>
       <expressionBuilders >
         <add expressionPrefix="dnnLoc" type="DotNetNuke.Services.Localization.LocalizationExpressionBuilder, DotNetNuke"/>


### PR DESCRIPTION
I did a `git bisect` which pointed me to the commits in #6038 to rollup the sql scripts for v10. This made no sense to me since it's not really related to web.config and @uzmannazari pointed out in #6503 that a similar issue was caused by the LocalizationModule missing from the web.config. Also I could not reproduce the issue on upgrades. Then I thought since we have that v10 rollup, it uses the 10.00.00.config for the web.config xml merge scripts and up. Investigating the commit history of that file and comparing with 9.8.0 one I found that in #4251, a bugfix was done to ensure that the LocalizationModule is right after the UrlRewriteModule.

This means that upon upgrades it would be in the right place but with clean installs, that would never run and it was also missing from the base web.config, thus making it not be there at all.

I was debating between putting this fix in the 10.00.00.config or just in the web.config I thought the web.config is fine as upon upgrades, the order would already have been fixed (as long as we document to upgrade to latest v9 before upgrading to v10). For clean installs it would just already be at the right place to start with.

Closes #6503 