### PR TITLE
Enhance Login Module Detection Flexibility (Multiple Keyword Support)

### DIFF
--- a/DNN Platform/Library/Common/Globals.cs
+++ b/DNN Platform/Library/Common/Globals.cs
@@ -3156,7 +3156,37 @@ namespace DotNetNuke.Common
         /// <returns><see langword="true"/> if the tab contains "Account Login" module, otherwise, <see langword="false"/>.</returns>
         public static bool ValidateLoginTabID(int tabId)
         {
-            return ValidateModuleInTab(tabId, "Account Login");
+            return ValidateModuleInTab(tabId, new[] { "login", "auth", "account" });
+        }
+
+        /// <summary>
+        /// Check whether the tab contains any module whose name contains any of the specified keywords.
+        /// </summary>
+        /// <param name="tabId">The tab id.</param>
+        /// <param name="moduleKeywords">
+        /// The array of keywords to check in the module names (case-insensitive, e.g., "login", "auth").
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the tab contains at least one module whose name includes any keyword; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool ValidateModuleInTab(int tabId, string[] moduleKeywords)
+        {
+            bool hasModule = Null.NullBoolean;
+            foreach (ModuleInfo objModule in ModuleController.Instance.GetTabModules(tabId).Values)
+            {
+                var name = objModule.ModuleDefinition.FriendlyName?.ToLower() ?? string.Empty;
+                if (moduleKeywords.Any(keyword => name.Contains(keyword.ToLower())))
+                {
+                    TabInfo tab = TabController.Instance.GetTab(tabId, objModule.PortalID, false);
+                    if (TabPermissionController.CanViewPage(tab))
+                    {
+                        hasModule = true;
+                        break;
+                    }
+                }
+            }
+
+            return hasModule;
         }
 
         /// <summary>Check whether the tab contains specific module.</summary>


### PR DESCRIPTION
Add support for multiple keywords in login module detection

## Summary
The original ValidateModuleInTab method only checked for a specific module name (such as "Account Login"). This was not flexible enough for scenarios where the login module might have a different name (like "User Login", "Authentication", "Account Auth", etc.), leading to incorrect login page validation.

## Solution

- Refactored ValidateModuleInTab to accept an array of keywords and return true if any of these keywords is found (case-insensitive) in any module's name on the given tab.
- Added an overload for backward compatibility to accept a single module name as before.
- Updated ValidateLoginTabID to use an array of relevant keywords (login, auth, account) for more robust login module detection.
- Added XML documentation for all updated methods.

## Benefits

- More flexible and robust detection of login modules, supporting custom and varied naming.
- No longer strictly tied to a specific module name.
- Backward compatibility preserved.

