### PR TITLE
feat: HTML5 compliance - replace <a name=""> with id attribute

### DIFF
--- a/DNN Platform/Library/UI/Skins/Pane.cs
+++ b/DNN Platform/Library/UI/Skins/Pane.cs
@@ -108,7 +108,7 @@ namespace DotNetNuke.UI.Skins
             {
                 if (!Globals.IsAdminControl() && (this.PortalSettings.InjectModuleHyperLink || Personalization.GetUserMode() != PortalSettings.Mode.View))
                 {
-                    this.containerWrapperControl.Controls.Add(new LiteralControl("<a name=\"" + module.ModuleID + "\"></a>"));
+                    _containerWrapperControl.Attributes["id"] = module.ModuleID.ToString();
                 }
 
                 // Load container control


### PR DESCRIPTION
## HTML5 Compliance Enhancement for Module Containers

**Fixes #6668** 

### Problem
DNN 10 currently generates deprecated `<a name="...">` elements for module bookmarking, which is not HTML5 compliant and can cause accessibility issues.

### Solution
Replace deprecated name attributes with modern id attributes on container controls, maintaining the same functionality while improving standards compliance.

### Changes
- **File**: `Library/UI/Skins/Pane.cs`
- **Change**: Replace `<a name="moduleId">` with `id="moduleId"` attribute
- **Impact**: HTML5 compliance improvement, no breaking changes

### Release Notes
Improved HTML5 compliance by replacing deprecated name attributes with id attributes in module containers, enhancing accessibility and future browser compatibility.

