### PR TITLE
Add 'rtl' class to body for right-to-left language support

### DIFF
--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -209,6 +209,21 @@ namespace DotNetNuke.Framework
         {
             base.OnInit(e);
 
+            // Add 'rtl' class to body for right-to-left language support
+            if (CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft)
+            {
+                string existingClass = this.Body.Attributes["class"];
+
+                if (string.IsNullOrEmpty(existingClass))
+                {
+                    this.Body.Attributes.Add("class", "rtl ");
+                }
+                else if (!existingClass.Contains("rtl"))
+                {
+                    this.Body.Attributes["class"] = existingClass + " rtl ";
+                }
+            }
+
             // set global page settings
             this.InitializePage();
 


### PR DESCRIPTION
This PR adds basic RTL language support by updating the <body> tag classes when the current UI culture is right-to-left:

Checks if the current UI culture is RTL.

If the ```<body>``` tag has no existing class, it adds ```"rtl"```.

If it already has classes but not ```"rtl"```, it appends ```"rtl"``` to ensure proper RTL layout rendering.

These changes improve layout direction handling for RTL languages such as Persian (fa-IR).

Notes:
Tested with Persian culture to confirm that the RTL class is applied correctly for proper layout rendering.

@microsoft-github-policy-service agree

