### PR TITLE
Fix: #5696, Do not convert unicode chars in filenames

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/Utility.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/Utility.cs
@@ -226,7 +226,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
             input = input.Replace("�", string.Empty);
 
             char[] invalidChars = Path.GetInvalidFileNameChars();
-            string input = string.Join("_", input.Split(invalidChars));
+            input = string.Join("_", input.Split(invalidChars));
 
             input = input.Replace("?", string.Empty); // replace the unknown char which created in above.
             input = input.Replace("�", string.Empty);

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/Utility.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Utilities/Utility.cs
@@ -225,7 +225,8 @@ namespace DNNConnect.CKEditorProvider.Utilities
 
             input = input.Replace("�", string.Empty);
 
-            input = Encoding.ASCII.GetString(Encoding.GetEncoding(1251).GetBytes(input));
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            string input = string.Join("_", input.Split(invalidChars));
 
             input = input.Replace("?", string.Empty); // replace the unknown char which created in above.
             input = input.Replace("�", string.Empty);


### PR DESCRIPTION
Closes #5696

## Summary

This pull request addresses the issue of file uploads failing when filenames contain Unicode characters, such as Farsi or Arabic.

The previous implementation used `Utility.ConvertUnicodeChars`, which incorrectly removed these characters from the filename, leading to upload failures.

This change replaces that flawed logic with a safer and more robust method:

* It gets the original filename, including all Unicode characters.
* It then sanitizes the filename by removing or replacing invalid characters using `Path.GetInvalidFileNameChars()` from the .NET framework.

This approach ensures that filenames with non-English characters are properly preserved while maintaining security against potential path traversal attacks. The fix is a direct and efficient solution that doesn't introduce any new dependencies.