### PR TITLE
Resolve SA1614 warnings in DotNetNuke.Library

### DIFF
--- a/DNN Platform/Library/Common/SerializableKeyValuePair.cs
+++ b/DNN Platform/Library/Common/SerializableKeyValuePair.cs
@@ -12,8 +12,8 @@ namespace DotNetNuke.Common
     public class SerializableKeyValuePair<TKey, TValue>
     {
         /// <summary>Initializes a new instance of the <see cref="SerializableKeyValuePair{TKey, TValue}"/> class.</summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
         public SerializableKeyValuePair(TKey key, TValue value)
         {
             this.Key = key;

--- a/DNN Platform/Library/Common/Utilities/CacheItemArgs.cs
+++ b/DNN Platform/Library/Common/Utilities/CacheItemArgs.cs
@@ -8,9 +8,6 @@ namespace DotNetNuke.Common.Utilities
 
     using DotNetNuke.Services.Cache;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.Common.Utilities
-    /// Class:      CacheItemArgs
     /// <summary>
     /// The CacheItemArgs class provides an EventArgs implementation for the
     /// CacheItemExpiredCallback delegate.
@@ -23,7 +20,7 @@ namespace DotNetNuke.Common.Utilities
         /// Initializes a new instance of the <see cref="CacheItemArgs"/> class.
         /// Constructs a new CacheItemArgs Object.
         /// </summary>
-        /// <param name="key"></param>
+        /// <param name="key">The cache item key.</param>
         public CacheItemArgs(string key)
             : this(key, 20, CacheItemPriority.Default, null)
         {
@@ -33,8 +30,8 @@ namespace DotNetNuke.Common.Utilities
         /// Initializes a new instance of the <see cref="CacheItemArgs"/> class.
         /// Constructs a new CacheItemArgs Object.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="timeout"></param>
+        /// <param name="key">The cache item key.</param>
+        /// <param name="timeout">The cache timeout. This value will be multiplied be <see cref="Host.PerformanceSetting"/> to determine the number of minutes.</param>
         public CacheItemArgs(string key, int timeout)
             : this(key, timeout, CacheItemPriority.Default, null)
         {
@@ -44,8 +41,8 @@ namespace DotNetNuke.Common.Utilities
         /// Initializes a new instance of the <see cref="CacheItemArgs"/> class.
         /// Constructs a new CacheItemArgs Object.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="priority"></param>
+        /// <param name="key">The cache item key.</param>
+        /// <param name="priority">The cache item priority.</param>
         public CacheItemArgs(string key, CacheItemPriority priority)
             : this(key, 20, priority, null)
         {
@@ -55,9 +52,9 @@ namespace DotNetNuke.Common.Utilities
         /// Initializes a new instance of the <see cref="CacheItemArgs"/> class.
         /// Constructs a new CacheItemArgs Object.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="timeout"></param>
-        /// <param name="priority"></param>
+        /// <param name="key">The cache item key.</param>
+        /// <param name="timeout">The cache timeout. This value will be multiplied be <see cref="Host.PerformanceSetting"/> to determine the number of minutes.</param>
+        /// <param name="priority">The cache item priority.</param>
         public CacheItemArgs(string key, int timeout, CacheItemPriority priority)
             : this(key, timeout, priority, null)
         {
@@ -67,10 +64,10 @@ namespace DotNetNuke.Common.Utilities
         /// Initializes a new instance of the <see cref="CacheItemArgs"/> class.
         /// Constructs a new CacheItemArgs Object.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="timeout"></param>
-        /// <param name="priority"></param>
-        /// <param name="parameters"></param>
+        /// <param name="key">The cache item key.</param>
+        /// <param name="timeout">The cache timeout. This value will be multiplied be <see cref="Host.PerformanceSetting"/> to determine the number of minutes.</param>
+        /// <param name="priority">The cache item priority.</param>
+        /// <param name="parameters">The parameters to pass to the callback.</param>
         public CacheItemArgs(string key, int timeout, CacheItemPriority priority, params object[] parameters)
         {
             this.CacheKey = key;

--- a/DNN Platform/Library/Common/Utilities/FileExtensionWhitelist.cs
+++ b/DNN Platform/Library/Common/Utilities/FileExtensionWhitelist.cs
@@ -57,7 +57,7 @@ namespace DotNetNuke.Common.Utilities
 
         /// <summary>Indicates if the file extension is permitted by the Host Whitelist.</summary>
         /// <param name="extension">The file extension with or without preceding '.'.</param>
-        /// <param name="additionalExtensions"></param>
+        /// <param name="additionalExtensions">Any other additional valid extensions or <see langword="null" />.</param>
         /// <returns>True if extension is in whitelist or whitelist is empty.  False otherwise.</returns>
         public bool IsAllowedExtension(string extension, IEnumerable<string> additionalExtensions)
         {

--- a/DNN Platform/Library/Common/Utilities/FileSystemPermissionVerifier.cs
+++ b/DNN Platform/Library/Common/Utilities/FileSystemPermissionVerifier.cs
@@ -9,10 +9,8 @@ namespace DotNetNuke.Common.Utilities
     using DotNetNuke.Common.Utilities.Internal;
     using DotNetNuke.Instrumentation;
 
-    /// <summary>  Verifies the abililty to create and delete files and folders.</summary>
-    /// <remarks>
-    ///   This class is not meant for use in modules, or in any other manner outside the DotNetNuke core.
-    /// </remarks>
+    /// <summary>Verifies the ability to create and delete files and folders.</summary>
+    /// <remarks>This class is not meant for use in modules, or in any other manner outside the DotNetNuke core.</remarks>
     public class FileSystemPermissionVerifier
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(FileSystemPermissionVerifier));
@@ -20,16 +18,16 @@ namespace DotNetNuke.Common.Utilities
 
         private int retryTimes = 30;
 
-        /// <summary>Initializes a new instance of the <see cref="FileSystemPermissionVerifier"/> class.</summary>
-        /// <param name="basePath"></param>
+        /// <summary>Initializes a new instance of the <see cref="FileSystemPermissionVerifier"/> class with a default of 30 retries.</summary>
+        /// <param name="basePath">The path at which to start verifying.</param>
         public FileSystemPermissionVerifier(string basePath)
         {
             this.basePath = basePath;
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileSystemPermissionVerifier"/> class.</summary>
-        /// <param name="basePath"></param>
-        /// <param name="retryTimes"></param>
+        /// <param name="basePath">The path at which to start verifying.</param>
+        /// <param name="retryTimes">The number of times to retry (defaults to 30).</param>
         public FileSystemPermissionVerifier(string basePath, int retryTimes)
             : this(basePath)
         {

--- a/DNN Platform/Library/Common/Utilities/HtmlUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/HtmlUtils.cs
@@ -75,9 +75,9 @@ namespace DotNetNuke.Common.Utilities
         }
 
         /// <summary>CleanWithTagInfo removes unspecified HTML Tags, Entities (and optionally any punctuation) from a string.</summary>
-        /// <param name="html"></param>
-        /// <param name="tagsFilter"></param>
-        /// <param name="removePunctuation"></param>
+        /// <param name="html">The HTML to clean.</param>
+        /// <param name="tagsFilter">A regular expression indicating attributes of which to keep the value, e.g. <c>"alt|href|src|title"</c>.</param>
+        /// <param name="removePunctuation">Whether to remove punctuation from <paramref name="html"/>.</param>
         /// <returns>The cleaned up string.</returns>
         public static string CleanWithTagInfo(string html, string tagsFilter, bool removePunctuation)
         {
@@ -89,7 +89,7 @@ namespace DotNetNuke.Common.Utilities
             // First remove unspecified HTML Tags ("<....>")
             html = StripUnspecifiedTags(html, tagsFilter, true);
 
-            // Second replace any HTML entities (&nbsp; &lt; etc) through their char symbol
+            // Second replace any HTML entities (&nbsp; &lt; etc.) through their char symbol
             html = HttpUtility.HtmlDecode(html);
 
             // Thirdly remove any punctuation
@@ -272,9 +272,9 @@ namespace DotNetNuke.Common.Utilities
         }
 
         /// <summary>  StripUnspecifiedTags removes the HTML tags from the content -- leaving behind the info for the specified HTML tags. </summary>
-        /// <param name="html"></param>
-        /// <param name="specifiedTags"></param>
-        /// <param name="retainSpace"></param>
+        /// <param name="html">The HTML to clean.</param>
+        /// <param name="specifiedTags">A regular expression indicating attributes of which to keep the value, e.g. <c>"alt|href|src|title"</c>.</param>
+        /// <param name="retainSpace">Whether to replace tags with spaces or <see cref="string.Empty"/>.</param>
         /// <returns>The cleaned up string.</returns>
         public static string StripUnspecifiedTags(string html, string specifiedTags, bool retainSpace)
         {

--- a/DNN Platform/Library/Common/Utilities/RetryableAction.cs
+++ b/DNN Platform/Library/Common/Utilities/RetryableAction.cs
@@ -23,21 +23,21 @@ namespace DotNetNuke.Common.Utilities.Internal
         }
 
         /// <summary>Initializes a new instance of the <see cref="RetryableAction"/> class.</summary>
-        /// <param name="action"></param>
-        /// <param name="description"></param>
-        /// <param name="maxRetries"></param>
-        /// <param name="delay"></param>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="description">A description of the action (for logging).</param>
+        /// <param name="maxRetries">The maximum number of retries.</param>
+        /// <param name="delay">The delay between retries.</param>
         public RetryableAction(Action action, string description, int maxRetries, TimeSpan delay)
             : this(action, description, maxRetries, delay, 1)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="RetryableAction"/> class.</summary>
-        /// <param name="action"></param>
-        /// <param name="description"></param>
-        /// <param name="maxRetries"></param>
-        /// <param name="delay"></param>
-        /// <param name="delayMultiplier"></param>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="description">A description of the action (for logging).</param>
+        /// <param name="maxRetries">The maximum number of retries.</param>
+        /// <param name="delay">The initial delay between retries.</param>
+        /// <param name="delayMultiplier">The amount to adjust the delay for each subsequent retry.</param>
         public RetryableAction(Action action, string description, int maxRetries, TimeSpan delay, float delayMultiplier)
         {
             if (delay.TotalMilliseconds > int.MaxValue)

--- a/DNN Platform/Library/ComponentModel/DataAnnotations/ColumnNameAttribute.cs
+++ b/DNN Platform/Library/ComponentModel/DataAnnotations/ColumnNameAttribute.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.ComponentModel.DataAnnotations
     public class ColumnNameAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="ColumnNameAttribute"/> class.</summary>
-        /// <param name="columnName"></param>
+        /// <param name="columnName">The name of the column.</param>
         public ColumnNameAttribute(string columnName)
         {
             this.ColumnName = columnName;

--- a/DNN Platform/Library/ComponentModel/DataAnnotations/PrimaryKeyAttribute.cs
+++ b/DNN Platform/Library/ComponentModel/DataAnnotations/PrimaryKeyAttribute.cs
@@ -8,15 +8,15 @@ namespace DotNetNuke.ComponentModel.DataAnnotations
     public class PrimaryKeyAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="PrimaryKeyAttribute"/> class.</summary>
-        /// <param name="columnName"></param>
+        /// <param name="columnName">The name of the column (or a comma-delimited list of column names) of the primary key for the table.</param>
         public PrimaryKeyAttribute(string columnName)
             : this(columnName, columnName)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PrimaryKeyAttribute"/> class.</summary>
-        /// <param name="columnName"></param>
-        /// <param name="propertyName"></param>
+        /// <param name="columnName">The name of the column (or a comma-delimited list of column names) of the primary key for the table.</param>
+        /// <param name="propertyName">The name of the property for the primary key.</param>
         public PrimaryKeyAttribute(string columnName, string propertyName)
         {
             this.ColumnName = columnName;

--- a/DNN Platform/Library/ComponentModel/DataAnnotations/ScopeAttribute.cs
+++ b/DNN Platform/Library/ComponentModel/DataAnnotations/ScopeAttribute.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.ComponentModel.DataAnnotations
     public class ScopeAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="ScopeAttribute"/> class.</summary>
-        /// <param name="scope"></param>
+        /// <param name="scope">The name of the column/property which defines the scope for the cache.</param>
         public ScopeAttribute(string scope)
         {
             this.Scope = scope;

--- a/DNN Platform/Library/ComponentModel/DataAnnotations/TableNameAttribute.cs
+++ b/DNN Platform/Library/ComponentModel/DataAnnotations/TableNameAttribute.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.ComponentModel.DataAnnotations
     public class TableNameAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="TableNameAttribute"/> class.</summary>
-        /// <param name="tableName"></param>
+        /// <param name="tableName">The name of the table.</param>
         public TableNameAttribute(string tableName)
         {
             this.TableName = tableName;

--- a/DNN Platform/Library/ComponentModel/InstanceComponentBuilder.cs
+++ b/DNN Platform/Library/ComponentModel/InstanceComponentBuilder.cs
@@ -10,8 +10,8 @@ namespace DotNetNuke.ComponentModel
         private readonly string name;
 
         /// <summary>Initializes a new instance of the <see cref="InstanceComponentBuilder"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="instance"></param>
+        /// <param name="name">The component name.</param>
+        /// <param name="instance">The component instance.</param>
         public InstanceComponentBuilder(string name, object instance)
         {
             this.name = name;

--- a/DNN Platform/Library/ComponentModel/ProviderInstaller.cs
+++ b/DNN Platform/Library/ComponentModel/ProviderInstaller.cs
@@ -20,8 +20,8 @@ namespace DotNetNuke.ComponentModel
         private Type defaultProvider;
 
         /// <summary>Initializes a new instance of the <see cref="ProviderInstaller"/> class.</summary>
-        /// <param name="providerType"></param>
-        /// <param name="providerInterface"></param>
+        /// <param name="providerType">The type name of the provider implementation.</param>
+        /// <param name="providerInterface">The <see cref="Type"/> of the provider interface.</param>
         public ProviderInstaller(string providerType, Type providerInterface)
         {
             this.componentLifeStyle = ComponentLifeStyleType.Singleton;
@@ -30,9 +30,9 @@ namespace DotNetNuke.ComponentModel
         }
 
         /// <summary>Initializes a new instance of the <see cref="ProviderInstaller"/> class.</summary>
-        /// <param name="providerType"></param>
-        /// <param name="providerInterface"></param>
-        /// <param name="defaultProvider"></param>
+        /// <param name="providerType">The type name of the provider implementation.</param>
+        /// <param name="providerInterface">The <see cref="Type"/> of the provider interface.</param>
+        /// <param name="defaultProvider">The default <see cref="Type"/> for the implementation.</param>
         public ProviderInstaller(string providerType, Type providerInterface, Type defaultProvider)
         {
             this.componentLifeStyle = ComponentLifeStyleType.Singleton;
@@ -42,9 +42,9 @@ namespace DotNetNuke.ComponentModel
         }
 
         /// <summary>Initializes a new instance of the <see cref="ProviderInstaller"/> class.</summary>
-        /// <param name="providerType"></param>
-        /// <param name="providerInterface"></param>
-        /// <param name="lifeStyle"></param>
+        /// <param name="providerType">The type name of the provider implementation.</param>
+        /// <param name="providerInterface">The <see cref="Type"/> of the provider interface.</param>
+        /// <param name="lifeStyle">The <see cref="ComponentLifeStyleType"/> of the instance.</param>
         public ProviderInstaller(string providerType, Type providerInterface, ComponentLifeStyleType lifeStyle)
         {
             this.componentLifeStyle = lifeStyle;

--- a/DNN Platform/Library/ComponentModel/SimpleContainer.cs
+++ b/DNN Platform/Library/ComponentModel/SimpleContainer.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.ComponentModel
         }
 
         /// <summary>Initializes a new instance of the <see cref="SimpleContainer"/> class.</summary>
-        /// <param name="name"></param>
+        /// <param name="name">The container name.</param>
         public SimpleContainer(string name)
         {
             this.name = name;

--- a/DNN Platform/Library/Data/ControllerBase.cs
+++ b/DNN Platform/Library/Data/ControllerBase.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Data
         }
 
         /// <summary>Initializes a new instance of the <see cref="ControllerBase{TEntity, TContract, TSelf}"/> class.</summary>
-        /// <param name="dataContext"></param>
+        /// <param name="dataContext">The data context.</param>
         protected ControllerBase(IDataContext dataContext)
         {
             // Argument Contract

--- a/DNN Platform/Library/Data/DataProvider.cs
+++ b/DNN Platform/Library/Data/DataProvider.cs
@@ -2798,8 +2798,8 @@ namespace DotNetNuke.Data
                 createdByUserID);
         }
 
-        /// <summary>Get a User Authentication record from slq database. DNN-4016.</summary>
-        /// <param name="userID"></param>
+        /// <summary>Get a User Authentication record from SQL database. DNN-4016.</summary>
+        /// <param name="userID">The ID of the user.</param>
         /// <returns>UserAuthentication record.</returns>
         public virtual IDataReader GetUserAuthentication(int userID)
         {

--- a/DNN Platform/Library/Data/PetaPoco/FluentColumnMap.cs
+++ b/DNN Platform/Library/Data/PetaPoco/FluentColumnMap.cs
@@ -17,24 +17,24 @@ namespace DotNetNuke.Data.PetaPoco
         }
 
         /// <summary>Initializes a new instance of the <see cref="FluentColumnMap"/> class.</summary>
-        /// <param name="columnInfo"></param>
+        /// <param name="columnInfo">Information about the column.</param>
         public FluentColumnMap(ColumnInfo columnInfo)
             : this(columnInfo, null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FluentColumnMap"/> class.</summary>
-        /// <param name="columnInfo"></param>
-        /// <param name="fromDbConverter"></param>
+        /// <param name="columnInfo">Information about the column.</param>
+        /// <param name="fromDbConverter">A function to convert the database value to the class value.</param>
         public FluentColumnMap(ColumnInfo columnInfo, Func<object, object> fromDbConverter)
             : this(columnInfo, fromDbConverter, null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FluentColumnMap"/> class.</summary>
-        /// <param name="columnInfo"></param>
-        /// <param name="fromDbConverter"></param>
-        /// <param name="toDbConverter"></param>
+        /// <param name="columnInfo">Information about the column.</param>
+        /// <param name="fromDbConverter">A function to convert the database value to the class value.</param>
+        /// <param name="toDbConverter">A function to convert the class value to the database value.</param>
         public FluentColumnMap(ColumnInfo columnInfo, Func<object, object> fromDbConverter, Func<object, object> toDbConverter)
         {
             this.ColumnInfo = columnInfo;

--- a/DNN Platform/Library/Data/PetaPoco/FluentMapper.cs
+++ b/DNN Platform/Library/Data/PetaPoco/FluentMapper.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Data.PetaPoco
         private readonly string tablePrefix;
 
         /// <summary>Initializes a new instance of the <see cref="FluentMapper{TModel}"/> class.</summary>
-        /// <param name="tablePrefix"></param>
+        /// <param name="tablePrefix">The prefix for the table.</param>
         public FluentMapper(string tablePrefix)
         {
             this.CacheKey = string.Empty;

--- a/DNN Platform/Library/Data/PetaPoco/PetaPocoDataContext.cs
+++ b/DNN Platform/Library/Data/PetaPoco/PetaPocoDataContext.cs
@@ -25,24 +25,24 @@ namespace DotNetNuke.Data.PetaPoco
         }
 
         /// <summary>Initializes a new instance of the <see cref="PetaPocoDataContext"/> class.</summary>
-        /// <param name="connectionStringName"></param>
+        /// <param name="connectionStringName">The connection string name.</param>
         public PetaPocoDataContext(string connectionStringName)
             : this(connectionStringName, string.Empty, new Dictionary<Type, IMapper>())
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PetaPocoDataContext"/> class.</summary>
-        /// <param name="connectionStringName"></param>
-        /// <param name="tablePrefix"></param>
+        /// <param name="connectionStringName">The connection string name.</param>
+        /// <param name="tablePrefix">The table prefix.</param>
         public PetaPocoDataContext(string connectionStringName, string tablePrefix)
             : this(connectionStringName, tablePrefix, new Dictionary<Type, IMapper>())
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PetaPocoDataContext"/> class.</summary>
-        /// <param name="connectionStringName"></param>
-        /// <param name="tablePrefix"></param>
-        /// <param name="mappers"></param>
+        /// <param name="connectionStringName">The connection string name.</param>
+        /// <param name="tablePrefix">The table prefix.</param>
+        /// <param name="mappers">A <see cref="Dictionary{TKey,TValue}"/> with <see cref="FluentMapper{TModel}"/> instances for types.</param>
         public PetaPocoDataContext(string connectionStringName, string tablePrefix, Dictionary<Type, IMapper> mappers)
         {
             Requires.NotNullOrEmpty("connectionStringName", connectionStringName);

--- a/DNN Platform/Library/Data/PetaPoco/PetaPocoMapper.cs
+++ b/DNN Platform/Library/Data/PetaPoco/PetaPocoMapper.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Data.PetaPoco
         private readonly string tablePrefix;
 
         /// <summary>Initializes a new instance of the <see cref="PetaPocoMapper"/> class.</summary>
-        /// <param name="tablePrefix"></param>
+        /// <param name="tablePrefix">The table prefix.</param>
         public PetaPocoMapper(string tablePrefix)
         {
             this.tablePrefix = tablePrefix;

--- a/DNN Platform/Library/Data/PetaPoco/PetaPocoRepository.cs
+++ b/DNN Platform/Library/Data/PetaPoco/PetaPocoRepository.cs
@@ -16,8 +16,8 @@ namespace DotNetNuke.Data.PetaPoco
         private readonly IMapper mapper;
 
         /// <summary>Initializes a new instance of the <see cref="PetaPocoRepository{T}"/> class.</summary>
-        /// <param name="database"></param>
-        /// <param name="mapper"></param>
+        /// <param name="database">The database.</param>
+        /// <param name="mapper">The mapper.</param>
         public PetaPocoRepository(Database database, IMapper mapper)
         {
             Requires.NotNull("database", database);

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -53,7 +53,7 @@
     <NoWarn>1591, 3001, 3002, 1574, 1573</NoWarn>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CS0618,CS0809,CS3005,CS3008,SA1600,SA1601,SA1602,SA1604,SA1605,SA1606,SA1608,SA1611,SA1612,SA1614</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CS0618,CS0809,CS3005,CS3008,SA1600,SA1601,SA1602,SA1604,SA1605,SA1606,SA1608,SA1611,SA1612</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\</OutputPath>
@@ -70,7 +70,7 @@
     <LangVersion>latest</LangVersion>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CS0618,CS0809,CS3005,CS3008,SA1600,SA1601,SA1602,SA1604,SA1605,SA1606,SA1608,SA1611,SA1612,SA1614</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CS0618,CS0809,CS3005,CS3008,SA1600,SA1601,SA1602,SA1604,SA1605,SA1606,SA1608,SA1611,SA1612</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>

--- a/DNN Platform/Library/Entities/Content/AttachmentController.cs
+++ b/DNN Platform/Library/Entities/Content/AttachmentController.cs
@@ -33,7 +33,7 @@ namespace DotNetNuke.Entities.Content
         }
 
         /// <summary>Initializes a new instance of the <see cref="AttachmentController"/> class.</summary>
-        /// <param name="contentController"></param>
+        /// <param name="contentController">The content controller.</param>
         public AttachmentController(IContentController contentController)
         {
             this.contentController = contentController;

--- a/DNN Platform/Library/Entities/Content/ContentType.cs
+++ b/DNN Platform/Library/Entities/Content/ContentType.cs
@@ -34,7 +34,7 @@ namespace DotNetNuke.Entities.Content
         }
 
         /// <summary>Initializes a new instance of the <see cref="ContentType"/> class.</summary>
-        /// <param name="contentType"></param>
+        /// <param name="contentType">The name of the content type.</param>
         public ContentType(string contentType)
         {
             this.ContentTypeId = Null.NullInteger;

--- a/DNN Platform/Library/Entities/Content/ContentTypeController.cs
+++ b/DNN Platform/Library/Entities/Content/ContentTypeController.cs
@@ -36,7 +36,7 @@ namespace DotNetNuke.Entities.Content
         }
 
         /// <summary>Initializes a new instance of the <see cref="ContentTypeController"/> class.</summary>
-        /// <param name="dataService"></param>
+        /// <param name="dataService">The data service.</param>
         public ContentTypeController(IDataService dataService)
         {
             this.dataService = dataService;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/ScopeType.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/ScopeType.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="ScopeType"/> class.</summary>
-        /// <param name="scopeType"></param>
+        /// <param name="scopeType">The name of the scope type.</param>
         public ScopeType(string scopeType)
         {
             this.ScopeTypeId = Null.NullInteger;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/ScopeTypeController.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/ScopeTypeController.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="ScopeTypeController"/> class.</summary>
-        /// <param name="dataService"></param>
+        /// <param name="dataService">The data service.</param>
         public ScopeTypeController(IDataService dataService)
         {
             this.dataService = dataService;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/Term.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/Term.cs
@@ -67,31 +67,31 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="Term"/> class.</summary>
-        /// <param name="vocabularyId"></param>
+        /// <param name="vocabularyId">The vocabulary ID.</param>
         public Term(int vocabularyId)
             : this(Null.NullString, Null.NullString, vocabularyId)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="Term"/> class.</summary>
-        /// <param name="name"></param>
+        /// <param name="name">The term name.</param>
         public Term(string name)
             : this(name, Null.NullString, Null.NullInteger)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="Term"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
+        /// <param name="name">The term name.</param>
+        /// <param name="description">The term description.</param>
         public Term(string name, string description)
             : this(name, description, Null.NullInteger)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="Term"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <param name="vocabularyId"></param>
+        /// <param name="name">The term name.</param>
+        /// <param name="description">The term description.</param>
+        /// <param name="vocabularyId">The vocabulary ID.</param>
         public Term(string name, string description, int vocabularyId)
         {
             this.Description = description;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/TermController.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/TermController.cs
@@ -38,7 +38,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="TermController"/> class.</summary>
-        /// <param name="dataService"></param>
+        /// <param name="dataService">The data service.</param>
         public TermController(IDataService dataService)
         {
             this.dataService = dataService;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/TermUsage.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/TermUsage.cs
@@ -15,10 +15,10 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="TermUsage"/> class.</summary>
-        /// <param name="total"></param>
-        /// <param name="month"></param>
-        /// <param name="week"></param>
-        /// <param name="day"></param>
+        /// <param name="total">The total usage count.</param>
+        /// <param name="month">The usage count for the month.</param>
+        /// <param name="week">The usage count for the week.</param>
+        /// <param name="day">The usage count for the day.</param>
         internal TermUsage(int total, int month, int week, int day)
         {
             this.TotalTermUsage = total;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/Vocabulary.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/Vocabulary.cs
@@ -38,31 +38,31 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="Vocabulary"/> class.</summary>
-        /// <param name="name"></param>
+        /// <param name="name">The name of the vocabulary.</param>
         public Vocabulary(string name)
             : this(name, Null.NullString, VocabularyType.Simple)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="Vocabulary"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
+        /// <param name="name">The name of the vocabulary.</param>
+        /// <param name="description">The description.</param>
         public Vocabulary(string name, string description)
             : this(name, description, VocabularyType.Simple)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="Vocabulary"/> class.</summary>
-        /// <param name="type"></param>
+        /// <param name="type">The vocabulary type.</param>
         public Vocabulary(VocabularyType type)
             : this(Null.NullString, Null.NullString, type)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="Vocabulary"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="description"></param>
-        /// <param name="type"></param>
+        /// <param name="name">The name of the vocabulary.</param>
+        /// <param name="description">The description.</param>
+        /// <param name="type">The vocabulary type.</param>
         public Vocabulary(string name, string description, VocabularyType type)
         {
             this.Description = description;

--- a/DNN Platform/Library/Entities/Content/Taxonomy/VocabularyController.cs
+++ b/DNN Platform/Library/Entities/Content/Taxonomy/VocabularyController.cs
@@ -26,7 +26,7 @@ namespace DotNetNuke.Entities.Content.Taxonomy
         }
 
         /// <summary>Initializes a new instance of the <see cref="VocabularyController"/> class.</summary>
-        /// <param name="dataService"></param>
+        /// <param name="dataService">The data service.</param>
         public VocabularyController(IDataService dataService)
         {
             this.dataService = dataService;

--- a/DNN Platform/Library/Entities/Content/Workflow/Exceptions/WorkflowException.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Exceptions/WorkflowException.cs
@@ -14,15 +14,15 @@ namespace DotNetNuke.Entities.Content.Workflow.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="WorkflowException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">A message that describes the error.</param>
         public WorkflowException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="WorkflowException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="innerException"></param>
+        /// <param name="message">A message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a <see langword="null"/> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public WorkflowException(string message, Exception innerException)
             : base(message, innerException)
         {

--- a/DNN Platform/Library/Entities/Content/Workflow/Exceptions/WorkflowInvalidOperationException.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Exceptions/WorkflowInvalidOperationException.cs
@@ -7,7 +7,7 @@ namespace DotNetNuke.Entities.Content.Workflow.Exceptions
     public class WorkflowInvalidOperationException : WorkflowException
     {
         /// <summary>Initializes a new instance of the <see cref="WorkflowInvalidOperationException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">A message that describes the error.</param>
         public WorkflowInvalidOperationException(string message)
             : base(message)
         {

--- a/DNN Platform/Library/Entities/Content/Workflow/Exceptions/WorkflowSecurityException.cs
+++ b/DNN Platform/Library/Entities/Content/Workflow/Exceptions/WorkflowSecurityException.cs
@@ -7,7 +7,7 @@ namespace DotNetNuke.Entities.Content.Workflow.Exceptions
     public class WorkflowSecurityException : WorkflowException
     {
         /// <summary>Initializes a new instance of the <see cref="WorkflowSecurityException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">A message that describes the error.</param>
         public WorkflowSecurityException(string message)
             : base(message)
         {

--- a/DNN Platform/Library/Entities/Controllers/IHostController.cs
+++ b/DNN Platform/Library/Entities/Controllers/IHostController.cs
@@ -77,8 +77,8 @@ namespace DotNetNuke.Entities.Controllers
         string GetString(string key);
 
         /// <summary>Gets the setting value for a specific key.</summary>
-        /// <param name="key">The seeting key string.</param>
-        /// <param name="defaultValue"></param>
+        /// <param name="key">The setting key string.</param>
+        /// <param name="defaultValue">The default value.</param>
         /// <returns>Default value returned if the setting is not found.</returns>
         string GetString(string key, string defaultValue);
 
@@ -90,8 +90,8 @@ namespace DotNetNuke.Entities.Controllers
         /// <param name="config">The configuration setting.</param>
         void Update(ConfigurationSetting config);
 
-        /// <summary>Updates the specified config, ontionally clearing the cache.</summary>
-        /// <param name="config">The configuaration setting.</param>
+        /// <summary>Updates the specified config, optionally clearing the cache.</summary>
+        /// <param name="config">The configuration setting.</param>
         /// <param name="clearCache">If set to <c>true</c>, will clear the cache after updating the setting.</param>
         void Update(ConfigurationSetting config, bool clearCache);
 

--- a/DNN Platform/Library/Entities/Host/ServerInfo.cs
+++ b/DNN Platform/Library/Entities/Host/ServerInfo.cs
@@ -20,8 +20,8 @@ namespace DotNetNuke.Entities.Host
         }
 
         /// <summary>Initializes a new instance of the <see cref="ServerInfo"/> class.</summary>
-        /// <param name="created"></param>
-        /// <param name="lastactivity"></param>
+        /// <param name="created">The created date for the server.</param>
+        /// <param name="lastactivity">The last activity date for the server.</param>
         public ServerInfo(DateTime created, DateTime lastactivity)
         {
             this.IISAppName = Globals.IISAppName;

--- a/DNN Platform/Library/Entities/Modules/Actions/ActionEventArgs.cs
+++ b/DNN Platform/Library/Entities/Modules/Actions/ActionEventArgs.cs
@@ -5,9 +5,6 @@ namespace DotNetNuke.Entities.Modules.Actions
 {
     using System;
 
-    /// Project     : DotNetNuke
-    /// Namespace   : DotNetNuke.Entities.Modules.Actions
-    /// Class       : ActionEventArgs
     /// <summary>ActionEventArgs provides a custom EventARgs class for Action Events.</summary>
     public class ActionEventArgs : EventArgs
     {
@@ -15,8 +12,8 @@ namespace DotNetNuke.Entities.Modules.Actions
         private readonly ModuleInfo moduleConfiguration;
 
         /// <summary>Initializes a new instance of the <see cref="ActionEventArgs"/> class.</summary>
-        /// <param name="action"></param>
-        /// <param name="moduleConfiguration"></param>
+        /// <param name="action">The action.</param>
+        /// <param name="moduleConfiguration">The module info.</param>
         public ActionEventArgs(ModuleAction action, ModuleInfo moduleConfiguration)
         {
             this.action = action;

--- a/DNN Platform/Library/Entities/Modules/Actions/ModuleAction.cs
+++ b/DNN Platform/Library/Entities/Modules/Actions/ModuleAction.cs
@@ -5,8 +5,6 @@ namespace DotNetNuke.Entities.Modules.Actions
 {
     using DotNetNuke.Security;
 
-    /// Project     : DotNetNuke
-    /// Class       : ModuleAction
     /// <summary>
     /// Each Module Action represents a separate functional action as defined by the
     /// associated module.
@@ -19,107 +17,107 @@ namespace DotNetNuke.Entities.Modules.Actions
     public class ModuleAction
     {
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
         public ModuleAction(int id)
             : this(id, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, false, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
         public ModuleAction(int id, string title, string cmdName)
             : this(id, title, cmdName, string.Empty, string.Empty, string.Empty, string.Empty, false, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg)
             : this(id, title, cmdName, cmdArg, string.Empty, string.Empty, string.Empty, false, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
-        /// <param name="icon"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
+        /// <param name="icon">The URL of the Icon to place next to this action.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon)
             : this(id, title, cmdName, cmdArg, icon, string.Empty, string.Empty, false, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
-        /// <param name="icon"></param>
-        /// <param name="url"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
+        /// <param name="icon">The URL of the Icon to place next to this action.</param>
+        /// <param name="url">The destination URL to redirect the client browser when this action is clicked.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon, string url)
             : this(id, title, cmdName, cmdArg, icon, url, string.Empty, false, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
-        /// <param name="icon"></param>
-        /// <param name="url"></param>
-        /// <param name="clientScript"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
+        /// <param name="icon">The URL of the Icon to place next to this action.</param>
+        /// <param name="url">The destination URL to redirect the client browser when this action is clicked.</param>
+        /// <param name="clientScript">JavaScript which will be run in the client's browser when the associated Module menu Action is selected, prior to a postback.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon, string url, string clientScript)
             : this(id, title, cmdName, cmdArg, icon, url, clientScript, false, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
-        /// <param name="icon"></param>
-        /// <param name="url"></param>
-        /// <param name="clientScript"></param>
-        /// <param name="useActionEvent"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
+        /// <param name="icon">The URL of the Icon to place next to this action.</param>
+        /// <param name="url">The destination URL to redirect the client browser when this action is clicked.</param>
+        /// <param name="clientScript">JavaScript which will be run in the client's browser when the associated Module menu Action is selected, prior to a postback.</param>
+        /// <param name="useActionEvent">Determines whether client will receive an event notification.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon, string url, string clientScript, bool useActionEvent)
             : this(id, title, cmdName, cmdArg, icon, url, clientScript, useActionEvent, SecurityAccessLevel.Anonymous, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
-        /// <param name="icon"></param>
-        /// <param name="url"></param>
-        /// <param name="clientScript"></param>
-        /// <param name="useActionEvent"></param>
-        /// <param name="secure"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
+        /// <param name="icon">The URL of the Icon to place next to this action.</param>
+        /// <param name="url">The destination URL to redirect the client browser when this action is clicked.</param>
+        /// <param name="clientScript">JavaScript which will be run in the client's browser when the associated Module menu Action is selected, prior to a postback.</param>
+        /// <param name="useActionEvent">Determines whether client will receive an event notification.</param>
+        /// <param name="secure">The security access level required for access to this action.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon, string url, string clientScript, bool useActionEvent, SecurityAccessLevel secure)
             : this(id, title, cmdName, cmdArg, icon, url, clientScript, useActionEvent, secure, true, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleAction"/> class.</summary>
-        /// <param name="id"></param>
-        /// <param name="title"></param>
-        /// <param name="cmdName"></param>
-        /// <param name="cmdArg"></param>
-        /// <param name="icon"></param>
-        /// <param name="url"></param>
-        /// <param name="clientScript"></param>
-        /// <param name="useActionEvent"></param>
-        /// <param name="secure"></param>
-        /// <param name="visible"></param>
+        /// <param name="id">This is the identifier to use for this action.</param>
+        /// <param name="title">This is the title that will be displayed for this action.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
+        /// <param name="icon">The URL of the Icon to place next to this action.</param>
+        /// <param name="url">The destination URL to redirect the client browser when this action is clicked.</param>
+        /// <param name="clientScript">JavaScript which will be run in the client's browser when the associated Module menu Action is selected, prior to a postback.</param>
+        /// <param name="useActionEvent">Determines whether client will receive an event notification.</param>
+        /// <param name="secure">The security access level required for access to this action.</param>
+        /// <param name="visible">Whether this action will be displayed.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon, string url, string clientScript, bool useActionEvent, SecurityAccessLevel secure, bool visible)
             : this(id, title, cmdName, cmdArg, icon, url, clientScript, useActionEvent, secure, visible, false)
         {
@@ -131,20 +129,15 @@ namespace DotNetNuke.Entities.Modules.Actions
         /// </summary>
         /// <param name="id">This is the identifier to use for this action.</param>
         /// <param name="title">This is the title that will be displayed for this action.</param>
-        /// <param name="cmdName">The command name passed to the client when this action is
-        /// clicked.</param>
-        /// <param name="cmdArg">The command argument passed to the client when this action is
-        /// clicked.</param>
+        /// <param name="cmdName">The command name passed to the client when this action is clicked.</param>
+        /// <param name="cmdArg">The command argument passed to the client when this action is clicked.</param>
         /// <param name="icon">The URL of the Icon to place next to this action.</param>
         /// <param name="url">The destination URL to redirect the client browser when this action is clicked.</param>
-        /// <param name="clientScript"></param>
+        /// <param name="clientScript">JavaScript which will be run in the client's browser when the associated Module menu Action is selected, prior to a postback.</param>
         /// <param name="useActionEvent">Determines whether client will receive an event notification.</param>
         /// <param name="secure">The security access level required for access to this action.</param>
         /// <param name="visible">Whether this action will be displayed.</param>
-        /// <param name="newWindow"></param>
-        /// <remarks>The moduleaction constructor is used to set the various properties of
-        /// the <see cref="T:DotNetNuke.Entities.Modules.Actions.ModuleAction" /> class at the time the instance is created.
-        /// </remarks>
+        /// <param name="newWindow">Whether to use a new window for the action.</param>
         public ModuleAction(int id, string title, string cmdName, string cmdArg, string icon, string url, string clientScript, bool useActionEvent, SecurityAccessLevel secure, bool visible, bool newWindow)
         {
             this.ID = id;

--- a/DNN Platform/Library/Entities/Modules/Actions/ModuleActionEventListener.cs
+++ b/DNN Platform/Library/Entities/Modules/Actions/ModuleActionEventListener.cs
@@ -4,9 +4,6 @@
 
 namespace DotNetNuke.Entities.Modules.Actions
 {
-    /// Project     : DotNetNuke
-    /// Class       : ModuleActionEventListener
-    ///
     /// <summary>
     ///
     /// </summary>
@@ -16,8 +13,8 @@ namespace DotNetNuke.Entities.Modules.Actions
         private readonly int moduleID;
 
         /// <summary>Initializes a new instance of the <see cref="ModuleActionEventListener"/> class.</summary>
-        /// <param name="modID"></param>
-        /// <param name="e"></param>
+        /// <param name="modID">The module ID.</param>
+        /// <param name="e">The event handler.</param>
         public ModuleActionEventListener(int modID, ActionEventHandler e)
         {
             this.moduleID = modID;

--- a/DNN Platform/Library/Entities/Modules/Communications/ModuleCommunicationEventArgs.cs
+++ b/DNN Platform/Library/Entities/Modules/Communications/ModuleCommunicationEventArgs.cs
@@ -13,17 +13,17 @@ namespace DotNetNuke.Entities.Modules.Communications
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleCommunicationEventArgs"/> class.</summary>
-        /// <param name="text"></param>
+        /// <param name="text">The text.</param>
         public ModuleCommunicationEventArgs(string text)
         {
             this.Text = text;
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleCommunicationEventArgs"/> class.</summary>
-        /// <param name="type"></param>
-        /// <param name="value"></param>
-        /// <param name="sender"></param>
-        /// <param name="target"></param>
+        /// <param name="type">The type.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="sender">The sender.</param>
+        /// <param name="target">The target.</param>
         public ModuleCommunicationEventArgs(string type, object value, string sender, string target)
         {
             this.Type = type;

--- a/DNN Platform/Library/Entities/Modules/IModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/IModuleController.cs
@@ -152,17 +152,17 @@ namespace DotNetNuke.Entities.Modules
         /// <returns>Arraylist of ModuleInfo for modules supporting search.</returns>
         ArrayList GetSearchModules(int portalID);
 
-        /// <summary>  get a Module object.</summary>
+        /// <summary>Get a Module object.</summary>
         /// <param name="tabModuleID">ID of the tabmodule.</param>
         /// <returns>An ModuleInfo object.</returns>
         ModuleInfo GetTabModule(int tabModuleID);
 
         /// <summary>Get all Module references on a tab.</summary>
-        /// <param name="tabId"></param>
+        /// <param name="tabId">The tab ID.</param>
         /// <returns>Dictionary of ModuleID and ModuleInfo.</returns>
         Dictionary<int, ModuleInfo> GetTabModules(int tabId);
 
-        /// <summary>  Get a list of all TabModule references of a module instance.</summary>
+        /// <summary>Get a list of all TabModule references of a module instance.</summary>
         /// <param name="moduleID">ID of the Module.</param>
         /// <returns>ArrayList of ModuleInfo.</returns>
         IList<ModuleInfo> GetTabModulesByModule(int moduleID);
@@ -171,13 +171,10 @@ namespace DotNetNuke.Entities.Modules
 
         void LocalizeModule(ModuleInfo sourceModule, Locale locale);
 
-        /// <summary>
-        /// MoveModule moes a Module from one Tab to another including all the
-        ///     TabModule settings.
-        /// </summary>
-        /// <param name="moduleId">The Id of the module to move.</param>
-        /// <param name="fromTabId">The Id of the source tab.</param>
-        /// <param name="toTabId">The Id of the destination tab.</param>
+        /// <summary>MoveModule moves a Module from one Tab to another including all the TabModule settings.</summary>
+        /// <param name="moduleId">The ID of the module to move.</param>
+        /// <param name="fromTabId">The ID of the source tab.</param>
+        /// <param name="toTabId">The ID of the destination tab.</param>
         /// <param name="toPaneName">The name of the Pane on the destination tab where the module will end up.</param>
         void MoveModule(int moduleId, int fromTabId, int toTabId, string toPaneName);
 

--- a/DNN Platform/Library/Entities/Modules/ModuleController.cs
+++ b/DNN Platform/Library/Entities/Modules/ModuleController.cs
@@ -1091,9 +1091,7 @@ namespace DotNetNuke.Entities.Modules
                 c => CBO.FillObject<ModuleInfo>(DataProvider.GetTabModule(tabModuleID)));
         }
 
-        /// <summary>Get all Module references on a tab.</summary>
-        /// <param name="tabId"></param>
-        /// <returns>Dictionary of ModuleID and ModuleInfo.</returns>
+        /// <inheritdoc />
         public Dictionary<int, ModuleInfo> GetTabModules(int tabId)
         {
             var cacheKey = string.Format(DataCache.TabModuleCacheKey, tabId);
@@ -2512,7 +2510,7 @@ namespace DotNetNuke.Entities.Modules
         }
 
         /// <summary>Update content item when the module title changed.</summary>
-        /// <param name="module"></param>
+        /// <param name="module">The module info.</param>
         private void UpdateContentItem(ModuleInfo module)
         {
             IContentController contentController = Util.GetContentController();

--- a/DNN Platform/Library/Entities/Portals/IPortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/IPortalController.cs
@@ -160,12 +160,12 @@ namespace DotNetNuke.Entities.Portals
         void MapLocalizedSpecialPages(int portalId, string cultureCode);
 
         /// <summary>Removes the related PortalLocalization record from the database, adds optional clear cache.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="clearCache">Whether to clear the portal cache.</param>
         void RemovePortalLocalization(int portalId, string cultureCode, bool clearCache = true);
 
-        /// <summary>Processess a template file for the new portal.</summary>
+        /// <summary>Processes a template file for the new portal.</summary>
         /// <param name="portalId">PortalId of the new portal.</param>
         /// <param name="template">The template.</param>
         /// <param name="administratorId">UserId for the portal administrator. This is used to assign roles to this user.</param>
@@ -193,7 +193,7 @@ namespace DotNetNuke.Entities.Portals
         void UpdatePortalExpiry(int portalId, string cultureCode);
 
         /// <summary>Updates basic portal information.</summary>
-        /// <param name="portal"></param>
+        /// <param name="portal">The portal info.</param>
         void UpdatePortalInfo(PortalInfo portal);
 
         [Obsolete("Deprecated in DotNetNuke 9.2.0. Use the overloaded one with the 'isSecure' parameter instead. Scheduled removal in v11.0.0.")]

--- a/DNN Platform/Library/Entities/Portals/PortalAliasExtensions.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasExtensions.cs
@@ -38,10 +38,11 @@ namespace DotNetNuke.Entities.Portals
             return aliasCultures;
         }
 
-        /// <summary>Returns the chosen portal alias for a specific portal Id and culture Code.</summary>
-        /// <param name="aliases"></param>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
+        /// <summary>Returns the chosen portal alias for a specific portal ID and culture Code.</summary>
+        /// <param name="aliases">The aliases.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="result">The URL action.</param>
+        /// <param name="cultureCode">The culture code.</param>
         /// <remarks>Detects the current browser type if possible.  If can't be detected 'normal' is used. If a specific browser type is required, use overload with browser type.</remarks>
         /// <returns>The closest <see cref="PortalAliasInfo"/> match.</returns>
         public static PortalAliasInfo GetAliasByPortalIdAndSettings(this IEnumerable<PortalAliasInfo> aliases, int portalId, UrlAction result, string cultureCode, FriendlyUrlSettings settings)
@@ -88,11 +89,11 @@ namespace DotNetNuke.Entities.Portals
         }
 
         /// <summary>Returns a ChosenPortalAlias object where the portalId, culture code and isMobile matches.</summary>
-        /// <param name="aliases"></param>
-        /// <param name="portalId"></param>
-        /// <param name="result"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="browserType"></param>
+        /// <param name="aliases">The aliases.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="result">The URL action.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="browserType">The browser type.</param>
         /// <returns>The closest <see cref="PortalAliasInfo"/> match.</returns>
         /// <remarks>Note will return a best-match by portal if no specific culture Code match found.</remarks>
         public static PortalAliasInfo GetAliasByPortalIdAndSettings(this IEnumerable<PortalAliasInfo> aliases, int portalId, UrlAction result, string cultureCode, BrowserTypes browserType)

--- a/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalAliasInfo.cs
@@ -27,14 +27,14 @@ namespace DotNetNuke.Entities.Portals
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalAliasInfo"/> class.</summary>
-        /// <param name="alias"></param>
+        /// <param name="alias">The alias to clone.</param>
         public PortalAliasInfo(PortalAliasInfo alias)
             : this((IPortalAliasInfo)alias)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalAliasInfo"/> class.</summary>
-        /// <param name="alias"></param>
+        /// <param name="alias">The alias to clone.</param>
         public PortalAliasInfo(IPortalAliasInfo alias)
         {
             this.ThisAsInterface.HttpAlias = alias.HttpAlias;

--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -694,7 +694,7 @@ namespace DotNetNuke.Entities.Portals
         ///   function provides the language for portalinfo requests
         ///   in case where language has not been installed yet, will return the core install default of en-us.
         /// </summary>
-        /// <param name="portalID"></param>
+        /// <param name="portalID">The portal ID.</param>
         /// <returns>The language identifier.</returns>
         public static string GetActivePortalLanguage(int portalID)
         {
@@ -754,8 +754,8 @@ namespace DotNetNuke.Entities.Portals
             return language;
         }
 
-        /// <summary>return the current DefaultLanguage value from the Portals table for the requested Portalid.</summary>
-        /// <param name="portalID"></param>
+        /// <summary>return the current DefaultLanguage value from the Portals table for the requested <paramref name="portalID"/>.</summary>
+        /// <param name="portalID">The portal ID.</param>
         /// <returns>The language identifier.</returns>
         public static string GetPortalDefaultLanguage(int portalID)
         {
@@ -767,8 +767,8 @@ namespace DotNetNuke.Entities.Portals
         ///   set the required DefaultLanguage in the Portals table for a particular portal
         ///   saves having to update an entire PortalInfo object.
         /// </summary>
-        /// <param name="portalID"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
         public static void UpdatePortalDefaultLanguage(int portalID, string cultureCode)
         {
             DataProvider.Instance().UpdatePortalDefaultLanguage(portalID, cultureCode);
@@ -849,7 +849,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="adminUserId">The obj admin user.</param>
         /// <param name="description">The description.</param>
         /// <param name="keyWords">The key words.</param>
-        /// <param name="template"> </param>
+        /// <param name="template">The portal template.</param>
         /// <param name="homeDirectory">The home directory.</param>
         /// <param name="portalAlias">The portal alias.</param>
         /// <param name="serverPath">The server path.</param>
@@ -922,7 +922,7 @@ namespace DotNetNuke.Entities.Portals
         /// <param name="adminUser">The obj admin user.</param>
         /// <param name="description">The description.</param>
         /// <param name="keyWords">The key words.</param>
-        /// <param name="template"> </param>
+        /// <param name="template">The portal template.</param>
         /// <param name="homeDirectory">The home directory.</param>
         /// <param name="portalAlias">The portal alias.</param>
         /// <param name="serverPath">The server path.</param>
@@ -1327,10 +1327,7 @@ namespace DotNetNuke.Entities.Portals
             this.UpdatePortalInternal(targetPortal, false);
         }
 
-        /// <summary>Removes the related PortalLocalization record from the database, adds optional clear cache.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <inheritdoc />
         public void RemovePortalLocalization(int portalId, string cultureCode, bool clearCache = true)
         {
             DataProvider.Instance().RemovePortalLocalization(portalId, cultureCode);
@@ -1340,7 +1337,7 @@ namespace DotNetNuke.Entities.Portals
             }
         }
 
-        /// <summary>Processess a template file for the new portal.</summary>
+        /// <summary>Processes a template file for the new portal.</summary>
         /// <param name="portalId">PortalId of the new portal.</param>
         /// <param name="template">The template.</param>
         /// <param name="administratorId">UserId for the portal administrator. This is used to assign roles to this user.</param>
@@ -1394,8 +1391,7 @@ namespace DotNetNuke.Entities.Portals
             this.UpdatePortalInfo(portal);
         }
 
-        /// <summary>Updates basic portal information.</summary>
-        /// <param name="portal"></param>
+        /// <inheritdoc />
         public void UpdatePortalInfo(PortalInfo portal)
         {
             this.UpdatePortalInternal(portal, true);
@@ -2319,8 +2315,8 @@ namespace DotNetNuke.Entities.Portals
             private string originalCultureCode;
 
             /// <summary>Initializes a new instance of the <see cref="PortalTemplateInfo"/> class.</summary>
-            /// <param name="templateFilePath"></param>
-            /// <param name="cultureCode"></param>
+            /// <param name="templateFilePath">The path to the template file.</param>
+            /// <param name="cultureCode">The culture code.</param>
             public PortalTemplateInfo(string templateFilePath, string cultureCode)
             {
                 this.TemplateFilePath = templateFilePath;

--- a/DNN Platform/Library/Entities/Portals/PortalGroupController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalGroupController.cs
@@ -31,8 +31,8 @@ namespace DotNetNuke.Entities.Portals
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalGroupController"/> class.</summary>
-        /// <param name="dataService"></param>
-        /// <param name="portalController"></param>
+        /// <param name="dataService">The data service.</param>
+        /// <param name="portalController">The portal controller.</param>
         public PortalGroupController(IDataService dataService, IPortalController portalController)
         {
             // Argument Contract

--- a/DNN Platform/Library/Entities/Portals/PortalSettings.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalSettings.cs
@@ -32,15 +32,15 @@ namespace DotNetNuke.Entities.Portals
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalSettings"/> class.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         public PortalSettings(int portalId)
             : this(Null.NullInteger, portalId)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalSettings"/> class.</summary>
-        /// <param name="tabId"></param>
-        /// <param name="portalId"></param>
+        /// <param name="tabId">The active tab ID.</param>
+        /// <param name="portalId">The portal ID.</param>
         public PortalSettings(int tabId, int portalId)
         {
             this.PortalId = portalId;
@@ -68,15 +68,15 @@ namespace DotNetNuke.Entities.Portals
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalSettings"/> class.</summary>
-        /// <param name="portal"></param>
+        /// <param name="portal">The portal info.</param>
         public PortalSettings(PortalInfo portal)
             : this(Null.NullInteger, portal)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalSettings"/> class.</summary>
-        /// <param name="tabId"></param>
-        /// <param name="portal"></param>
+        /// <param name="tabId">The active tab ID.</param>
+        /// <param name="portal">The portal info.</param>
         public PortalSettings(int tabId, PortalInfo portal)
         {
             this.PortalId = portal != null ? portal.PortalID : Null.NullInteger;

--- a/DNN Platform/Library/Entities/Portals/Templates/PortalTemplateInfo.cs
+++ b/DNN Platform/Library/Entities/Portals/Templates/PortalTemplateInfo.cs
@@ -21,8 +21,8 @@ namespace DotNetNuke.Entities.Portals.Templates
         private string resourceFilePath;
 
         /// <summary>Initializes a new instance of the <see cref="PortalTemplateInfo"/> class.</summary>
-        /// <param name="templateFilePath"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="templateFilePath">The path to the template file.</param>
+        /// <param name="cultureCode">The culture code.</param>
         public PortalTemplateInfo(string templateFilePath, string cultureCode)
         {
             this.TemplateFilePath = templateFilePath;

--- a/DNN Platform/Library/Entities/Profile/ProfilePropertyDefinition.cs
+++ b/DNN Platform/Library/Entities/Profile/ProfilePropertyDefinition.cs
@@ -58,7 +58,7 @@ namespace DotNetNuke.Entities.Profile
         }
 
         /// <summary>Initializes a new instance of the <see cref="ProfilePropertyDefinition"/> class.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         public ProfilePropertyDefinition(int portalId)
         {
             this.PropertyDefinitionId = Null.NullInteger;

--- a/DNN Platform/Library/Entities/Profile/ProfileVisibility.cs
+++ b/DNN Platform/Library/Entities/Profile/ProfileVisibility.cs
@@ -24,8 +24,8 @@ namespace DotNetNuke.Entities.Profile
         }
 
         /// <summary>Initializes a new instance of the <see cref="ProfileVisibility"/> class.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="extendedVisibility"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="extendedVisibility">The extended visibility string, a semicolon-delimited list of comma-delimited lists of role IDs and relationship IDs.</param>
         public ProfileVisibility(int portalId, string extendedVisibility)
             : this()
         {

--- a/DNN Platform/Library/Entities/Tabs/ITabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/ITabController.cs
@@ -12,20 +12,20 @@ namespace DotNetNuke.Entities.Tabs
     using DotNetNuke.Services.Localization;
 
     /// <summary>
-    /// Do not implement.  This interface is only implemented by the DotNetNuke core framework. Outside the framework it should used as a type and for unit test purposes only.
+    /// Do not implement.  This interface is only implemented by the DotNetNuke core framework. Outside the framework it should be used as a type and for unit test purposes only.
     /// There is no guarantee that this interface will not change.
     /// </summary>
     public interface ITabController
     {
         /// <summary>Adds localized copies of the page in all missing languages.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
         [Obsolete("Deprecated in DotNetNuke 9.11.1. Use AddMissingLanguagesWithWarnings. Scheduled removal in v11.0.0.")]
         void AddMissingLanguages(int portalId, int tabId);
 
         /// <summary>Adds localized copies of the page in all missing languages.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
         /// <returns>Whether all missing languages were added.</returns>
         bool AddMissingLanguagesWithWarnings(int portalId, int tabId);
 
@@ -59,10 +59,10 @@ namespace DotNetNuke.Entities.Tabs
         void ClearCache(int portalId);
 
         /// <summary>Converts one single tab to a neutral culture clears the tab cache optionally.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="clearCache">Whether to clear the portal cache.</param>
         void ConvertTabToNeutralLanguage(int portalId, int tabId, string cultureCode, bool clearCache);
 
         /// <summary>Creates content item for the tab..</summary>
@@ -110,9 +110,9 @@ namespace DotNetNuke.Entities.Tabs
         /// Deletes all tabs for a specific language. Double checks if we are not deleting pages for the default language
         /// Clears the tab cache optionally.
         /// </summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="clearCache">Whether to clear the portal cache.</param>
         /// <returns><see langword="true"/> if the deletion completes.</returns>
         bool DeleteTranslatedTabs(int portalId, string cultureCode, bool clearCache);
 
@@ -120,9 +120,9 @@ namespace DotNetNuke.Entities.Tabs
         /// Reverts page culture back to Neutral (Null), to ensure a non localized site
         /// clears the tab cache optionally.
         /// </summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="clearCache">Whether to clear the portal cache.</param>
         void EnsureNeutralLanguage(int portalId, string cultureCode, bool clearCache);
 
         /// <summary>Get the list of skins per alias at tab level.</summary>
@@ -191,7 +191,7 @@ namespace DotNetNuke.Entities.Tabs
         /// Get the actual visible tabs for a given portal id.
         /// System Tabs and Admin Tabs are excluded from the result set.
         /// </summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         /// <returns>tab collection.</returns>
         TabCollection GetTabsByPortal(int portalId);
 
@@ -219,8 +219,8 @@ namespace DotNetNuke.Entities.Tabs
         void GiveTranslatorRoleEditRights(TabInfo localizedTab, Dictionary<int, UserInfo> users);
 
         /// <summary>Returns True if a page is missing a translated version in at least one other language.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
         /// <returns><see langword="true"/> if the page has missing languages, otherwise <see langword="false"/>.</returns>
         bool HasMissingLanguages(int portalId, int tabId);
 
@@ -240,9 +240,9 @@ namespace DotNetNuke.Entities.Tabs
         void LocalizeTab(TabInfo originalTab, Locale locale);
 
         /// <summary>Localizes the tab, with optional clear cache.</summary>
-        /// <param name="originalTab"></param>
-        /// <param name="locale"></param>
-        /// <param name="clearCache"></param>
+        /// <param name="originalTab">The original tab.</param>
+        /// <param name="locale">The locale.</param>
+        /// <param name="clearCache">Whether to clean the cache.</param>
         void LocalizeTab(TabInfo originalTab, Locale locale, bool clearCache);
 
         /// <summary>Moves the tab after a specific tab.</summary>
@@ -316,8 +316,8 @@ namespace DotNetNuke.Entities.Tabs
         void UpdateTranslationStatus(TabInfo localizedTab, bool isTranslated);
 
         /// <summary>Refresh the tabinfo in cache object of portal tabs collection, use this instead of clear the whole cache to improve performance.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
         void RefreshCache(int portalId, int tabId);
     }
 }

--- a/DNN Platform/Library/Entities/Tabs/PermissionsNotMetException.cs
+++ b/DNN Platform/Library/Entities/Tabs/PermissionsNotMetException.cs
@@ -6,8 +6,8 @@ namespace DotNetNuke.Entities.Tabs
     public class PermissionsNotMetException : TabException
     {
         /// <summary>Initializes a new instance of the <see cref="PermissionsNotMetException"/> class.</summary>
-        /// <param name="tabId"></param>
-        /// <param name="message"></param>
+        /// <param name="tabId">The tab ID.</param>
+        /// <param name="message">The message that describes the error.</param>
         public PermissionsNotMetException(int tabId, string message)
             : base(tabId, message)
         {

--- a/DNN Platform/Library/Entities/Tabs/TabCollection.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabCollection.cs
@@ -41,8 +41,8 @@ namespace DotNetNuke.Entities.Tabs
         // The special constructor is used to deserialize values.
 
         /// <summary>Initializes a new instance of the <see cref="TabCollection"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public TabCollection(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -52,7 +52,7 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         /// <summary>Initializes a new instance of the <see cref="TabCollection"/> class.</summary>
-        /// <param name="tabs"></param>
+        /// <param name="tabs">The tabs.</param>
         public TabCollection(IEnumerable<TabInfo> tabs)
             : this()
         {

--- a/DNN Platform/Library/Entities/Tabs/TabController.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabController.cs
@@ -975,10 +975,7 @@ namespace DotNetNuke.Entities.Tabs
             return true;
         }
 
-        /// <summary>Adds localized copies of the page in all missing languages.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
-        /// <returns>Whether all missing languages were added.</returns>
+        /// <inheritdoc />
         public bool AddMissingLanguagesWithWarnings(int portalId, int tabId)
         {
             var addedAllMissingLanguages = true;
@@ -1111,14 +1108,7 @@ namespace DotNetNuke.Entities.Tabs
             }
         }
 
-        /// <summary>
-        /// Converts one single tab to a neutral culture
-        /// clears the tab cache optionally.
-        /// </summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <inheritdoc />
         public void ConvertTabToNeutralLanguage(int portalId, int tabId, string cultureCode, bool clearCache)
         {
             // parent tabs can not be deleted
@@ -1294,13 +1284,7 @@ namespace DotNetNuke.Entities.Tabs
             return true;
         }
 
-        /// <summary>
-        /// Reverts page culture back to Neutral (Null), to ensure a non localized site
-        /// clears the tab cache optionally.
-        /// </summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="clearCache"></param>
+        /// <inheritdoc />
         public void EnsureNeutralLanguage(int portalId, string cultureCode, bool clearCache)
         {
             this.dataProvider.EnsureNeutralLanguage(portalId, cultureCode);
@@ -1526,12 +1510,7 @@ namespace DotNetNuke.Entities.Tabs
                                                             });
         }
 
-        /// <summary>
-        /// Get the actual visible tabs for a given portal id.
-        /// System Tabs and Admin Tabs are excluded from the result set.
-        /// </summary>
-        /// <param name="portalId"></param>
-        /// <returns>A new <see cref="TabCollection"/> instance.</returns>
+        /// <inheritdoc />
         public TabCollection GetUserTabsByPortal(int portalId)
         {
             var tabs = this.GetTabsByPortal(portalId);
@@ -1690,10 +1669,7 @@ namespace DotNetNuke.Entities.Tabs
             this.LocalizeTab(originalTab, locale, true);
         }
 
-        /// <summary>Localizes the tab, with optional clear cache.</summary>
-        /// <param name="originalTab"></param>
-        /// <param name="locale"></param>
-        /// <param name="clearCache"></param>
+        /// <inheritdoc />
         public void LocalizeTab(TabInfo originalTab, Locale locale, bool clearCache)
         {
             this.dataProvider.LocalizeTab(originalTab.TabID, locale.Code, UserController.Instance.GetCurrentUserInfo().UserID);
@@ -2572,8 +2548,8 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         /// <summary>If a parent tab is localized, its localized children need to be updated to point at their corresponding localized parents.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="parentTabId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="parentTabId">The parent tab ID.</param>
         private void UpdateChildTabLocalizedParents(int portalId, int parentTabId)
         {
             var childTabs = GetTabsByParent(parentTabId, portalId);

--- a/DNN Platform/Library/Entities/Tabs/TabException.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabException.cs
@@ -8,8 +8,8 @@ namespace DotNetNuke.Entities.Tabs
     public class TabException : Exception
     {
         /// <summary>Initializes a new instance of the <see cref="TabException"/> class.</summary>
-        /// <param name="tabId"></param>
-        /// <param name="message"></param>
+        /// <param name="tabId">The ID of the tab.</param>
+        /// <param name="message">The message that describes the error.</param>
         public TabException(int tabId, string message)
             : base(message)
         {

--- a/DNN Platform/Library/Entities/Tabs/TabExistsException.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabExistsException.cs
@@ -6,8 +6,8 @@ namespace DotNetNuke.Entities.Tabs
     public class TabExistsException : TabException
     {
         /// <summary>Initializes a new instance of the <see cref="TabExistsException"/> class.</summary>
-        /// <param name="tabId"></param>
-        /// <param name="message"></param>
+        /// <param name="tabId">The ID of the existing tab.</param>
+        /// <param name="message">The message that describes the error.</param>
         public TabExistsException(int tabId, string message)
             : base(tabId, message)
         {

--- a/DNN Platform/Library/Entities/Tabs/TabVersions/ITabVersionBuilder.cs
+++ b/DNN Platform/Library/Entities/Tabs/TabVersions/ITabVersionBuilder.cs
@@ -48,13 +48,13 @@ namespace DotNetNuke.Entities.Tabs.TabVersions
         TabVersion GetCurrentVersion(int tabId, bool ignoreCache = false);
 
         /// <summary>Get the unpublished version or Null if Tab has not any unpublished version.</summary>
-        /// <param name="tabId"></param>
+        /// <param name="tabId">The tab ID.</param>
         /// <returns>TabVersion filled with the unpublished version data.</returns>
         /// <remarks>If Tab has not an unpublished version yet, it will return null.</remarks>
         TabVersion GetUnPublishedVersion(int tabId);
 
         /// <summary>Get all ModuleInfo objects associated with the unpublished version of a page.</summary>
-        /// <param name="tabId"></param>
+        /// <param name="tabId">The tab ID.</param>
         /// <returns>List of ModuleInfo objects.</returns>
         IEnumerable<ModuleInfo> GetUnPublishedVersionModules(int tabId);
 

--- a/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedFriendlyUrlProvider.cs
@@ -29,7 +29,7 @@ namespace DotNetNuke.Entities.Urls
         private static readonly Regex CodePatternRegex = new Regex(CodePattern, RegexOptions.Compiled);
 
         /// <summary>Initializes a new instance of the <see cref="AdvancedFriendlyUrlProvider"/> class.</summary>
-        /// <param name="attributes"></param>
+        /// <param name="attributes">The provider attributes.</param>
         internal AdvancedFriendlyUrlProvider(NameValueCollection attributes)
             : base(attributes)
         {
@@ -42,7 +42,7 @@ namespace DotNetNuke.Entities.Urls
         /// <param name="httpAlias">The current portal alias to use.</param>
         /// <param name="ignoreCustomRedirects">If true, then the Friendly Url will be constructed without using any custom redirects.</param>
         /// <param name="settings">The current Friendly Url Settings to use.</param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>The friendly URL.</returns>
         public static string ImprovedFriendlyUrl(
             TabInfo tab,

--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -155,8 +155,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Make sure any redirect to the site root doesn't append the nasty /default.aspx on the end.</summary>
-        /// <param name="alias"></param>
-        /// <param name="destUrl"></param>
+        /// <param name="alias">The portal alias.</param>
+        /// <param name="destUrl">The destination URL.</param>
         /// <returns><paramref name="destUrl"/> without <see cref="Globals.glbDefaultPage"/> at the end.</returns>
         internal static string CheckForSiteRootRedirect(string alias, string destUrl)
         {
@@ -1172,9 +1172,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Redirects an alias if that is allowed by the settings.</summary>
-        /// <param name="httpAlias"></param>
-        /// <param name="result"></param>
-        /// <param name="settings"></param>
+        /// <param name="httpAlias">The HTTP alias.</param>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <returns><see langword="true"/> if the <paramref name="result"/> is a redirect, otherwise <see langword="false"/>.</returns>
         private static bool RedirectPortalAlias(string httpAlias, ref UrlAction result, FriendlyUrlSettings settings)
         {
@@ -1216,9 +1216,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Checks to see whether the specified alias is a customTabAlias.</summary>
-        /// <param name="result"></param>
-        /// <param name="httpAlias"></param>
-        /// <param name="settings"></param>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="httpAlias">The HTTP alias.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <returns><see langword="true"/> if the alias is a custom tab alias, otherwise <see langword="false"/>.</returns>
         private static bool CheckIfAliasIsCustomTabAlias(ref UrlAction result, string httpAlias, FriendlyUrlSettings settings)
         {
@@ -1242,9 +1242,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Checks to see whether the specified alias is a customTabAlias for the TabId in result.</summary>
-        /// <param name="result"></param>
-        /// <param name="settings"></param>
-        /// <returns><see langword="true"/> if the the current alias is a custom tab alias, otherwise <see langword="false"/>.</returns>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <returns><see langword="true"/> if the current alias is a custom tab alias, otherwise <see langword="false"/>.</returns>
         private static bool CheckIfAliasIsCurrentTabCustomTabAlias(ref UrlAction result, FriendlyUrlSettings settings)
         {
             var customAliasesForTab = TabController.Instance.GetCustomAliases(result.TabId, result.PortalId);
@@ -1275,13 +1275,13 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Configures the result object to set the correct Alias redirect parameters and destination URL.</summary>
-        /// <param name="result"></param>
-        /// <param name="wrongAlias"></param>
-        /// <param name="rightAlias"></param>
-        /// <param name="ignoreCustomAliasTabs"></param>
-        /// <param name="redirectReason"></param>
-        /// <param name="internalAliases"></param>
-        /// <param name="settings"></param>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="wrongAlias">The alias to redirect from.</param>
+        /// <param name="rightAlias">The alias to redirect to.</param>
+        /// <param name="ignoreCustomAliasTabs">Whether to ignore custom aliases for the page.</param>
+        /// <param name="redirectReason">The redirect reason.</param>
+        /// <param name="internalAliases">A list of internal aliases.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <returns><see langword="true"/> if the <paramref name="result"/> is a redirect, otherwise <see langword="false"/>.</returns>
         private static bool ConfigurePortalAliasRedirect(
             ref UrlAction result,
@@ -1383,10 +1383,10 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Determines if this is a request from an install / upgrade url.</summary>
-        /// <param name="physicalPath"></param>
-        /// <param name="refererPath"></param>
-        /// <param name="requestedDomain"></param>
-        /// <param name="refererDomain"></param>
+        /// <param name="physicalPath">The physical path of the request.</param>
+        /// <param name="refererPath">The referrer path for the request.</param>
+        /// <param name="requestedDomain">The requested domain.</param>
+        /// <param name="refererDomain">The domain of the referrer.</param>
         /// <returns><see langword="true"/> if the request is for an install URL, otherwise <see langword="false"/>.</returns>
         /// <remarks>
         /// //875 : cater for the upgradewizard.aspx Url that is new to DNN 6.1.
@@ -2042,7 +2042,7 @@ namespace DotNetNuke.Entities.Urls
             {
                 string fullUrl, querystring;
 
-                // 699: get the full url based on the request and the quersytring, rather than the requestUri.ToString()
+                // 699: get the full url based on the request and the querystring, rather than the requestUri.ToString()
                 // there is a difference in encoding, which can corrupt results when an encoded value is in the querystring
                 RewriteController.GetUrlWithQuerystring(request, requestUri, out fullUrl, out querystring);
 

--- a/DNN Platform/Library/Entities/Urls/BasicFriendlyUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/BasicFriendlyUrlProvider.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Entities.Urls
         private readonly string regexMatch;
 
         /// <summary>Initializes a new instance of the <see cref="BasicFriendlyUrlProvider"/> class.</summary>
-        /// <param name="attributes"></param>
+        /// <param name="attributes">The provider attributes.</param>
         internal BasicFriendlyUrlProvider(NameValueCollection attributes)
             : base(attributes)
         {

--- a/DNN Platform/Library/Entities/Urls/CacheController.cs
+++ b/DNN Platform/Library/Entities/Urls/CacheController.cs
@@ -65,8 +65,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Returns a portal info object for the portal.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="exceptionOnNull"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="exceptionOnNull">Whether to throw an exception if the portal is not found.</param>
         /// <remarks>This method wraps the PortalController.GetPortal method, and adds a check if the result is null.</remarks>.
         /// <returns>A <see cref="PortalInfo"/> instance or <see langword="null"/> if the portal isn't found and <paramref name="exceptionOnNull"/> is <see langword="false"/>.</returns>
         public static PortalInfo GetPortal(int portalId, bool exceptionOnNull)
@@ -236,7 +236,7 @@ namespace DotNetNuke.Entities.Urls
 
         /// <summary>Finds the best match friendlyurlparms.config file path.</summary>
         /// <param name="portalId">The portalId to search for. -1 if all portals required.</param>
-        /// <param name="portalSpecificFound"></param>
+        /// <param name="portalSpecificFound">Whether a portal specific config file was found.</param>
         /// <returns>If a non-zero length string, a valid file path.  If a zero length string, no file was found.</returns>
         /// <remarks>
         /// First priority is a file called n.friendlyurlparms.config, in the root path
@@ -587,9 +587,9 @@ namespace DotNetNuke.Entities.Urls
         /// If a tab doesn't appear on this cached list, then the cache isn't checked
         /// for that particular tabid/portalId combination.
         /// </summary>
-        /// <param name="providers"></param>
-        /// <param name="portalId"></param>
-        /// <param name="settings"></param>
+        /// <param name="providers">A list of extension providers.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         internal static void StoreListOfTabsWithProviders(List<ExtensionUrlProvider> providers, int portalId, FriendlyUrlSettings settings)
         {
             // go through the list of providers and store all the tabs that they are configured for
@@ -742,9 +742,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Retrieve the Url Dictionary for the installation.</summary>
-        /// <param name="urlDict"></param>
-        /// <param name="urlPortals"></param>
-        /// <param name="customAliasTabs"></param>
+        /// <param name="urlDict">A dictionary of tabs for all portals.</param>
+        /// <param name="urlPortals">The portal IDs.</param>
+        /// <param name="customAliasTabs">A dictionary of portals for which we've retrieved the tabs.</param>
         internal void GetFriendlyUrlIndexFromCache(
             out SharedDictionary<int, SharedDictionary<string, string>> urlDict,
             out ConcurrentBag<int> urlPortals,
@@ -796,11 +796,11 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Store the Url Dictionary (all tab urls / tabids) for the installation.</summary>
-        /// <param name="urlDict"></param>
-        /// <param name="urlPortals"></param>
-        /// <param name="customAliasTabs"></param>
-        /// <param name="settings"></param>
-        /// <param name="reason"></param>
+        /// <param name="urlDict">A dictionary of tabs for all portals.</param>
+        /// <param name="urlPortals">The portal IDs.</param>
+        /// <param name="customAliasTabs">A dictionary of portals for which we've retrieved the tabs.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="reason">The reason for rebuilding the index (for logging).</param>
         internal void StoreFriendlyUrlIndexInCache(
             SharedDictionary<int, SharedDictionary<string, string>> urlDict,
             ConcurrentBag<int> urlPortals,

--- a/DNN Platform/Library/Entities/Urls/CollectionExtensions.cs
+++ b/DNN Platform/Library/Entities/Urls/CollectionExtensions.cs
@@ -101,12 +101,12 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Returns all the redirect rules for the specified portal.</summary>
-        /// <param name="actions"></param>
-        /// <param name="fileName"></param>
-        /// <param name="portalId"></param>
+        /// <param name="actions">A dictionary of <see cref="ParameterRedirectAction"/> instances mapped by tab ID.</param>
+        /// <param name="fileName">The file path of the XML file.</param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="portalSpecific">If true, all rules belong to supplied portalId, even if not specified.</param>
-        /// <param name="messages"></param>
-        /// <remarks>807 : change to allow specificatoin of assumption that all rules belong to the supplied portal.</remarks>
+        /// <param name="messages">A list to which debugging messages will be added.</param>
+        /// <remarks>807 : change to allow specification of assumption that all rules belong to the supplied portal.</remarks>
         public static void LoadFromXmlFile(this Dictionary<int, List<ParameterRedirectAction>> actions, string fileName, int portalId, bool portalSpecific, ref List<string> messages)
         {
             if (messages == null)

--- a/DNN Platform/Library/Entities/Urls/CustomUrlDictController.cs
+++ b/DNN Platform/Library/Entities/Urls/CustomUrlDictController.cs
@@ -15,12 +15,12 @@ namespace DotNetNuke.Entities.Urls
     internal static class CustomUrlDictController
     {
         /// <summary>returns a tabId indexed dictionary of Friendly Urls.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="forceRebuild"></param>
-        /// <param name="bypassCache"></param>
-        /// <param name="settings"></param>
-        /// <param name="customAliasForTabs"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="forceRebuild">Whether to force a rebuild of the dictionary.</param>
+        /// <param name="bypassCache">Whether to bypass the cache for the dictionary.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="customAliasForTabs">A collection of custom alises for each tab.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>A <see cref="SharedDictionary{TKey,TValue}"/> where the key is a tab ID and the value is a <see cref="SharedDictionary{TKey,TValue}"/> with keys of URL culture and values of URLs.</returns>
         internal static SharedDictionary<int, SharedDictionary<string, string>> FetchCustomUrlDictionary(
             int portalId,
@@ -93,10 +93,10 @@ namespace DotNetNuke.Entities.Urls
         /// Assumes that the dictionary should have any existing items replaced if the portal ID is specified
         /// and the portal tabs already exist in the dictionary.
         /// </summary>
-        /// <param name="existingTabs"></param>
-        /// <param name="portalId"></param>
-        /// <param name="settings"></param>
-        /// <param name="customAliasTabs"></param>
+        /// <param name="existingTabs">The collection of tab URLs.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="customAliasTabs">A collection of custom aliases for the tabs.</param>
         /// <remarks>
         ///    Each dictionary entry in the return value is a complex data type of another dictionary that is indexed by the url culture.  If there is
         ///    only one culture for the Url, it will be that culture.

--- a/DNN Platform/Library/Entities/Urls/DupKeyCheck.cs
+++ b/DNN Platform/Library/Entities/Urls/DupKeyCheck.cs
@@ -8,10 +8,10 @@ namespace DotNetNuke.Entities.Urls
     internal class DupKeyCheck
     {
         /// <summary>Initializes a new instance of the <see cref="DupKeyCheck"/> class.</summary>
-        /// <param name="tabKey"></param>
-        /// <param name="tabIdOriginal"></param>
-        /// <param name="tabPath"></param>
-        /// <param name="isDeleted"></param>
+        /// <param name="tabKey">The tab key.</param>
+        /// <param name="tabIdOriginal">The original tab ID.</param>
+        /// <param name="tabPath">The tab path.</param>
+        /// <param name="isDeleted">Whether the tab is disabled or deleted.</param>
         public DupKeyCheck(string tabKey, string tabIdOriginal, string tabPath, bool isDeleted)
         {
             this.TabKey = tabKey;

--- a/DNN Platform/Library/Entities/Urls/ExtensionUrlProvider.cs
+++ b/DNN Platform/Library/Entities/Urls/ExtensionUrlProvider.cs
@@ -48,15 +48,15 @@ namespace DotNetNuke.Entities.Urls
             out bool useDnnPagePath,
             ref List<string> messages);
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="tabId"></param>
-        /// <param name="portalid"></param>
-        /// <param name="requestUri"></param>
-        /// <param name="queryStringCol"></param>
-        /// <param name="options"></param>
-        /// <param name="messages"></param>
+        /// <summary>Determines whether the request should be redirected.</summary>
+        /// <param name="tabId">The tab ID.</param>
+        /// <param name="portalid">The portal ID.</param>
+        /// <param name="httpAlias">The portal's HTTP alias for the request.</param>
+        /// <param name="requestUri">The request URI.</param>
+        /// <param name="queryStringCol">The parsed query string.</param>
+        /// <param name="options">The friendly URL options.</param>
+        /// <param name="redirectLocation">The URL to which the request should be redirected.</param>
+        /// <param name="messages">A list to which debugging messages should be added.</param>
         /// <returns><see langword="true"/> if there should be a redirect, otherwise <see langword="false"/>.</returns>
         public abstract bool CheckForRedirect(
             int tabId,

--- a/DNN Platform/Library/Entities/Urls/ExtensionUrlProviderController.cs
+++ b/DNN Platform/Library/Entities/Urls/ExtensionUrlProviderController.cs
@@ -157,11 +157,11 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>logs an exception related to a module provider once per cache-lifetime.</summary>
-        /// <param name="ex"></param>
-        /// <param name="status"></param>
-        /// <param name="result"></param>
-        /// <param name="messages"></param>
-        /// <param name="provider"></param>
+        /// <param name="ex">The exception.</param>
+        /// <param name="status">The HTTP status.</param>
+        /// <param name="provider">The extension URL provider.</param>
+        /// <param name="result">The URL action.</param>
+        /// <param name="messages">The list of messages to log.</param>
         public static void LogModuleProviderExceptionInRequest(Exception ex, string status, ExtensionUrlProvider provider, UrlAction result, List<string> messages)
         {
             if (ex != null)
@@ -279,10 +279,10 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Checks to see if any providers are marked as 'always call for rewrites'.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
-        /// <param name="settings"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns><see langword="true"/> if the there are providers that need to always be called, otherwise <see langword="false"/>.</returns>
         internal static bool CheckForAlwaysCallProviders(int portalId, int tabId, FriendlyUrlSettings settings, Guid parentTraceId)
         {
@@ -655,10 +655,10 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Returns the providers to call. Returns tab ID matches first, and any portal ID matches after that.</summary>
-        /// <param name="tabId"></param>
-        /// <param name="portalId"></param>
-        /// <param name="settings"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="tabId">The tab ID.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>A <see cref="List{T}"/> of <see cref="ExtensionUrlProvider"/> instances.</returns>
         private static List<ExtensionUrlProvider> GetProvidersToCall(
             int tabId,

--- a/DNN Platform/Library/Entities/Urls/FriendlyUrlController.cs
+++ b/DNN Platform/Library/Entities/Urls/FriendlyUrlController.cs
@@ -798,8 +798,8 @@ private static object CallFriendlyUrlProviderDllMethod(string methodName, string
         }
 
         /// <summary>Ensures that the path starts with the leading character.</summary>
-        /// <param name="leading"></param>
-        /// <param name="path"></param>
+        /// <param name="leading">The content to ensure is at the beginning of the <paramref name="path"/>.</param>
+        /// <param name="path">The path to ensure starts with <paramref name="leading"/>.</param>
         /// <returns>The <paramref name="path"/> with <paramref name="leading"/> at the start.</returns>
         public static string EnsureLeadingChar(string leading, string path)
         {
@@ -961,8 +961,9 @@ private static object CallFriendlyUrlProviderDllMethod(string methodName, string
         }
 
         /// <summary>Replaces the core IsAdminTab call which was decommissioned for DNN 5.0.</summary>
-        /// <param name="tabPath">The path of the tab //admin//someothername.</param>
-        /// <param name="settings"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabPath">The path of the tab, e.g. <c>"//admin//someothername"</c>.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <returns><see langword="true"/> if the page is an admin page, otherwise <see langword="false"/>.</returns>
         internal static bool IsAdminTab(int portalId, string tabPath, FriendlyUrlSettings settings)
         {

--- a/DNN Platform/Library/Entities/Urls/FriendlyUrlPathController.cs
+++ b/DNN Platform/Library/Entities/Urls/FriendlyUrlPathController.cs
@@ -15,14 +15,14 @@ namespace DotNetNuke.Entities.Urls
     internal class FriendlyUrlPathController
     {
         /// <summary>This method checks the list of rules for parameter replacement and modifies the parameter path accordingly.</summary>
-        /// <param name="parameterPath"></param>
-        /// <param name="tab"></param>
-        /// <param name="settings"></param>
-        /// <param name="portalId"></param>
-        /// <param name="replacedPath"></param>
-        /// <param name="messages"></param>
-        /// <param name="changeToSiteRoot"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="parameterPath">The path to replace.</param>
+        /// <param name="tab">The tab info.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="replacedPath">The updated path.</param>
+        /// <param name="messages">A list to which debugging messages will be added.</param>
+        /// <param name="changeToSiteRoot">Whether the path was changed to the site root.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns><see langword="true"/> if a replacement was made, otherwise <see langword="false"/>.</returns>
         internal static bool CheckParameterRegexReplacement(
             string parameterPath,
@@ -232,11 +232,11 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Splits out the userid value from the supplied Friendly Url Path.</summary>
-        /// <param name="parmName"></param>
-        /// <param name="otherParametersPath">The 'other' parameters which form the total UserProfile Url (if supplied).</param>
-        /// <param name="rawUserId"></param>
-        /// <param name="remainingPath">The remaining path not associated with the user id.</param>
-        /// <param name="urlPath"></param>
+        /// <param name="urlPath">The URL path.</param>
+        /// <param name="parmName">The parameter name.</param>
+        /// <param name="otherParametersPath">The 'other' parameters which form the total UserProfile URL (if supplied).</param>
+        /// <param name="rawUserId">The user ID string or <see langword="null"/>.</param>
+        /// <param name="remainingPath">The remaining path not associated with the user ID.</param>
         private static void SplitUserIdFromFriendlyUrlPath(
             string urlPath,
             string parmName,

--- a/DNN Platform/Library/Entities/Urls/PagingInfo.cs
+++ b/DNN Platform/Library/Entities/Urls/PagingInfo.cs
@@ -8,8 +8,8 @@ namespace DotNetNuke.Entities.Urls
     public class PagingInfo
     {
         /// <summary>Initializes a new instance of the <see cref="PagingInfo"/> class.</summary>
-        /// <param name="pageNumber"></param>
-        /// <param name="pageSize"></param>
+        /// <param name="pageNumber">The page number.</param>
+        /// <param name="pageSize">The page size.</param>
         public PagingInfo(int pageNumber, int pageSize)
         {
             this.PageNumber = pageNumber;

--- a/DNN Platform/Library/Entities/Urls/RedirectController.cs
+++ b/DNN Platform/Library/Entities/Urls/RedirectController.cs
@@ -17,10 +17,10 @@ namespace DotNetNuke.Entities.Urls
     internal class RedirectController
     {
         /// <summary>Cancels a redirect.</summary>
-        /// <param name="result"></param>
-        /// <param name="context"></param>
-        /// <param name="settings"></param>
-        /// <param name="message"></param>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="context">The HTTP context.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="message">The message to add to <see cref="UrlAction.DebugMessages"/>.</param>
         internal static void CancelRedirect(ref UrlAction result, HttpContext context, FriendlyUrlSettings settings, string message)
         {
             result.Action = ActionType.Continue;
@@ -48,11 +48,11 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Checks for a redirect based on a module friendly url provider rule.</summary>
-        /// <param name="requestUri"></param>
-        /// <param name="result"></param>
-        /// <param name="queryStringCol"></param>
-        /// <param name="settings"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="requestUri">The request URI.</param>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="queryStringCol">The query string.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns><see langword="true"/> if the <paramref name="result"/> is a redirect, otherwise <see langword="false"/>.</returns>
         internal static bool CheckForModuleProviderRedirect(
             Uri requestUri,
@@ -390,12 +390,12 @@ namespace DotNetNuke.Entities.Urls
         /// Gets a redirect Url for when the tab has a specified external Url that is of type 'TabType.Tab'.  This covers both
         /// 'PermanentRedirect' and 'ExternalUrl' scenarios, where the settings are to redirect the value.
         /// </summary>
-        /// <param name="tab"></param>
-        /// <param name="settings"></param>
-        /// <param name="cleanPath"></param>
-        /// <param name="result"></param>
-        /// <param name="permRedirect"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="tab">The tab info.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="cleanPath">The cleaned path.</param>
+        /// <param name="result">The URL action.</param>
+        /// <param name="permRedirect">Whether it's a permanent redirect.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>The friendly URL or <see langword="null"/>.</returns>
         /// <remarks>823 : Moved from CheckForRedirects to allow call earlier in pipeline.</remarks>
         internal static string GetTabRedirectUrl(

--- a/DNN Platform/Library/Entities/Urls/RedirectTokens.cs
+++ b/DNN Platform/Library/Entities/Urls/RedirectTokens.cs
@@ -26,9 +26,9 @@ namespace DotNetNuke.Entities.Urls
             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         /// <summary>Adds on a redirect reason to the rewrite path.</summary>
-        /// <param name="existingRewritePath"></param>
-        /// <param name="action"></param>
-        /// <param name="reason"></param>
+        /// <param name="existingRewritePath">The existing rewrite path.</param>
+        /// <param name="action">The action type.</param>
+        /// <param name="reason">The redirect reason.</param>
         /// <returns>The <paramref name="existingRewritePath"/> with the <paramref name="reason"/> added.</returns>
         internal static string AddRedirectReasonToRewritePath(string existingRewritePath, ActionType action, RedirectReason reason)
         {
@@ -309,8 +309,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Removes any redirect tokens from the rewrite path.</summary>
-        /// <param name="path"></param>
-        /// <param name="queryStringCol"></param>
+        /// <param name="path">The path from which to remove tokens.</param>
+        /// <param name="queryStringCol">The query string.</param>
         /// <returns>The <paramref name="path"/> without any tokens.</returns>
         internal static string RemoveAnyRedirectTokens(string path, NameValueCollection queryStringCol)
         {
@@ -395,8 +395,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Sets the Action and Reason values in the UrlAction parameter.</summary>
-        /// <param name="result"></param>
-        /// <param name="settings"></param>
+        /// <param name="result">The result to update.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         internal static void SetRedirectReasonAndAction(ref UrlAction result, FriendlyUrlSettings settings)
         {
             RedirectReason reason;

--- a/DNN Platform/Library/Entities/Urls/RewriteController.cs
+++ b/DNN Platform/Library/Entities/Urls/RewriteController.cs
@@ -83,8 +83,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>appends a language/culture code value if it is not already present in the rewrite path.</summary>
-        /// <param name="rewritePath"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="rewritePath">The rewrite path to update.</param>
+        /// <param name="cultureCode">The culture code.</param>
         /// <returns><see langword="true"/> if the <paramref name="rewritePath"/> was changed, otherwise <see langword="false"/>.</returns>
         internal static bool AddLanguageCodeToRewritePath(ref string rewritePath, string cultureCode)
         {
@@ -108,11 +108,11 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>appends a skin value to the rewrite path, as long as there is no existing skin in the path.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="tabId">The tab ID.</param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="rewritePath">The current rewrite path.</param>
         /// <param name="skin">The selected skin.</param>
-        /// <param name="tabId"></param>
-        /// <param name="message"></param>
+        /// <param name="message">A message.</param>
         /// <remarks>852 : Add skin src to rewrite path for specific aliases.</remarks>
         /// <returns><see langword="true"/> if the rewrite path was changed, otherwise <see langword="false"/>.</returns>
         internal static bool AddSkinToRewritePath(int tabId, int portalId, ref string rewritePath, string skin, out string message)
@@ -151,9 +151,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Checks for exclusions on Rewriting the path, based on a regex pattern.</summary>
-        /// <param name="result"></param>
-        /// <param name="requestedPath"></param>
-        /// <param name="settings"></param>
+        /// <param name="result">The URL action.</param>
+        /// <param name="requestedPath">The requested path.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <returns><see langword="true"/> if the requested path is allowed to be rewritten, otherwise <see langword="false"/>.</returns>
         internal static bool CanRewriteRequest(UrlAction result, string requestedPath, FriendlyUrlSettings settings)
         {
@@ -251,8 +251,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Returns either the rewritten path (if a rewrite used) or the requested path (if no rewrite used).</summary>
-        /// <param name="result"></param>
-        /// <param name="requestUri"></param>
+        /// <param name="result">The URL action.</param>
+        /// <param name="requestUri">The request URI.</param>
         /// <returns>Url suitable for input into friendly url generation routine.</returns>
         internal static string GetRewriteOrRequestedPath(UrlAction result, Uri requestUri)
         {
@@ -731,14 +731,14 @@ namespace DotNetNuke.Entities.Urls
 
         /// <summary>Identifies a request for a physical file on the system.</summary>
         /// <param name="physicalPath">The Physical Path property of the request.</param>
-        /// <param name="fullUrl"></param>
-        /// <param name="queryStringCol"></param>
-        /// <param name="result"></param>
-        /// <param name="useFriendlyUrls"></param>
-        /// <param name="settings"></param>
-        /// <param name="isPhysicalResource"></param>
-        /// <param name="checkFurtherForRewrite"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="fullUrl">The full URL of the request.</param>
+        /// <param name="queryStringCol">The parsed query string.</param>
+        /// <param name="result">The URL action to update.</param>
+        /// <param name="useFriendlyUrls">Whether to use friendly URLs.</param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="isPhysicalResource">Whether the request is for a physical resource.</param>
+        /// <param name="checkFurtherForRewrite">Whether further rewrite checks should be done.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         internal static void IdentifyByPhysicalResource(
             string physicalPath,
             string fullUrl,
@@ -984,9 +984,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Replaces the core IsAdminTab call which was decommissioned for DNN 5.0.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="tabPath">The path of the tab //admin//someothername.</param>
-        /// <param name="settings"></param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <returns><see langword="true"/> if the page is an admin page, otherwise <see langword="false"/>.</returns>
         internal static bool IsAdminTab(int portalId, string tabPath, FriendlyUrlSettings settings)
         {
@@ -1013,8 +1013,8 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Determines if the tab is excluded from FriendlyUrl Processing.</summary>
-        /// <param name="tab"></param>
-        /// <param name="settings"></param>
+        /// <param name="tab">The tab info.</param>
+        /// <param name="settings">The friendly URL settings.</param>
         /// <param name="rewriting">If true, we are checking for rewriting purposes, if false, we are checking for friendly Url Generating.</param>
         /// <returns><see langword="true"/> if the page is excluded from friendly URLs, otherwise <see langword="false"/>.</returns>
         internal static bool IsExcludedFromFriendlyUrls(TabInfo tab, FriendlyUrlSettings settings, bool rewriting)
@@ -1039,9 +1039,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Checks for a current parameter belonging to one of the built in 'ctl' values.</summary>
-        /// <param name="urlParm"></param>
-        /// <param name="rewritePath"></param>
-        /// <param name="result"></param>
+        /// <param name="urlParm">The URL parameter.</param>
+        /// <param name="rewritePath">The rewrite path (for logging).</param>
+        /// <param name="result">The URL action to update.</param>
         /// <remarks>Sets the Action parameter of the Result to 'CheckFor301' if suspected. Actual redirect taken care of by friendly url redirection logic.</remarks>
         internal static void RequestRedirectOnBuiltInUrl(string urlParm, string rewritePath, UrlAction result)
         {
@@ -1257,13 +1257,13 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Scans the collection of Rewrite Parameter rules, and rewrites the parameters if a match is found.</summary>
-        /// <param name="newUrl"></param>
-        /// <param name="tabKeyVal"></param>
-        /// <param name="urlParms"></param>
-        /// <param name="isSiteRoot"></param>
-        /// <param name="urlAction"></param>
-        /// <param name="rewriteParms"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="newUrl">The new URL.</param>
+        /// <param name="tabKeyVal">The value of the tab key.</param>
+        /// <param name="urlParms">The URL parameters.</param>
+        /// <param name="isSiteRoot">Whether the request matches the site root.</param>
+        /// <param name="urlAction">The URL action.</param>
+        /// <param name="rewriteParms">Whether the parameters were rewritten.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>The new URL with the parameters rewritten onto the end of the old URL.</returns>
         internal static string RewriteParameters(
             string newUrl,

--- a/DNN Platform/Library/Entities/Urls/TabIndexController.cs
+++ b/DNN Platform/Library/Entities/Urls/TabIndexController.cs
@@ -65,15 +65,15 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Gets the Tab Dictionary from the DataCache memory location, if it's empty or missing, builds a new one.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="minTabPathDepth">ByRef parameter to return the minimum tab path depth (the number of '/' in the tab path).</param>
         /// <param name="maxTabPathDepth">ByRef parameter to return the maximum tab path depth (the number of '/' in the tab path).</param>
         /// <param name="minAliasPathDepth">ByRef parameter to return the minimum alias path depth (the number of '/' in the alias path.</param>
         /// <param name="maxAliasPathDepth">ByRef parameter to return the maximum alias path depth (the number of '/' in the alias path).</param>
-        /// <param name="settings"></param>
-        /// <param name="forceRebuild"></param>
-        /// <param name="bypassCache"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="settings">The friendly URL settings.</param>
+        /// <param name="forceRebuild">Whether to force a rebuild of the dictionary.</param>
+        /// <param name="bypassCache">Whether to bypass the cache.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>Dictionary (string, string) of Tab paths in tab key, with the rewrite path as the value.</returns>
         /// <remarks>
         /// Changes
@@ -299,9 +299,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Returns the tab path of the base DNN tab.  Ie /Home or /Somepage/SomeOtherPage.</summary>
-        /// <param name="tab"></param>
-        /// <param name="options"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="tab">The tab info.</param>
+        /// <param name="options">The friendly URL options.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <remarks>Will remove // from the tabPath as stored in the Tabs object/table.</remarks>
         /// <returns>The friendly URL path.</returns>
         internal static string GetTabPath(TabInfo tab, FriendlyUrlOptions options, Guid parentTraceId)

--- a/DNN Platform/Library/Entities/Urls/TabPathHelper.cs
+++ b/DNN Platform/Library/Entities/Urls/TabPathHelper.cs
@@ -62,9 +62,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Get the tab path for the supplied Tab.</summary>
-        /// <param name="tab"></param>
-        /// <param name="options"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="tab">The tab info.</param>
+        /// <param name="options">The friendly URL options.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <returns>The friendly URL path.</returns>
         internal static string GetFriendlyUrlTabPath(TabInfo tab, FriendlyUrlOptions options, Guid parentTraceId)
         {
@@ -88,8 +88,8 @@ namespace DotNetNuke.Entities.Urls
 
         /// <summary>Finds a culture-specific homepage tab ID for a non-default language.</summary>
         /// <param name="defaultCulture">The default culture of the portal.</param>
-        /// <param name="cultureCode"></param>
-        /// <param name="portalId"></param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="defaultHomeTabId">The default home page tab id.</param>
         /// <returns>The valid home page tab ID for the portal ID and culture.</returns>
         /// <remarks>Note if no specific home page found for the culture, will return defaultHomeTabId back.</remarks>
@@ -135,17 +135,17 @@ namespace DotNetNuke.Entities.Urls
         /// <summary>For the supplied options, return a tab path for the specified tab.</summary>
         /// <param name="tab">TabInfo object of selected tab.</param>
         /// <param name="settings">FriendlyUrlSettings.</param>
-        /// <param name="options"></param>
+        /// <param name="options">The friendly URL options.</param>
         /// <param name="ignoreCustomRedirects">Whether to add in the customised Tab redirects or not.</param>
-        /// <param name="homePageSiteRoot"></param>
-        /// <param name="isHomeTab"></param>
-        /// <param name="cultureCode"></param>
-        /// <param name="isDefaultCultureCode"></param>
-        /// <param name="hasPath"></param>
-        /// <param name="dropLangParms"></param>
-        /// <param name="customHttpAlias"></param>
-        /// <param name="isCustomPath"></param>
-        /// <param name="parentTraceId"></param>
+        /// <param name="homePageSiteRoot">Whether the home page is the site root.</param>
+        /// <param name="isHomeTab">Whether it's the home tab.</param>
+        /// <param name="cultureCode">The culture code.</param>
+        /// <param name="isDefaultCultureCode">Whether it's the default culture code.</param>
+        /// <param name="hasPath">Whether there's a path….</param>
+        /// <param name="dropLangParms">Whether the language parameters were removed.</param>
+        /// <param name="customHttpAlias">The custom HTTP alias that was used, if any.</param>
+        /// <param name="isCustomPath">Whether it's a custom path.</param>
+        /// <param name="parentTraceId">The parent trace ID.</param>
         /// <remarks>751 : include isDefaultCultureCode flag to determine when using the portal default language
         /// 770 : include custom http alias output for when the Url uses a specific alias due to custom Url rules
         ///  : include new out parameter 'isCustomPath' to return whether the Url was generated from Url-Master custom url.

--- a/DNN Platform/Library/Entities/Urls/UrlAction.cs
+++ b/DNN Platform/Library/Entities/Urls/UrlAction.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Entities.Urls
         // 829 add in constructor that works around physical path length restriction
 
         /// <summary>Initializes a new instance of the <see cref="UrlAction"/> class.</summary>
-        /// <param name="request"></param>
+        /// <param name="request">An HTTP request.</param>
         public UrlAction(HttpRequest request)
         {
             this.BrowserType = BrowserTypes.Normal;
@@ -52,9 +52,9 @@ namespace DotNetNuke.Entities.Urls
         }
 
         /// <summary>Initializes a new instance of the <see cref="UrlAction"/> class.</summary>
-        /// <param name="scheme"></param>
-        /// <param name="applicationPath"></param>
-        /// <param name="physicalPath"></param>
+        /// <param name="scheme">The scheme of a URL.</param>
+        /// <param name="applicationPath">The application path of a URL.</param>
+        /// <param name="physicalPath">The corresponding physical path.</param>
         public UrlAction(string scheme, string applicationPath, string physicalPath)
         {
             this.BrowserType = BrowserTypes.Normal;
@@ -170,7 +170,7 @@ namespace DotNetNuke.Entities.Urls
         /// Sets the action value, but checks to ensure that the action is
         /// not being 'downgraded' (example: cannot set 'Redirect301' to 'CheckFor301').
         /// </summary>
-        /// <param name="newAction"></param>
+        /// <param name="newAction">The new action type.</param>
         public void SetActionWithNoDowngrade(ActionType newAction)
         {
             switch (newAction)
@@ -230,9 +230,9 @@ namespace DotNetNuke.Entities.Urls
             return this.licensedProviders.Contains(providerName.ToLowerInvariant());
         }
 
-        /// <summary>Copies the original request path to the OriginalPath variables (originalPath, originanPathNoAlias).</summary>
-        /// <param name="path"></param>
-        /// <param name="settings"></param>
+        /// <summary>Copies the original request path to the OriginalPath variables (originalPath, originalPathNoAlias).</summary>
+        /// <param name="path">The original path.</param>
+        /// <param name="settings">The URL settings.</param>
         public void SetOriginalPath(string path, FriendlyUrlSettings settings)
         {
             this.OriginalPath = path;

--- a/DNN Platform/Library/Entities/Urls/XmlHelpers.cs
+++ b/DNN Platform/Library/Entities/Urls/XmlHelpers.cs
@@ -11,11 +11,11 @@ namespace DotNetNuke.Entities.Urls
     /// <summary>The Xml Helpers class is used to read in parameter rewrite/replace/redirect rules from the friendlyUrlParms.config file.</summary>
     internal static class XmlHelpers
     {
-        /// <summary>Returns a tab id from either a raw tabId, or a list of tab names delimited by ';'.</summary>
-        /// <param name="tabIdsRaw"></param>
-        /// <param name="tabNames"></param>
-        /// <param name="portalId"></param>
-        /// <param name="messages"></param>
+        /// <summary>Converts <paramref name="tabIdsRaw"/> and <paramref name="tabNames"/> into a list of tab IDs.</summary>
+        /// <param name="tabIdsRaw">A semicolon-delimited list of tab IDs.</param>
+        /// <param name="tabNames">Either <c>"All"</c> or a semicolon-delimited list of tab names.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="messages">A list to be filled with messages.</param>
         /// <returns>A <see cref="List{T}"/> of tab IDs (<c>-1</c> indicates "all", <c>-2</c> indicates "default.aspx", and <c>-3</c> indicates site root).</returns>
         internal static List<int> TabIdsFromAttributes(string tabIdsRaw, string tabNames, int portalId, ref List<string> messages)
         {

--- a/DNN Platform/Library/Entities/Users/Exceptions/InvalidUserRegisterException.cs
+++ b/DNN Platform/Library/Entities/Users/Exceptions/InvalidUserRegisterException.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidUserRegisterException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidUserRegisterException(string message)
             : base(message)
         {

--- a/DNN Platform/Library/Entities/Users/Exceptions/InvalidVerificationCodeException.cs
+++ b/DNN Platform/Library/Entities/Users/Exceptions/InvalidVerificationCodeException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidVerificationCodeException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidVerificationCodeException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidVerificationCodeException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidVerificationCodeException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidVerificationCodeException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidVerificationCodeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Exceptions/UserAlreadyVerifiedException.cs
+++ b/DNN Platform/Library/Entities/Users/Exceptions/UserAlreadyVerifiedException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserAlreadyVerifiedException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserAlreadyVerifiedException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserAlreadyVerifiedException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserAlreadyVerifiedException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserAlreadyVerifiedException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserAlreadyVerifiedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Exceptions/UserDoesNotExistException.cs
+++ b/DNN Platform/Library/Entities/Users/Exceptions/UserDoesNotExistException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserDoesNotExistException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserDoesNotExistException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserDoesNotExistException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserDoesNotExistException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Membership/MembershipPropertyAccess.cs
+++ b/DNN Platform/Library/Entities/Users/Membership/MembershipPropertyAccess.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Entities.Users
         private readonly UserInfo objUser;
 
         /// <summary>Initializes a new instance of the <see cref="MembershipPropertyAccess"/> class.</summary>
-        /// <param name="user"></param>
+        /// <param name="user">The user info.</param>
         public MembershipPropertyAccess(UserInfo user)
         {
             this.objUser = user;

--- a/DNN Platform/Library/Entities/Users/Membership/UserMembership.cs
+++ b/DNN Platform/Library/Entities/Users/Membership/UserMembership.cs
@@ -5,9 +5,6 @@ namespace DotNetNuke.Entities.Users
 {
     using System;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.Entities.Users
-    /// Class:      UserMembership
     /// <summary>
     /// The UserMembership class provides Business Layer model for the Users Membership
     /// related properties.
@@ -25,7 +22,7 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserMembership"/> class.</summary>
-        /// <param name="user"></param>
+        /// <param name="user">The user info.</param>
         public UserMembership(UserInfo user)
         {
             this.approved = true;

--- a/DNN Platform/Library/Entities/Users/RelationshipEventArgs.cs
+++ b/DNN Platform/Library/Entities/Users/RelationshipEventArgs.cs
@@ -11,8 +11,8 @@ namespace DotNetNuke.Entities.Users
     public class RelationshipEventArgs : EventArgs
     {
         /// <summary>Initializes a new instance of the <see cref="RelationshipEventArgs"/> class.</summary>
-        /// <param name="relationship"></param>
-        /// <param name="portalId"></param>
+        /// <param name="relationship">The relationship.</param>
+        /// <param name="portalId">The portal ID.</param>
         internal RelationshipEventArgs(UserRelationship relationship, int portalId)
         {
             this.Relationship = relationship;

--- a/DNN Platform/Library/Entities/Users/Social/Exceptions/InvalidRelationshipTypeException.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Exceptions/InvalidRelationshipTypeException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidRelationshipTypeException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidRelationshipTypeException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidRelationshipTypeException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidRelationshipTypeException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidRelationshipTypeException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidRelationshipTypeException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipBlockedException.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipBlockedException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipBlockedException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserRelationshipBlockedException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipBlockedException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserRelationshipBlockedException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipBlockedException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserRelationshipBlockedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipDoesNotExistException.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipDoesNotExistException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipDoesNotExistException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserRelationshipDoesNotExistException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipDoesNotExistException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserRelationshipDoesNotExistException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipDoesNotExistException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserRelationshipDoesNotExistException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipExistsException.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipExistsException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipExistsException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserRelationshipExistsException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipExistsException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserRelationshipExistsException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipExistsException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserRelationshipExistsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipForDifferentPortalException.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipForDifferentPortalException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipForDifferentPortalException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserRelationshipForDifferentPortalException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipForDifferentPortalException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserRelationshipForDifferentPortalException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipForDifferentPortalException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserRelationshipForDifferentPortalException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipForSameUsersException.cs
+++ b/DNN Platform/Library/Entities/Users/Social/Exceptions/UserRelationshipForSameUsersException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Entities.Users
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipForSameUsersException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public UserRelationshipForSameUsersException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipForSameUsersException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public UserRelationshipForSameUsersException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserRelationshipForSameUsersException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public UserRelationshipForSameUsersException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Entities/Users/Social/UserSocial.cs
+++ b/DNN Platform/Library/Entities/Users/Social/UserSocial.cs
@@ -10,9 +10,6 @@ namespace DotNetNuke.Entities.Users.Social
 
     using DotNetNuke.Security.Roles;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.Entities.Users
-    /// Class:      UserSocial
     /// <summary>
     /// The UserSocial is a high-level class describing social details of a user.
     /// As an example, this class contains Friends, Followers, Follows lists.
@@ -26,7 +23,7 @@ namespace DotNetNuke.Entities.Users.Social
         private IList<UserRoleInfo> roles;
 
         /// <summary>Initializes a new instance of the <see cref="UserSocial"/> class.</summary>
-        /// <param name="userInfo"></param>
+        /// <param name="userInfo">The user info.</param>
         public UserSocial(UserInfo userInfo)
         {
             this.userInfo = userInfo;

--- a/DNN Platform/Library/ExtensionPoints/Filters/FilterByHostMenu.cs
+++ b/DNN Platform/Library/ExtensionPoints/Filters/FilterByHostMenu.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.ExtensionPoints.Filters
         private readonly bool isHostMenu;
 
         /// <summary>Initializes a new instance of the <see cref="FilterByHostMenu"/> class.</summary>
-        /// <param name="isHostMenu"></param>
+        /// <param name="isHostMenu">Whether this filter is for the host menu.</param>
         public FilterByHostMenu(bool isHostMenu)
         {
             this.isHostMenu = isHostMenu;

--- a/DNN Platform/Library/ExtensionPoints/Filters/FilterByUnauthenticated.cs
+++ b/DNN Platform/Library/ExtensionPoints/Filters/FilterByUnauthenticated.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.ExtensionPoints.Filters
         private readonly bool isAuthenticated;
 
         /// <summary>Initializes a new instance of the <see cref="FilterByUnauthenticated"/> class.</summary>
-        /// <param name="isAuthenticated"></param>
+        /// <param name="isAuthenticated">Whether this filter is for authenticated users.</param>
         public FilterByUnauthenticated(bool isAuthenticated)
         {
             this.isAuthenticated = isAuthenticated;

--- a/DNN Platform/Library/ExtensionPoints/SafeDirectoryCatalog.cs
+++ b/DNN Platform/Library/ExtensionPoints/SafeDirectoryCatalog.cs
@@ -16,7 +16,7 @@ namespace DotNetNuke.ExtensionPoints
         private readonly AggregateCatalog catalog;
 
         /// <summary>Initializes a new instance of the <see cref="SafeDirectoryCatalog"/> class.</summary>
-        /// <param name="directory"></param>
+        /// <param name="directory">The directory path in which to search for assemblies (recursively).</param>
         public SafeDirectoryCatalog(string directory)
         {
             var files = Directory.EnumerateFiles(directory, "*.dll", SearchOption.AllDirectories);

--- a/DNN Platform/Library/Framework/Providers/Provider.cs
+++ b/DNN Platform/Library/Framework/Providers/Provider.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Framework.Providers
         private readonly string providerType;
 
         /// <summary>Initializes a new instance of the <see cref="Provider"/> class.</summary>
-        /// <param name="attributes"></param>
+        /// <param name="attributes">The XML attributes. <c>name</c> and <c>type</c> are required, any additional attributes will be in <see cref="Attributes"/>.</param>
         public Provider(XmlAttributeCollection attributes)
         {
             // Set the name of the provider

--- a/DNN Platform/Library/Framework/Reflections/AssemblyWrapper.cs
+++ b/DNN Platform/Library/Framework/Reflections/AssemblyWrapper.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.Framework.Reflections
         private readonly Assembly assembly;
 
         /// <summary>Initializes a new instance of the <see cref="AssemblyWrapper"/> class.</summary>
-        /// <param name="assembly"></param>
+        /// <param name="assembly">The assembly.</param>
         public AssemblyWrapper(Assembly assembly)
         {
             this.assembly = assembly;

--- a/DNN Platform/Library/Modules/NavigationEventArgs.cs
+++ b/DNN Platform/Library/Modules/NavigationEventArgs.cs
@@ -16,8 +16,8 @@ namespace DotNetNuke.Modules.NavigationProvider
         public DNNNode Node;
 
         /// <summary>Initializes a new instance of the <see cref="NavigationEventArgs"/> class.</summary>
-        /// <param name="strID"></param>
-        /// <param name="objNode"></param>
+        /// <param name="strID">The ID.</param>
+        /// <param name="objNode">The node.</param>
         public NavigationEventArgs(string strID, DNNNode objNode)
         {
             this.ID = strID;

--- a/DNN Platform/Library/Obsolete/TabController.cs
+++ b/DNN Platform/Library/Obsolete/TabController.cs
@@ -121,8 +121,8 @@ namespace DotNetNuke.Entities.Tabs
         }
 
         /// <summary>Adds localized copies of the page in all missing languages.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="tabId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="tabId">The tab ID.</param>
         [DnnDeprecated(9, 11, 1, "Use AddMissingLanguagesWithWarnings")]
         public partial void AddMissingLanguages(int portalId, int tabId)
         {

--- a/DNN Platform/Library/Prompt/Attributes/ConsoleCommandAttribute.cs
+++ b/DNN Platform/Library/Prompt/Attributes/ConsoleCommandAttribute.cs
@@ -9,9 +9,9 @@ namespace DotNetNuke.Prompt
     public class ConsoleCommandAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="ConsoleCommandAttribute"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="categoryKey"></param>
-        /// <param name="descriptionKey"></param>
+        /// <param name="name">The command name.</param>
+        /// <param name="categoryKey">The resource key for the command category.</param>
+        /// <param name="descriptionKey">The resource key for the command description.</param>
         public ConsoleCommandAttribute(string name, string categoryKey, string descriptionKey)
         {
             this.Name = name;

--- a/DNN Platform/Library/Prompt/Attributes/ConsoleCommandParameterAttribute.cs
+++ b/DNN Platform/Library/Prompt/Attributes/ConsoleCommandParameterAttribute.cs
@@ -9,10 +9,10 @@ namespace DotNetNuke.Prompt
     public class ConsoleCommandParameterAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="ConsoleCommandParameterAttribute"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="descriptionKey"></param>
-        /// <param name="required"></param>
-        /// <param name="defaultValue"></param>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="descriptionKey">The resource key for the parameter description.</param>
+        /// <param name="required">Whether the parameter is required.</param>
+        /// <param name="defaultValue">The default value for the parameter.</param>
         public ConsoleCommandParameterAttribute(string name, string descriptionKey, bool required, string defaultValue)
         {
             this.Name = name;
@@ -22,26 +22,26 @@ namespace DotNetNuke.Prompt
         }
 
         /// <summary>Initializes a new instance of the <see cref="ConsoleCommandParameterAttribute"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="descriptionKey"></param>
-        /// <param name="required"></param>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="descriptionKey">The resource key for the parameter description.</param>
+        /// <param name="required">Whether the parameter is required.</param>
         public ConsoleCommandParameterAttribute(string name, string descriptionKey, bool required)
             : this(name, descriptionKey, required, string.Empty)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="ConsoleCommandParameterAttribute"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="descriptionKey"></param>
-        /// <param name="defaultValue"></param>
+        /// <summary>Initializes a new instance of the <see cref="ConsoleCommandParameterAttribute"/> class for an optional parameter.</summary>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="descriptionKey">The resource key for the parameter description.</param>
+        /// <param name="defaultValue">The default value for the parameter.</param>
         public ConsoleCommandParameterAttribute(string name, string descriptionKey, string defaultValue)
             : this(name, descriptionKey, false, defaultValue)
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="ConsoleCommandParameterAttribute"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="descriptionKey"></param>
+        /// <summary>Initializes a new instance of the <see cref="ConsoleCommandParameterAttribute"/> class for an optional parameter.</summary>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="descriptionKey">The resource key for the parameter description.</param>
         public ConsoleCommandParameterAttribute(string name, string descriptionKey)
             : this(name, descriptionKey, false, string.Empty)
         {

--- a/DNN Platform/Library/Prompt/Output/ConsoleErrorResultModel.cs
+++ b/DNN Platform/Library/Prompt/Output/ConsoleErrorResultModel.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.Prompt
         }
 
         /// <summary>Initializes a new instance of the <see cref="ConsoleErrorResultModel"/> class.</summary>
-        /// <param name="errMessage"></param>
+        /// <param name="errMessage">The error message.</param>
         public ConsoleErrorResultModel(string errMessage)
         {
             this.IsError = true;

--- a/DNN Platform/Library/Prompt/Output/ConsoleResultModel.cs
+++ b/DNN Platform/Library/Prompt/Output/ConsoleResultModel.cs
@@ -16,7 +16,7 @@ namespace DotNetNuke.Prompt
         }
 
         /// <summary>Initializes a new instance of the <see cref="ConsoleResultModel"/> class.</summary>
-        /// <param name="output"></param>
+        /// <param name="output">The output text.</param>
         public ConsoleResultModel(string output)
         {
             this.Output = output;

--- a/DNN Platform/Library/Security/Permissions/DesktopModulePermissionCollection.cs
+++ b/DNN Platform/Library/Security/Permissions/DesktopModulePermissionCollection.cs
@@ -9,13 +9,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
 
-    /// Project  : DotNetNuke
-    /// Namespace: DotNetNuke.Security.Permissions
-    /// Class    : DesktopModulePermissionCollection
-    /// <summary>
-    /// DesktopModulePermissionCollection provides the a custom collection for DesktopModulePermissionInfo
-    /// objects.
-    /// </summary>
+    /// <summary>DesktopModulePermissionCollection provides a custom collection for <see cref="DesktopModulePermissionInfo"/> objects.</summary>
     [Serializable]
     public class DesktopModulePermissionCollection : CollectionBase
     {
@@ -25,22 +19,22 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <summary>Initializes a new instance of the <see cref="DesktopModulePermissionCollection"/> class.</summary>
-        /// <param name="desktopModulePermissions"></param>
+        /// <param name="desktopModulePermissions">An <see cref="ArrayList"/> of <see cref="DesktopModulePermissionInfo"/> instances.</param>
         public DesktopModulePermissionCollection(ArrayList desktopModulePermissions)
         {
             this.AddRange(desktopModulePermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="DesktopModulePermissionCollection"/> class.</summary>
-        /// <param name="desktopModulePermissions"></param>
+        /// <param name="desktopModulePermissions">A collection of <see cref="DesktopModulePermissionInfo"/> instances.</param>
         public DesktopModulePermissionCollection(DesktopModulePermissionCollection desktopModulePermissions)
         {
             this.AddRange(desktopModulePermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="DesktopModulePermissionCollection"/> class.</summary>
-        /// <param name="desktopModulePermissions"></param>
-        /// <param name="desktopModulePermissionID"></param>
+        /// <param name="desktopModulePermissions">An <see cref="ArrayList"/> of <see cref="DesktopModulePermissionInfo"/> instances.</param>
+        /// <param name="desktopModulePermissionID">The ID of the desktop module by which to filter <paramref name="desktopModulePermissions"/>.</param>
         public DesktopModulePermissionCollection(ArrayList desktopModulePermissions, int desktopModulePermissionID)
         {
             foreach (DesktopModulePermissionInfo permission in desktopModulePermissions)

--- a/DNN Platform/Library/Security/Permissions/FolderPermissionCollection.cs
+++ b/DNN Platform/Library/Security/Permissions/FolderPermissionCollection.cs
@@ -18,22 +18,22 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderPermissionCollection"/> class.</summary>
-        /// <param name="folderPermissions"></param>
+        /// <param name="folderPermissions">An <see cref="ArrayList"/> of <see cref="FolderPermissionInfo"/> instances.</param>
         public FolderPermissionCollection(ArrayList folderPermissions)
         {
             this.AddRange(folderPermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderPermissionCollection"/> class.</summary>
-        /// <param name="folderPermissions"></param>
+        /// <param name="folderPermissions">A collection of <see cref="FolderPermissionInfo"/> instances.</param>
         public FolderPermissionCollection(FolderPermissionCollection folderPermissions)
         {
             this.AddRange(folderPermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderPermissionCollection"/> class.</summary>
-        /// <param name="folderPermissions"></param>
-        /// <param name="folderPath"></param>
+        /// <param name="folderPermissions">An <see cref="ArrayList"/> of <see cref="FolderPermissionInfo"/> instances.</param>
+        /// <param name="folderPath">The path of the folder by which to filter <paramref name="folderPermissions"/>.</param>
         public FolderPermissionCollection(ArrayList folderPermissions, string folderPath)
         {
             foreach (FolderPermissionInfo permission in folderPermissions)

--- a/DNN Platform/Library/Security/Permissions/ModulePermissionCollection.cs
+++ b/DNN Platform/Library/Security/Permissions/ModulePermissionCollection.cs
@@ -11,13 +11,7 @@ namespace DotNetNuke.Security.Permissions
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
 
-    /// Project  : DotNetNuke
-    /// Namespace: DotNetNuke.Security.Permissions
-    /// Class    : ModulePermissionCollection
-    /// <summary>
-    /// ModulePermissionCollection provides the a custom collection for ModulePermissionInfo
-    /// objects.
-    /// </summary>
+    /// <summary>ModulePermissionCollection provides a custom collection for <see cref="ModulePermissionInfo"/> objects.</summary>
     [Serializable]
     public class ModulePermissionCollection : CollectionBase
     {
@@ -27,22 +21,22 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePermissionCollection"/> class.</summary>
-        /// <param name="modulePermissions"></param>
+        /// <param name="modulePermissions">An <see cref="ArrayList"/> of <see cref="ModulePermissionInfo"/> instances.</param>
         public ModulePermissionCollection(ArrayList modulePermissions)
         {
             this.AddRange(modulePermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePermissionCollection"/> class.</summary>
-        /// <param name="modulePermissions"></param>
+        /// <param name="modulePermissions">A collection of <see cref="ModulePermissionInfo"/> instances.</param>
         public ModulePermissionCollection(ModulePermissionCollection modulePermissions)
         {
             this.AddRange(modulePermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePermissionCollection"/> class.</summary>
-        /// <param name="modulePermissions"></param>
-        /// <param name="moduleID"></param>
+        /// <param name="modulePermissions">An <see cref="ArrayList"/> of <see cref="ModulePermissionInfo"/> instances.</param>
+        /// <param name="moduleID">The ID of the module by which to filter <paramref name="modulePermissions"/>.</param>
         public ModulePermissionCollection(ArrayList modulePermissions, int moduleID)
         {
             foreach (ModulePermissionInfo permission in modulePermissions)
@@ -55,7 +49,7 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePermissionCollection"/> class.</summary>
-        /// <param name="objModule"></param>
+        /// <param name="objModule">A module from which to copy <see cref="ModuleInfo.ModulePermissions"/>.</param>
         public ModulePermissionCollection(ModuleInfo objModule)
         {
             foreach (ModulePermissionInfo permission in objModule.ModulePermissions)

--- a/DNN Platform/Library/Security/Permissions/PortalPermissionCollection.cs
+++ b/DNN Platform/Library/Security/Permissions/PortalPermissionCollection.cs
@@ -11,13 +11,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
 
-    /// Project  : DotNetNuke
-    /// Namespace: DotNetNuke.Security.Permissions
-    /// Class    : PortalPermissionCollection
-    /// <summary>
-    /// PortalPermissionCollection provides the a custom collection for PortalPermissionInfo
-    /// objects.
-    /// </summary>
+    /// <summary>PortalPermissionCollection provides a custom collection for <see cref="PortalPermissionInfo"/> objects.</summary>
     [Serializable]
     [XmlRoot("portalpermissions")]
     public class PortalPermissionCollection : CollectionBase
@@ -28,22 +22,22 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.</summary>
-        /// <param name="portalPermissions"></param>
+        /// <param name="portalPermissions">An <see cref="ArrayList"/> of <see cref="PortalPermissionInfo"/> instances.</param>
         public PortalPermissionCollection(ArrayList portalPermissions)
         {
             this.AddRange(portalPermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.</summary>
-        /// <param name="portalPermissions"></param>
+        /// <param name="portalPermissions">A collection of <see cref="PortalPermissionInfo"/> instances.</param>
         public PortalPermissionCollection(PortalPermissionCollection portalPermissions)
         {
             this.AddRange(portalPermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="PortalPermissionCollection"/> class.</summary>
-        /// <param name="portalPermissions"></param>
-        /// <param name="portalId"></param>
+        /// <param name="portalPermissions">An <see cref="ArrayList"/> of <see cref="PortalPermissionInfo"/> instances.</param>
+        /// <param name="portalId">The ID of the portal by which to filter <paramref name="portalPermissions"/>.</param>
         public PortalPermissionCollection(ArrayList portalPermissions, int portalId)
         {
             foreach (PortalPermissionInfo permission in portalPermissions)

--- a/DNN Platform/Library/Security/Permissions/TabPermissionCollection.cs
+++ b/DNN Platform/Library/Security/Permissions/TabPermissionCollection.cs
@@ -11,13 +11,7 @@ namespace DotNetNuke.Security.Permissions
 
     using DotNetNuke.Common.Utilities;
 
-    /// Project  : DotNetNuke
-    /// Namespace: DotNetNuke.Security.Permissions
-    /// Class    : TabPermissionCollection
-    /// <summary>
-    /// TabPermissionCollection provides the a custom collection for TabPermissionInfo
-    /// objects.
-    /// </summary>
+    /// <summary>TabPermissionCollection provides a custom collection for <see cref="TabPermissionInfo"/> objects.</summary>
     [Serializable]
     [XmlRoot("tabpermissions")]
     public class TabPermissionCollection : CollectionBase
@@ -28,22 +22,22 @@ namespace DotNetNuke.Security.Permissions
         }
 
         /// <summary>Initializes a new instance of the <see cref="TabPermissionCollection"/> class.</summary>
-        /// <param name="tabPermissions"></param>
+        /// <param name="tabPermissions">An <see cref="ArrayList"/> of <see cref="TabPermissionInfo"/> instances.</param>
         public TabPermissionCollection(ArrayList tabPermissions)
         {
             this.AddRange(tabPermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="TabPermissionCollection"/> class.</summary>
-        /// <param name="tabPermissions"></param>
+        /// <param name="tabPermissions">A collection of <see cref="TabPermissionInfo"/> instances.</param>
         public TabPermissionCollection(TabPermissionCollection tabPermissions)
         {
             this.AddRange(tabPermissions);
         }
 
         /// <summary>Initializes a new instance of the <see cref="TabPermissionCollection"/> class.</summary>
-        /// <param name="tabPermissions"></param>
-        /// <param name="tabId"></param>
+        /// <param name="tabPermissions">An <see cref="ArrayList"/> of <see cref="TabPermissionInfo"/> instances.</param>
+        /// <param name="tabId">The ID of the tab by which to filter <paramref name="tabPermissions"/>.</param>
         public TabPermissionCollection(ArrayList tabPermissions, int tabId)
         {
             foreach (TabPermissionInfo permission in tabPermissions)

--- a/DNN Platform/Library/Security/RegistrationSettings.cs
+++ b/DNN Platform/Library/Security/RegistrationSettings.cs
@@ -37,7 +37,7 @@ namespace DotNetNuke.Security
         }
 
         /// <summary>Initializes a new instance of the <see cref="RegistrationSettings"/> class.</summary>
-        /// <param name="settings"></param>
+        /// <param name="settings">The settings dictionary.</param>
         public RegistrationSettings(Dictionary<string, string> settings)
             : this()
         {

--- a/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
+++ b/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
@@ -30,9 +30,9 @@ namespace DotNetNuke.Security.Roles
         }
 
         /// <summary>Initializes a new instance of the <see cref="RoleGroupInfo"/> class.</summary>
-        /// <param name="roleGroupID"></param>
-        /// <param name="portalID"></param>
-        /// <param name="loadRoles"></param>
+        /// <param name="roleGroupID">The role group ID.</param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="loadRoles">Whether to eagerly load the group's roles.</param>
         public RoleGroupInfo(int roleGroupID, int portalID, bool loadRoles)
         {
             this.portalID = portalID;

--- a/DNN Platform/Library/Services/Assets/AssetManagerException.cs
+++ b/DNN Platform/Library/Services/Assets/AssetManagerException.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Services.Assets
     public class AssetManagerException : Exception
     {
         /// <summary>Initializes a new instance of the <see cref="AssetManagerException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public AssetManagerException(string message)
             : base(message)
         {

--- a/DNN Platform/Library/Services/Assets/IAssetManager.cs
+++ b/DNN Platform/Library/Services/Assets/IAssetManager.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.Services.Assets
         /// <param name="startIndex">Start index to retrieve items.</param>
         /// <param name="numItems">Max Number of items.</param>
         /// <param name="sortExpression">The sort expression in a SQL format, e.g. FileName ASC.</param>
-        /// <param name="subfolderFilter"></param>
+        /// <param name="subfolderFilter">The <see cref="SubfolderFilter"/>.</param>
         /// <returns>The list of files and folders contained in the specified folder paginated.</returns>
         ContentPage GetFolderContent(int folderId, int startIndex, int numItems, string sortExpression = null, SubfolderFilter subfolderFilter = SubfolderFilter.IncludeSubfoldersFolderStructure);
 
@@ -25,6 +25,7 @@ namespace DotNetNuke.Services.Assets
         /// <param name="startIndex">Start index to retrieve items.</param>
         /// <param name="numItems">Max Number of items.</param>
         /// <param name="sortExpression">The sort expression in a SQL format, e.g. FileName ASC.</param>
+        /// <param name="subfolderFilter">The <see cref="SubfolderFilter"/>.</param>
         /// <returns>The list of files and folders contained in the specified folder paginated.</returns>
         ContentPage SearchFolderContent(int folderId, string pattern, int startIndex, int numItems, string sortExpression = null, SubfolderFilter subfolderFilter = SubfolderFilter.IncludeSubfoldersFolderStructure);
 

--- a/DNN Platform/Library/Services/Authentication/AuthenticationConfig.cs
+++ b/DNN Platform/Library/Services/Authentication/AuthenticationConfig.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Services.Authentication
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(AuthenticationConfig));
 
         /// <summary>Initializes a new instance of the <see cref="AuthenticationConfig"/> class.</summary>
-        /// <param name="portalID"></param>
+        /// <param name="portalID">The portal ID.</param>
         protected AuthenticationConfig(int portalID)
             : base(portalID)
         {

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthClientBase.cs
@@ -44,7 +44,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
         private const string OAuthClientIdKey = "client_id";
         private const string OAuthClientSecretKey = "client_secret";
         private const string OAuthRedirectUriKey = "redirect_uri";
-        private const string OAuthGrantTyepKey = "grant_type";
+        private const string OAuthGrantTypeKey = "grant_type";
         private const string OAuthCodeKey = "code";
 
         private const string UnreservedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
@@ -58,9 +58,9 @@ namespace DotNetNuke.Services.Authentication.OAuth
         private readonly Random random = new Random();
 
         /// <summary>Initializes a new instance of the <see cref="OAuthClientBase"/> class.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="mode"></param>
-        /// <param name="service"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="mode">The auth mode.</param>
+        /// <param name="service">The service name.</param>
         protected OAuthClientBase(int portalId, AuthMode mode, string service)
         {
             // Set default Expiry to 14 days
@@ -302,13 +302,13 @@ namespace DotNetNuke.Services.Authentication.OAuth
         /// <param name="url">The full url that needs to be signed including its non OAuth url parameters.</param>
         /// <param name="token">The token, if available. If not available pass null or an empty string.</param>
         /// <param name="tokenSecret">The token secret, if available. If not available pass null or an empty string.</param>
-        /// <param name="callbackurl"> </param>
+        /// <param name="callbackurl">The callback URL.</param>
         /// <param name="oauthVerifier">This value MUST be included when exchanging Request Tokens for Access Tokens. Otherwise pass a null or an empty string.</param>
         /// <param name="httpMethod">The http method used. Must be a valid HTTP method verb (POST,GET,PUT, etc).</param>
-        /// <param name="timeStamp"> </param>
-        /// <param name="nonce"> </param>
-        /// <param name="normalizedUrl"> </param>
-        /// <param name="requestParameters"> </param>
+        /// <param name="timeStamp">The Unix-formatted timestamp.</param>
+        /// <param name="nonce">The nonce.</param>
+        /// <param name="normalizedUrl">A normalized version of <paramref name="url"/>.</param>
+        /// <param name="requestParameters">The OAuth request parameters.</param>
         /// <returns>A base64 string of the hash value.</returns>
         public string GenerateSignature(Uri url, string token, string tokenSecret, string callbackurl, string oauthVerifier, string httpMethod, string timeStamp, string nonce, out string normalizedUrl, out List<QueryParameter> requestParameters)
         {
@@ -509,7 +509,7 @@ namespace DotNetNuke.Services.Authentication.OAuth
 
             // DNN-6265 Support for OAuth V2 Secrets which are not URL Friendly
             parameters.Add(new QueryParameter(OAuthClientSecretKey, HttpContext.Current.Server.UrlEncode(this.APISecret.ToString())));
-            parameters.Add(new QueryParameter(OAuthGrantTyepKey, "authorization_code"));
+            parameters.Add(new QueryParameter(OAuthGrantTypeKey, "authorization_code"));
             parameters.Add(new QueryParameter(OAuthCodeKey, this.VerificationCode));
 
             // DNN-6265 Support for OAuth V2 optional parameter

--- a/DNN Platform/Library/Services/Authentication/OAuth/OAuthConfigBase.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/OAuthConfigBase.cs
@@ -18,8 +18,8 @@ namespace DotNetNuke.Services.Authentication.OAuth
         private const string CacheKey = "Authentication";
 
         /// <summary>Initializes a new instance of the <see cref="OAuthConfigBase"/> class.</summary>
-        /// <param name="service"></param>
-        /// <param name="portalId"></param>
+        /// <param name="service">The service name (used as a prefix for settings and cache keys).</param>
+        /// <param name="portalId">The portal ID.</param>
         protected OAuthConfigBase(string service, int portalId)
             : base(portalId)
         {

--- a/DNN Platform/Library/Services/Authentication/OAuth/QueryParameter.cs
+++ b/DNN Platform/Library/Services/Authentication/OAuth/QueryParameter.cs
@@ -8,8 +8,8 @@ namespace DotNetNuke.Services.Authentication.OAuth
     public class QueryParameter
     {
         /// <summary>Initializes a new instance of the <see cref="QueryParameter"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="value"></param>
+        /// <param name="name">The name.</param>
+        /// <param name="value">The value.</param>
         public QueryParameter(string name, string value)
         {
             this.Name = name;

--- a/DNN Platform/Library/Services/Cache/DNNCacheDependency.cs
+++ b/DNN Platform/Library/Services/Cache/DNNCacheDependency.cs
@@ -26,14 +26,14 @@ namespace DotNetNuke.Services.Cache
         }
 
         /// <summary>Initializes a new instance of the <see cref="DNNCacheDependency"/> class that monitors a file or directory for changes.</summary>
-        /// <param name="filename"></param>
+        /// <param name="filename">The path to a file which the cache depends on.</param>
         public DNNCacheDependency(string filename)
         {
             this.fileNames = new[] { filename };
         }
 
         /// <summary>Initializes a new instance of the <see cref="DNNCacheDependency"/> class that monitors an array of paths (to files or directories) for changes.</summary>
-        /// <param name="filenames">set the cache depend on muti files.</param>
+        /// <param name="filenames">set the cache depend on multiple files.</param>
         public DNNCacheDependency(string[] filenames)
         {
             this.fileNames = filenames;

--- a/DNN Platform/Library/Services/Cache/PurgeCache.cs
+++ b/DNN Platform/Library/Services/Cache/PurgeCache.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Services.Cache
     public class PurgeCache : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="PurgeCache"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeCache(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem; // REQUIRED

--- a/DNN Platform/Library/Services/ClientDependency/PurgeClientDependencyFiles.cs
+++ b/DNN Platform/Library/Services/ClientDependency/PurgeClientDependencyFiles.cs
@@ -11,7 +11,7 @@ namespace DotNetNuke.Services.ClientDependency
     internal class PurgeClientDependencyFiles : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="PurgeClientDependencyFiles"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeClientDependencyFiles(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem; // REQUIRED

--- a/DNN Platform/Library/Services/Connections/ConnectorArgumentException.cs
+++ b/DNN Platform/Library/Services/Connections/ConnectorArgumentException.cs
@@ -14,15 +14,15 @@ namespace DotNetNuke.Services.Connections
         }
 
         /// <summary>Initializes a new instance of the <see cref="ConnectorArgumentException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">A message that describes the error.</param>
         public ConnectorArgumentException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ConnectorArgumentException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="innerException"></param>
+        /// <param name="message">A message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public ConnectorArgumentException(string message, Exception innerException)
             : base(message, innerException)
         {

--- a/DNN Platform/Library/Services/EventQueue/Config/SubscriberInfo.cs
+++ b/DNN Platform/Library/Services/EventQueue/Config/SubscriberInfo.cs
@@ -22,7 +22,7 @@ namespace DotNetNuke.Services.EventQueue.Config
         }
 
         /// <summary>Initializes a new instance of the <see cref="SubscriberInfo"/> class.</summary>
-        /// <param name="subscriberName"></param>
+        /// <param name="subscriberName">The subscriber name.</param>
         public SubscriberInfo(string subscriberName)
             : this()
         {

--- a/DNN Platform/Library/Services/Exceptions/ErrorContainer.cs
+++ b/DNN Platform/Library/Services/Exceptions/ErrorContainer.cs
@@ -16,24 +16,24 @@ namespace DotNetNuke.Services.Exceptions
     public class ErrorContainer : Control
     {
         /// <summary>Initializes a new instance of the <see cref="ErrorContainer"/> class.</summary>
-        /// <param name="strError"></param>
+        /// <param name="strError">The error message.</param>
         public ErrorContainer(string strError)
         {
             this.Container = this.FormatException(strError);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ErrorContainer"/> class.</summary>
-        /// <param name="strError"></param>
-        /// <param name="exc"></param>
+        /// <param name="strError">The error message.</param>
+        /// <param name="exc">The exception.</param>
         public ErrorContainer(string strError, Exception exc)
         {
             this.Container = this.FormatException(strError, exc);
         }
 
         /// <summary>Initializes a new instance of the <see cref="ErrorContainer"/> class.</summary>
-        /// <param name="portalSettings"></param>
-        /// <param name="strError"></param>
-        /// <param name="exc"></param>
+        /// <param name="portalSettings">The portal settings.</param>
+        /// <param name="strError">The error message.</param>
+        /// <param name="exc">The exception.</param>
         public ErrorContainer(PortalSettings portalSettings, string strError, Exception exc)
         {
             UserInfo objUserInfo = UserController.Instance.GetCurrentUserInfo();

--- a/DNN Platform/Library/Services/Exceptions/ExceptionInfo.cs
+++ b/DNN Platform/Library/Services/Exceptions/ExceptionInfo.cs
@@ -21,7 +21,7 @@ namespace DotNetNuke.Services.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="ExceptionInfo"/> class.</summary>
-        /// <param name="e"></param>
+        /// <param name="e">The exception.</param>
         public ExceptionInfo(Exception e)
         {
             this.Message = e.Message;

--- a/DNN Platform/Library/Services/Exceptions/ModuleLoadException.cs
+++ b/DNN Platform/Library/Services/Exceptions/ModuleLoadException.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with exception message
 
         /// <summary>Initializes a new instance of the <see cref="ModuleLoadException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public ModuleLoadException(string message)
             : base(message)
         {
@@ -37,9 +37,9 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with exception message
 
         /// <summary>Initializes a new instance of the <see cref="ModuleLoadException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
-        /// <param name="moduleConfiguration"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        /// <param name="moduleConfiguration">The module info.</param>
         public ModuleLoadException(string message, Exception inner, ModuleInfo moduleConfiguration)
             : base(message, inner)
         {
@@ -50,8 +50,8 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with message and inner exception
 
         /// <summary>Initializes a new instance of the <see cref="ModuleLoadException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public ModuleLoadException(string message, Exception inner)
             : base(message, inner)
         {
@@ -59,8 +59,8 @@ namespace DotNetNuke.Services.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleLoadException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected ModuleLoadException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Exceptions/ObjectHydrationException.cs
+++ b/DNN Platform/Library/Services/Exceptions/ObjectHydrationException.cs
@@ -14,18 +14,18 @@ namespace DotNetNuke.Services.Exceptions
         private Type type;
 
         /// <summary>Initializes a new instance of the <see cref="ObjectHydrationException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="innerException"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public ObjectHydrationException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObjectHydrationException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="innerException"></param>
-        /// <param name="type"></param>
-        /// <param name="dr"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        /// <param name="type">The type being hydrated.</param>
+        /// <param name="dr">The data reader (for getting column names).</param>
         public ObjectHydrationException(string message, Exception innerException, Type type, IDataReader dr)
             : base(message, innerException)
         {
@@ -38,8 +38,8 @@ namespace DotNetNuke.Services.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="ObjectHydrationException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected ObjectHydrationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Exceptions/PageLoadException.cs
+++ b/DNN Platform/Library/Services/Exceptions/PageLoadException.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with exception message
 
         /// <summary>Initializes a new instance of the <see cref="PageLoadException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public PageLoadException(string message)
             : base(message)
         {
@@ -27,16 +27,16 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with message and inner exception
 
         /// <summary>Initializes a new instance of the <see cref="PageLoadException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public PageLoadException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PageLoadException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected PageLoadException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Exceptions/SchedulerException.cs
+++ b/DNN Platform/Library/Services/Exceptions/SchedulerException.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with exception message
 
         /// <summary>Initializes a new instance of the <see cref="SchedulerException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public SchedulerException(string message)
             : base(message)
         {
@@ -27,16 +27,16 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with message and inner exception
 
         /// <summary>Initializes a new instance of the <see cref="SchedulerException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public SchedulerException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="SchedulerException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected SchedulerException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Exceptions/SearchIndexEmptyException.cs
+++ b/DNN Platform/Library/Services/Exceptions/SearchIndexEmptyException.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Services.Exceptions
     public class SearchIndexEmptyException : Exception
     {
         /// <summary>Initializes a new instance of the <see cref="SearchIndexEmptyException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public SearchIndexEmptyException(string message)
             : base(message)
         {

--- a/DNN Platform/Library/Services/Exceptions/SecurityException.cs
+++ b/DNN Platform/Library/Services/Exceptions/SecurityException.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with exception message
 
         /// <summary>Initializes a new instance of the <see cref="SecurityException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public SecurityException(string message)
             : base(message)
         {
@@ -37,8 +37,8 @@ namespace DotNetNuke.Services.Exceptions
         // constructor with message and inner exception
 
         /// <summary>Initializes a new instance of the <see cref="SecurityException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public SecurityException(string message, Exception inner)
             : base(message, inner)
         {
@@ -46,8 +46,8 @@ namespace DotNetNuke.Services.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="SecurityException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected SecurityException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/FileAlreadyExistsException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/FileAlreadyExistsException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileAlreadyExistsException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public FileAlreadyExistsException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileAlreadyExistsException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public FileAlreadyExistsException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileAlreadyExistsException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public FileAlreadyExistsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/FileLockedException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/FileLockedException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileLockedException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public FileLockedException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileLockedException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public FileLockedException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileLockedException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public FileLockedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/FolderAlreadyExistsException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/FolderAlreadyExistsException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderAlreadyExistsException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public FolderAlreadyExistsException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderAlreadyExistsException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public FolderAlreadyExistsException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderAlreadyExistsException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public FolderAlreadyExistsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/FolderProviderException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/FolderProviderException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderProviderException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public FolderProviderException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderProviderException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public FolderProviderException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderProviderException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public FolderProviderException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFileContentException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFileContentException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFileContentException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidFileContentException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFileContentException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidFileContentException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFileContentException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidFileContentException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFileExtensionException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFileExtensionException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFileExtensionException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidFileExtensionException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFileExtensionException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidFileExtensionException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFileExtensionException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidFileExtensionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFilenameException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFilenameException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFilenameException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidFilenameException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFilenameException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidFilenameException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFilenameException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidFilenameException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFolderPathException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidFolderPathException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFolderPathException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidFolderPathException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFolderPathException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidFolderPathException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidFolderPathException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidFolderPathException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidMetadataValuesException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/InvalidMetadataValuesException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidMetadataValuesException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public InvalidMetadataValuesException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidMetadataValuesException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public InvalidMetadataValuesException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="InvalidMetadataValuesException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public InvalidMetadataValuesException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/NoNetworkAvailableException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/NoNetworkAvailableException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="NoNetworkAvailableException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public NoNetworkAvailableException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="NoNetworkAvailableException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public NoNetworkAvailableException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="NoNetworkAvailableException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public NoNetworkAvailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/NoSpaceAvailableException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/NoSpaceAvailableException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="NoSpaceAvailableException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public NoSpaceAvailableException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="NoSpaceAvailableException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public NoSpaceAvailableException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="NoSpaceAvailableException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public NoSpaceAvailableException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/Exceptions/PermissionsNotMetException.cs
+++ b/DNN Platform/Library/Services/FileSystem/Exceptions/PermissionsNotMetException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="PermissionsNotMetException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public PermissionsNotMetException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PermissionsNotMetException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public PermissionsNotMetException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="PermissionsNotMetException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public PermissionsNotMetException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/FileSystem/FileInfo.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileInfo.cs
@@ -18,10 +18,7 @@ namespace DotNetNuke.Services.FileSystem
     using DotNetNuke.Instrumentation;
     using Newtonsoft.Json;
 
-    /// Project  : DotNetNuke
-    /// Class    : FileInfo
-    ///
-    /// <summary>  Represents the File object and holds the Properties of that object.</summary>
+    /// <summary>Represents the File object and holds the Properties of that object.</summary>
     [XmlRoot("file", IsNullable = false)]
     [Serializable]
     public class FileInfo : BaseEntityInfo, IHydratable, IFileInfo
@@ -44,55 +41,55 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileInfo"/> class.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="filename"></param>
-        /// <param name="extension"></param>
-        /// <param name="filesize"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="contentType"></param>
-        /// <param name="folder"></param>
-        /// <param name="folderId"></param>
-        /// <param name="storageLocation"></param>
-        /// <param name="cached"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="filename">The name of the file.</param>
+        /// <param name="extension">The extension of the file (without leading <c>.</c>).</param>
+        /// <param name="filesize">The length of the file in bytes.</param>
+        /// <param name="width">If the file is an image, the width of the image in pixels, otherwise <see cref="Null.NullInteger"/>.</param>
+        /// <param name="height">If the file is an image, the height of the image in pixels, otherwise <see cref="Null.NullInteger"/>.</param>
+        /// <param name="contentType">The content type of the file.</param>
+        /// <param name="folder">The folder path of the file's folder.</param>
+        /// <param name="folderId">The ID of the file's folder.</param>
+        /// <param name="storageLocation">The value of the <see cref="FolderController.StorageLocationTypes"/> for this file.</param>
+        /// <param name="cached">Whether the file is cached.</param>
         public FileInfo(int portalId, string filename, string extension, int filesize, int width, int height, string contentType, string folder, int folderId, int storageLocation, bool cached)
             : this(portalId, filename, extension, filesize, width, height, contentType, folder, folderId, storageLocation, cached, Null.NullString)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileInfo"/> class.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="filename"></param>
-        /// <param name="extension"></param>
-        /// <param name="filesize"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="contentType"></param>
-        /// <param name="folder"></param>
-        /// <param name="folderId"></param>
-        /// <param name="storageLocation"></param>
-        /// <param name="cached"></param>
-        /// <param name="hash"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="filename">The name of the file.</param>
+        /// <param name="extension">The extension of the file (without leading <c>.</c>).</param>
+        /// <param name="filesize">The length of the file in bytes.</param>
+        /// <param name="width">If the file is an image, the width of the image in pixels, otherwise <see cref="Null.NullInteger"/>.</param>
+        /// <param name="height">If the file is an image, the height of the image in pixels, otherwise <see cref="Null.NullInteger"/>.</param>
+        /// <param name="contentType">The content type of the file.</param>
+        /// <param name="folder">The folder path of the file's folder.</param>
+        /// <param name="folderId">The ID of the file's folder.</param>
+        /// <param name="storageLocation">The value of the <see cref="FolderController.StorageLocationTypes"/> for this file.</param>
+        /// <param name="cached">Whether the file is cached.</param>
+        /// <param name="hash">The SHA1 hash of the file contents.</param>
         public FileInfo(int portalId, string filename, string extension, int filesize, int width, int height, string contentType, string folder, int folderId, int storageLocation, bool cached, string hash)
             : this(Guid.NewGuid(), Guid.NewGuid(), portalId, filename, extension, filesize, width, height, contentType, folder, folderId, storageLocation, cached, hash)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="FileInfo"/> class.</summary>
-        /// <param name="uniqueId"></param>
-        /// <param name="versionGuid"></param>
-        /// <param name="portalId"></param>
-        /// <param name="filename"></param>
-        /// <param name="extension"></param>
-        /// <param name="filesize"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="contentType"></param>
-        /// <param name="folder"></param>
-        /// <param name="folderId"></param>
-        /// <param name="storageLocation"></param>
-        /// <param name="cached"></param>
-        /// <param name="hash"></param>
+        /// <param name="uniqueId">The unique ID of the file.</param>
+        /// <param name="versionGuid">The unique ID of the file version.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="filename">The name of the file.</param>
+        /// <param name="extension">The extension of the file (without leading <c>.</c>).</param>
+        /// <param name="filesize">The length of the file in bytes.</param>
+        /// <param name="width">If the file is an image, the width of the image in pixels, otherwise <see cref="Null.NullInteger"/>.</param>
+        /// <param name="height">If the file is an image, the height of the image in pixels, otherwise <see cref="Null.NullInteger"/>.</param>
+        /// <param name="contentType">The content type of the file.</param>
+        /// <param name="folder">The folder path of the file's folder.</param>
+        /// <param name="folderId">The ID of the file's folder.</param>
+        /// <param name="storageLocation">The value of the <see cref="FolderController.StorageLocationTypes"/> for this file.</param>
+        /// <param name="cached">Whether the file is cached.</param>
+        /// <param name="hash">The SHA1 hash of the file contents or <see cref="Null.NullString"/>.</param>
         public FileInfo(Guid uniqueId, Guid versionGuid, int portalId, string filename, string extension, int filesize, int width, int height, string contentType, string folder, int folderId, int storageLocation, bool cached, string hash)
         {
             this.UniqueId = uniqueId;

--- a/DNN Platform/Library/Services/FileSystem/FileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileManager.cs
@@ -1695,7 +1695,7 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Rotate/Flip the image as per the metadata and reset the metadata.</summary>
-        /// <param name="content"></param>
+        /// <param name="content">The image contents.</param>
         private void RotateFlipImage(ref Stream content)
         {
             try

--- a/DNN Platform/Library/Services/FileSystem/FolderInfo.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderInfo.cs
@@ -34,7 +34,7 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderInfo"/> class.</summary>
-        /// <param name="initialiseEmptyPermissions"></param>
+        /// <param name="initialiseEmptyPermissions">Whether to initialize the permissions to an empty collection.</param>
         internal FolderInfo(bool initialiseEmptyPermissions)
         {
             this.FolderID = Null.NullInteger;

--- a/DNN Platform/Library/Services/FileSystem/FolderMappings/FolderMappingInfo.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderMappings/FolderMappingInfo.cs
@@ -28,9 +28,9 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Initializes a new instance of the <see cref="FolderMappingInfo"/> class.</summary>
-        /// <param name="portalID"></param>
-        /// <param name="mappingName"></param>
-        /// <param name="folderProviderType"></param>
+        /// <param name="portalID">The portal ID.</param>
+        /// <param name="mappingName">The mapping name.</param>
+        /// <param name="folderProviderType">The name of the <see cref="Type"/> of the <see cref="FolderProvider"/>.</param>
         public FolderMappingInfo(int portalID, string mappingName, string folderProviderType)
         {
             this.FolderMappingID = Null.NullInteger;

--- a/DNN Platform/Library/Services/FileSystem/FolderMappings/IFolderMappingsConfigController.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderMappings/IFolderMappingsConfigController.cs
@@ -17,11 +17,11 @@ namespace DotNetNuke.Services.FileSystem.FolderMappings
         void LoadConfig();
 
         /// <summary>Save data in folderMappings config file.</summary>
-        /// <param name="folderMappinsSettings"></param>
+        /// <param name="folderMappinsSettings">The folder mapping settings XML.</param>
         void SaveConfig(string folderMappinsSettings);
 
         /// <summary>Gets the folderMapping configured for a specific folder.</summary>
-        /// <param name="portalId">Portal Id where the folder is.</param>
+        /// <param name="portalId">Portal ID where the folder is.</param>
         /// <param name="folderPath">Specific folder path.</param>
         /// <returns>A <see cref="FolderMappingInfo"/> instance or <see langword="null"/>.</returns>
         FolderMappingInfo GetFolderMapping(int portalId, string folderPath);

--- a/DNN Platform/Library/Services/FileSystem/FolderProvider.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderProvider.cs
@@ -166,7 +166,8 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         /// <summary>Moves a file to a new folder.</summary>
-        /// <param name="file"></param>
+        /// <param name="file">The file to move.</param>
+        /// <param name="destinationFolder">The folder to which <paramref name="file"/> is to be moved.</param>
         public virtual void MoveFile(IFileInfo file, IFolderInfo destinationFolder)
         {
             throw new NotImplementedException("This provider does not implement MoveFile");

--- a/DNN Platform/Library/Services/FileSystem/SynchronizeFileSystem.cs
+++ b/DNN Platform/Library/Services/FileSystem/SynchronizeFileSystem.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Services.FileSystem
     public class SynchronizeFileSystem : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="SynchronizeFileSystem"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public SynchronizeFileSystem(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem;

--- a/DNN Platform/Library/Services/GeneratedImage/GeneratedImage.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/GeneratedImage.cs
@@ -26,8 +26,8 @@ namespace DotNetNuke.Services.GeneratedImage
         }
 
         /// <summary>Initializes a new instance of the <see cref="GeneratedImage"/> class.</summary>
-        /// <param name="context"></param>
-        /// <param name="bindingContainer"></param>
+        /// <param name="context">The HTTP context.</param>
+        /// <param name="bindingContainer">The control into which the image should be rendered.</param>
         internal GeneratedImage(HttpContextBase context, Control bindingContainer)
             : this()
         {

--- a/DNN Platform/Library/Services/GeneratedImage/ImageHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageHandler.cs
@@ -15,8 +15,8 @@ namespace DotNetNuke.Services.GeneratedImage
     public abstract class ImageHandler : IHttpHandler
     {
         /// <summary>Initializes a new instance of the <see cref="ImageHandler"/> class.</summary>
-        /// <param name="imageStore"></param>
-        /// <param name="now"></param>
+        /// <param name="imageStore">The image store.</param>
+        /// <param name="now">The current <see cref="DateTime"/>.</param>
         internal ImageHandler(IImageStore imageStore, DateTime now)
             : this(new ImageHandlerInternal(imageStore, now))
         {

--- a/DNN Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageHandlerInternal.cs
@@ -42,8 +42,8 @@ namespace DotNetNuke.Services.GeneratedImage
         }
 
         /// <summary>Initializes a new instance of the <see cref="ImageHandlerInternal"/> class.</summary>
-        /// <param name="imageStore"></param>
-        /// <param name="now"></param>
+        /// <param name="imageStore">The image store.</param>
+        /// <param name="now">The current <see cref="DateTime"/>.</param>
         internal ImageHandlerInternal(IImageStore imageStore, DateTime now)
             : this()
         {

--- a/DNN Platform/Library/Services/GeneratedImage/ImageInfo.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageInfo.cs
@@ -12,14 +12,14 @@ namespace DotNetNuke.Services.GeneratedImage
     public class ImageInfo
     {
         /// <summary>Initializes a new instance of the <see cref="ImageInfo"/> class.</summary>
-        /// <param name="statusCode"></param>
+        /// <param name="statusCode">The HTTP status code.</param>
         public ImageInfo(HttpStatusCode statusCode)
         {
             this.HttpStatusCode = statusCode;
         }
 
         /// <summary>Initializes a new instance of the <see cref="ImageInfo"/> class.</summary>
-        /// <param name="image"></param>
+        /// <param name="image">The image.</param>
         public ImageInfo(Image image)
         {
             if (image == null)
@@ -31,7 +31,7 @@ namespace DotNetNuke.Services.GeneratedImage
         }
 
         /// <summary>Initializes a new instance of the <see cref="ImageInfo"/> class.</summary>
-        /// <param name="imageBuffer"></param>
+        /// <param name="imageBuffer">An array of bytes representing the contents of the image.</param>
         public ImageInfo(byte[] imageBuffer)
         {
             if (imageBuffer == null)

--- a/DNN Platform/Library/Services/GeneratedImage/ImageQuantization/Quantizer.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageQuantization/Quantizer.cs
@@ -247,7 +247,7 @@ namespace DotNetNuke.Services.GeneratedImage.ImageQuantization
             public int ARGB;
 
             /// <summary>Initializes a new instance of the <see cref="Color32"/> struct.</summary>
-            /// <param name="pSourcePixel"></param>
+            /// <param name="pSourcePixel">A pointer to the value.</param>
             public Color32(IntPtr pSourcePixel)
             {
                 this = (Color32)Marshal.PtrToStructure(pSourcePixel, typeof(Color32));

--- a/DNN Platform/Library/Services/GeneratedImage/ImageTransform.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ImageTransform.cs
@@ -33,7 +33,7 @@ namespace DotNetNuke.Services.GeneratedImage
         public abstract Image ProcessImage(Image image);
 
         /// <summary>Creates a new image from stream. The created image is independent of the stream.</summary>
-        /// <param name="imgStream"></param>
+        /// <param name="imgStream">A stream with the contents of the image to copy.</param>
         /// <returns>Image object.</returns>
         public virtual Bitmap CopyImage(Stream imgStream)
         {

--- a/DNN Platform/Library/Services/GeneratedImage/ProfileEventHandler.cs
+++ b/DNN Platform/Library/Services/GeneratedImage/ProfileEventHandler.cs
@@ -17,8 +17,8 @@ namespace DotNetNuke.Services.GeneratedImage
     public class ProfileEventHandler : IProfileEventHandlers
     {
         /// <summary>This method add the updated user id into cache to clear image from disk before returning to UI.</summary>
-        /// <param name="sender"></param>
-        /// <param name="profileArgs"></param>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="profileArgs">The event arguments.</param>
         public void ProfileUpdated(object sender, ProfileEventArgs profileArgs)
         {
             if (profileArgs?.User == null || profileArgs.OldProfile == null)

--- a/DNN Platform/Library/Services/Installer/Installers/LanguageInstaller.cs
+++ b/DNN Platform/Library/Services/Installer/Installers/LanguageInstaller.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke.Services.Installer.Installers
         private Locale tempLanguage;
 
         /// <summary>Initializes a new instance of the <see cref="LanguageInstaller"/> class.</summary>
-        /// <param name="type"></param>
+        /// <param name="type">The language pack type.</param>
         public LanguageInstaller(LanguagePackType type)
         {
             this.languagePackType = type;

--- a/DNN Platform/Library/Services/Installer/LegacyUtil.cs
+++ b/DNN Platform/Library/Services/Installer/LegacyUtil.cs
@@ -171,7 +171,7 @@ namespace DotNetNuke.Services.Installer
             var skinWriter = new SkinPackageWriter(skin, package, tempInstallFolder, subFolder);
             skinWriter.GetFiles(false);
 
-            // We need to reset the BasePath so it using the correct basePath rather than the Temp InstallFolder
+            // We need to reset the BasePath so it's using the correct basePath rather than the Temp InstallFolder
             skinWriter.SetBasePath();
 
             // Writer package manifest fragment to writer

--- a/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
+++ b/DNN Platform/Library/Services/Installer/Packages/PackageController.cs
@@ -339,7 +339,7 @@ namespace DotNetNuke.Services.Installer.Packages
         }
 
         /// <summary>Save or update the package.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package.</param>
         public void SaveExtensionPackage(PackageInfo package)
         {
             if (package.PackageID == Null.NullInteger)

--- a/DNN Platform/Library/Services/Installer/Writers/AssemblyComponentWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/AssemblyComponentWriter.cs
@@ -14,9 +14,9 @@ namespace DotNetNuke.Services.Installer.Writers
     public class AssemblyComponentWriter : FileComponentWriter
     {
         /// <summary>Initializes a new instance of the <see cref="AssemblyComponentWriter"/> class.</summary>
-        /// <param name="basePath"></param>
-        /// <param name="assemblies"></param>
-        /// <param name="package"></param>
+        /// <param name="basePath">The assembly file base path.</param>
+        /// <param name="assemblies">The assembly files.</param>
+        /// <param name="package">The package info.</param>
         public AssemblyComponentWriter(string basePath, Dictionary<string, InstallFile> assemblies, PackageInfo package)
             : base(basePath, assemblies, package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/AuthenticationPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/AuthenticationPackageWriter.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Services.Installer.Writers
     public class AuthenticationPackageWriter : PackageWriterBase
     {
         /// <summary>Initializes a new instance of the <see cref="AuthenticationPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public AuthenticationPackageWriter(PackageInfo package)
             : base(package)
         {
@@ -22,8 +22,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="AuthenticationPackageWriter"/> class.</summary>
-        /// <param name="authSystem"></param>
-        /// <param name="package"></param>
+        /// <param name="authSystem">The auth system info.</param>
+        /// <param name="package">The package info.</param>
         public AuthenticationPackageWriter(AuthenticationInfo authSystem, PackageInfo package)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/ContainerComponentWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ContainerComponentWriter.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke.Services.Installer.Writers
         /// <param name="containerName">The name of the Container.</param>
         /// <param name="basePath">The Base Path for the files.</param>
         /// <param name="files">A Dictionary of files.</param>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public ContainerComponentWriter(string containerName, string basePath, Dictionary<string, InstallFile> files, PackageInfo package)
             : base(containerName, basePath, files, package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/ContainerPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ContainerPackageWriter.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Services.Installer.Writers
     public class ContainerPackageWriter : SkinPackageWriter
     {
         /// <summary>Initializes a new instance of the <see cref="ContainerPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public ContainerPackageWriter(PackageInfo package)
             : base(package)
         {
@@ -20,8 +20,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="ContainerPackageWriter"/> class.</summary>
-        /// <param name="skinPackage"></param>
-        /// <param name="package"></param>
+        /// <param name="skinPackage">The skin package info.</param>
+        /// <param name="package">The package info.</param>
         public ContainerPackageWriter(SkinPackageInfo skinPackage, PackageInfo package)
             : base(skinPackage, package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/LanguagePackWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/LanguagePackWriter.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Services.Installer.Writers
         private LanguagePackInfo languagePack;
 
         /// <summary>Initializes a new instance of the <see cref="LanguagePackWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public LanguagePackWriter(PackageInfo package)
             : base(package)
         {
@@ -50,8 +50,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="LanguagePackWriter"/> class.</summary>
-        /// <param name="manifestNav"></param>
-        /// <param name="installer"></param>
+        /// <param name="manifestNav">The XPath navigator for the manifest section.</param>
+        /// <param name="installer">The installer info.</param>
         public LanguagePackWriter(XPathNavigator manifestNav, InstallerInfo installer)
         {
             this.language = new Locale();
@@ -83,8 +83,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="LanguagePackWriter"/> class.</summary>
-        /// <param name="language"></param>
-        /// <param name="package"></param>
+        /// <param name="language">The locale.</param>
+        /// <param name="package">The package info.</param>
         public LanguagePackWriter(Locale language, PackageInfo package)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/LibraryPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/LibraryPackageWriter.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.Services.Installer.Writers
     public class LibraryPackageWriter : PackageWriterBase
     {
         /// <summary>Initializes a new instance of the <see cref="LibraryPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public LibraryPackageWriter(PackageInfo package)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/ModulePackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ModulePackageWriter.cs
@@ -24,8 +24,8 @@ namespace DotNetNuke.Services.Installer.Writers
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ModulePackageWriter));
 
         /// <summary>Initializes a new instance of the <see cref="ModulePackageWriter"/> class.</summary>
-        /// <param name="manifestNav"></param>
-        /// <param name="installer"></param>
+        /// <param name="manifestNav">The legacy manifest XPath navigator.</param>
+        /// <param name="installer">The installer info.</param>
         public ModulePackageWriter(XPathNavigator manifestNav, InstallerInfo installer)
         {
             this.DesktopModule = new DesktopModuleInfo();
@@ -51,9 +51,9 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePackageWriter"/> class.</summary>
-        /// <param name="desktopModule"></param>
-        /// <param name="manifestNav"></param>
-        /// <param name="package"></param>
+        /// <param name="desktopModule">The desktop module info.</param>
+        /// <param name="manifestNav">The legacy manifest XPath navigator or <see langword="null"/>.</param>
+        /// <param name="package">The package info.</param>
         public ModulePackageWriter(DesktopModuleInfo desktopModule, XPathNavigator manifestNav, PackageInfo package)
             : base(package)
         {
@@ -70,7 +70,7 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public ModulePackageWriter(PackageInfo package)
             : base(package)
         {
@@ -79,8 +79,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModulePackageWriter"/> class.</summary>
-        /// <param name="desktopModule"></param>
-        /// <param name="package"></param>
+        /// <param name="desktopModule">The desktop module info.</param>
+        /// <param name="package">The package info.</param>
         public ModulePackageWriter(DesktopModuleInfo desktopModule, PackageInfo package)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/ProviderPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ProviderPackageWriter.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Services.Installer.Writers
     public class ProviderPackageWriter : PackageWriterBase
     {
         /// <summary>Initializes a new instance of the <see cref="ProviderPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public ProviderPackageWriter(PackageInfo package)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/ResourceFileComponentWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ResourceFileComponentWriter.cs
@@ -19,7 +19,7 @@ namespace DotNetNuke.Services.Installer.Writers
         /// </summary>
         /// <param name="basePath">The Base Path for the files.</param>
         /// <param name="files">A Dictionary of files.</param>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public ResourceFileComponentWriter(string basePath, Dictionary<string, InstallFile> files, PackageInfo package)
             : base(basePath, files, package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/ScriptComponentWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/ScriptComponentWriter.cs
@@ -18,9 +18,9 @@ namespace DotNetNuke.Services.Installer.Writers
     public class ScriptComponentWriter : FileComponentWriter
     {
         /// <summary>Initializes a new instance of the <see cref="ScriptComponentWriter"/> class.</summary>
-        /// <param name="basePath"></param>
-        /// <param name="scripts"></param>
-        /// <param name="package"></param>
+        /// <param name="basePath">The script files base path.</param>
+        /// <param name="scripts">The script files.</param>
+        /// <param name="package">The package info.</param>
         public ScriptComponentWriter(string basePath, Dictionary<string, InstallFile> scripts, PackageInfo package)
             : base(basePath, scripts, package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/SkinControlPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/SkinControlPackageWriter.cs
@@ -16,7 +16,7 @@ namespace DotNetNuke.Services.Installer.Writers
     public class SkinControlPackageWriter : PackageWriterBase
     {
         /// <summary>Initializes a new instance of the <see cref="SkinControlPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public SkinControlPackageWriter(PackageInfo package)
             : base(package)
         {
@@ -26,8 +26,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="SkinControlPackageWriter"/> class.</summary>
-        /// <param name="skinControl"></param>
-        /// <param name="package"></param>
+        /// <param name="skinControl">The skin control info.</param>
+        /// <param name="package">The package info.</param>
         public SkinControlPackageWriter(SkinControlInfo skinControl, PackageInfo package)
             : base(package)
         {
@@ -37,8 +37,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="SkinControlPackageWriter"/> class.</summary>
-        /// <param name="manifestNav"></param>
-        /// <param name="installer"></param>
+        /// <param name="manifestNav">The XPath navigator for the legacy manifest.</param>
+        /// <param name="installer">The installer info.</param>
         public SkinControlPackageWriter(XPathNavigator manifestNav, InstallerInfo installer)
         {
             this.SkinControl = new SkinControlInfo();

--- a/DNN Platform/Library/Services/Installer/Writers/SkinPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/SkinPackageWriter.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Services.Installer.Writers
         private readonly string subFolder;
 
         /// <summary>Initializes a new instance of the <see cref="SkinPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public SkinPackageWriter(PackageInfo package)
             : base(package)
         {
@@ -26,8 +26,8 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="SkinPackageWriter"/> class.</summary>
-        /// <param name="skinPackage"></param>
-        /// <param name="package"></param>
+        /// <param name="skinPackage">The skin package info.</param>
+        /// <param name="package">The package info.</param>
         public SkinPackageWriter(SkinPackageInfo skinPackage, PackageInfo package)
             : base(package)
         {
@@ -36,9 +36,9 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="SkinPackageWriter"/> class.</summary>
-        /// <param name="skinPackage"></param>
-        /// <param name="package"></param>
-        /// <param name="basePath"></param>
+        /// <param name="skinPackage">The skin package info.</param>
+        /// <param name="package">The package info.</param>
+        /// <param name="basePath">The base path for the skin.</param>
         public SkinPackageWriter(SkinPackageInfo skinPackage, PackageInfo package, string basePath)
             : base(package)
         {
@@ -47,10 +47,10 @@ namespace DotNetNuke.Services.Installer.Writers
         }
 
         /// <summary>Initializes a new instance of the <see cref="SkinPackageWriter"/> class.</summary>
-        /// <param name="skinPackage"></param>
-        /// <param name="package"></param>
-        /// <param name="basePath"></param>
-        /// <param name="subFolder"></param>
+        /// <param name="skinPackage">The skin package info.</param>
+        /// <param name="package">The package info.</param>
+        /// <param name="basePath">The base path for the skin.</param>
+        /// <param name="subFolder">The folder under <paramref name="basePath"/> for this skin.</param>
         public SkinPackageWriter(SkinPackageInfo skinPackage, PackageInfo package, string basePath, string subFolder)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/WidgetComponentWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/WidgetComponentWriter.cs
@@ -11,9 +11,9 @@ namespace DotNetNuke.Services.Installer.Writers
     public class WidgetComponentWriter : FileComponentWriter
     {
         /// <summary>Initializes a new instance of the <see cref="WidgetComponentWriter"/> class.</summary>
-        /// <param name="basePath"></param>
-        /// <param name="files"></param>
-        /// <param name="package"></param>
+        /// <param name="basePath">The base path.</param>
+        /// <param name="files">The files.</param>
+        /// <param name="package">The package.</param>
         public WidgetComponentWriter(string basePath, Dictionary<string, InstallFile> files, PackageInfo package)
             : base(basePath, files, package)
         {

--- a/DNN Platform/Library/Services/Installer/Writers/WidgetPackageWriter.cs
+++ b/DNN Platform/Library/Services/Installer/Writers/WidgetPackageWriter.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Services.Installer.Writers
     public class WidgetPackageWriter : PackageWriterBase
     {
         /// <summary>Initializes a new instance of the <see cref="WidgetPackageWriter"/> class.</summary>
-        /// <param name="package"></param>
+        /// <param name="package">The package info.</param>
         public WidgetPackageWriter(PackageInfo package)
             : base(package)
         {

--- a/DNN Platform/Library/Services/Installer/XmlMerge.cs
+++ b/DNN Platform/Library/Services/Installer/XmlMerge.cs
@@ -24,9 +24,9 @@ namespace DotNetNuke.Services.Installer
         private IDictionary<string, XmlDocument> pendingDocuments;
 
         /// <summary>Initializes a new instance of the <see cref="XmlMerge"/> class.</summary>
-        /// <param name="version"></param>
-        /// <param name="sender"></param>
-        /// <param name="sourceFileName"></param>
+        /// <param name="sourceFileName">The path to the XML merge file.</param>
+        /// <param name="version">The version for which the merge is being done.</param>
+        /// <param name="sender">The name of the component responsible for the merge.</param>
         public XmlMerge(string sourceFileName, string version, string sender)
         {
             this.Version = version;
@@ -36,9 +36,9 @@ namespace DotNetNuke.Services.Installer
         }
 
         /// <summary>Initializes a new instance of the <see cref="XmlMerge"/> class.</summary>
-        /// <param name="version"></param>
-        /// <param name="sender"></param>
-        /// <param name="sourceStream"></param>
+        /// <param name="sourceStream">A stream with the source config.</param>
+        /// <param name="version">The version for which the merge is being done.</param>
+        /// <param name="sender">The name of the component responsible for the merge.</param>
         public XmlMerge(Stream sourceStream, string version, string sender)
         {
             this.Version = version;
@@ -48,9 +48,9 @@ namespace DotNetNuke.Services.Installer
         }
 
         /// <summary>Initializes a new instance of the <see cref="XmlMerge"/> class.</summary>
-        /// <param name="version"></param>
-        /// <param name="sender"></param>
-        /// <param name="sourceReader"></param>
+        /// <param name="sourceReader">A reader with the source config.</param>
+        /// <param name="version">The version for which the merge is being done.</param>
+        /// <param name="sender">The name of the component responsible for the merge.</param>
         public XmlMerge(TextReader sourceReader, string version, string sender)
         {
             this.Version = version;
@@ -60,9 +60,9 @@ namespace DotNetNuke.Services.Installer
         }
 
         /// <summary>Initializes a new instance of the <see cref="XmlMerge"/> class.</summary>
-        /// <param name="version"></param>
-        /// <param name="sender"></param>
-        /// <param name="sourceDoc"></param>
+        /// <param name="sourceDoc">A document with the source config.</param>
+        /// <param name="version">The version for which the merge is being done.</param>
+        /// <param name="sender">The name of the component responsible for the merge.</param>
         public XmlMerge(XmlDocument sourceDoc, string version, string sender)
         {
             this.Version = version;

--- a/DNN Platform/Library/Services/Journal/Content.cs
+++ b/DNN Platform/Library/Services/Journal/Content.cs
@@ -134,7 +134,7 @@ namespace DotNetNuke.Services.Journal
         }
 
         /// <summary>Creates the content text.</summary>
-        /// <param name="objJournalItem"></param>
+        /// <param name="objJournalItem">The journal item.</param>
         /// <returns>The content body or <see langword="null"/>.</returns>
         private static string GetContentBody(JournalItem objJournalItem)
         {

--- a/DNN Platform/Library/Services/Journal/JournalControllerImpl.cs
+++ b/DNN Platform/Library/Services/Journal/JournalControllerImpl.cs
@@ -406,50 +406,50 @@ namespace DotNetNuke.Services.Journal
         // Delete Journal Items
 
         /// <summary>HARD deletes journal items.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="currentUserId"></param>
-        /// <param name="journalId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="currentUserId">The user ID.</param>
+        /// <param name="journalId">The journal ID.</param>
         public void DeleteJournalItem(int portalId, int currentUserId, int journalId)
         {
             this.DeleteJournalItem(portalId, currentUserId, journalId, false);
         }
 
         /// <summary>HARD deletes journal items based on item key.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="objectKey"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="objectKey">The key.</param>
         public void DeleteJournalItemByKey(int portalId, string objectKey)
         {
             this.dataService.Journal_DeleteByKey(portalId, objectKey);
         }
 
-        /// <summary>HARD deletes journal items based on group Id.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="groupId"></param>
+        /// <summary>HARD deletes journal items based on group ID.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="groupId">The group ID.</param>
         public void DeleteJournalItemByGroupId(int portalId, int groupId)
         {
             this.dataService.Journal_DeleteByGroupId(portalId, groupId);
         }
 
         /// <summary>SOFT deletes journal items.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="currentUserId"></param>
-        /// <param name="journalId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="currentUserId">The user ID.</param>
+        /// <param name="journalId">The journal ID.</param>
         public void SoftDeleteJournalItem(int portalId, int currentUserId, int journalId)
         {
             this.DeleteJournalItem(portalId, currentUserId, journalId, true);
         }
 
         /// <summary>SOFT deletes journal items based on item key.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="objectKey"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="objectKey">The key.</param>
         public void SoftDeleteJournalItemByKey(int portalId, string objectKey)
         {
             this.dataService.Journal_SoftDeleteByKey(portalId, objectKey);
         }
 
-        /// <summary>SOFT deletes journal items based on group Id.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="groupId"></param>
+        /// <summary>SOFT deletes journal items based on group ID.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="groupId">The group ID.</param>
         public void SoftDeleteJournalItemByGroupId(int portalId, int groupId)
         {
             this.dataService.Journal_SoftDeleteByGroupId(portalId, groupId);

--- a/DNN Platform/Library/Services/Journal/JournalEntity.cs
+++ b/DNN Platform/Library/Services/Journal/JournalEntity.cs
@@ -16,7 +16,7 @@ namespace DotNetNuke.Services.Journal
         }
 
         /// <summary>Initializes a new instance of the <see cref="JournalEntity"/> class.</summary>
-        /// <param name="entityXML"></param>
+        /// <param name="entityXML">XML serialized entity.</param>
         public JournalEntity(string entityXML)
         {
             if (!string.IsNullOrEmpty(entityXML))

--- a/DNN Platform/Library/Services/Localization/CultureInfoComparer.cs
+++ b/DNN Platform/Library/Services/Localization/CultureInfoComparer.cs
@@ -11,7 +11,7 @@ namespace DotNetNuke.Services.Localization
         private readonly string compare;
 
         /// <summary>Initializes a new instance of the <see cref="CultureInfoComparer"/> class.</summary>
-        /// <param name="compareBy"></param>
+        /// <param name="compareBy"><c>"ENGLISH"</c> to compare by <see cref="CultureInfo.EnglishName"/>, <c>"NATIVE"</c> to compare by <see cref="CultureInfo.NativeName"/>, or anything else to compare by <see cref="CultureInfo.Name"/>.</param>
         public CultureInfoComparer(string compareBy)
         {
             this.compare = compareBy;

--- a/DNN Platform/Library/Services/Localization/Localization.cs
+++ b/DNN Platform/Library/Services/Localization/Localization.cs
@@ -1114,10 +1114,10 @@ namespace DotNetNuke.Services.Localization
         /// <para>This overload allows us to filter a language from the dropdown. To do so pass a language code to the Filter parameter.</para>
         /// <para>This overload allows us to display all installed languages. To do so, pass the value True to the Host parameter.</para>
         /// </summary>
-        /// <param name="displayType"></param>
-        /// <param name="selectedValue"></param>
-        /// <param name="filter"></param>
-        /// <param name="host"></param>
+        /// <param name="displayType">The <see cref="CultureDropDownTypes"/>.</param>
+        /// <param name="selectedValue">The selected value.</param>
+        /// <param name="filter">The value to exclude from the list.</param>
+        /// <param name="host">Whether to get host-level locales or the locales for the current portal.</param>
         /// <returns>A sequence of new <see cref="ListItem"/> instances.</returns>
         public static IEnumerable<ListItem> LoadCultureInListItems(CultureDropDownTypes displayType, string selectedValue, string filter, bool host)
         {
@@ -1259,8 +1259,8 @@ namespace DotNetNuke.Services.Localization
             }
         }
 
-        /// <summary>Localizes headers and fields on a DetailsView control.</summary>
-        /// <param name="detailsView"></param>
+        /// <summary>Localizes headers and fields on a <see cref="DetailsView"/> control.</summary>
+        /// <param name="detailsView">The <see cref="DetailsView"/> to localize.</param>
         /// <param name="resourceFile">The root name of the resource file where the localized texts can be found.</param>
         public static void LocalizeDetailsView(ref DetailsView detailsView, string resourceFile)
         {

--- a/DNN Platform/Library/Services/Log/EventLog/LogDetailInfo.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/LogDetailInfo.cs
@@ -20,8 +20,8 @@ namespace DotNetNuke.Services.Log.EventLog
         }
 
         /// <summary>Initializes a new instance of the <see cref="LogDetailInfo"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="value"></param>
+        /// <param name="name">The name.</param>
+        /// <param name="value">The value.</param>
         public LogDetailInfo(string name, string value)
         {
             this.PropertyName = name;

--- a/DNN Platform/Library/Services/Log/EventLog/LogInfo.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/LogInfo.cs
@@ -30,7 +30,7 @@ namespace DotNetNuke.Services.Log.EventLog
         }
 
         /// <summary>Initializes a new instance of the <see cref="LogInfo"/> class.</summary>
-        /// <param name="content"></param>
+        /// <param name="content">XML serialized log info.</param>
         public LogInfo(string content)
             : this()
         {

--- a/DNN Platform/Library/Services/Log/EventLog/PurgeLogBuffer.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/PurgeLogBuffer.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Services.Log.EventLog
     public class PurgeLogBuffer : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="PurgeLogBuffer"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeLogBuffer(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem;

--- a/DNN Platform/Library/Services/Log/EventLog/SendLogNotifications.cs
+++ b/DNN Platform/Library/Services/Log/EventLog/SendLogNotifications.cs
@@ -10,7 +10,7 @@ namespace DotNetNuke.Services.Log.EventLog
     public class SendLogNotifications : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="SendLogNotifications"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public SendLogNotifications(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem;

--- a/DNN Platform/Library/Services/Mail/MailAttachment.cs
+++ b/DNN Platform/Library/Services/Mail/MailAttachment.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Services.Mail
         private const string DefaultContentType = "application/octet-stream";
 
         /// <summary>Initializes a new instance of the <see cref="MailAttachment"/> class.</summary>
-        /// <param name="filePath"></param>
+        /// <param name="filePath">The path to the file to attach.</param>
         public MailAttachment(string filePath)
         {
             var content = File.ReadAllBytes(filePath);
@@ -24,17 +24,17 @@ namespace DotNetNuke.Services.Mail
         }
 
         /// <summary>Initializes a new instance of the <see cref="MailAttachment"/> class.</summary>
-        /// <param name="filename"></param>
-        /// <param name="content"></param>
+        /// <param name="filename">The name of the attachment.</param>
+        /// <param name="content">The contents of the attachment.</param>
         public MailAttachment(string filename, byte[] content)
         {
             this.MailAttachmentInternal(filename, content, MimeMapping.GetMimeMapping(filename));
         }
 
         /// <summary>Initializes a new instance of the <see cref="MailAttachment"/> class.</summary>
-        /// <param name="filename"></param>
-        /// <param name="content"></param>
-        /// <param name="contentType"></param>
+        /// <param name="filename">The name of the attachment.</param>
+        /// <param name="content">The contents of the attachment.</param>
+        /// <param name="contentType">The MIME content type of the attachment.</param>
         public MailAttachment(string filename, byte[] content, string contentType)
         {
             this.MailAttachmentInternal(filename, content, contentType);

--- a/DNN Platform/Library/Services/Mail/SendTokenizedBulkEmail.cs
+++ b/DNN Platform/Library/Services/Mail/SendTokenizedBulkEmail.cs
@@ -70,11 +70,11 @@ namespace DotNetNuke.Services.Mail
         }
 
         /// <summary>Initializes a new instance of the <see cref="SendTokenizedBulkEmail"/> class.</summary>
-        /// <param name="addressedRoles"></param>
-        /// <param name="addressedUsers"></param>
-        /// <param name="removeDuplicates"></param>
-        /// <param name="subject"></param>
-        /// <param name="body"></param>
+        /// <param name="addressedRoles">The names of the roles to which the email is addressed.</param>
+        /// <param name="addressedUsers">The users to which the email is addressed.</param>
+        /// <param name="removeDuplicates">Whether to remove duplicate recipients.</param>
+        /// <param name="subject">The email's subject.</param>
+        /// <param name="body">The email's body.</param>
         public SendTokenizedBulkEmail(List<string> addressedRoles, List<UserInfo> addressedUsers, bool removeDuplicates, string subject, string body)
         {
             this.ReportRecipients = true;

--- a/DNN Platform/Library/Services/Mobile/RedirectionController.cs
+++ b/DNN Platform/Library/Services/Mobile/RedirectionController.cs
@@ -462,7 +462,7 @@ namespace DotNetNuke.Services.Mobile
         }
 
         /// <summary>Deletes all redirection rules that were set for pages that have been soft or hard deleted.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         public void PurgeInvalidRedirections(int portalId)
         {
             var allTabs = TabController.Instance.GetTabsByPortal(portalId);
@@ -568,9 +568,9 @@ namespace DotNetNuke.Services.Mobile
         }
 
         /// <summary>returns a target URL for the specific redirection.</summary>
-        /// <param name="redirection"></param>
-        /// <param name="portalId"></param>
-        /// <param name="currentTabId"></param>
+        /// <param name="redirection">The redirection rule.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="currentTabId">The tab ID.</param>
         /// <returns>The URL (or <see cref="string.Empty"/> if there's no redirect).</returns>
         public string GetRedirectUrlFromRule(IRedirection redirection, int portalId, int currentTabId)
         {

--- a/DNN Platform/Library/Services/ModuleCache/PurgeModuleCache.cs
+++ b/DNN Platform/Library/Services/ModuleCache/PurgeModuleCache.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.Services.ModuleCache
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(PurgeModuleCache));
 
         /// <summary>Initializes a new instance of the <see cref="PurgeModuleCache"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeModuleCache(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem; // REQUIRED

--- a/DNN Platform/Library/Services/OutputCache/OutputCacheResponseFilter.cs
+++ b/DNN Platform/Library/Services/OutputCache/OutputCacheResponseFilter.cs
@@ -13,10 +13,10 @@ namespace DotNetNuke.Services.OutputCache
         private Stream captureStream;
 
         /// <summary>Initializes a new instance of the <see cref="OutputCacheResponseFilter"/> class.</summary>
-        /// <param name="filterChain"></param>
-        /// <param name="cacheKey"></param>
-        /// <param name="cacheDuration"></param>
-        /// <param name="maxVaryByCount"></param>
+        /// <param name="filterChain">The stream to write into <see cref="CaptureStream"/>.</param>
+        /// <param name="cacheKey">The cache key.</param>
+        /// <param name="cacheDuration">The duration for which the response should be cached.</param>
+        /// <param name="maxVaryByCount">The maximum number of values by which the cached response can vary.</param>
         public OutputCacheResponseFilter(Stream filterChain, string cacheKey, TimeSpan cacheDuration, int maxVaryByCount)
         {
             this.ChainedStream = filterChain;

--- a/DNN Platform/Library/Services/OutputCache/Providers/DatabaseResponseFilter.cs
+++ b/DNN Platform/Library/Services/OutputCache/Providers/DatabaseResponseFilter.cs
@@ -9,15 +9,15 @@ namespace DotNetNuke.Services.OutputCache.Providers
 
     using DotNetNuke.Data;
 
-    /// <summary>FileResponseFilter implements the OutputCacheRepsonseFilter to capture the response into database.</summary>
+    /// <summary>FileResponseFilter implements <see cref="OutputCacheResponseFilter"/> to capture the response into database.</summary>
     public class DatabaseResponseFilter : OutputCacheResponseFilter
     {
         /// <summary>Initializes a new instance of the <see cref="DatabaseResponseFilter"/> class.</summary>
-        /// <param name="itemId"></param>
-        /// <param name="maxVaryByCount"></param>
-        /// <param name="filterChain"></param>
-        /// <param name="cacheKey"></param>
-        /// <param name="cacheDuration"></param>
+        /// <param name="itemId">The tab ID.</param>
+        /// <param name="maxVaryByCount">The maximum number of values by which the cached response can vary.</param>
+        /// <param name="filterChain">The stream to write into the database.</param>
+        /// <param name="cacheKey">The cache key.</param>
+        /// <param name="cacheDuration">The duration for which the response should be cached.</param>
         internal DatabaseResponseFilter(int itemId, int maxVaryByCount, Stream filterChain, string cacheKey, TimeSpan cacheDuration)
             : base(filterChain, cacheKey, cacheDuration, maxVaryByCount)
         {

--- a/DNN Platform/Library/Services/OutputCache/Providers/FileResponseFilter.cs
+++ b/DNN Platform/Library/Services/OutputCache/Providers/FileResponseFilter.cs
@@ -10,18 +10,18 @@ namespace DotNetNuke.Services.OutputCache.Providers
 
     using DotNetNuke.Common.Utilities;
 
-    /// <summary>FileResponseFilter implements the OutputCacheRepsonseFilter to capture the response into files.</summary>
+    /// <summary>FileResponseFilter implements <see cref="OutputCacheResponseFilter"/> to capture the response into files.</summary>
     public class FileResponseFilter : OutputCacheResponseFilter
     {
         // Private _content As StringBuilder
         private DateTime cacheExpiration;
 
         /// <summary>Initializes a new instance of the <see cref="FileResponseFilter"/> class.</summary>
-        /// <param name="itemId"></param>
-        /// <param name="maxVaryByCount"></param>
-        /// <param name="filterChain"></param>
-        /// <param name="cacheKey"></param>
-        /// <param name="cacheDuration"></param>
+        /// <param name="itemId">The tab ID.</param>
+        /// <param name="maxVaryByCount">The maximum number of values by which the cached response can vary.</param>
+        /// <param name="filterChain">The stream to write into the file.</param>
+        /// <param name="cacheKey">The cache key.</param>
+        /// <param name="cacheDuration">The duration for which the response should be cached.</param>
         internal FileResponseFilter(int itemId, int maxVaryByCount, Stream filterChain, string cacheKey, TimeSpan cacheDuration)
             : base(filterChain, cacheKey, cacheDuration, maxVaryByCount)
         {

--- a/DNN Platform/Library/Services/OutputCache/Providers/MemoryResponseFilter.cs
+++ b/DNN Platform/Library/Services/OutputCache/Providers/MemoryResponseFilter.cs
@@ -9,18 +9,18 @@ namespace DotNetNuke.Services.OutputCache.Providers
     using System.Web;
     using System.Web.Caching;
 
-    /// <summary>FileResponseFilter implements the OutputCacheRepsonseFilter to capture the response into memory.</summary>
+    /// <summary>FileResponseFilter implements <see cref="OutputCacheResponseFilter"/> to capture the response into memory.</summary>
     public class MemoryResponseFilter : OutputCacheResponseFilter
     {
         // Private _content As StringBuilder
         private static System.Web.Caching.Cache runtimeCache;
 
         /// <summary>Initializes a new instance of the <see cref="MemoryResponseFilter"/> class.</summary>
-        /// <param name="itemId"></param>
-        /// <param name="maxVaryByCount"></param>
-        /// <param name="filterChain"></param>
-        /// <param name="cacheKey"></param>
-        /// <param name="cacheDuration"></param>
+        /// <param name="itemId">The tab ID.</param>
+        /// <param name="maxVaryByCount">The maximum number of values by which the cached response can vary.</param>
+        /// <param name="filterChain">The stream to write into the cache.</param>
+        /// <param name="cacheKey">The cache key.</param>
+        /// <param name="cacheDuration">The duration for which the response should be cached.</param>
         internal MemoryResponseFilter(int itemId, int maxVaryByCount, Stream filterChain, string cacheKey, TimeSpan cacheDuration)
             : base(filterChain, cacheKey, cacheDuration, maxVaryByCount)
         {

--- a/DNN Platform/Library/Services/OutputCache/PurgeOutputCache.cs
+++ b/DNN Platform/Library/Services/OutputCache/PurgeOutputCache.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.Services.OutputCache
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(PurgeOutputCache));
 
         /// <summary>Initializes a new instance of the <see cref="PurgeOutputCache"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeOutputCache(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem; // REQUIRED

--- a/DNN Platform/Library/Services/Scheduling/PurgeScheduleHistory.cs
+++ b/DNN Platform/Library/Services/Scheduling/PurgeScheduleHistory.cs
@@ -8,7 +8,7 @@ namespace DotNetNuke.Services.Scheduling
     public class PurgeScheduleHistory : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="PurgeScheduleHistory"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeScheduleHistory(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem;

--- a/DNN Platform/Library/Services/Scheduling/ScheduleHistoryItem.cs
+++ b/DNN Platform/Library/Services/Scheduling/ScheduleHistoryItem.cs
@@ -33,7 +33,7 @@ namespace DotNetNuke.Services.Scheduling
         }
 
         /// <summary>Initializes a new instance of the <see cref="ScheduleHistoryItem"/> class.</summary>
-        /// <param name="objScheduleItem"></param>
+        /// <param name="objScheduleItem">The schedule item.</param>
         public ScheduleHistoryItem(ScheduleItem objScheduleItem)
         {
             this.AttachToEvent = objScheduleItem.AttachToEvent;

--- a/DNN Platform/Library/Services/Scheduling/Scheduler.cs
+++ b/DNN Platform/Library/Services/Scheduling/Scheduler.cs
@@ -146,7 +146,7 @@ namespace DotNetNuke.Services.Scheduling
             }
 
             /// <summary>Adds an item to the collection of schedule items in queue.</summary>
-            /// <param name="scheduleHistoryItem"></param>
+            /// <param name="scheduleHistoryItem">The schedule history item.</param>
             /// <remarks>Thread Safe.</remarks>
             public static void AddToScheduleQueue(ScheduleHistoryItem scheduleHistoryItem)
             {
@@ -1367,7 +1367,7 @@ namespace DotNetNuke.Services.Scheduling
             }
 
             /// <summary>Removes an item from the collection of schedule items in progress.</summary>
-            /// <param name="scheduleItem"></param>
+            /// <param name="scheduleItem">The schedule item.</param>
             /// <remarks>Thread Safe.</remarks>
             private static void RemoveFromScheduleInProgress(ScheduleItem scheduleItem)
             {
@@ -1391,7 +1391,7 @@ namespace DotNetNuke.Services.Scheduling
             }
 
             /// <summary>Gets a schedulehistory item from the collection of schedule items in progress.</summary>
-            /// <param name="scheduleItem"></param>
+            /// <param name="scheduleItem">The schedule item.</param>
             /// <remarks>Thread Safe.</remarks>
             private static ScheduleHistoryItem GetScheduleItemFromScheduleInProgress(ScheduleItem scheduleItem)
             {

--- a/DNN Platform/Library/Services/Search/Internals/IInternalSearchController.cs
+++ b/DNN Platform/Library/Services/Search/Internals/IInternalSearchController.cs
@@ -32,22 +32,22 @@ namespace DotNetNuke.Services.Search.Internals
 
         /// <summary>Adds the collection of search documents to the search index.</summary>
         /// <remarks>The controller auto-commits at the end of this method.</remarks>
-        /// <param name="searchDocumentList"></param>
+        /// <param name="searchDocumentList">The search documents to all.</param>
         void AddSearchDocuments(IEnumerable<SearchDocument> searchDocumentList);
 
         /// <summary>Delete a Search Document from the Search Index. REQUIRES: searchDocument to have PortalId, UniqueKey, SearchTypeId properties set.</summary>
-        /// <param name="searchDocument"></param>
+        /// <param name="searchDocument">The search document to delete.</param>
         void DeleteSearchDocument(SearchDocument searchDocument);
 
         /// <summary>Delete all search documents related to a particular module.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="moduleId"></param>
-        /// <param name="moduleDefId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="moduleId">The module ID.</param>
+        /// <param name="moduleDefId">The module definition ID.</param>
         void DeleteSearchDocumentsByModule(int portalId, int moduleId, int moduleDefId);
 
         /// <summary>Deletes all documents of a specified portal and search type (used for re-index operation).</summary>
-        /// <param name="portalId"></param>
-        /// <param name="searchTypeId"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="searchTypeId">The search type ID.</param>
         void DeleteAllDocuments(int portalId, int searchTypeId);
 
         /// <summary>Commits individually added/deleted documents to the search index.</summary>

--- a/DNN Platform/Library/Services/Search/Internals/ISearchHelper.cs
+++ b/DNN Platform/Library/Services/Search/Internals/ISearchHelper.cs
@@ -39,50 +39,50 @@ namespace DotNetNuke.Services.Search.Internals
 
         /// <summary>Adds a synonyms group to system.</summary>
         /// <param name="synonymsTags">synonyms tags separated by comma, like this: <c>"dnn,dotnetnuke"</c>.</param>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="cultureCode">culture code.</param>
         /// <returns>The new synonyms group ID, or <c>0</c> if the input was invalid.</returns>
         int AddSynonymsGroup(string synonymsTags, int portalId, string cultureCode, out string duplicateWord);
 
         /// <summary>Updates a synonyms group.</summary>
-        /// <param name="synonymsGroupId"></param>
+        /// <param name="synonymsGroupId">The synonyms group ID.</param>
         /// <param name="synonymsTags">synonyms tags separated by comma, like this: <c>"dnn,dotnetnuke"</c>.</param>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="cultureCode">culture code.</param>
         /// <returns><paramref name="synonymsGroupId"/> or <c>0</c> if the input was invalid.</returns>
         int UpdateSynonymsGroup(int synonymsGroupId, string synonymsTags, int portalId, string cultureCode, out string duplicateWord);
 
         /// <summary>Deletes a synonyms group.</summary>
-        /// <param name="synonymsGroupId"></param>
-        /// <param name="portalId"></param>
+        /// <param name="synonymsGroupId">The synonyms group ID.</param>
+        /// <param name="portalId">The portal ID.</param>
         /// <param name="cultureCode">culture code.</param>
         void DeleteSynonymsGroup(int synonymsGroupId, int portalId, string cultureCode);
 
         /// <summary>Gets a search stop words.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
         /// <returns>A <see cref="SearchStopWords"/> instance or <see langword="null"/>.</returns>
         SearchStopWords GetSearchStopWords(int portalId, string cultureCode);
 
         /// <summary>Adds a search stop words.</summary>
-        /// <param name="stopWords"></param>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="stopWords">A comma-delimited list of stop words.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
         /// <returns>The new stop-words ID, or <c>0</c> if the input was invalid.</returns>
         int AddSearchStopWords(string stopWords, int portalId, string cultureCode);
 
         /// <summary>Updates a search stop words.</summary>
-        /// <param name="stopWordsId"></param>
-        /// <param name="stopWords"></param>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="stopWordsId">The stop words ID.</param>
+        /// <param name="stopWords">A comma-delimited list of stop words.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
         /// <returns><paramref name="stopWordsId"/>, or <c>0</c> if the input was invalid.</returns>
         int UpdateSearchStopWords(int stopWordsId, string stopWords, int portalId, string cultureCode);
 
         /// <summary>Deletes a search stop words.</summary>
-        /// <param name="stopWordsId"></param>
-        /// <param name="portalId"></param>
-        /// <param name="cultureCode"></param>
+        /// <param name="stopWordsId">The stop words ID.</param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="cultureCode">The culture code.</param>
         void DeleteSearchStopWords(int stopWordsId, int portalId, string cultureCode);
 
         DateTime GetSearchReindexRequestTime(int portalId);

--- a/DNN Platform/Library/Services/Search/Internals/SearchHelperImpl.cs
+++ b/DNN Platform/Library/Services/Search/Internals/SearchHelperImpl.cs
@@ -325,7 +325,7 @@ namespace DotNetNuke.Services.Search.Internals
         }
 
         /// <summary>Returns a collection of portal ID's to reindex if it was requested since last indexing.</summary>
-        /// <param name="startDate"></param>
+        /// <param name="startDate">The date of the last index.</param>
         /// <returns>A sequence of portal IDs.</returns>
         public IEnumerable<int> GetPortalsToReindex(DateTime startDate)
         {
@@ -470,9 +470,9 @@ namespace DotNetNuke.Services.Search.Internals
         }
 
         /// <summary>Processes and re-phrases the search text by looking into exact-match and wildcard option.</summary>
-        /// <param name="searchPhrase"></param>
-        /// <param name="useWildCard"></param>
-        /// <param name="allowLeadingWildcard"></param>
+        /// <param name="searchPhrase">The original search phrase.</param>
+        /// <param name="useWildCard">Whether to use wildcards.</param>
+        /// <param name="allowLeadingWildcard">Whether to allow a leading wildcard.</param>
         /// <returns>cleaned and pre-processed search phrase.</returns>
         public string RephraseSearchText(string searchPhrase, bool useWildCard, bool allowLeadingWildcard = false)
         {

--- a/DNN Platform/Library/Services/Search/Internals/SearchQueryAnalyzer.cs
+++ b/DNN Platform/Library/Services/Search/Internals/SearchQueryAnalyzer.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.Services.Search.Internals
         private readonly bool useStemmingFilter;
 
         /// <summary>Initializes a new instance of the <see cref="SearchQueryAnalyzer"/> class.</summary>
-        /// <param name="useStemmingFilter"></param>
+        /// <param name="useStemmingFilter">Whether to use the stemming filter.</param>
         public SearchQueryAnalyzer(bool useStemmingFilter)
         {
             this.useStemmingFilter = useStemmingFilter;
@@ -25,7 +25,7 @@ namespace DotNetNuke.Services.Search.Internals
         {
             var wordLengthMinMax = SearchHelper.Instance.GetSearchMinMaxLength();
 
-            // Note: the order of filtering is important for both operation and performane, so we try to make it work faster
+            // Note: the order of filtering is important for both operation and performance, so we try to make it work faster
             // Also, note that filters are applied from the innermost outwards.
             var filter =
                 new ASCIIFoldingFilter(// accents filter

--- a/DNN Platform/Library/Services/Search/Internals/SearchSecurityTrimmer.cs
+++ b/DNN Platform/Library/Services/Search/Internals/SearchSecurityTrimmer.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Services.Search.Internals
         private List<ScoreDoc> scoreDocs;
 
         /// <summary>Initializes a new instance of the <see cref="SearchSecurityTrimmer"/> class.</summary>
-        /// <param name="searchContext"></param>
+        /// <param name="searchContext">The search context.</param>
         public SearchSecurityTrimmer(SearchSecurityTrimmerContext searchContext)
         {
             this.securityChecker = searchContext.SecurityChecker;

--- a/DNN Platform/Library/Services/Search/Internals/SynonymFilter.cs
+++ b/DNN Platform/Library/Services/Search/Internals/SynonymFilter.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Services.Search.Internals
         private State current;
 
         /// <summary>Initializes a new instance of the <see cref="SynonymFilter"/> class.</summary>
-        /// <param name="input"></param>
+        /// <param name="input">The token stream.</param>
         public SynonymFilter(TokenStream input)
             : base(input)
         {

--- a/DNN Platform/Library/Services/Search/ModuleIndexer.cs
+++ b/DNN Platform/Library/Services/Search/ModuleIndexer.cs
@@ -41,7 +41,7 @@ namespace DotNetNuke.Services.Search
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleIndexer"/> class.</summary>
-        /// <param name="needSearchModules"></param>
+        /// <param name="needSearchModules">Whether to pre-populate the collection of search modules.</param>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IBusinessControllerProvider. Scheduled removal in v12.0.0.")]
         public ModuleIndexer(bool needSearchModules)
             : this(needSearchModules, null)
@@ -49,7 +49,7 @@ namespace DotNetNuke.Services.Search
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleIndexer"/> class.</summary>
-        /// <param name="needSearchModules"></param>
+        /// <param name="needSearchModules">Whether to pre-populate the collection of search modules.</param>
         /// <param name="businessControllerProvider">The business controller provider.</param>
         public ModuleIndexer(bool needSearchModules, IBusinessControllerProvider businessControllerProvider)
         {
@@ -134,8 +134,8 @@ namespace DotNetNuke.Services.Search
         }
 
         /// <summary>Returns a collection of SearchDocuments containing module metadata (title, header, footer...) of Searchable Modules.</summary>
-        /// <param name="portalId"></param>
-        /// <param name="startDate"></param>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="startDate">The date after which to look for changes.</param>
         /// <returns>A <see cref="List{T}"/> of <see cref="SearchDocument"/> instances.</returns>
         public List<SearchDocument> GetModuleMetaData(int portalId, DateTime startDate)
         {
@@ -181,7 +181,7 @@ namespace DotNetNuke.Services.Search
         }
 
         /// <summary>Gets a list of modules that are listed as "Searchable" from the module definition and check if they implement <see cref="ModuleSearchBase"/> -- which is a newer implementation of search that replaces <see cref="ISearchable"/>.</summary>
-        /// <param name="portalId"></param>
+        /// <param name="portalId">The portal ID.</param>
         /// <returns>A sequence of <see cref="ModuleInfo"/> instances.</returns>
         protected IEnumerable<ModuleInfo> GetSearchModules(int portalId)
         {

--- a/DNN Platform/Library/Services/Search/SearchEngineScheduler.cs
+++ b/DNN Platform/Library/Services/Search/SearchEngineScheduler.cs
@@ -20,7 +20,7 @@ namespace DotNetNuke.Services.Search
         private readonly IBusinessControllerProvider businessControllerProvider;
 
         /// <summary>Initializes a new instance of the <see cref="SearchEngineScheduler"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IBusinessControllerProvider. Scheduled removal in v12.0.0.")]
         public SearchEngineScheduler(ScheduleHistoryItem objScheduleHistoryItem)
             : this(objScheduleHistoryItem, null)
@@ -28,7 +28,7 @@ namespace DotNetNuke.Services.Search
         }
 
         /// <summary>Initializes a new instance of the <see cref="SearchEngineScheduler"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public SearchEngineScheduler(ScheduleHistoryItem objScheduleHistoryItem, IBusinessControllerProvider businessControllerProvider)
         {
             this.businessControllerProvider = businessControllerProvider ?? Globals.DependencyProvider.GetRequiredService<IBusinessControllerProvider>();

--- a/DNN Platform/Library/Services/Social/Messaging/Exceptions/AttachmentsNotAllowed.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/Exceptions/AttachmentsNotAllowed.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.Social.Messaging.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="AttachmentsNotAllowed"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public AttachmentsNotAllowed(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="AttachmentsNotAllowed"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public AttachmentsNotAllowed(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="AttachmentsNotAllowed"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public AttachmentsNotAllowed(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Social/Messaging/Exceptions/MessageOrRecipientNotFoundException.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/Exceptions/MessageOrRecipientNotFoundException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.Social.Messaging.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="MessageOrRecipientNotFoundException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public MessageOrRecipientNotFoundException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="MessageOrRecipientNotFoundException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public MessageOrRecipientNotFoundException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="MessageOrRecipientNotFoundException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public MessageOrRecipientNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Social/Messaging/Exceptions/RecipientLimitExceededException.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/Exceptions/RecipientLimitExceededException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.Social.Messaging.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="RecipientLimitExceededException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public RecipientLimitExceededException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="RecipientLimitExceededException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public RecipientLimitExceededException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="RecipientLimitExceededException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public RecipientLimitExceededException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Social/Messaging/Exceptions/ThrottlingIntervalNotMetException.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/Exceptions/ThrottlingIntervalNotMetException.cs
@@ -16,23 +16,23 @@ namespace DotNetNuke.Services.Social.Messaging.Exceptions
         }
 
         /// <summary>Initializes a new instance of the <see cref="ThrottlingIntervalNotMetException"/> class.</summary>
-        /// <param name="message"></param>
+        /// <param name="message">The message that describes the error.</param>
         public ThrottlingIntervalNotMetException(string message)
             : base(message)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ThrottlingIntervalNotMetException"/> class.</summary>
-        /// <param name="message"></param>
-        /// <param name="inner"></param>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If the <paramref name="inner"/> is not a <see langword="null" /> reference, the current exception is raised in a catch block that handles the inner exception.</param>
         public ThrottlingIntervalNotMetException(string message, Exception inner)
             : base(message, inner)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ThrottlingIntervalNotMetException"/> class.</summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         public ThrottlingIntervalNotMetException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/DNN Platform/Library/Services/Social/Messaging/UserPreferencesController.cs
+++ b/DNN Platform/Library/Services/Social/Messaging/UserPreferencesController.cs
@@ -23,7 +23,7 @@ namespace DotNetNuke.Services.Social.Messaging
         }
 
         /// <summary>Initializes a new instance of the <see cref="UserPreferencesController"/> class.</summary>
-        /// <param name="dataService"></param>
+        /// <param name="dataService">The data service.</param>
         public UserPreferencesController(IDataService dataService)
         {
             // Argument Contract

--- a/DNN Platform/Library/Services/Social/Notifications/INotificationsController.cs
+++ b/DNN Platform/Library/Services/Social/Notifications/INotificationsController.cs
@@ -13,7 +13,7 @@ namespace DotNetNuke.Services.Social.Notifications
     public interface INotificationsController
     {
         /// <summary>Creates a new notification type.</summary>
-        /// <param name="notificationType"> </param>
+        /// <param name="notificationType">The notification type.</param>
         void CreateNotificationType(NotificationType notificationType);
 
         /// <summary>Deletes an existing notification type.</summary>

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/ArrayListPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/ArrayListPropertyAccess.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.Services.Tokens
         private readonly ArrayList custom;
 
         /// <summary>Initializes a new instance of the <see cref="ArrayListPropertyAccess"/> class.</summary>
-        /// <param name="list"></param>
+        /// <param name="list">The list of custom properties.</param>
         public ArrayListPropertyAccess(ArrayList list)
         {
             this.custom = list;

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/CssPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/CssPropertyAccess.cs
@@ -17,7 +17,7 @@ namespace DotNetNuke.Services.Tokens
         private readonly Page page;
 
         /// <summary>Initializes a new instance of the <see cref="CssPropertyAccess"/> class.</summary>
-        /// <param name="page"></param>
+        /// <param name="page">The page to which the CSS should be registered.</param>
         public CssPropertyAccess(Page page)
         {
             this.page = page;

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/DataRowPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/DataRowPropertyAccess.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.Services.Tokens
         private readonly DataRow dr;
 
         /// <summary>Initializes a new instance of the <see cref="DataRowPropertyAccess"/> class.</summary>
-        /// <param name="row"></param>
+        /// <param name="row">The data row with token values.</param>
         public DataRowPropertyAccess(DataRow row)
         {
             this.dr = row;

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/DictionaryPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/DictionaryPropertyAccess.cs
@@ -14,7 +14,7 @@ namespace DotNetNuke.Services.Tokens
         private readonly IDictionary nameValueCollection;
 
         /// <summary>Initializes a new instance of the <see cref="DictionaryPropertyAccess"/> class.</summary>
-        /// <param name="list"></param>
+        /// <param name="list">The dictionary of token values.</param>
         public DictionaryPropertyAccess(IDictionary list)
         {
             this.nameValueCollection = list;

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/PropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/PropertyAccess.cs
@@ -18,7 +18,7 @@ namespace DotNetNuke.Services.Tokens
         private readonly object obj;
 
         /// <summary>Initializes a new instance of the <see cref="PropertyAccess"/> class.</summary>
-        /// <param name="tokenSource"></param>
+        /// <param name="tokenSource">The object to use as the source for the tokens.</param>
         public PropertyAccess(object tokenSource)
         {
             this.obj = tokenSource;

--- a/DNN Platform/Library/Services/Tokens/TokenReplace.cs
+++ b/DNN Platform/Library/Services/Tokens/TokenReplace.cs
@@ -144,7 +144,7 @@ namespace DotNetNuke.Services.Tokens
 
         /// <summary>Replaces tokens in sourceText parameter with the property values.</summary>
         /// <param name="sourceText">String with [Object:Property] tokens.</param>
-        /// <param name="row"></param>
+        /// <param name="row">The data row to use as the source.</param>
         /// <returns>string containing replaced values.</returns>
         public string ReplaceEnvironmentTokens(string sourceText, DataRow row)
         {
@@ -156,8 +156,8 @@ namespace DotNetNuke.Services.Tokens
 
         /// <summary>Replaces tokens in sourceText parameter with the property values.</summary>
         /// <param name="sourceText">String with [Object:Property] tokens.</param>
-        /// <param name="custom"></param>
-        /// <param name="customCaption"></param>
+        /// <param name="custom">A list of custom properties.</param>
+        /// <param name="customCaption">The prefix for the custom properties.</param>
         /// <returns>string containing replaced values.</returns>
         public string ReplaceEnvironmentTokens(string sourceText, ArrayList custom, string customCaption)
         {
@@ -256,7 +256,7 @@ namespace DotNetNuke.Services.Tokens
         }
 
         /// <summary>Load the module for the Module Token Provider.</summary>
-        /// <param name="moduleId"></param>
+        /// <param name="moduleId">The module ID.</param>
         /// <returns>The populated ModuleInfo or null.</returns>
         /// <remarks>
         /// This method is called by the Setter of ModuleId.

--- a/DNN Platform/Library/Services/Upgrade/Internals/IInstallController.cs
+++ b/DNN Platform/Library/Services/Upgrade/Internals/IInstallController.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Services.Upgrade.Internals
         void SetInstallConfig(InstallConfig installConfig);
 
         /// <summary>RemoveFromInstallConfig - Removes the specified XML Node from the InstallConfig.</summary>
-        /// <param name="xmlNodePath"></param>
+        /// <param name="xmlNodePath">An XPath selector for the nodes to remove.</param>
         void RemoveFromInstallConfig(string xmlNodePath);
 
         /// <summary>GetConnectionFromWebConfig - Returns Connection Configuration in web.config file.</summary>

--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -134,12 +134,12 @@ namespace DotNetNuke.Services.Upgrade
         }
 
         /// <summary>AddAdminPages adds an Admin Page and an associated Module to all configured Portals.</summary>
-        /// <param name="tabName">The Name to give this new Tab.</param>
-        /// <param name="description"></param>
-        /// <param name="tabIconFile">The Icon for this new Tab.</param>
-        /// <param name="tabIconFileLarge"></param>
+        /// <param name="tabName">The Name to give this new tab.</param>
+        /// <param name="description">The page description.</param>
+        /// <param name="tabIconFile">The icon for this new tab.</param>
+        /// <param name="tabIconFileLarge">The large icon for this new tab.</param>
         /// <param name="isVisible">A flag indicating whether the tab is visible.</param>
-        /// <param name="moduleDefId">The Module Definition Id for the module to be added to this tab.</param>
+        /// <param name="moduleDefId">The Module Definition ID for the module to be added to this tab.</param>
         /// <param name="moduleTitle">The Module's title.</param>
         /// <param name="moduleIconFile">The Module's icon.</param>
         /// <param name="inheritPermissions">Modules Inherit the Pages View Permissions.</param>
@@ -162,10 +162,10 @@ namespace DotNetNuke.Services.Upgrade
 
         /// <summary>AddAdminPage adds an Admin Tab Page.</summary>
         /// <param name="portal">The Portal.</param>
-        /// <param name="tabName">The Name to give this new Tab.</param>
-        /// <param name="description"></param>
-        /// <param name="tabIconFile">The Icon for this new Tab.</param>
-        /// <param name="tabIconFileLarge"></param>
+        /// <param name="tabName">The Name to give this new tab.</param>
+        /// <param name="description">The page description.</param>
+        /// <param name="tabIconFile">The icon for this new tab.</param>
+        /// <param name="tabIconFileLarge">The large icon for this new tab.</param>
         /// <param name="isVisible">A flag indicating whether the tab is visible.</param>
         /// <returns>A <see cref="TabInfo"/> instance or <see langword="null"/>.</returns>
         public static TabInfo AddAdminPage(PortalInfo portal, string tabName, string description, string tabIconFile, string tabIconFileLarge, bool isVisible)
@@ -185,10 +185,10 @@ namespace DotNetNuke.Services.Upgrade
         }
 
         /// <summary>AddHostPage adds a Host Tab Page.</summary>
-        /// <param name="tabName">The Name to give this new Tab.</param>
-        /// <param name="description"></param>
-        /// <param name="tabIconFile">The Icon for this new Tab.</param>
-        /// <param name="tabIconFileLarge"></param>
+        /// <param name="tabName">The Name to give this new tab.</param>
+        /// <param name="description">The page description.</param>
+        /// <param name="tabIconFile">The icon for this new tab.</param>
+        /// <param name="tabIconFileLarge">The large icon for this new tab.</param>
         /// <param name="isVisible">A flag indicating whether the tab is visible.</param>
         /// <returns>A <see cref="TabInfo"/> instance or <see langword="null"/>.</returns>
         public static TabInfo AddHostPage(string tabName, string description, string tabIconFile, string tabIconFileLarge, bool isVisible)
@@ -919,8 +919,8 @@ namespace DotNetNuke.Services.Upgrade
         }
 
         /// <summary>InstallDatabase runs all the "scripts" identified in the Install Template to install the base version.</summary>
-        /// <param name="version"></param>
-        /// <param name="providerPath"></param>
+        /// <param name="version">The version for which to run installation scripts.</param>
+        /// <param name="providerPath">The data provider path.</param>
         /// <param name="xmlDoc">The Xml Document to load.</param>
         /// <param name="writeFeedback">A flag that determines whether to output feedback to the Response Stream.</param>
         /// <returns>A string which contains the error message - if appropriate.</returns>

--- a/DNN Platform/Library/Services/UserRequest/IUserRequestIPAddressController.cs
+++ b/DNN Platform/Library/Services/UserRequest/IUserRequestIPAddressController.cs
@@ -9,14 +9,14 @@ namespace DotNetNuke.Services.UserRequest
     public interface IUserRequestIPAddressController
     {
         /// <summary> To retrieve IPv4 of user making request to application.</summary>
-        /// <param name="request"></param>
-        /// <returns>IP address.</returns>
+        /// <param name="request">The HTTP request.</param>
+        /// <returns>IP address or <see cref="string.Empty"/>.</returns>
         string GetUserRequestIPAddress(HttpRequestBase request);
 
         /// <summary> To retrieve IPv4/IPv6 of user making request to application.</summary>
-        /// <param name="request"></param>
-        /// <param name="ipFamily"></param>
-        /// <returns>IP address.</returns>
+        /// <param name="request">The HTTP request.</param>
+        /// <param name="ipFamily">The type of IP address to get (<see cref="string.Empty"/> will be returned if the address does not match).</param>
+        /// <returns>IP address or <see cref="string.Empty"/>.</returns>
         string GetUserRequestIPAddress(HttpRequestBase request, IPAddressFamily ipFamily);
     }
 }

--- a/DNN Platform/Library/Services/Users/PurgeDeletedUsers.cs
+++ b/DNN Platform/Library/Services/Users/PurgeDeletedUsers.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Services.Users
     public class PurgeDeletedUsers : SchedulerClient
     {
         /// <summary>Initializes a new instance of the <see cref="PurgeDeletedUsers"/> class.</summary>
-        /// <param name="objScheduleHistoryItem"></param>
+        /// <param name="objScheduleHistoryItem">The schedule history item.</param>
         public PurgeDeletedUsers(ScheduleHistoryItem objScheduleHistoryItem)
         {
             this.ScheduleHistoryItem = objScheduleHistoryItem;

--- a/DNN Platform/Library/UI/Containers/EventListeners/ContainerEventArgs.cs
+++ b/DNN Platform/Library/UI/Containers/EventListeners/ContainerEventArgs.cs
@@ -11,7 +11,7 @@ namespace DotNetNuke.UI.Containers.EventListeners
         private readonly Container container;
 
         /// <summary>Initializes a new instance of the <see cref="ContainerEventArgs"/> class.</summary>
-        /// <param name="container"></param>
+        /// <param name="container">The container.</param>
         public ContainerEventArgs(Container container)
         {
             this.container = container;

--- a/DNN Platform/Library/UI/Containers/EventListeners/ContainerEventListener.cs
+++ b/DNN Platform/Library/UI/Containers/EventListeners/ContainerEventListener.cs
@@ -10,8 +10,8 @@ namespace DotNetNuke.UI.Containers.EventListeners
         private readonly ContainerEventType type;
 
         /// <summary>Initializes a new instance of the <see cref="ContainerEventListener"/> class.</summary>
-        /// <param name="type"></param>
-        /// <param name="e"></param>
+        /// <param name="type">The event type.</param>
+        /// <param name="e">The event handler.</param>
         public ContainerEventListener(ContainerEventType type, ContainerEventHandler e)
         {
             this.type = type;

--- a/DNN Platform/Library/UI/Modules/Html5/ModuleActionsPropertyAccess.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/ModuleActionsPropertyAccess.cs
@@ -17,8 +17,8 @@ namespace DotNetNuke.UI.Modules.Html5
         private readonly ModuleInstanceContext moduleContext;
 
         /// <summary>Initializes a new instance of the <see cref="ModuleActionsPropertyAccess"/> class.</summary>
-        /// <param name="moduleContext"></param>
-        /// <param name="moduleActions"></param>
+        /// <param name="moduleContext">The module context.</param>
+        /// <param name="moduleActions">The module actions.</param>
         public ModuleActionsPropertyAccess(ModuleInstanceContext moduleContext, ModuleActionCollection moduleActions)
         {
             this.moduleContext = moduleContext;

--- a/DNN Platform/Library/UI/Modules/Html5/ModuleContextPropertyAccess.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/ModuleContextPropertyAccess.cs
@@ -15,7 +15,7 @@ namespace DotNetNuke.UI.Modules.Html5
         private readonly ModuleInstanceContext moduleContext;
 
         /// <summary>Initializes a new instance of the <see cref="ModuleContextPropertyAccess"/> class.</summary>
-        /// <param name="moduleContext"></param>
+        /// <param name="moduleContext">The module context.</param>
         public ModuleContextPropertyAccess(ModuleInstanceContext moduleContext)
         {
             this.moduleContext = moduleContext;

--- a/DNN Platform/Library/UI/Modules/Html5/ModuleLocalizationPropertyAccess.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/ModuleLocalizationPropertyAccess.cs
@@ -16,8 +16,8 @@ namespace DotNetNuke.UI.Modules.Html5
         private readonly string html5File;
 
         /// <summary>Initializes a new instance of the <see cref="ModuleLocalizationPropertyAccess"/> class.</summary>
-        /// <param name="moduleContext"></param>
-        /// <param name="html5File"></param>
+        /// <param name="moduleContext">The module context.</param>
+        /// <param name="html5File">The HTML file.</param>
         public ModuleLocalizationPropertyAccess(ModuleInstanceContext moduleContext, string html5File)
         {
             this.html5File = html5File;

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -42,7 +42,7 @@ namespace DotNetNuke.UI.Modules
         }
 
         /// <summary>Initializes a new instance of the <see cref="ModuleInstanceContext"/> class.</summary>
-        /// <param name="moduleControl"></param>
+        /// <param name="moduleControl">The module control.</param>
         public ModuleInstanceContext(IModuleControl moduleControl)
         {
             this.moduleControl = moduleControl;

--- a/DNN Platform/Library/UI/Navigation.cs
+++ b/DNN Platform/Library/UI/Navigation.cs
@@ -319,7 +319,7 @@ namespace DotNetNuke.UI
         /// <param name="objNodes">Node collection to append new node to.</param>
         /// <param name="objBreadCrumbs">Hashtable of breadcrumb IDs to efficiently determine node's BreadCrumb property.</param>
         /// <param name="objPortalSettings">Portal settings object to determine if node is selected.</param>
-        /// <param name="eToolTips"></param>
+        /// <param name="eToolTips">The tool-tip source.</param>
         /// <remarks>Logic moved to separate sub to make GetNavigationNodes cleaner.</remarks>
         private static void AddNode(TabInfo objTab, DNNNodeCollection objNodes, Hashtable objBreadCrumbs, PortalSettings objPortalSettings, ToolTipSource eToolTips, IDictionary<string, DNNNode> nodesLookup)
         {

--- a/DNN Platform/Library/UI/Skins/Controls/LanguagePropertyAccess.cs
+++ b/DNN Platform/Library/UI/Skins/Controls/LanguagePropertyAccess.cs
@@ -35,8 +35,8 @@ namespace DotNetNuke.UI.Skins.Controls
         private readonly PortalSettings objPortal;
 
         /// <summary>Initializes a new instance of the <see cref="LanguagePropertyAccess"/> class.</summary>
-        /// <param name="parent"></param>
-        /// <param name="settings"></param>
+        /// <param name="parent">The <see cref="LanguageTokenReplace"/> for the parent language.</param>
+        /// <param name="settings">The portal settings.</param>
         public LanguagePropertyAccess(LanguageTokenReplace parent, PortalSettings settings)
         {
             this.objPortal = settings;
@@ -88,7 +88,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// (because NavigateUrl adds the portalId param to the qs).
         /// </summary>
         /// <param name="newLanguage">Language to switch into.</param>
-        /// <param name="isLocalized"></param>
+        /// <param name="isLocalized">Whether it's a localized tab.</param>
         /// <returns>A collection of query string segments, in <c>"key=value"</c> format.</returns>
         private string[] GetQsParams(string newLanguage, bool isLocalized)
         {
@@ -205,7 +205,7 @@ namespace DotNetNuke.UI.Skins.Controls
         /// newUrl returns the new URL based on the new language.
         /// Basically it is just a call to NavigateUrl, with stripped qs parameters.
         /// </summary>
-        /// <param name="newLanguage"></param>
+        /// <param name="newLanguage">The language for the URL.</param>
         private string NewUrl(string newLanguage)
         {
             var newLocale = LocaleController.Instance.GetLocale(newLanguage);

--- a/DNN Platform/Library/UI/Skins/EventListeners/SkinEventArgs.cs
+++ b/DNN Platform/Library/UI/Skins/EventListeners/SkinEventArgs.cs
@@ -11,7 +11,7 @@ namespace DotNetNuke.UI.Skins.EventListeners
         private readonly Skin skin;
 
         /// <summary>Initializes a new instance of the <see cref="SkinEventArgs"/> class.</summary>
-        /// <param name="skin"></param>
+        /// <param name="skin">The skin.</param>
         public SkinEventArgs(Skin skin)
         {
             this.skin = skin;

--- a/DNN Platform/Library/UI/Skins/EventListeners/SkinEventListener.cs
+++ b/DNN Platform/Library/UI/Skins/EventListeners/SkinEventListener.cs
@@ -7,8 +7,8 @@ namespace DotNetNuke.UI.Skins.EventListeners
     public class SkinEventListener
     {
         /// <summary>Initializes a new instance of the <see cref="SkinEventListener"/> class.</summary>
-        /// <param name="type"></param>
-        /// <param name="e"></param>
+        /// <param name="type">The event type.</param>
+        /// <param name="e">The event handler.</param>
         public SkinEventListener(SkinEventType type, SkinEventHandler e)
         {
             this.EventType = type;

--- a/DNN Platform/Library/UI/Skins/SkinFileProcessor.cs
+++ b/DNN Platform/Library/UI/Skins/SkinFileProcessor.cs
@@ -261,14 +261,11 @@ namespace DotNetNuke.UI.Skins
             return contents;
         }
 
-        /// Project  : DotNetNuke
-        /// Class    : SkinFileProcessor.ControlParser
-        ///
         /// <summary>    Parsing functionality for token replacement in new skin files.</summary>
         /// <remarks>
         ///     This class encapsulates the data and methods necessary to appropriately
         ///     handle all the token parsing needs for new skin files (which is appropriate
-        ///     only for HTML files).  The parser accomodates some ill formatting of tokens
+        ///     only for HTML files).  The parser accommodates some ill formatting of tokens
         ///     (ignoring whitespace and casing) and allows for naming of token instances
         ///     if more than one instance of a particular control is desired on a skin.  The
         ///     proper syntax for an instance is: "[TOKEN:INSTANCE]" where the instance can
@@ -1002,15 +999,12 @@ namespace DotNetNuke.UI.Skins
             private string fILEFORMATDETAIL = Util.GetLocalizedString("FileFormat.Detail");
             private string messages = string.Empty;
 
-            /// <summary>
-            /// Initializes a new instance of the <see cref="SkinFile"/> class.
-            ///     SkinFile class constructor.
-            /// </summary>
-            /// <param name="skinContents"></param>
-            /// <param name="skinAttributes"></param>
+            /// <summary>Initializes a new instance of the <see cref="SkinFile"/> class.</summary>
+            /// <param name="skinContents">The contents of the skin file.</param>
+            /// <param name="skinAttributes">The attributes to merge into the skin file.</param>
             /// <remarks>
             ///     The constructor primes the utility class with basic file information.
-            ///     It also checks for the existentce of a skinfile level attribute file
+            ///     It also checks for the existence of a skinfile level attribute file
             ///     and read it in, if found.
             /// </remarks>
             public SkinFile(string skinContents, XmlDocument skinAttributes)
@@ -1019,16 +1013,13 @@ namespace DotNetNuke.UI.Skins
                 this.Contents = skinContents;
             }
 
-            /// <summary>
-            /// Initializes a new instance of the <see cref="SkinFile"/> class.
-            ///     SkinFile class constructor.
-            /// </summary>
-            /// <param name="skinRoot"></param>
-            /// <param name="fileName"></param>
-            /// <param name="skinAttributes"></param>
+            /// <summary>Initializes a new instance of the <see cref="SkinFile"/> class.</summary>
+            /// <param name="skinRoot">The root path for the skin.</param>
+            /// <param name="fileName">The name of the skin file.</param>
+            /// <param name="skinAttributes">The attributes to merge into the skin file.</param>
             /// <remarks>
             ///     The constructor primes the utility class with basic file information.
-            ///     It also checks for the existentce of a skinfile level attribute file
+            ///     It also checks for the existence of a skinfile level attribute file
             ///     and read it in, if found.
             /// </remarks>
             public SkinFile(string skinRoot, string fileName, XmlDocument skinAttributes)

--- a/DNN Platform/Library/UI/UserControls/SectionHeadControl.cs
+++ b/DNN Platform/Library/UI/UserControls/SectionHeadControl.cs
@@ -130,7 +130,7 @@ namespace DotNetNuke.UI.UserControls
         }
 
         /// <summary>Assign resource key to label for localization.</summary>
-        /// <param name="e"></param>
+        /// <param name="e">The event args.</param>
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
@@ -150,7 +150,7 @@ namespace DotNetNuke.UI.UserControls
         }
 
         /// <summary>Renders the SectionHeadControl.</summary>
-        /// <param name="e"></param>
+        /// <param name="e">The event args.</param>
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);

--- a/DNN Platform/Library/UI/WebControls/DataGrids/CheckBoxColumnTemplate.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/CheckBoxColumnTemplate.cs
@@ -29,7 +29,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Initializes a new instance of the <see cref="CheckBoxColumnTemplate"/> class.</summary>
-        /// <param name="itemType"></param>
+        /// <param name="itemType">The list item type.</param>
         public CheckBoxColumnTemplate(ListItemType itemType)
         {
             this.ItemType = itemType;

--- a/DNN Platform/Library/UI/WebControls/DataGrids/DNNDataGridCheckChangedEventArgs.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/DNNDataGridCheckChangedEventArgs.cs
@@ -7,29 +7,26 @@ namespace DotNetNuke.UI.WebControls
 
     public delegate void DNNDataGridCheckedColumnEventHandler(object sender, DNNDataGridCheckChangedEventArgs e);
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.UI.WebControls
-    /// Class:      DNNDataGrid
     /// <summary>
-    /// The DNNDataGridCheckChangedEventArgs class is a cusom EventArgs class for
+    /// The DNNDataGridCheckChangedEventArgs class is a custom EventArgs class for
     /// handling Event Args from the CheckChanged event in a CheckBox Column.
     /// </summary>
     public class DNNDataGridCheckChangedEventArgs : DataGridItemEventArgs
     {
         /// <summary>Initializes a new instance of the <see cref="DNNDataGridCheckChangedEventArgs"/> class.</summary>
-        /// <param name="item"></param>
-        /// <param name="isChecked"></param>
-        /// <param name="field"></param>
+        /// <param name="item">The data grid item.</param>
+        /// <param name="isChecked">Whether it's checked.</param>
+        /// <param name="field">The field name.</param>
         public DNNDataGridCheckChangedEventArgs(DataGridItem item, bool isChecked, string field)
             : this(item, isChecked, field, false)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DNNDataGridCheckChangedEventArgs"/> class.</summary>
-        /// <param name="item"></param>
-        /// <param name="isChecked"></param>
-        /// <param name="field"></param>
-        /// <param name="isAll"></param>
+        /// <param name="item">The data grid item.</param>
+        /// <param name="isChecked">Whether it's checked.</param>
+        /// <param name="field">The field name.</param>
+        /// <param name="isAll">Whether this is the "All" item for the column.</param>
         public DNNDataGridCheckChangedEventArgs(DataGridItem item, bool isChecked, string field, bool isAll)
             : base(item)
         {

--- a/DNN Platform/Library/UI/WebControls/DataGrids/DNNMultiStateBoxColumnTemplate.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/DNNMultiStateBoxColumnTemplate.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Initializes a new instance of the <see cref="DNNMultiStateBoxColumnTemplate"/> class.</summary>
-        /// <param name="itemType"></param>
+        /// <param name="itemType">The list item type.</param>
         public DNNMultiStateBoxColumnTemplate(ListItemType itemType)
         {
             this.ItemType = itemType;

--- a/DNN Platform/Library/UI/WebControls/DataGrids/ImageCommandColumnTemplate.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/ImageCommandColumnTemplate.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Initializes a new instance of the <see cref="ImageCommandColumnTemplate"/> class.</summary>
-        /// <param name="itemType"></param>
+        /// <param name="itemType">The list item type.</param>
         public ImageCommandColumnTemplate(ListItemType itemType)
         {
             this.ItemType = itemType;

--- a/DNN Platform/Library/UI/WebControls/DataGrids/PermissionTriStateTemplate.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/PermissionTriStateTemplate.cs
@@ -16,7 +16,7 @@ namespace DotNetNuke.UI.WebControls.Internal
         private readonly PermissionInfo permission;
 
         /// <summary>Initializes a new instance of the <see cref="PermissionTriStateTemplate"/> class.</summary>
-        /// <param name="permission"></param>
+        /// <param name="permission">The permission info.</param>
         public PermissionTriStateTemplate(PermissionInfo permission)
         {
             this.permission = permission;

--- a/DNN Platform/Library/UI/WebControls/DataGrids/RolesSelectionGrid.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/RolesSelectionGrid.cs
@@ -307,7 +307,7 @@ namespace DotNetNuke.UI.WebControls
 
         /// <summary>Updates a Selection.</summary>
         /// <param name="roleName">The name of the role.</param>
-        /// <param name="selected"></param>
+        /// <param name="selected">Whether it's selected.</param>
         protected virtual void UpdateSelection(string roleName, bool selected)
         {
             var isMatch = false;

--- a/DNN Platform/Library/UI/WebControls/DataGrids/TextColumnTemplate.cs
+++ b/DNN Platform/Library/UI/WebControls/DataGrids/TextColumnTemplate.cs
@@ -24,7 +24,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Initializes a new instance of the <see cref="TextColumnTemplate"/> class.</summary>
-        /// <param name="itemType"></param>
+        /// <param name="itemType">The list item type.</param>
         public TextColumnTemplate(ListItemType itemType)
         {
             this.ItemType = itemType;

--- a/DNN Platform/Library/UI/WebControls/LiteralTemplate.cs
+++ b/DNN Platform/Library/UI/WebControls/LiteralTemplate.cs
@@ -11,14 +11,14 @@ namespace DotNetNuke.UI.WebControls
         private readonly string strHTML = string.Empty;
 
         /// <summary>Initializes a new instance of the <see cref="LiteralTemplate"/> class.</summary>
-        /// <param name="html"></param>
+        /// <param name="html">The literal HTML that is the contents of this template.</param>
         public LiteralTemplate(string html)
         {
             this.strHTML = html;
         }
 
         /// <summary>Initializes a new instance of the <see cref="LiteralTemplate"/> class.</summary>
-        /// <param name="ctl"></param>
+        /// <param name="ctl">A control that is the contents of this template.</param>
         public LiteralTemplate(Control ctl)
         {
             this.objControl = ctl;

--- a/DNN Platform/Library/UI/WebControls/NavDataSource/NavDataPageHierarchyData.cs
+++ b/DNN Platform/Library/UI/WebControls/NavDataSource/NavDataPageHierarchyData.cs
@@ -168,7 +168,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Computes valuepath necessary for ASP.NET controls to guarantee uniqueness.</summary>
-        /// <param name="objNode"></param>
+        /// <param name="objNode">The nav node.</param>
         /// <returns>ValuePath.</returns>
         /// <remarks>Not sure if it is ok to hardcode the "\" separator, but also not sure where I would get it from.</remarks>
         private string GetValuePath(DNNNode objNode)

--- a/DNN Platform/Library/UI/WebControls/NavDataSource/NavDataSourceView.cs
+++ b/DNN Platform/Library/UI/WebControls/NavDataSource/NavDataSourceView.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.UI.WebControls
         private string sNamespace = "MyNS";
 
         /// <summary>Initializes a new instance of the <see cref="NavDataSourceView"/> class.</summary>
-        /// <param name="viewPath"></param>
+        /// <param name="viewPath">The view path by which to filter nav nodes.</param>
         public NavDataSourceView(string viewPath)
         {
             if (string.IsNullOrEmpty(viewPath))

--- a/DNN Platform/Library/UI/WebControls/PagingControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PagingControl.cs
@@ -350,7 +350,7 @@ namespace DotNetNuke.UI.WebControls
             private readonly PagingControl pagingControl;
 
             /// <summary>Initializes a new instance of the <see cref="PageNumberLinkTemplate"/> class.</summary>
-            /// <param name="ctlPagingControl"></param>
+            /// <param name="ctlPagingControl">The paging control.</param>
             public PageNumberLinkTemplate(PagingControl ctlPagingControl)
             {
                 this.pagingControl = ctlPagingControl;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Adapters/CollectionEditorInfoAdapter.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Adapters/CollectionEditorInfoAdapter.cs
@@ -12,10 +12,7 @@ namespace DotNetNuke.UI.WebControls
     using DotNetNuke.Entities.Profile;
     using DotNetNuke.Entities.Users;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.UI.WebControls
-    /// Class:      CollectionEditorInfoFactory
-    /// <summary>The CollectionEditorInfoAdapter control provides an Adapter for Collection Onjects.</summary>
+    /// <summary>The CollectionEditorInfoAdapter control provides an Adapter for Collection Objects.</summary>
     public class CollectionEditorInfoAdapter : IEditorInfoAdapter
     {
         private readonly object dataSource;
@@ -23,10 +20,10 @@ namespace DotNetNuke.UI.WebControls
         private readonly string name;
 
         /// <summary>Initializes a new instance of the <see cref="CollectionEditorInfoAdapter"/> class.</summary>
-        /// <param name="dataSource"></param>
-        /// <param name="name"></param>
-        /// <param name="fieldName"></param>
-        /// <param name="fieldNames"></param>
+        /// <param name="dataSource">The data source object.</param>
+        /// <param name="name">The resource key name prefix.</param>
+        /// <param name="fieldName">The field name.</param>
+        /// <param name="fieldNames">The field names.</param>
         public CollectionEditorInfoAdapter(object dataSource, string name, string fieldName, Hashtable fieldNames)
         {
             this.dataSource = dataSource;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Adapters/SettingsEditorInfoAdapter.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Adapters/SettingsEditorInfoAdapter.cs
@@ -9,9 +9,6 @@ namespace DotNetNuke.UI.WebControls
 
     using DotNetNuke.Common.Utilities;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.UI.WebControls
-    /// Class:      SettingsEditorInfoAdapter
     /// <summary>
     /// The SettingsEditorInfoAdapter control provides a factory for creating the
     /// appropriate EditInfo object.
@@ -23,9 +20,9 @@ namespace DotNetNuke.UI.WebControls
         private string fieldName;
 
         /// <summary>Initializes a new instance of the <see cref="SettingsEditorInfoAdapter"/> class.</summary>
-        /// <param name="dataSource"></param>
-        /// <param name="dataMember"></param>
-        /// <param name="fieldName"></param>
+        /// <param name="dataSource">The data source <see cref="Hashtable"/>.</param>
+        /// <param name="dataMember">The <see cref="SettingInfo"/> instance.</param>
+        /// <param name="fieldName">The field name.</param>
         public SettingsEditorInfoAdapter(object dataSource, object dataMember, string fieldName)
         {
             this.dataMember = dataMember;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Adapters/StandardEditorInfoAdapter.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Adapters/StandardEditorInfoAdapter.cs
@@ -11,9 +11,6 @@ namespace DotNetNuke.UI.WebControls
     using DotNetNuke.Entities.Profile;
     using DotNetNuke.Entities.Users;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.UI.WebControls
-    /// Class:      StandardEditorInfoAdapter
     /// <summary>The StandardEditorInfoAdapter control provides an Adapter for standard datasources.</summary>
     public class StandardEditorInfoAdapter : IEditorInfoAdapter
     {
@@ -21,8 +18,8 @@ namespace DotNetNuke.UI.WebControls
         private readonly string fieldName;
 
         /// <summary>Initializes a new instance of the <see cref="StandardEditorInfoAdapter"/> class.</summary>
-        /// <param name="dataSource"></param>
-        /// <param name="fieldName"></param>
+        /// <param name="dataSource">The data source object.</param>
+        /// <param name="fieldName">The field/property name.</param>
         public StandardEditorInfoAdapter(object dataSource, string fieldName)
         {
             this.dataSource = dataSource;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNCountryAutocompleteControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNCountryAutocompleteControl.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnCountryAutocompleteControl"/> class.</summary>
-        /// <param name="type"></param>
+        /// <param name="type">A string representing the <see cref="Type"/> being edited.</param>
         public DnnCountryAutocompleteControl(string type)
         {
             this.Init += this.DnnCountryRegionControl_Init;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNRegionEditControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNRegionEditControl.cs
@@ -18,9 +18,6 @@ namespace DotNetNuke.UI.WebControls
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.Client.ClientResourceManagement;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.UI.WebControls
-    /// Class:      DNNRegionEditControl
     /// <summary>
     /// The DNNRegionEditControl control provides a standard UI component for editing
     /// Regions.
@@ -43,7 +40,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>Initializes a new instance of the <see cref="DNNRegionEditControl"/> class.</summary>
-        /// <param name="type"></param>
+        /// <param name="type">A string representing the <see cref="Type"/> being edited.</param>
         public DNNRegionEditControl(string type)
         {
             this.Init += this.DnnRegionControl_Init;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DateEditControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DateEditControl.cs
@@ -200,7 +200,7 @@ namespace DotNetNuke.UI.WebControls
         }
 
         /// <summary>RenderEditMode is called by the base control to render the control in Edit Mode.</summary>
-        /// <param name="writer"></param>
+        /// <param name="writer">The HTML text writer to which this control is to be rendered.</param>
         protected override void RenderEditMode(HtmlTextWriter writer)
         {
             this.RenderChildren(writer);

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/PropertyAttributes/SortOrderAttribute.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/PropertyAttributes/SortOrderAttribute.cs
@@ -9,7 +9,7 @@ namespace DotNetNuke.UI.WebControls
     public sealed class SortOrderAttribute : Attribute
     {
         /// <summary>Initializes a new instance of the <see cref="SortOrderAttribute"/> class.</summary>
-        /// <param name="order"></param>
+        /// <param name="order">The sort order of the property.</param>
         public SortOrderAttribute(int order)
         {
             this.Order = order;

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/SettingInfo.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/SettingInfo.cs
@@ -7,9 +7,6 @@ namespace DotNetNuke.UI.WebControls
 
     using DotNetNuke.Instrumentation;
 
-    /// Project:    DotNetNuke
-    /// Namespace:  DotNetNuke.UI.WebControls
-    /// Class:      SettingInfo
     /// <summary>The SettingInfo class provides a helper class for the Settings Editor.</summary>
     public class SettingInfo
     {
@@ -17,8 +14,8 @@ namespace DotNetNuke.UI.WebControls
         private Type type;
 
         /// <summary>Initializes a new instance of the <see cref="SettingInfo"/> class.</summary>
-        /// <param name="name"></param>
-        /// <param name="value"></param>
+        /// <param name="name">The setting name.</param>
+        /// <param name="value">The setting value.</param>
         public SettingInfo(object name, object value)
         {
             this.Name = Convert.ToString(name);


### PR DESCRIPTION
## Summary
This PR resolves [SA1614](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1614.md) in the DotNetNuke.Library project. It also makes SA1614 a build error for that project.

SA1614 states that `<param>` document elements must not be empty.