### PR TITLE
Update password hash algorithm to SHA256

### DIFF
--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -207,7 +207,7 @@
           domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
     <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain=""/>
-    <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
+    <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15" hashAlgorithmType="SHA256">
       <providers>
         <clear/>
         <!-- Configuration for AspNetSqlMembershipProvider:

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -208,7 +208,7 @@
           domain="[domain]"                                   Enables output of the "domain" cookie attribute set to the specified value
         -->
     <anonymousIdentification enabled="true" cookieName=".ASPXANONYMOUS" cookieTimeout="100000" cookiePath="/" cookieRequireSSL="false" cookieSlidingExpiration="true" cookieProtection="None" domain=""/>
-    <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15">
+    <membership defaultProvider="AspNetSqlMembershipProvider" userIsOnlineTimeWindow="15" hashAlgorithmType="SHA256">
       <providers>
         <clear/>
         <!-- Configuration for AspNetSqlMembershipProvider:


### PR DESCRIPTION
This PR updates the default hash algorithm to SHA256. It does _not_ add any logic for migrating users from SHA1 hashes, it only affects new installations.

I have tested that password history works as expected.

Fixes #6614