### PR TITLE
Bump Microsoft.TestPlatform from 17.12.0 to 17.14.1

### DIFF
--- a/Build/Program.cs
+++ b/Build/Program.cs
@@ -12,7 +12,7 @@ namespace DotNetNuke.Build
     public class Program
     {
         /// <summary>The version of the Microsoft.TestPlatform NuGet package.</summary>
-        internal const string MicrosoftTestPlatformVersion = "17.12.0";
+        internal const string MicrosoftTestPlatformVersion = "17.14.1";
 
         /// <summary>The version of the NUnit3TestAdapter NuGet package.</summary>
         internal const string NUnit3TestAdapterVersion = "5.0.0";


### PR DESCRIPTION
## Summary
This PR bumps the version of the following NuGet tools used by the Cake build:
- Microsoft.TestPlatform from 17.12.0 to 17.14.1
