### PR TITLE
Consolidate System.Runtime.CompilerServices.Unsafe.dll and ensure it's in the bin folder during install

### DIFF
--- a/Build/Tasks/packaging.json
+++ b/Build/Tasks/packaging.json
@@ -50,7 +50,6 @@
     "/bin/Microsoft.Web.Infrastructure.dll",
     "/bin/Newtonsoft.Json.Bson.dll",
     "/bin/System.Memory.dll",
-    "/bin/System.Runtime.CompilerServices.Unsafe.dll",
     "/bin/BouncyCastle.Cryptography.dll",
     "/bin/Microsoft.Bcl.Memory.dll",
     "/bin/Microsoft.Bcl.TimeProvider.dll",

--- a/DNN Platform/Admin Modules/Dnn.Modules.Console/Dnn.Modules.Console.csproj
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Console/Dnn.Modules.Console.csproj
@@ -69,8 +69,8 @@
       <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Admin Modules/Dnn.Modules.Console/packages.config
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Console/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Connectors/Azure/Dnn.AzureConnector.csproj
+++ b/DNN Platform/Connectors/Azure/Dnn.AzureConnector.csproj
@@ -95,8 +95,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Connectors/Azure/packages.config
+++ b/DNN Platform/Connectors/Azure/packages.config
@@ -11,6 +11,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Connectors/GoogleAnalytics/Dnn.GoogleAnalyticsConnector.csproj
+++ b/DNN Platform/Connectors/GoogleAnalytics/Dnn.GoogleAnalyticsConnector.csproj
@@ -90,8 +90,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Connectors/GoogleAnalytics/packages.config
+++ b/DNN Platform/Connectors/GoogleAnalytics/packages.config
@@ -9,6 +9,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Connectors/GoogleAnalytics4/Dnn.GoogleAnalytics4Connector.csproj
+++ b/DNN Platform/Connectors/GoogleAnalytics4/Dnn.GoogleAnalytics4Connector.csproj
@@ -90,8 +90,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Connectors/GoogleAnalytics4/packages.config
+++ b/DNN Platform/Connectors/GoogleAnalytics4/packages.config
@@ -9,6 +9,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Connectors/GoogleTagManager/Dnn.GoogleTagManagerConnector.csproj
+++ b/DNN Platform/Connectors/GoogleTagManager/Dnn.GoogleTagManagerConnector.csproj
@@ -91,8 +91,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Connectors/GoogleTagManager/packages.config
+++ b/DNN Platform/Connectors/GoogleTagManager/packages.config
@@ -9,6 +9,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Dnn.AuthServices.Jwt/Dnn.AuthServices.Jwt.csproj
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Dnn.AuthServices.Jwt.csproj
@@ -100,8 +100,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Text.Encodings.Web, Version=9.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Dnn.AuthServices.Jwt/packages.config
+++ b/DNN Platform/Dnn.AuthServices.Jwt/packages.config
@@ -22,7 +22,7 @@
   <package id="System.IO.Pipelines" version="9.0.2" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Text.Encodings.Web" version="9.0.2" targetFramework="net48" />
   <package id="System.Text.Json" version="8.0.5" targetFramework="net48" />

