### PR TITLE
Fixed an issue where ServiceRequestScopeModule was missing from web.config

### DIFF
--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -83,6 +83,7 @@
       <clientCache cacheControlCustom="public" cacheControlMode="UseMaxAge" cacheControlMaxAge="365.00:00:00" />
     </staticContent>
     <modules>
+      <add name="ServiceRequestScopeModule" type="DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -83,6 +83,7 @@
       <clientCache cacheControlCustom="public" cacheControlMode="UseMaxAge" cacheControlMaxAge="365.00:00:00" />
     </staticContent>
     <modules>
+      <add name="ServiceRequestScopeModule" type="DotNetNuke.HttpModules.DependencyInjection.ServiceRequestScopeModule, DotNetNuke.HttpModules" preCondition="managedHandler" />
       <add name="RequestFilter" type="DotNetNuke.HttpModules.RequestFilter.RequestFilterModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="UrlRewrite" type="DotNetNuke.HttpModules.UrlRewriteModule, DotNetNuke.HttpModules" preCondition="managedHandler"/>
       <add name="Localization" type="DotNetNuke.HttpModules.Localization.LocalizationModule, DotNetNuke.HttpModules" preCondition="managedHandler" />


### PR DESCRIPTION
This was only done in 10.00.00.config but xml-merge scripts only run upon upgrades of that version, hence this would be missing from clean installs and needs to exist in the base web.config for a clean install.

I have also verified the rest of 10.00.00.config and everything else appears to be pre-exising in the base web.config files.

Completes an extra detail from https://github.com/dnnsoftware/Dnn.Platform/issues/6503 
