### PR TITLE
Fix cacheability settings issue by fixing inconsistencies

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Application/CacheControlHeader.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Application/CacheControlHeader.cs
@@ -22,11 +22,11 @@ public enum CacheControlHeader
     Server = 3,
 
     /// <summary>Applies the settings of both <see cref="Server" /> and <see cref="NoCache" /> to indicate that the content is cached at the server but all others are explicitly denied the ability to cache the response.</summary>
-    ServerAndNoCache = 3,
+    ServerAndNoCache = 4,
 
     /// <summary>Sets <c>Cache-Control: public</c> to specify that the response is cacheable by clients and shared (proxy) caches.</summary>
-    Public = 4,
+    Public = 5,
 
     /// <summary>Indicates that the response is cached at the server and at the client but nowhere else. Proxy servers are not allowed to cache the response.</summary>
-    ServerAndPrivate = 5,
+    ServerAndPrivate = 6,
 }

--- a/DNN Platform/Library/Entities/Host/HostSettings.cs
+++ b/DNN Platform/Library/Entities/Host/HostSettings.cs
@@ -404,12 +404,12 @@ public class HostSettings(IHostSettingsService hostSettingsService) : IHostSetti
     private static CacheControlHeader ToCacheControlHeader(string headerId)
         => headerId switch
         {
-            "0" => CacheControlHeader.NoCache,
-            "1" => CacheControlHeader.Private,
-            "2" => CacheControlHeader.Public,
+            "1" => CacheControlHeader.NoCache,
+            "2" => CacheControlHeader.Private,
             "3" => CacheControlHeader.Server,
             "4" => CacheControlHeader.ServerAndNoCache,
-            "5" => CacheControlHeader.ServerAndPrivate,
+            "5" => CacheControlHeader.Public,
+            "6" => CacheControlHeader.ServerAndPrivate,
             _ => CacheControlHeader.Unknown,
         };
 }

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -447,11 +447,14 @@ namespace DotNetNuke.Framework
                 case CacheControlHeader.Private:
                     this.Response.Cache.SetCacheability(HttpCacheability.Private);
                     break;
-                case CacheControlHeader.Public:
-                    this.Response.Cache.SetCacheability(HttpCacheability.Public);
+                case CacheControlHeader.Server:
+                    this.Response.Cache.SetCacheability(HttpCacheability.Server);
                     break;
                 case CacheControlHeader.ServerAndNoCache:
                     this.Response.Cache.SetCacheability(HttpCacheability.ServerAndNoCache);
+                    break;
+                case CacheControlHeader.Public:
+                    this.Response.Cache.SetCacheability(HttpCacheability.Public);
                     break;
                 case CacheControlHeader.ServerAndPrivate:
                     this.Response.Cache.SetCacheability(HttpCacheability.ServerAndPrivate);

--- a/DNN Platform/Website/DotNetNuke.Website.csproj
+++ b/DNN Platform/Website/DotNetNuke.Website.csproj
@@ -1268,6 +1268,17 @@
     <Content Include="Install\Config\09.13.04.config" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.13.04.SqlDataProvider" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.13.08.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\10.00.01.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\10.01.00.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\10.01.01.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.13.09.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\10.00.00.01.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\10.00.00.02.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\10.00.00.03.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.13.00.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.13.02.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.13.03.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.12.00.SqlDataProvider" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.01.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.01.01.SqlDataProvider
@@ -1,0 +1,37 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/
+
+
+/* Fix Cacheability Settings */
+/************************************************************/
+
+UPDATE {databaseOwner}[{objectQualifier}HostSettings]
+SET SettingValue='6'
+WHERE SettingName IN ('AuthenticatedCacheability', 'UnauthenticatedCacheability')
+AND SettingValue='5'
+GO
+
+UPDATE {databaseOwner}[{objectQualifier}HostSettings]
+SET SettingValue='5'
+WHERE SettingName IN ('AuthenticatedCacheability', 'UnauthenticatedCacheability')
+AND SettingValue='2'
+GO
+
+UPDATE {databaseOwner}[{objectQualifier}HostSettings]
+SET SettingValue='2'
+WHERE SettingName IN ('AuthenticatedCacheability', 'UnauthenticatedCacheability')
+AND SettingValue='1'
+GO
+
+UPDATE {databaseOwner}[{objectQualifier}HostSettings]
+SET SettingValue='1'
+WHERE SettingName IN ('AuthenticatedCacheability', 'UnauthenticatedCacheability')
+AND SettingValue='0'
+GO

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Servers/PerformanceSettings/PerformanceController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Servers/PerformanceSettings/PerformanceController.cs
@@ -54,12 +54,13 @@ namespace Dnn.PersonaBar.Servers.Components.PerformanceSettings
         {
             return new[]
             {
-                new KeyValuePair<string, string>("NoCache", "0"),
-                new KeyValuePair<string, string>("Private", "1"),
-                new KeyValuePair<string, string>("Public", "2"),
-                new KeyValuePair<string, string>("Server", "3"),
-                new KeyValuePair<string, string>("ServerAndNoCache", "4"),
-                new KeyValuePair<string, string>("ServerAndPrivate", "5"),
+                new KeyValuePair<string, int>("Unknown", 0),
+                new KeyValuePair<string, int>("NoCache", 1),
+                new KeyValuePair<string, int>("Private", 2),
+                new KeyValuePair<string, int>("Server", 3),
+                new KeyValuePair<string, int>("ServerAndNoCache", 4),
+                new KeyValuePair<string, int>("Public", 5),
+                new KeyValuePair<string, int>("ServerAndPrivate", 6),
             };
         }
 


### PR DESCRIPTION
The framework uses three places to deserialize and deserialize the cacheability settings. Unfortunately the enumerations differ between these places. This, plus the fact that the UI was receiving these options in the wrong format, has meant these settings would not be used correctly.

This should fix #6703 