--- a/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
+++ b/DNN Platform/DotNetNuke.DependencyInjection/DotNetNuke.DependencyInjection.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.Maintenance/DotNetNuke.Maintenance.csproj
+++ b/DNN Platform/DotNetNuke.Maintenance/DotNetNuke.Maintenance.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
+++ b/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
@@ -31,6 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj
+++ b/DNN Platform/DotNetNuke.Web.Client/DotNetNuke.Web.Client.csproj
@@ -66,8 +66,8 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/DotNetNuke.Web.Client/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Client/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.SourceLink.GitHub" version="8.0.0" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DotNetNuke.Web.Mvc.csproj
@@ -94,8 +94,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/DotNetNuke.Web.Mvc/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Mvc/packages.config
@@ -23,6 +23,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web.Razor/DotNetNuke.Web.Razor.csproj
+++ b/DNN Platform/DotNetNuke.Web.Razor/DotNetNuke.Web.Razor.csproj
@@ -75,8 +75,8 @@
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/DotNetNuke.Web.Razor/packages.config
+++ b/DNN Platform/DotNetNuke.Web.Razor/packages.config
@@ -14,6 +14,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
+++ b/DNN Platform/DotNetNuke.Web/DotNetNuke.Web.csproj
@@ -145,8 +145,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/DNN Platform/DotNetNuke.Web/packages.config
+++ b/DNN Platform/DotNetNuke.Web/packages.config
@@ -21,7 +21,7 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="WebFormsMvp" version="1.4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
+++ b/DNN Platform/HttpModules/DotNetNuke.HttpModules.csproj
@@ -80,8 +80,8 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/HttpModules/packages.config
+++ b/DNN Platform/HttpModules/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.SourceLink.GitHub" version="8.0.0" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -172,8 +172,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />

--- a/DNN Platform/Library/packages.config
+++ b/DNN Platform/Library/packages.config
@@ -27,7 +27,7 @@
   <package id="System.Formats.Asn1" version="9.0.2" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
+++ b/DNN Platform/Modules/CoreMessaging/DotNetNuke.Modules.CoreMessaging.csproj
@@ -91,8 +91,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Modules/CoreMessaging/packages.config
+++ b/DNN Platform/Modules/CoreMessaging/packages.config
@@ -11,6 +11,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
+++ b/DNN Platform/Modules/DDRMenu/DotNetNuke.Modules.DDRMenu.csproj
@@ -100,8 +100,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/DDRMenu/packages.config
+++ b/DNN Platform/Modules/DDRMenu/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/DnnExportImport/DnnExportImport.csproj
+++ b/DNN Platform/Modules/DnnExportImport/DnnExportImport.csproj
@@ -88,8 +88,8 @@
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/DnnExportImport/packages.config
+++ b/DNN Platform/Modules/DnnExportImport/packages.config
@@ -15,6 +15,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/Groups/DotNetNuke.Modules.Groups.csproj
+++ b/DNN Platform/Modules/Groups/DotNetNuke.Modules.Groups.csproj
@@ -91,8 +91,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/Groups/packages.config
+++ b/DNN Platform/Modules/Groups/packages.config
@@ -14,6 +14,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/HTML/DotNetNuke.Modules.Html.csproj
+++ b/DNN Platform/Modules/HTML/DotNetNuke.Modules.Html.csproj
@@ -110,8 +110,8 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/HTML/packages.config
+++ b/DNN Platform/Modules/HTML/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/Journal/DotNetNuke.Modules.Journal.csproj
+++ b/DNN Platform/Modules/Journal/DotNetNuke.Modules.Journal.csproj
@@ -100,8 +100,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/Journal/packages.config
+++ b/DNN Platform/Modules/Journal/packages.config
@@ -14,6 +14,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
+++ b/DNN Platform/Modules/MemberDirectory/DotNetNuke.Modules.MemberDirectory.csproj
@@ -93,8 +93,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/MemberDirectory/packages.config
+++ b/DNN Platform/Modules/MemberDirectory/packages.config
@@ -11,7 +11,7 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="WebFormsMvp" version="1.4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/RazorHost/DotNetNuke.Modules.RazorHost.csproj
+++ b/DNN Platform/Modules/RazorHost/DotNetNuke.Modules.RazorHost.csproj
@@ -82,8 +82,8 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/RazorHost/packages.config
+++ b/DNN Platform/Modules/RazorHost/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
+++ b/DNN Platform/Modules/ResourceManager/Dnn.Modules.ResourceManager.csproj
@@ -83,8 +83,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Modules/ResourceManager/packages.config
+++ b/DNN Platform/Modules/ResourceManager/packages.config
@@ -12,6 +12,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Modules/TelerikRemoval/Dnn.Modules.TelerikRemoval.csproj
+++ b/DNN Platform/Modules/TelerikRemoval/Dnn.Modules.TelerikRemoval.csproj
@@ -61,8 +61,8 @@
       <HintPath>..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Modules/TelerikRemoval/packages.config
