### PR TITLE
Feature: Adds ascending/descending sort toggle to Resource Manager

### DIFF
--- a/DNN Platform/Modules/ResourceManager/App_LocalResources/ResourceManager.resx
+++ b/DNN Platform/Modules/ResourceManager/App_LocalResources/ResourceManager.resx
@@ -324,6 +324,12 @@
   <data name="SortField_CreatedOnDate.Text" xml:space="preserve">
     <value>Date Created</value>
   </data>
+  <data name="SortOrder_Ascending.Text" xml:space="preserve">
+    <value>Ascending</value>
+  </data>
+  <data name="SortOrder_Descending.Text" xml:space="preserve">
+    <value>Descending</value>
+  </data>
   <data name="Sort.Text" xml:space="preserve">
     <value>Sort</value>
   </data>

--- a/DNN Platform/Modules/ResourceManager/Components/IItemsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/IItemsManager.cs
@@ -22,6 +22,16 @@ namespace Dnn.Modules.ResourceManager.Components
         /// <returns>A <see cref="ContentPage"/> with the items in the folder.</returns>
         ContentPage GetFolderContent(int folderId, int startIndex, int numItems, string sorting, int moduleMode);
 
+        /// <summary>Get the items contained on the folder.</summary>
+        /// <param name="folderId">Container folder id.</param>
+        /// <param name="startIndex">Index of the first item to be returned.</param>
+        /// <param name="numItems">Max number of items to return.</param>
+        /// <param name="sorting">Sorting option.</param>
+        /// <param name="sortingOrder">Sorting order.</param>
+        /// <param name="moduleMode">Current mode of module instance.</param>
+        /// <returns>A <see cref="ContentPage"/> with the items in the folder.</returns>
+        ContentPage GetFolderContent(int folderId, int startIndex, int numItems, string sorting, string sortingOrder, int moduleMode);
+
         /// <summary>Get the content of a file.</summary>
         /// <param name="fileId">Id of the file.</param>
         /// <param name="fileName">Name of the file.</param>

--- a/DNN Platform/Modules/ResourceManager/Components/ItemsManager.cs
+++ b/DNN Platform/Modules/ResourceManager/Components/ItemsManager.cs
@@ -44,6 +44,12 @@ namespace Dnn.Modules.ResourceManager.Components
         /// <inheritdoc />
         public ContentPage GetFolderContent(int folderId, int startIndex, int numItems, string sorting, int moduleMode)
         {
+            return this.GetFolderContent(folderId, startIndex, numItems, sorting, "Ascending", moduleMode);
+        }
+
+        /// <inheritdoc />
+        public ContentPage GetFolderContent(int folderId, int startIndex, int numItems, string sorting, string sortingOrder, int moduleMode)
+        {
             var noPermissionMessage = Localization.GetExceptionMessage(
                 "UserHasNoPermissionToBrowseFolder",
                 Constants.UserHasNoPermissionToBrowseFolderDefaultMessage);
@@ -53,9 +59,11 @@ namespace Dnn.Modules.ResourceManager.Components
                 throw new FolderPermissionNotMetException(noPermissionMessage);
             }
 
+            string sortingOrderShort = sortingOrder == "Ascending" ? "ASC" : "DESC";
+
             try
             {
-                return AssetManager.Instance.GetFolderContent(folderId, startIndex, numItems, sorting + " ASC");
+                return AssetManager.Instance.GetFolderContent(folderId, startIndex, numItems, sorting + " " + sortingOrderShort);
             }
             catch (AssetManagerException)
             {

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/dnn-rm-actions-bar.scss
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/dnn-rm-actions-bar.scss
@@ -53,6 +53,12 @@ button{
     }
   }
 }
+.right-controls{
+  .sort{
+    display: flex;
+    flex-direction: row;
+  }
+}
 dnn-vertical-overflow-menu{
   flex-grow: 1;
   margin-left:24px;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/dnn-rm-actions-bar.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-actions-bar/dnn-rm-actions-bar.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, State } from '@stencil/core';
 import state from '../../store/store';
 import { sortField, SortFieldInfo } from "../../enums/SortField";
