### PR TITLE
refactor: Allow SQL to do recursive search for files in subfolders

### DIFF
--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -2027,7 +2027,7 @@ namespace DotNetNuke.Services.FileSystem
 
             // Simple filter with folder permission lookup
             return fileCollection
-                .Where(f => regex.IsMatch(f.FileName) && allowedFolderPaths.Contains(f.Folder))
+                .Where(f => allowedFolderPaths.Contains(f.Folder) && regex.IsMatch(f.FileName))
                 .Cast<IFileInfo>();
         }
 


### PR DESCRIPTION
## Summary

Eliminates excessive database load during file searches by making a single recursive call instead of one per sub-folder.

* **Closes:** #6581 
* **Area:** Core – `FolderManager.SearchFiles`  
* **Type:** Performance enhancement (non-breaking)

---

## Problem statement

On portals with deep folder hierarchies every search triggers **N × `dbo.GetFiles`** calls (N = folder count). Though each query costs < 35 ms CPU, thousands executed serially drive SQL Server to 100 % CPU and users wait ~1 minute.

---

## Implementation details

* Propagate the `recursive` flag to `GetFiles`.  
* Consolidate result filtering & permission checks in memory.  
* No DB schema changes, no new indexes, no public API changes.  
* Existing unit tests remain green.

---

## Performance results

| Metric (67 k files / 2 700 folders) | **Before** | **After** |
|------------------------------------|-----------:|----------:|
| Total runtime (search “d”)         | ~60 s | **~2 s** |
| DB calls to `GetFiles`             | ~2 700 | **5** |
| SQL CPU utilisation                | 100 % | **< 15 %** |

---

## Test plan

1. Seed sample portal.  
2. Search “d” in **Global Assets** and record timings/logs.  
3. Run **DotNetNuke.Tests.Core.Providers.Folder** – all pass.  

---

### Evidence

**Before Fix**

https://github.com/user-attachments/assets/f131ad22-f798-4246-b116-448a1bed9ede

**After Fix**

https://github.com/user-attachments/assets/c5ce50cf-c97d-43a4-a831-c351efaf5f5e