+++ b/DNN Platform/Modules/TelerikRemoval/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net48" />
   <package id="StyleCop.Analyzers" version="1.2.0-beta.556" targetFramework="net48" developmentDependency="true" />
   <package id="StyleCop.Analyzers.Unstable" version="1.2.0.556" targetFramework="net48" developmentDependency="true" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.csproj
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.csproj
@@ -119,8 +119,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/packages.config
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/packages.config
@@ -14,6 +14,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Providers/SmtpOAuthProviders/ExchangeOnlineAuthProvider/Dnn.ExchangeOnlineAuthProvider.csproj
+++ b/DNN Platform/Providers/SmtpOAuthProviders/ExchangeOnlineAuthProvider/Dnn.ExchangeOnlineAuthProvider.csproj
@@ -126,8 +126,8 @@
       <HintPath>..\..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Providers/SmtpOAuthProviders/ExchangeOnlineAuthProvider/packages.config
+++ b/DNN Platform/Providers/SmtpOAuthProviders/ExchangeOnlineAuthProvider/packages.config
@@ -21,7 +21,7 @@
   <package id="System.Formats.Asn1" version="9.0.2" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Providers/SmtpOAuthProviders/GoogleMailAuthProvider/Dnn.GoogleMailAuthProvider.csproj
+++ b/DNN Platform/Providers/SmtpOAuthProviders/GoogleMailAuthProvider/Dnn.GoogleMailAuthProvider.csproj
@@ -126,8 +126,8 @@
       <HintPath>..\..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Providers/SmtpOAuthProviders/GoogleMailAuthProvider/packages.config
+++ b/DNN Platform/Providers/SmtpOAuthProviders/GoogleMailAuthProvider/packages.config
@@ -21,7 +21,7 @@
   <package id="System.Formats.Asn1" version="9.0.2" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DNN.Integration.Test.Framework/DNN.Integration.Test.Framework.csproj
+++ b/DNN Platform/Tests/DNN.Integration.Test.Framework/DNN.Integration.Test.Framework.csproj
@@ -124,8 +124,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DNN.Integration.Test.Framework/packages.config
+++ b/DNN Platform/Tests/DNN.Integration.Test.Framework/packages.config
@@ -27,7 +27,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/DotNetNuke.Tests.AspNetCCP.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/DotNetNuke.Tests.AspNetCCP.csproj
@@ -118,8 +118,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.AspNetCCP/packages.config
@@ -20,7 +20,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Authentication/DotNetNuke.Tests.Authentication.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Authentication/DotNetNuke.Tests.Authentication.csproj
@@ -137,8 +137,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Authentication/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Authentication/packages.config
@@ -20,7 +20,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/DotNetNuke.Tests.Content.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/DotNetNuke.Tests.Content.csproj
@@ -149,8 +149,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Content/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Content/packages.config
@@ -24,7 +24,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj
@@ -171,8 +171,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/packages.config
@@ -24,7 +24,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/DotNetNuke.Tests.Data.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/DotNetNuke.Tests.Data.csproj
@@ -152,8 +152,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Data/packages.config
@@ -24,7 +24,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/DotNetNuke.Tests.Integration.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/DotNetNuke.Tests.Integration.csproj
@@ -162,8 +162,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Integration/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Integration/packages.config
@@ -30,7 +30,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="TestStack.Dossier" version="4.0.0" targetFramework="net48" />

