### PR TITLE
Adjust Localize helpers

### DIFF
--- a/DNN Platform/Admin Modules/Dnn.Modules.Console/Settings.ascx.cs
+++ b/DNN Platform/Admin Modules/Dnn.Modules.Console/Settings.ascx.cs
@@ -260,16 +260,16 @@ namespace Dnn.Modules.Console
 
                 visibilityDropDown.Items.Clear();
 
-                visibilityDropDown.AddItem(this.LocalizeString("AllUsers"), "AllUsers");
+                visibilityDropDown.AddItem(this.LocalizeText("AllUsers"), "AllUsers");
                 if (this.modeList.SelectedValue == "Profile")
                 {
-                    visibilityDropDown.AddItem(this.LocalizeString("Friends"), "Friends");
-                    visibilityDropDown.AddItem(this.LocalizeString("User"), "User");
+                    visibilityDropDown.AddItem(this.LocalizeText("Friends"), "Friends");
+                    visibilityDropDown.AddItem(this.LocalizeText("User"), "User");
                 }
                 else
                 {
-                    visibilityDropDown.AddItem(this.LocalizeString("Owner"), "Owner");
-                    visibilityDropDown.AddItem(this.LocalizeString("Members"), "Members");
+                    visibilityDropDown.AddItem(this.LocalizeText("Owner"), "Owner");
+                    visibilityDropDown.AddItem(this.LocalizeText("Members"), "Members");
                 }
 
                 tabLabel.Text = tab.TabName;

--- a/DNN Platform/Library/Common/Utilities/HtmlUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/HtmlUtils.cs
@@ -362,7 +362,7 @@ namespace DotNetNuke.Common.Utilities
             return StripNonWordRegex.Replace(html, repString);
         }
 
-        /// <summary>Determines whether or not the passed in string contains any HTML tags.</summary>
+        /// <summary>Determines whether the passed in string contains any HTML tags.</summary>
         /// <param name="text">Text to be inspected.</param>
         /// <returns>True for HTML and False for plain text.</returns>
         public static bool IsHtml(string text)
@@ -567,5 +567,13 @@ namespace DotNetNuke.Common.Utilities
 
             return html;
         }
+
+        /// <inheritdoc cref="HttpUtility.JavaScriptStringEncode(string)"/>
+        public static IHtmlString JavaScriptStringEncode(string value)
+            => JavaScriptStringEncode(value, false);
+
+        /// <inheritdoc cref="HttpUtility.JavaScriptStringEncode(string,bool)"/>
+        public static IHtmlString JavaScriptStringEncode(string value, bool addDoubleQuotes)
+            => new HtmlString(HttpUtility.JavaScriptStringEncode(value, addDoubleQuotes));
     }
 }

--- a/DNN Platform/Library/Entities/Modules/PortalModuleBase.cs
+++ b/DNN Platform/Library/Entities/Modules/PortalModuleBase.cs
@@ -9,9 +9,11 @@ namespace DotNetNuke.Entities.Modules
     using System.IO;
     using System.Text.RegularExpressions;
     using System.Threading;
+    using System.Web;
     using System.Web.UI;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules.Actions;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
@@ -457,14 +459,37 @@ namespace DotNetNuke.Entities.Modules
             }
         }
 
-        protected string LocalizeString(string key)
+        /// <inheritdoc cref="Localization.GetString(string,string)"/>
+        [DnnDeprecated(10, 0, 2, "Use LocalizeText or LocalizeHtml")]
+        protected partial string LocalizeString(string key)
         {
             return Localization.GetString(key, this.LocalResourceFile);
         }
 
-        protected string LocalizeSafeJsString(string key)
+        /// <inheritdoc cref="Localization.GetSafeJSString(string,string)"/>
+        [DnnDeprecated(10, 0, 2, "Use LocalizeJsString")]
+        protected partial string LocalizeSafeJsString(string key)
         {
             return Localization.GetSafeJSString(key, this.LocalResourceFile);
         }
