### PR TITLE
Fix double-encoding in DnnDatePicker internal control

### DIFF
--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/Internal/DnnDatePicker.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/Internal/DnnDatePicker.cs
@@ -64,8 +64,8 @@ namespace DotNetNuke.Web.UI.WebControls.Internal
         {
             return new Dictionary<string, object>
             {
-                { "minDate", this.MinDate > DateTime.MinValue ? $"$new Date({HttpUtility.JavaScriptStringEncode(this.MinDate.ToString(this.Format, CultureInfo.InvariantCulture), addDoubleQuotes: true)})$" : string.Empty },
-                { "maxDate", this.MaxDate > DateTime.MinValue ? $"$new Date({HttpUtility.JavaScriptStringEncode(this.MaxDate.ToString(this.Format, CultureInfo.InvariantCulture), addDoubleQuotes: true)})$" : string.Empty },
+                { "minDate", this.MinDate > DateTime.MinValue ? $"$new Date('{HttpUtility.JavaScriptStringEncode(this.MinDate.ToString(this.Format, CultureInfo.InvariantCulture))}')$" : string.Empty },
+                { "maxDate", this.MaxDate > DateTime.MinValue ? $"$new Date('{HttpUtility.JavaScriptStringEncode(this.MaxDate.ToString(this.Format, CultureInfo.InvariantCulture))}')$" : string.Empty },
                 { "format", this.ClientFormat },
             };
         }


### PR DESCRIPTION
## Summary
The internal `DnnDatePicker` and `DnnDateTimePicker` controls are not working since 9.13.9 (cf. 34c72c988f47ab08128f4084c820703451b835a0) because of quotes being double-encoded (because the control is JSON encoding strings which are not really strings, but intended to be arbitrary JS expressions, in this case `new Date('…')`).

This PR adjusts that encoding so that it works as it did previously.