--- a/DNN Platform/Tests/DotNetNuke.Tests.Mail/DotNetNuke.Tests.Mail.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Mail/DotNetNuke.Tests.Mail.csproj
@@ -121,8 +121,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Mail/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Mail/packages.config
@@ -23,7 +23,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules.DDRMenu/DotNetNuke.Tests.Modules.DDRMenu.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules.DDRMenu/DotNetNuke.Tests.Modules.DDRMenu.csproj
@@ -110,8 +110,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules.DDRMenu/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules.DDRMenu/packages.config
@@ -17,7 +17,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/DotNetNuke.Tests.Modules.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/DotNetNuke.Tests.Modules.csproj
@@ -137,8 +137,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/packages.config
@@ -20,7 +20,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.UI/DotNetNuke.Tests.UI.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.UI/DotNetNuke.Tests.UI.csproj
@@ -137,8 +137,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.UI/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.UI/packages.config
@@ -20,7 +20,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/DotNetNuke.Tests.Urls.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/DotNetNuke.Tests.Urls.csproj
@@ -134,8 +134,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Urls/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Urls/packages.config
@@ -26,7 +26,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/DotNetNuke.Tests.Utilities.csproj
@@ -163,8 +163,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/packages.config
@@ -29,7 +29,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/DotNetNuke.Tests.Web.Mvc.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/DotNetNuke.Tests.Web.Mvc.csproj
@@ -127,8 +127,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/packages.config
@@ -28,7 +28,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/DotNetNuke.Tests.Web.csproj
@@ -137,8 +137,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web/packages.config
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web/packages.config
@@ -29,7 +29,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="WebFormsMvp" version="1.4.5.0" targetFramework="net48" />

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -125,8 +125,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -261,6 +261,10 @@
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-32767.32767.32767.32767" newVersion="6.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Web.Http.WebHost" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>

--- a/DNN Platform/Website/packages.config
+++ b/DNN Platform/Website/packages.config
@@ -17,6 +17,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -262,6 +262,10 @@
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-32767.32767.32767.32767" newVersion="6.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Web.Http.WebHost" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -769,8 +769,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/packages.config
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/packages.config
@@ -14,6 +14,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Dnn.EditBar.UI.csproj
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Dnn.EditBar.UI.csproj
@@ -301,8 +301,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/packages.config
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/packages.config
@@ -12,6 +12,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
@@ -185,8 +185,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/packages.config
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/packages.config
@@ -15,6 +15,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Dnn.PersonaBar.UI.csproj
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/Dnn.PersonaBar.UI.csproj
@@ -95,8 +95,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/packages.config
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/packages.config
@@ -17,6 +17,6 @@
   <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/Dnn.PersonaBar.ConfigConsole.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/Dnn.PersonaBar.ConfigConsole.Tests.csproj
@@ -119,8 +119,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/packages.config
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.ConfigConsole.Tests/packages.config
@@ -23,7 +23,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/Dnn.PersonaBar.Pages.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/Dnn.PersonaBar.Pages.Tests.csproj
@@ -120,8 +120,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/packages.config
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/packages.config
@@ -23,7 +23,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
@@ -132,8 +132,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/packages.config
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Security.Tests/packages.config
@@ -26,7 +26,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Users.Tests/Dnn.PersonaBar.Users.Tests.csproj
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Users.Tests/Dnn.PersonaBar.Users.Tests.csproj
@@ -120,8 +120,8 @@
       <HintPath>..\..\..\packages\System.Reflection.Metadata.9.0.2\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Users.Tests/packages.config
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Users.Tests/packages.config
@@ -23,7 +23,7 @@
   <package id="System.Memory" version="4.6.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="9.0.2" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/DotNetNuke.Internal.SourceGenerators/DotNetNuke.Internal.SourceGenerators.csproj
+++ b/DotNetNuke.Internal.SourceGenerators/DotNetNuke.Internal.SourceGenerators.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">


### PR DESCRIPTION
This PR is an alternative to #6525 Both aim to address an issue where the installation of DNN will fail because System.Runtime.CompilerServices.Unsafe.dll is not in the bin folder when it first starts up. This assembly is required by the ServiceRequestScopeModule which is now part of the default installation.

This PR also consolidates the versions of this assembly in the project as we had 3 different versions until now.