+
+        /// <summary>Gets the text associated with the <paramref name="key"/> in this control's <see cref="LocalResourceFile"/>.</summary>
+        /// <param name="key">The resource key.</param>
+        /// <returns>The localized text.</returns>
+        protected string LocalizeText(string key)
+            => Localization.GetString(key, this.LocalResourceFile);
+
+        /// <summary>Gets the HTML associated with the <paramref name="key"/> in this control's <see cref="LocalResourceFile"/>.</summary>
+        /// <param name="key">The resource key.</param>
+        /// <returns>The localized text as HTML.</returns>
+        protected IHtmlString LocalizeHtml(string key)
+            => new HtmlString(Localization.GetString(key, this.LocalResourceFile));
+
+        /// <summary>Gets the text associated with the <paramref name="key"/> in this control's <see cref="LocalResourceFile"/>.</summary>
+        /// <param name="key">The resource key.</param>
+        /// <param name="addDoubleQuotes">A value that indicates whether double quotation marks will be included around the encoded string.</param>
+        /// <returns>The localized text encoded as a JavaScript string.</returns>
+        protected IHtmlString LocalizeJsString(string key, bool addDoubleQuotes = false)
+            => HtmlUtils.JavaScriptStringEncode(Localization.GetString(key, this.LocalResourceFile), addDoubleQuotes);
     }
 }

--- a/DNN Platform/Library/Framework/PageBase.cs
+++ b/DNN Platform/Library/Framework/PageBase.cs
@@ -128,6 +128,14 @@ namespace DotNetNuke.Framework
             }
         }
 
+        /// <inheritdoc cref="HtmlUtils.JavaScriptStringEncode(string)"/>
+        public static IHtmlString JavaScriptStringEncode(string value)
+            => HtmlUtils.JavaScriptStringEncode(value);
+
+        /// <inheritdoc cref="HtmlUtils.JavaScriptStringEncode(string,bool)"/>
+        public static IHtmlString JavaScriptStringEncode(string value, bool addDoubleQuotes)
+            => HtmlUtils.JavaScriptStringEncode(value, addDoubleQuotes);
+
         /// <summary>
         /// <para>RemoveKeyAttribute remove the key attribute from the control. If this isn't done, then the HTML output will have
         /// a bad attribute on it which could cause some older browsers problems.</para>

--- a/DNN Platform/Library/Framework/UserControlBase.cs
+++ b/DNN Platform/Library/Framework/UserControlBase.cs
@@ -4,9 +4,11 @@
 namespace DotNetNuke.Framework
 {
     using System.ComponentModel;
+    using System.Web;
     using System.Web.UI;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
 
     /// <summary>
@@ -32,5 +34,13 @@ namespace DotNetNuke.Framework
                 return PortalController.Instance.GetCurrentPortalSettings();
             }
         }
+
+        /// <inheritdoc cref="HtmlUtils.JavaScriptStringEncode(string)"/>
+        public static IHtmlString JavaScriptStringEncode(string value)
+            => HtmlUtils.JavaScriptStringEncode(value);
+
+        /// <inheritdoc cref="HtmlUtils.JavaScriptStringEncode(string,bool)"/>
+        public static IHtmlString JavaScriptStringEncode(string value, bool addDoubleQuotes)
+            => HtmlUtils.JavaScriptStringEncode(value, addDoubleQuotes);
     }
 }

--- a/DNN Platform/Website/DesktopModules/Admin/Security/DataConsent.ascx
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/DataConsent.ascx
@@ -1,21 +1,14 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="false" CodeBehind="DataConsent.ascx.cs" Inherits="DotNetNuke.Modules.Admin.Users.DataConsent" %>
-<%@ Register TagPrefix="dnn" TagName="Label" Src="~/controls/LabelControl.ascx" %>
-<%@ Register TagPrefix="dnn" Assembly="DotNetNuke" Namespace="DotNetNuke.UI.WebControls" %>
 <div class="dnnForm dnnPasswordReset dnnClear">
  <div>
   <asp:CheckBox runat="server" ID="chkAgree" />
