### PR TITLE
Add RTL (Right-To-Left) language support for Persian localization

### DIFF
--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -209,17 +209,19 @@ namespace DotNetNuke.Framework
         {
             base.OnInit(e);
 
-            // Set Persian culture to support localization when culture is fa-IR (e.g. for 404 pages)
-            if (this.PortalSettings.CultureCode == "fa-IR")
-            {
-                var newCulture = Services.Localization.Persian.PersianController.GetPersianCultureInfo();
-                System.Threading.Thread.CurrentThread.CurrentUICulture = newCulture;
-            }
-
             // Add 'rtl' class to body for right-to-left language support
             if (CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft)
             {
-                this.Body.Attributes.Add("class", "rtl ");
+                string existingClass = this.Body.Attributes["class"];
+
+                if (string.IsNullOrEmpty(existingClass))
+                {
+                    this.Body.Attributes.Add("class", "rtl ");
+                }
+                else if (!existingClass.Contains("rtl"))
+                {
+                    this.Body.Attributes["class"] = existingClass + " rtl ";
+                }
             }
 
             // set global page settings

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -209,6 +209,19 @@ namespace DotNetNuke.Framework
         {
             base.OnInit(e);
 
+            // Set Persian culture to support localization when culture is fa-IR (e.g. for 404 pages)
+            if (this.PortalSettings.CultureCode == "fa-IR")
+            {
+                var newCulture = Services.Localization.Persian.PersianController.GetPersianCultureInfo();
+                System.Threading.Thread.CurrentThread.CurrentUICulture = newCulture;
+            }
+
+            // Add 'rtl' class to body for right-to-left language support
+            if (CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft)
+            {
+                this.Body.Attributes.Add("class", "rtl ");
+            }
+
             // set global page settings
             this.InitializePage();
 


### PR DESCRIPTION
This PR adds basic RTL language support to ensure proper layout and localization for Persian (fa-IR) users:

Sets Persian culture (fa-IR) to enable correct localization (e.g. for 404 pages).

Adds the rtl CSS class to the <body> tag when the current culture is right-to-left to handle RTL layouts properly.

These changes improve usability and layout rendering for RTL languages in DNN.

Notes:
Tested with Persian culture to ensure layout direction and localization are applied correctly.

@microsoft-github-policy-service agree
