### PR TITLE
Clean up legacy code

### DIFF
--- a/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
+++ b/DNN Platform/DotNetNuke.ModulePipeline/DotNetNuke.ModulePipeline.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/DNN Platform/DotNetNuke.ModulePipeline/ModuleControlPipeline.cs
+++ b/DNN Platform/DotNetNuke.ModulePipeline/ModuleControlPipeline.cs
@@ -7,33 +7,17 @@ namespace DotNetNuke.ModulePipeline
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-#if NETFRAMEWORK
     using System.Web.UI;
-#endif
 
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.UI.Modules;
-    using DotNetNuke.UI.Modules.Html5;
-    using DotNetNuke.Web.Mvc;
-    using DotNetNuke.Web.Razor;
 
     /// <summary>
     /// The Module Pipeline that determines which Module pattern
     /// to invoke based on the input module type.
     /// </summary>
-    public class ModuleControlPipeline
-
-    // MULTI-TARGETTING PIPELINE
-    // -------------------------
-    // This file multi-targets .NET Framework and .NET Standard,
-    // which is needed as DNN migrates to .NET Core. The 'NETFRAMEWORK'
-    // pre-processor directives are to fully support Legacy DNN.
-    // As the Pipeline is upgraded to be more complaint with
-    // .NET Standard 2.0 use the appropriate pre-processor directives.
-#if NETFRAMEWORK
-        : IModuleControlPipeline
-#endif
+    public class ModuleControlPipeline : IModuleControlPipeline
     {
         private static readonly ILog TraceLogger = LoggerSource.Instance.GetLogger("DNN.Trace");
         private readonly IModuleControlFactory[] factories;
@@ -45,7 +29,6 @@ namespace DotNetNuke.ModulePipeline
             this.factories = factories.OrderByDescending(f => f.Priority).ToArray();
         }
 
-#if NETFRAMEWORK
         /// <inheritdoc />
         public Control LoadModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlKey, string controlSrc)
         {
@@ -196,6 +179,5 @@ namespace DotNetNuke.ModulePipeline
             // The following exception should never be thrown, as the default factory should always be able to create a control
             throw new NotSupportedException($"No module control factory found for module {moduleConfiguration.ModuleID} with control source {controlSrc}");
         }
-#endif
     }
 }

--- a/DNN Platform/DotNetNuke.ModulePipeline/Startup.cs
+++ b/DNN Platform/DotNetNuke.ModulePipeline/Startup.cs
@@ -13,16 +13,7 @@ namespace DotNetNuke.ModulePipeline
         /// <inheritdoc/>
         public void ConfigureServices(IServiceCollection services)
         {
-            // MULTI-TARGETTING PIPELINE
-            // -------------------------
-            // This file multi-targets .NET Framework and .NET Standard,
-            // which is needed as DNN migrates to .NET Core. The 'NETFRAMEWORK'
-            // pre-processor directives are to fully support Legacy DNN.
-            // As the Pipeline is upgraded to be more complaint with
-            // .NET Standard 2.0 use the appropriate pre-processor directives.
-#if NETFRAMEWORK
             services.AddSingleton<IModuleControlPipeline, ModuleControlPipeline>();
-#endif
         }
     }
 }

--- a/DNN Platform/Library/UI/Modules/IModuleControlPipeline.cs
+++ b/DNN Platform/Library/UI/Modules/IModuleControlPipeline.cs
@@ -8,16 +8,51 @@ namespace DotNetNuke.UI.Modules
 
     using DotNetNuke.Entities.Modules;
 
+    /// <summary>
+    /// Defines the contract for a pipeline that handles the loading and creation of module controls.
+    /// </summary>
     public interface IModuleControlPipeline
     {
+        /// <summary>
+        /// Loads a module control based on the specified container control, module configuration, control key, and control source.
+        /// </summary>
+        /// <param name="containerControl">The container control in which the module control will be loaded.</param>
+        /// <param name="moduleConfiguration">The configuration of the module to be loaded.</param>
+        /// <param name="controlKey">The control key.</param>
+        /// <param name="controlSrc">The control source from the module control.</param>
+        /// <returns>The loaded module control.</returns>
         Control LoadModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlKey, string controlSrc);
 
+        /// <summary>
+        /// Loads a module control based on the specified container control and module configuration.
+        /// </summary>
+        /// <param name="containerControl">The container control in which the module control will be loaded.</param>
+        /// <param name="moduleConfiguration">The configuration of the module to be loaded.</param>
+        /// <returns>The loaded module control.</returns>
         Control LoadModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration);
 
+        /// <summary>
+        /// Loads a settings control based on the specified container control, module configuration, and control source.
+        /// </summary>
+        /// <param name="containerControl">The container control in which the settings control will be loaded.</param>
+        /// <param name="moduleConfiguration">The configuration of the module for which the settings control will be loaded.</param>
+        /// <param name="controlSrc">The control source from the module control.</param>
+        /// <returns>The loaded settings control.</returns>
         Control LoadSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc);
 
+        /// <summary>
+        /// Creates a cached control based on the specified cached content and module configuration.
+        /// </summary>
+        /// <param name="cachedContent">The cached content to use for creating the control.</param>
+        /// <param name="moduleConfiguration">The configuration of the module for which the cached control will be created.</param>
+        /// <returns>The created cached control.</returns>
         Control CreateCachedControl(string cachedContent, ModuleInfo moduleConfiguration);
 
+        /// <summary>
+        /// Creates a module control based on the specified module configuration.
+        /// </summary>
+        /// <param name="moduleConfiguration">The configuration of the module for which the control will be created.</param>
+        /// <returns>The created module control.</returns>
         Control CreateModuleControl(ModuleInfo moduleConfiguration);
     }
 }


### PR DESCRIPTION
It seems we are not doing multitargeting and the NETFRAMEWORK directive can sometimes lead to code being erroneously marked as absent when it is not.

This also begs the question whether we really need this library in the project and if we should move the code back in, IMHO.