### PR TITLE
Bump Yarn from 4.9.1 to 4.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
   "resolutions": {
     "@types/ws": "8.5.4"
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.9.2"
 }


### PR DESCRIPTION
## Summary
This PR bumps Yarn from 4.9.1 to [4.9.2](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.9.2).