-  <%= String.Format(DotNetNuke.Services.Localization.Localization.GetString("DataConsent", LocalResourceFile),
-    PortalSettings.Current.TermsTabId == Null.NullInteger ? DotNetNuke.Common.Globals.NavigateURL(PortalSettings.Current.ActiveTab.TabID, "Terms") : DotNetNuke.Common.Globals.NavigateURL(PortalSettings.Current.TermsTabId),
-    PortalSettings.Current.PrivacyTabId == Null.NullInteger ? DotNetNuke.Common.Globals.NavigateURL(PortalSettings.Current.ActiveTab.TabID, "Privacy") : DotNetNuke.Common.Globals.NavigateURL(PortalSettings.Current.PrivacyTabId)) %>
+  <%: DataConsentHtml %>
  </div>
  <asp:Panel runat="server" ID="pnlNoAgreement">
  </asp:Panel>
  <ul class="dnnActions dnnClear">
-  <li>
-   <asp:Button ID="cmdSubmit" CssClass="dnnPrimaryAction" runat="server" resourcekey="cmdSubmit" /></li>
-  <li>
-   <asp:Button ID="cmdCancel" CssClass="dnnSecondaryAction" runat="server" resourcekey="cmdCancel" /></li>
-  <li>
-   <asp:Button ID="cmdDeleteMe" CssClass="dnnSecondaryAction" runat="server" resourcekey="cmdDeleteMe" /></li>
+  <li><asp:Button ID="cmdSubmit" CssClass="dnnPrimaryAction" runat="server" resourcekey="cmdSubmit" /></li>
+  <li><asp:Button ID="cmdCancel" CssClass="dnnSecondaryAction" runat="server" resourcekey="cmdCancel" /></li>
+  <li><asp:Button ID="cmdDeleteMe" CssClass="dnnSecondaryAction" runat="server" resourcekey="cmdDeleteMe" /></li>
  </ul>
 </div>

