### PR TITLE
Add support for replacing CSS files with .rtl.css versions for RTL cultures

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
+++ b/DNN Platform/DotNetNuke.Web.Client/ClientResourceManager.cs
@@ -430,7 +430,10 @@ namespace DotNetNuke.Web.Client.ClientResourceManagement
             }
 
             // Replace CSS file with its RTL version if the current culture is right-to-left and the RTL file exists
-            if ((System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft && filePath.Contains(".css")) && !filePath.Contains("http"))
+            if ((System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft &&
+                filePath.EndsWith(".css", StringComparison.OrdinalIgnoreCase)) &&
+                !filePath.EndsWith(".rtl.css", StringComparison.OrdinalIgnoreCase) &&
+                !filePath.Contains("http"))
             {
                 string locfile = filePath.Replace(".css", ".rtl.css");
                 if (FileExists(page, locfile))


### PR DESCRIPTION
This change adds functionality to check if the current culture is right-to-left (RTL) and replace the CSS file with its corresponding .rtl.css version if it exists.

This approach allows RTL-specific styles to be kept in separate CSS files rather than merging them into the main CSS, which:

Prevents bloating the default CSS files with RTL overrides
Improves site performance by loading only necessary styles
Keeps RTL styles modular and easier to maintain
In summary, it optimises loading for RTL cultures by using dedicated .rtl.css files when available.