### PR TITLE
Deny anonymous users access to CKE endpoints

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.dnn
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/DNNConnect.CKEditorProvider.dnn
@@ -1,119 +1,141 @@
 ﻿<dotnetnuke type="Package" version="5.0">
-  <packages><package name="DNNConnect.CKEditorProvider" type="Provider" version="10.01.00">
-            <friendlyName>CKEditor Provider</friendlyName>
-            <description>CKEditor Provider for DNN</description>
-            <iconFile>~/Providers/HtmlEditorProviders/DNNConnect.CKE/LogoCKEditor.png</iconFile>
-            <azureCompatible>true</azureCompatible>
-            <owner>
-                <name>.NET Foundation and Contributors</name>
-                <organization>DNN Community</organization>
-                <url>https://dnncommunity.org</url>
-                <email>info@dnncommunity.org</email>
-            </owner>
-            <license src="license.txt" />
-            <releaseNotes src="releaseNotes.txt" />
-            <components>
-                <component type="Assembly">
-                    <assemblies>
-                        <assembly>
-                            <path>bin</path>
-                            <name>DNNConnect.CKEditorProvider.dll</name>
-                        </assembly>
-                    </assemblies>
-                </component>
-                <component type="ResourceFile">
-                    <resourceFiles>
-                        <basePath>Providers\HtmlEditorProviders\DNNConnect.CKE</basePath>
-                        <resourceFile>
-                            <name>Resources.zip</name>
-                        </resourceFile>
-                    </resourceFiles>
-                </component>
-                <component type="Script">
-                    <scripts>
-                        <basePath>Providers\HtmlEditorProviders\DNNConnect.CKE\</basePath>
-                        <script type="Install">
-                            <path>Install</path>
-                            <name>01.00.00.SqlDataProvider</name>
-                            <version>01.00.00</version>
-                        </script>
-                        <script type="Install">
-                            <path>Install</path>
-                            <name>01.00.02.SqlDataProvider</name>
-                            <version>01.00.02</version>
-                        </script>
-                        <script type="UnInstall">
-                            <path>Install</path>
-                            <name>Uninstall.SqlDataProvider</name>
-                        </script>
-                    </scripts>
-                </component>
-                <component type="File">
-                    <files>
-                        <basePath>Portals\_default</basePath>
-                        <file>
-                            <path>Install</path>
-                            <name>Dnn.CKEditorDefaultSettings.xml</name>
-                        </file>
-                        <file>
-                            <path>Install</path>
-                            <name>Dnn.CKToolbarButtons.xml</name>
-                        </file>
-                        <file>
-                            <path>Install</path>
-                            <name>Dnn.CKToolbarSets.xml</name>
-                        </file>
-                    </files>
-                </component>
-                <component type="File">
-                    <files>
-                        <basePath>Providers\HtmlEditorProviders\DNNConnect.CKE</basePath>
-                        <file>
-                            <name>LogoCKEditor.png</name>
-                            <sourceFileName>LogoCKEditor.png</sourceFileName>
-                        </file>
-                    </files>
-                </component>
-                <component type="Config">
-                    <config>
-                        <configFile>web.config</configFile>
-                        <install>
-                            <configuration>
-                                <nodes>
-                                    <node path="/configuration/dotnetnuke/htmlEditor[@defaultProvider='' or @defaultProvider='DotNetNuke.RadEditorProvider']"
+	<packages>
+		<package name="DNNConnect.CKEditorProvider" type="Provider" version="10.01.00">
+			<friendlyName>CKEditor Provider</friendlyName>
+			<description>CKEditor Provider for DNN</description>
+			<iconFile>~/Providers/HtmlEditorProviders/DNNConnect.CKE/LogoCKEditor.png</iconFile>
+			<azureCompatible>true</azureCompatible>
+			<owner>
+				<name>.NET Foundation and Contributors</name>
+				<organization>DNN Community</organization>
+				<url>https://dnncommunity.org</url>
+				<email>info@dnncommunity.org</email>
+			</owner>
+			<license src="license.txt" />
+			<releaseNotes src="releaseNotes.txt" />
+			<components>
+				<component type="Assembly">
+					<assemblies>
+						<assembly>
+							<path>bin</path>
+							<name>DNNConnect.CKEditorProvider.dll</name>
+						</assembly>
+					</assemblies>
+				</component>
+				<component type="ResourceFile">
+					<resourceFiles>
+						<basePath>Providers\HtmlEditorProviders\DNNConnect.CKE</basePath>
+						<resourceFile>
+							<name>Resources.zip</name>
+						</resourceFile>
+					</resourceFiles>
+				</component>
+				<component type="Script">
+					<scripts>
+						<basePath>Providers\HtmlEditorProviders\DNNConnect.CKE\</basePath>
+						<script type="Install">
+							<path>Install</path>
+							<name>01.00.00.SqlDataProvider</name>
+							<version>01.00.00</version>
+						</script>
+						<script type="Install">
+							<path>Install</path>
+							<name>01.00.02.SqlDataProvider</name>
+							<version>01.00.02</version>
+						</script>
+						<script type="UnInstall">
+							<path>Install</path>
+							<name>Uninstall.SqlDataProvider</name>
+						</script>
+					</scripts>
+				</component>
+				<component type="File">
+					<files>
+						<basePath>Portals\_default</basePath>
+						<file>
+							<path>Install</path>
+							<name>Dnn.CKEditorDefaultSettings.xml</name>
+						</file>
+						<file>
+							<path>Install</path>
+							<name>Dnn.CKToolbarButtons.xml</name>
+						</file>
+						<file>
+							<path>Install</path>
+							<name>Dnn.CKToolbarSets.xml</name>
+						</file>
+					</files>
+				</component>
+				<component type="File">
+					<files>
+						<basePath>Providers\HtmlEditorProviders\DNNConnect.CKE</basePath>
+						<file>
+							<name>LogoCKEditor.png</name>
+							<sourceFileName>LogoCKEditor.png</sourceFileName>
+						</file>
+					</files>
+				</component>
+				<component type="Config">
+					<config>
+						<configFile>web.config</configFile>
+						<install>
+							<configuration>
+								<nodes>
+									<node path="/configuration/dotnetnuke/htmlEditor[@defaultProvider='' or @defaultProvider='DotNetNuke.RadEditorProvider']"
                                           action="updateattribute"
                                           name="defaultProvider"
                                           value="DNNConnect.CKE" />