--- a/DNN Platform/Website/DesktopModules/Admin/Security/DataConsent.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/DataConsent.ascx.cs
@@ -5,21 +5,45 @@ namespace DotNetNuke.Modules.Admin.Users
 {
     using System;
     using System.Web;
-    using System.Web.UI;
 
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Security;
-    using DotNetNuke.Services.Log.EventLog;
+    using DotNetNuke.Services.Localization;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>A control which handles a user's consent to the site's usage of their data.</summary>
     public partial class DataConsent : UserModuleBase
     {
+        private readonly INavigationManager navigationManager;
+
+        /// <summary>Initializes a new instance of the <see cref="DataConsent"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.0.2. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
+        public DataConsent()
+            : this(null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DataConsent"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        public DataConsent(INavigationManager navigationManager)
+        {
+            this.navigationManager = navigationManager ?? Common.Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>A function which handles the <see cref="DataConsent.DataConsentCompleted"/> event.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
         public delegate void DataConsentEventHandler(object sender, DataConsentEventArgs e);
 
+        /// <summary>An event which is triggered when the user takes a data consent action.</summary>
         public event DataConsentEventHandler DataConsentCompleted;
 
+        /// <summary>The options a user can take from the data consent screen.</summary>
         public enum DataConsentStatus
         {
             /// <summary>Consented.</summary>
@@ -35,6 +59,7 @@ namespace DotNetNuke.Modules.Admin.Users
             FailedToRemoveAccount = 3,
         }
 
+        /// <summary>Gets the confirmation text to display when a user chooses for their account to be deleted.</summary>
         public string DeleteMeConfirmString
         {
             get
@@ -42,17 +67,38 @@ namespace DotNetNuke.Modules.Admin.Users
                 switch (this.PortalSettings.DataConsentUserDeleteAction)
                 {
                     case PortalSettings.UserDeleteAction.Manual:
-                        return this.LocalizeString("ManualDelete.Confirm");
+                        return this.LocalizeText("ManualDelete.Confirm");
                     case PortalSettings.UserDeleteAction.DelayedHardDelete:
-                        return this.LocalizeString("DelayedHardDelete.Confirm");
+                        return this.LocalizeText("DelayedHardDelete.Confirm");
                     case PortalSettings.UserDeleteAction.HardDelete:
-                        return this.LocalizeString("HardDelete.Confirm");
+                        return this.LocalizeText("HardDelete.Confirm");
                 }
 
                 return string.Empty;
             }
         }
 
+        /// <summary>Gets the HTML to display with the statement agreeing to the terms and privacy policies.</summary>
+        protected IHtmlString DataConsentHtml
+        {
+            get
+            {
+                var termsUrl = this.PortalSettings.TermsTabId == Null.NullInteger
+                    ? this.navigationManager.NavigateURL(this.TabId, "Terms")
+                    : this.navigationManager.NavigateURL(this.PortalSettings.TermsTabId);
+                var privacyUrl = this.PortalSettings.PrivacyTabId == Null.NullInteger
+                    ? this.navigationManager.NavigateURL(this.TabId, "Privacy")
+                    : this.navigationManager.NavigateURL(this.PortalSettings.PrivacyTabId);
+                var dataConsentHtml = string.Format(
+                    Localization.GetString("DataConsent"),
+                    termsUrl,
+                    privacyUrl);
+                return new HtmlString(dataConsentHtml);
+            }
+        }
+
+        /// <summary>Called when any data consent action is completed.</summary>
+        /// <param name="e">The details of the action.</param>
         public void OnDataConsentComplete(DataConsentEventArgs e)
         {
             this.DataConsentCompleted?.Invoke(this, e);
@@ -128,16 +174,10 @@ namespace DotNetNuke.Modules.Admin.Users
             }
         }
 
-        /// <summary>
-        /// The DataConsentEventArgs class provides a customised EventArgs class for
-        /// the DataConsent Event.
-        /// </summary>
+        /// <summary>The DataConsentEventArgs class provides a customised EventArgs class for the <see cref="DataConsent.DataConsentCompleted"/> Event.</summary>
         public class DataConsentEventArgs
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="DataConsentEventArgs"/> class.
-            /// Constructs a new DataConsentEventArgs.
-            /// </summary>
+            /// <summary>Initializes a new instance of the <see cref="DataConsentEventArgs"/> class.</summary>
             /// <param name="status">The Data Consent Status.</param>
             public DataConsentEventArgs(DataConsentStatus status)
             {

--- a/DNN Platform/Website/DesktopModules/Admin/Security/Membership.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/Membership.ascx.cs
@@ -196,13 +196,13 @@ namespace DotNetNuke.Modules.Admin.Users
 
             this.lastLockoutDate.Value = this.UserMembership.LastLockoutDate.Year > 2000
                                         ? (object)this.UserMembership.LastLockoutDate
-                                        : this.LocalizeString("Never");
+                                        : this.LocalizeText("Never");
 
             // ReSharper disable SpecifyACultureInStringConversionExplicitly
-            this.lockedOut.Value = this.LocalizeString(this.UserMembership.LockedOut.ToString());
-            this.approved.Value = this.LocalizeString(this.UserMembership.Approved.ToString());
-            this.updatePassword.Value = this.LocalizeString(this.UserMembership.UpdatePassword.ToString());
-            this.isDeleted.Value = this.LocalizeString(this.UserMembership.IsDeleted.ToString());
+            this.lockedOut.Value = this.LocalizeText(this.UserMembership.LockedOut.ToString());
+            this.approved.Value = this.LocalizeText(this.UserMembership.Approved.ToString());
+            this.updatePassword.Value = this.LocalizeText(this.UserMembership.UpdatePassword.ToString());
+            this.isDeleted.Value = this.LocalizeText(this.UserMembership.IsDeleted.ToString());
 
             // show the user folder path without default parent folder, and only visible to admin.
             this.userFolder.Visible = this.UserInfo.IsInRole(this.PortalSettings.AdministratorRoleName);

--- a/DNN Platform/Website/DesktopModules/Admin/Security/ProfileDefinitions.ascx
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/ProfileDefinitions.ascx
@@ -20,7 +20,7 @@
             <asp:TemplateColumn HeaderText="DataType">
                 <ItemStyle Width="60px"></ItemStyle>
                 <ItemTemplate>
-                    <asp:label id="lblDataType" runat="server" Text='<%# DisplayDataType((DotNetNuke.Entities.Profile.ProfilePropertyDefinition)Container.DataItem) %>'></asp:label>
+                    <asp:label id="lblDataType" runat="server" Text='<%#: DisplayDataType((DotNetNuke.Entities.Profile.ProfilePropertyDefinition)Container.DataItem) %>'></asp:label>
                 </ItemTemplate>
             </asp:TemplateColumn>
             <dnn:textcolumn DataField="Length" HeaderText="Length" Width="50px" />
@@ -29,7 +29,7 @@
             <asp:TemplateColumn HeaderText="DefaultVisibility">
                 <ItemStyle Width="100px"></ItemStyle>
                 <ItemTemplate>
-                    <asp:label id="lbDefaultVisibility" runat="server" Text='<%# DisplayDefaultVisibility((DotNetNuke.Entities.Profile.ProfilePropertyDefinition)Container.DataItem) %>'></asp:label>
+                    <asp:label id="lbDefaultVisibility" runat="server" Text='<%#: DisplayDefaultVisibility((DotNetNuke.Entities.Profile.ProfilePropertyDefinition)Container.DataItem) %>'></asp:label>
                 </ItemTemplate>
             </asp:TemplateColumn>
             <dnn:checkboxcolumn DataField="Required" HeaderText="Required" AutoPostBack="True" />

--- a/DNN Platform/Website/DesktopModules/Admin/Security/ProfileDefinitions.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/ProfileDefinitions.ascx.cs
@@ -162,7 +162,7 @@ namespace DotNetNuke.Modules.Admin.Users
             string retValue = Null.NullString;
             if (!string.IsNullOrEmpty(definition.DefaultVisibility.ToString()))
             {
-                retValue = this.LocalizeString(definition.DefaultVisibility.ToString()) ?? definition.DefaultVisibility.ToString();
+                retValue = this.LocalizeText(definition.DefaultVisibility.ToString()) ?? definition.DefaultVisibility.ToString();
             }
 
             return retValue;

--- a/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/Register.ascx.cs
@@ -911,7 +911,7 @@ namespace DotNetNuke.Modules.Admin.Users
             }
             else
             {
-                this.AddLocalizedModuleMessage(this.LocalizeString("NoEmail"), ModuleMessage.ModuleMessageType.RedError, true);
+                this.AddLocalizedModuleMessage(this.LocalizeText("NoEmail"), ModuleMessage.ModuleMessageType.RedError, true);
                 foreach (DnnFormItemBase formItem in this.userForm.Items)
                 {
                     formItem.Visible = formItem.DataField == "Email";

--- a/DNN Platform/Website/DesktopModules/Admin/Security/User.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/Security/User.ascx.cs
@@ -563,7 +563,7 @@ namespace DotNetNuke.Modules.Admin.Users
                             var usersWithSameDisplayName = (System.Collections.Generic.List<UserInfo>)MembershipProvider.Instance().GetUsersBasicSearch(this.PortalId, 0, 2, "DisplayName", true, "DisplayName", this.User.DisplayName);
                             if (usersWithSameDisplayName.Any(user => user.UserID != this.User.UserID))
                             {
-                                UI.Skins.Skin.AddModuleMessage(this, this.LocalizeString("DisplayNameNotUnique"), UI.Skins.Controls.ModuleMessage.ModuleMessageType.RedError);
+                                UI.Skins.Skin.AddModuleMessage(this, this.LocalizeText("DisplayNameNotUnique"), UI.Skins.Controls.ModuleMessage.ModuleMessageType.RedError);
                                 return;
                             }
                         }

--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx
@@ -1,6 +1,7 @@
 <%@ Control Language="C#" Inherits="DotNetNuke.Modules.Admin.Authentication.DNN.Login" AutoEventWireup="false" CodeBehind="Login.ascx.cs" %>
 <%@ Register TagPrefix="dnn" Assembly="DotNetNuke" Namespace="DotNetNuke.UI.WebControls"%>
 <%@ Register TagPrefix="dnn" Namespace="DotNetNuke.Web.UI.WebControls.Internal" Assembly="DotNetNuke.Web" %>
+<%@ Import Namespace="DotNetNuke.Common.Utilities" %>
 <div class="dnnForm dnnLoginService dnnClear">
     <div class="dnnFormItem">
 		<div class="dnnLabel">
@@ -44,7 +45,7 @@
         /*globals jQuery, window, Sys */
         (function ($, Sys) {
             const disabledActionClass = "dnnDisabledAction";
-            const actionLinks = $('a[id^="dnn_ctr<%=ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN"]');
+            const actionLinks = $('a[id^="dnn_ctr<%:ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN"]');
             function isActionDisabled($el) {
                 return $el && $el.hasClass(disabledActionClass);
             }
@@ -76,7 +77,7 @@
             $(document).ready(function () {
                 $(document).on('keydown', '.dnnLoginService', function (e) {
                     if ($(e.target).is('input:text,input:password') && e.keyCode === 13) {
-                        var $loginButton = $('#dnn_ctr<%=ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN_cmdLogin');
+                        var $loginButton = $('#dnn_ctr<%:ModuleId > Null.NullInteger ? ModuleId.ToString() : ""%>_Login_Login_DNN_cmdLogin');
                         if (isActionDisabled($loginButton)) {
                             return false;
                         }

--- a/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/AuthenticationServices/DNN/Login.ascx.cs
@@ -221,7 +221,7 @@ namespace DotNetNuke.Modules.Admin.Authentication.DNN
                 useEmailAsUserName = !registrationFields.Contains("Username");
             }
 
-            this.plUsername.Text = this.LocalizeString(useEmailAsUserName ? "Email" : "Username");
+            this.plUsername.Text = this.LocalizeText(useEmailAsUserName ? "Email" : "Username");
             this.divCaptcha1.Visible = this.UseCaptcha;
             this.divCaptcha2.Visible = this.UseCaptcha;
         }

--- a/DNN Platform/Website/admin/Security/PasswordReset.ascx.cs
+++ b/DNN Platform/Website/admin/Security/PasswordReset.ascx.cs
@@ -113,10 +113,10 @@ namespace DotNetNuke.Modules.Admin.Security
                 this.lblInfo.Text = Localization.GetString("ForcedResetInfo", this.LocalResourceFile);
             }
 
-            this.txtUsername.Attributes.Add("data-default", useEmailAsUserName ? this.LocalizeString("Email") : this.LocalizeString("Username"));
-            this.txtPassword.Attributes.Add("data-default", this.LocalizeString("Password"));
-            this.txtConfirmPassword.Attributes.Add("data-default", this.LocalizeString("Confirm"));
-            this.txtAnswer.Attributes.Add("data-default", this.LocalizeString("Answer"));
+            this.txtUsername.Attributes.Add("data-default", useEmailAsUserName ? this.LocalizeText("Email") : this.LocalizeText("Username"));
+            this.txtPassword.Attributes.Add("data-default", this.LocalizeText("Password"));
+            this.txtConfirmPassword.Attributes.Add("data-default", this.LocalizeText("Confirm"));
+            this.txtAnswer.Attributes.Add("data-default", this.LocalizeText("Answer"));
 
             if (!this.Page.IsPostBack)
             {


### PR DESCRIPTION
## Summary
`PortalModuleBase` exposes two helpers, `LocalizeString` and `LocalizeSafeJsString`. I propose that these are deprecated and replaced with three helpers, `LocalizeText`, `LocalizeHtml`, and `LocalizeJsString`, which use the `IHtmlString` abstraction to provide proper encoding. This will allow markup to more easily transition to using the safer `<%: something %>` code placeholders (colloquially, bee-stings) instead of `<%= something %>`.

Fixes #6571 

This PR also adds the following static helper methods:
- `IHtmlString HtmlUtils.JavaScriptStringEncode(string)`
- `IHtmlString PageBase.JavaScriptStringEncode(string)`
- `IHtmlString UserControlBase.JavaScriptStringEncode(string)`
- `IHtmlString HtmlUtils.JavaScriptStringEncode(string, bool)`
- `IHtmlString PageBase.JavaScriptStringEncode(string, bool)`
- `IHtmlString UserControlBase.JavaScriptStringEncode(string, bool)`

Finally, due to marking some members as obsolete, this PR also replaces usages of `LocalizeString` with `LocalizeText` in projects where obsolete usage is a compilation error. In those controls, I also adjusted the frontend markup to use `<%:` bee stings.