+import { sortOrder } from "../../enums/SortOrder";
 import { InternalServicesClient } from '../../services/InternalServicesClient';
 import { ItemsClient } from '../../services/ItemsClient';
 @Component({
@@ -55,6 +56,15 @@ export class DnnRmActionsBar {
     }
   }
 
+  private renderSortOrderButtonIcon(){
+    if (state.sortOrder.sortOrderKey == sortOrder.ascending.sortOrderKey) {
+      return <path d="M10 6h4v2h-4v-2zm-2 5h8v2h-8v-2zm-2 5h12v2h-12v-2z"/>
+    }
+    else {
+      return <path d="M6 6h12v2h-12v-2zm2 5h8v2h-8v-2zm2 5h4v2h-4v-2z"/>
+    }
+  }
+
   private syncFolderContent(recursive: boolean = false): void {
     this.itemsClient.syncFolderContent(
       state.currentItems.folder.folderId,
@@ -75,7 +85,8 @@ export class DnnRmActionsBar {
         state.currentItems.folder.folderId,
         0,
         state.pageSize,
-        state.sortField)
+        state.sortField,
+        state.sortOrder)
       .then(data => state.currentItems = data)
       .catch(error => console.error(error));
     })
@@ -91,6 +102,10 @@ export class DnnRmActionsBar {
       })
       .catch(reason => reject(reason));
     });