-                                    <node path="/configuration/dotnetnuke/htmlEditor/providers"
+									<node path="/configuration/dotnetnuke/htmlEditor/providers"
                                           action="update"
                                           key="name"
                                           collision="ignore">
-                                        <add name="DNNConnect.CKE"
+										<add name="DNNConnect.CKE"
                                              type="DNNConnect.CKEditorProvider.CKHtmlEditorProvider, DNNConnect.CKEditorProvider"
                                              providerPath="~/Providers/HtmlEditorProviders/DNNConnect.CKE/"
                                              settingsControlPath="~/Providers/HtmlEditorProviders/DNNConnect.CKE/Module/EditorConfigManager.ascx" />
-                                    </node>
-                                </nodes>
-                            </configuration>
-                        </install>
-                        <uninstall>
-                            <configuration>
-                                <nodes>
-                                    <node path="/configuration/dotnetnuke/htmlEditor[@defaultProvider='DNNConnect.CKE']"
+									</node>
+									<node path="/configuration" action="update" key="path" collision="ignore">
+										<location path="Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx">
+											<system.web>
+												<authorization>
+													<deny users="?" />
+													<!-- Deny anonymous users -->
+												</authorization>
+											</system.web>
+										</location>
+										<location path="Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx">
+											<system.web>
+												<authorization>
+													<deny users="?" />
+													<!-- Deny anonymous users -->
+												</authorization>
+											</system.web>
+										</location>
+									</node>
+								</nodes>
+							</configuration>
+						</install>
+						<uninstall>
+							<configuration>
+								<nodes>
+									<node path="/configuration/dotnetnuke/htmlEditor[@defaultProvider='DNNConnect.CKE']"
                                           action="updateattribute"
                                           name="defaultProvider"
                                           value="DotNetNuke.RadEditorProvider" />
-                                    <node path="/configuration/dotnetnuke/htmlEditor/providers/add[@name='DNNConnect.CKE']"
+									<node path="/configuration/dotnetnuke/htmlEditor/providers/add[@name='DNNConnect.CKE']"
                                           action="remove" />
-                                </nodes>
-                            </configuration>
-                        </uninstall>
-                    </config>
-                </component>
-                <component type="Cleanup"
-                           glob="Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/**/*">
-                </component>
-            </components>
-        </package>
-    </packages>
+									<node path="/configuration/location[@path='Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/FileUploader.ashx']"
+                                          action="remove" />
+									<node path="/configuration/location[@path='Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx']"
+                                          action="remove" />
+								</nodes>
+							</configuration>
+						</uninstall>
+					</config>
+				</component>
+				<component type="Cleanup"
+                           glob="Providers/HtmlEditorProviders/DNNConnect.CKE/js/ckeditor/4.15.1/**/*" />
+			</components>
+		</package>
+	</packages>
 </dotnetnuke>


### PR DESCRIPTION
## Summary
As a defense-in-depth strategy, we realized that only in very exceptional circumstances does there need to be anonymous access to upload files via the CKEditor. This PR adds a `web.config` level denial of access to the CKEditor upload endpoints for anonymous users.

Thanks @r90727 for calling this out and the initial implementation.