### PR TITLE
Fixed an issue where CustomCss module would not load

### DIFF
--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/src/components/AdminLog/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/src/components/AdminLog/index.jsx
@@ -47,7 +47,7 @@ class AdminLogPanelBody extends Component {
         const {props} = this;
         props.dispatch(LogActions.getPortalList(util.settings.isHost, (dataPortal) => {
             let portalList = Object.assign([], dataPortal.Results);
-            let currentPortalId = portalList[0].PortalID;
+            let currentPortalId = portalList[0].PortalId;
             let currentPortal = portalList[0].PortalName;
             this.setState({
                 portalList,

--- a/Dnn.AdminExperience/ClientSide/AdminLogs.Web/src/reducerHelpers/index.js
+++ b/Dnn.AdminExperience/ClientSide/AdminLogs.Web/src/reducerHelpers/index.js
@@ -42,7 +42,7 @@ export function createPortalOptions(actionPortalList) {
     let portalOptions = [];
     if (actionPortalList !== undefined) {
         portalOptions = actionPortalList.map((item) => {
-            return { label: item.PortalName, value: item.PortalID };
+            return { label: item.PortalName, value: item.PortalId };
         });
     }
     return portalOptions;

--- a/Dnn.AdminExperience/ClientSide/Security.Web/src/components/apiTokens/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Security.Web/src/components/apiTokens/index.jsx
@@ -42,7 +42,7 @@ class ApiTokensPanelBody extends Component {
         if (isHost) {
             props.dispatch(SecurityActions.getPortalList(util.settings.isHost, (dataPortal) => {
                 let portalList = Object.assign([], dataPortal.Results);
-                let currentPortalId = portalList[0].PortalID;
+                let currentPortalId = portalList[0].PortalId;
                 let currentPortal = portalList[0].PortalName;
                 this.setState({
                     portalList,
@@ -249,12 +249,12 @@ class ApiTokensPanelBody extends Component {
                                     value={state.currentPortalId}
                                     style={{ width: "100%" }}
                                     options={state.portalList.map((item) => {
-                                        return { label: item.PortalName, value: item.PortalID };
+                                        return { label: item.PortalName, value: item.PortalId };
                                     })}
                                     withBorder={false}
                                     onSelect={(value) => {
                                         let currentPortal = state.portalList.filter((item) => {
-                                            return item.PortalID === value.value;
+                                            return item.PortalId === value.value;
                                         })[0].PortalName;
                                         this.setState({
                                             currentPortalId: value.value,

--- a/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/src/components/Dashboard/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/SiteImportExport.Web/src/components/Dashboard/index.jsx
@@ -29,8 +29,8 @@ class DashboardPanelBody extends Component {
         const { props } = this;
         props.dispatch(ImportExportActions.getPortals((data) => {
             if (data.TotalResults === 1) {
-                props.dispatch(ImportExportActions.siteSelected(data.Results[0].PortalID, data.Results[0].PortalName, () => {
-                    props.dispatch(ImportExportActions.getAllJobs(this.getNextPage(data.Results[0].PortalID), (data) => {
+                props.dispatch(ImportExportActions.siteSelected(data.Results[0].PortalId, data.Results[0].PortalName, () => {
+                    props.dispatch(ImportExportActions.getAllJobs(this.getNextPage(data.Results[0].PortalId), (data) => {
                         if (data.Jobs && data.Jobs.find(j => j.Status < 2 && !j.Cancelled)) {
                             this.addInterval(props);
                         }
@@ -134,7 +134,7 @@ class DashboardPanelBody extends Component {
             options = props.portals.map((item) => {
                 return {
                     label: item.PortalName,
-                    value: item.PortalID
+                    value: item.PortalId
                 };
             });
             if (options.length > 1) {
@@ -380,7 +380,7 @@ class DashboardPanelBody extends Component {
                         jobType={job.JobType}
                         jobDate={job.CreatedOnString}
                         jobUser={job.User}
-                        jobPortal={props.portals.find(p => p.PortalID === job.PortalId) ? props.portals.find(p => p.PortalID === job.PortalId).PortalName : Localization.get("DeletedPortal")}
+                        jobPortal={props.portals.find(p => p.PortalId === job.PortalId) ? props.portals.find(p => p.PortalId === job.PortalId).PortalName : Localization.get("DeletedPortal")}
                         jobStatus={job.Status}
                         jobCancelled={job.Cancelled}
                         index={index}

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.CssEditor/scripts/CssEditor.js
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.CssEditor/scripts/CssEditor.js
@@ -79,8 +79,8 @@ define([
         }
 
         var portalChanged = function(data) {
-            if (data != null && data.PortalID != curPortalId) {
-                curPortalId = data.PortalID;
+            if (data != null && data.PortalId != curPortalId) {
+                curPortalId = data.PortalId;
                 getStyleSheet();
             }
         }


### PR DESCRIPTION
Closes #6601

The global personaBarSettings javascript objet is merged from the backend with some portal settings, I guess in some place, stuff was changed from PortalSettings to IPortalSettings which means we now have `PortalId` instead of `PortalID`.

Luckily, it appears that value was only used in a few places, so this PR changes the casing in those places fixing the CSS module and some more areas affected by the same issue.