+  }
+
+  private toggleSortOrder() {
+    state.sortOrder = (state.sortOrder.sortOrderKey == sortOrder.ascending.sortOrderKey) ? sortOrder.descending : sortOrder.ascending;
   }
 
   render() {
@@ -151,6 +166,20 @@ export class DnnRmActionsBar {
               <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"/></svg>
               <span>{state.localization.Sort}</span>
               <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/></svg>
+            </button>
+            <button id="sort-order-button"
+              title={`Order: ${state.sortOrder.localizedName}`}
+              onClick={() =>
+                {
+                     this.toggleSortOrder();
+                     this.getFolderContent();
+                }
+              }
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+                  <path d="M0 0h24v24H0z" fill="none"/>
+                  {this.renderSortOrderButtonIcon()}
+              </svg>
             </button>
             <dnn-collapsible expanded={this.sortDropdownExpanded}>
               <div class="dropdown">

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-files-pane/dnn-rm-files-pane.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-files-pane/dnn-rm-files-pane.tsx
@@ -91,7 +91,8 @@ export class DnnRmFilesPane {
         state.currentItems.folder.folderId,
         state.currentItems.items.length,
         state.pageSize,
-        state.sortField)
+        state.sortField,
+        state.sortOrder)
       .then(data => state.currentItems = {
         ...state.currentItems,
         items: [...state.currentItems.items, ...data.items],

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-folder-list/dnn-rm-folder-list.tsx
@@ -48,7 +48,8 @@ export class DnnRmFolderList {
         state.settings.HomeFolderId,
         0,
         state.pageSize,
-        state.sortField)
+        state.sortField,
+        state.sortOrder)
       .then(data => state.currentItems = data)
       .catch(error => console.error(error));
     })

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-left-pane/dnn-rm-left-pane.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-left-pane/dnn-rm-left-pane.tsx
@@ -22,7 +22,8 @@ export class DnnRmLeftPane {
       Number.parseInt(e.detail.data.key),
       0,
       state.pageSize,
-      state.sortField)
+      state.sortField,
+      state.sortOrder)
     .then(data => state.currentItems = data)
     .catch(error => console.error(error));
   }

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-top-bar/dnn-rm-top-bar.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-top-bar/dnn-rm-top-bar.tsx
@@ -38,7 +38,8 @@ export class DnnRmTopBar {
         state.currentItems.folder.folderId,
         0,
         state.pageSize,
-        state.sortField)
+        state.sortField,
+        state.sortOrder)
       .then(data => {
         state.lastSearchRequestedPage = 1;
         state.itemsSearchTerm = undefined;

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/enums/SortOrder.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/enums/SortOrder.ts
@@ -1,0 +1,25 @@
+import state from "../store/store"
+ 
+ export class SortOrder{
+     readonly ascending: SortOrderInfo;
+     readonly descending: SortOrderInfo;
+ 
+     constructor(){
+         this.ascending = new SortOrderInfo("Ascending");
+         this.descending = new SortOrderInfo("Descending");
+     }
+ }
+ 
+ export class SortOrderInfo{
+     readonly sortOrderKey: string;
+ 
+     get localizedName(){
+         return state.localization[`SortOrder_${this.sortOrderKey}`];
+     }
+ 
+     constructor(sortOrderKey: string = "Ascending"){
+         this.sortOrderKey = sortOrderKey;
+     }
+ }
+ 
+ export const sortOrder = new SortOrder();

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/services/ItemsClient.ts
@@ -4,6 +4,7 @@ import { IRoleGroup } from "@dnncommunity/dnn-elements/dist/types/components/dnn
 import { IRole } from "@dnncommunity/dnn-elements/dist/types/components/dnn-permissions-grid/role-interface";
 import { ISearchedUser } from "@dnncommunity/dnn-elements/dist/types/components/dnn-permissions-grid/searched-user-interface";
 import { SortFieldInfo } from "../enums/SortField";
+import { SortOrderInfo } from "../enums/SortOrder";
 
 export class ItemsClient{
     private sf: DnnServicesFramework;
@@ -54,9 +55,10 @@ export class ItemsClient{
         folderId: number,
         startIndex = 0,
         numItems = 20,
-        sorting: SortFieldInfo = new SortFieldInfo("ItemName")){
+        sortingField: SortFieldInfo = new SortFieldInfo("ItemName"),
+        sortingOrder: SortOrderInfo = new SortOrderInfo()){
         return new Promise<GetFolderContentResponse>((resolve, reject) => {
-            const url = `${this.requestUrl}GetFolderContent?folderId=${folderId}&startIndex=${startIndex}&numItems=${numItems}&sorting=${sorting.sortKey}`;
+            const url = `${this.requestUrl}GetFolderContent?folderId=${folderId}&startIndex=${startIndex}&numItems=${numItems}&sorting=${sortingField.sortKey}&sortingOrder=${sortingOrder.sortOrderKey}`;
             const headers = this.sf.getModuleHeaders();
             headers.append("groupId", this.getGroupId());
             this.abortController?.abort();

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/store/store.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/store/store.ts
@@ -1,5 +1,6 @@
 import { createStore } from "@stencil/store";
 import { SortFieldInfo } from "../enums/SortField";
+import { SortOrderInfo } from "../enums/SortOrder";
 import { GetFoldersResponse } from "../services/InternalServicesClient";
 import { GetFolderContentResponse, GetSettingsResponse, Item } from "../services/ItemsClient";
 import { LocalizedStrings } from "../services/LocalizationClient";
@@ -14,6 +15,7 @@ const { state } = createStore<{
     pageSize: number;
     lastSearchRequestedPage: number;
     sortField?: SortFieldInfo;
+    sortOrder?: SortOrderInfo;
     selectedItems: Item[];
     settings?: GetSettingsResponse;
     canManageFolderTypes: boolean;
@@ -24,6 +26,7 @@ const { state } = createStore<{
     lastSearchRequestedPage: 1,
     selectedItems: [],
     canManageFolderTypes: false,
+    sortOrder: new SortOrderInfo()
 });
 
 export default state;

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -71,8 +71,22 @@ namespace Dnn.Modules.ResourceManager.Services
         /// An object containing the folder information, a list of the folder contents and the permissions relating to that folder.
         /// </returns>
         [HttpGet]
-
         public HttpResponseMessage GetFolderContent(int folderId, int startIndex, int numItems, string sorting)
+        {
+            return this.GetFolderContent(folderId, startIndex, numItems, sorting, "Ascending");
+        }
+ 
+        /// <summary>Gets the content for a specific folder.</summary>
+        /// <param name="folderId">The id of the folder.</param>
+        /// <param name="startIndex">The page number to get.</param>
+        /// <param name="numItems">How many items to get per page.</param>
+        /// <param name="sorting">How to sort the list.</param>
+        /// <param name="sortingOrder">The order to sort the list.</param>
+        /// <returns>
+        /// An object containing the folder information, a list of the folder contents and the permissions relating to that folder.
+        /// </returns>
+        [HttpGet]
+        public HttpResponseMessage GetFolderContent(int folderId, int startIndex, int numItems, string sorting, string sortingOrder)
         {
             ContentPage p;
             var groupId = this.FindGroupId(this.Request);
@@ -80,7 +94,7 @@ namespace Dnn.Modules.ResourceManager.Services
             var moduleMode = new SettingsManager(moduleId, groupId).Mode;
             var permissionsManager = PermissionsManager.Instance;
 
-            p = ItemsManager.Instance.GetFolderContent(folderId, startIndex, numItems, sorting, moduleMode);
+            p = ItemsManager.Instance.GetFolderContent(folderId, startIndex, numItems, sorting, sortingOrder, moduleMode);
 
             return this.Request.CreateResponse(HttpStatusCode.OK, new
             {

--- a/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
+++ b/DNN Platform/Modules/ResourceManager/Services/ItemsController.cs
@@ -75,7 +75,7 @@ namespace Dnn.Modules.ResourceManager.Services
         {
             return this.GetFolderContent(folderId, startIndex, numItems, sorting, "Ascending");
         }
- 
+
         /// <summary>Gets the content for a specific folder.</summary>
         /// <param name="folderId">The id of the folder.</param>
         /// <param name="startIndex">The page number to get.</param>


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

Implements #5430 on 9.13.x

# Summary

While allowing the user to sort files by name, date and size, the current implementation of the Resource Manager core module does not allow choosing the sort order (ascending/descending). This implementation adds this functionality.

# Changes made

## API

**Current:** The logic for sorting files in ascending/descending order is already implemented in `AssetManager.Instance.GetFolderContent(...)`, but the chain of calls from the endpoint `GetFolderContent` to the class `ItemsManager` has no option to change the default *ascending* order.

**Change:** Logic for forwarding and taking into consideration the optional HTTP GET argument "sortingOrder" is implemented. *Ascending* order is used by default (i.e., when argument is not provided).

## Frontend

**Current:** There is no toggle button for *ascending*/*descending* order.

**Change:** Added the toggle button, state for controlling the selected order, and adjusted existing calls to the API to always include the argument *sortingOrder* to persist the selected order.

![Screenshot 2025-04-30 142344](https://github.com/user-attachments/assets/7b8870c0-de40-415c-a451-247ba947b965)

## Resources

Added words "Ascending" and "Descending" to the localization texts so that the respective state name is show when cursor moves over the added button.

# Result

| Sorting ASC/DESC by name | Sorting ASC/DESC by size |
|:-:|:-:|
| ![Screenshot 2025-04-30 142344](https://github.com/user-attachments/assets/89514f93-574e-4867-9f0d-d0b0d86d67a8) |  ![Screenshot 2025-04-30 142431](https://github.com/user-attachments/assets/df17afec-21f9-4632-94f5-ab1b15b7c436) |
| ![Screenshot 2025-04-30 142354](https://github.com/user-attachments/assets/131a32a7-ed5f-4ce1-8978-750a14bdc748) | ![Screenshot 2025-04-30 142421](https://github.com/user-attachments/assets/320a0f50-ebae-474f-9a42-355a0516596b) |