### PR TITLE
[WIP] Priority-based IPageService for page metadata, head tags, and messages

### DIFF
--- a/DNN Platform/DotNetNuke.Abstractions/Pages/IPageService.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/IPageService.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Pages
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Provides services for managing page content with priority-based storage.
+    /// </summary>
+    public interface IPageService
+    {
+        /// <summary>
+        /// Set the Page Title.
+        /// </summary>
+        /// <param name="value">The title value to set.</param>
+        /// <param name="priority">The priority of this title (lower number = higher priority).</param>
+        void SetTitle(string value, int priority = PagePriority.Default);
+
+        /// <summary>
+        /// Set the Page Description.
+        /// </summary>
+        /// <param name="value">The description value to set.</param>
+        /// <param name="priority">The priority of this description (lower number = higher priority).</param>
+        void SetDescription(string value, int priority = PagePriority.Default);
+
+        /// <summary>
+        /// Set the Page Keywords.
+        /// </summary>
+        /// <param name="value">The keywords value to set.</param>
+        /// <param name="priority">The priority of these keywords (lower number = higher priority).</param>
+        void SetKeyWords(string value, int priority = PagePriority.Default);
+
+        /// <summary>
+        /// Set the Page Canonical Link URL.
+        /// </summary>
+        /// <param name="value">The canonical link URL value to set.</param>
+        /// <param name="priority">The priority of this canonical link URL (lower number = higher priority).</param>
+        void SetCanonicalLinkUrl(string value, int priority = PagePriority.Default);
+
+        /// <summary>
+        /// Add a tag to the header of the page.
+        /// </summary>
+        /// <param name="tagItem">Priority item containing the tag and priority information.</param>
+        void AddToHead(PageTag tagItem);
+
+        /// <summary>
+        /// Add a standard meta header tag.
+        /// </summary>
+        /// <param name="metaItem">Priority meta item containing the meta tag information and priority.</param>
+        void AddMeta(PageMeta metaItem);
+
+        /// <summary>
+        /// Add a message to be displayed on the page.
+        /// </summary>
+        /// <param name="messageItem">Priority message item containing the message information and priority.</param>
+        void AddMessage(PageMessage messageItem);
+
+        /// <summary>
+        /// Gets the current title value with highest priority.
+        /// </summary>
+        /// <returns>The title value or null if not set.</returns>
+        string GetTitle();
+
+        /// <summary>
+        /// Gets the current description value with highest priority.
+        /// </summary>
+        /// <returns>The description value or null if not set.</returns>
+        string GetDescription();
+
+        /// <summary>
+        /// Gets the current keywords value with highest priority.
+        /// </summary>
+        /// <returns>The keywords value or null if not set.</returns>
+        string GetKeyWords();
+
+        /// <summary>
+        /// Gets the canonical link URL.
+        /// </summary>
+        /// <returns>The canonical link URL or null if not set.</returns>
+        string GetCanonicalLinkUrl();
+
+        /// <summary>
+        /// Gets all head tags ordered by priority (lowest priority first).
+        /// </summary>
+        /// <returns>List of head tags ordered by priority.</returns>
+        List<PageTag> GetHeadTags();
+
+        /// <summary>
+        /// Gets all meta tags ordered by priority (lowest priority first).
+        /// </summary>
+        /// <returns>List of meta tags ordered by priority.</returns>
+        List<PageMeta> GetMetaTags();
+
+        /// <summary>
+        /// Gets all messages ordered by priority (lowest priority first).
+        /// </summary>
+        /// <returns>List of messages ordered by priority.</returns>
+        List<PageMessage> GetMessages();
+
+        /// <summary>
+        /// Clears all stored page data. Useful for testing or resetting state.
+        /// </summary>
+        void Clear();
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Pages/PageMessage.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/PageMessage.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Pages
+{
+    /// <summary>
+    /// Represents a message with priority information for display on a page.
+    /// Messages can include success notifications, warnings, errors, or informational content.
+    /// </summary>
+    /// <remarks>
+    /// This class is used to store messages that will be displayed to users on a page.
+    /// Priority determines the order in which messages are displayed, with lower numbers having higher priority.
+    /// Common priority values are defined in <see cref="PagePriority"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Create a success message with high priority
+    /// var successMessage = new PriorityMessage(
+    ///     "Operation Successful",
+    ///     "The data has been saved successfully.",
+    ///     MessageType.Success,
+    ///     "/images/success-icon.png",
+    ///     PagePriority.Site);
+    ///
+    /// // Create an error message with default priority
+    /// var errorMessage = new PriorityMessage(
+    ///     "Validation Error",
+    ///     "Please check the required fields.",
+    ///     MessageType.Error,
+    ///     "",
+    ///     PagePriority.Default);
+    /// </code>
+    /// </example>
+    public class PageMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageMessage"/> class.
+        /// </summary>
+        /// <param name="heading">The heading text for the message.</param>
+        /// <param name="message">The message text content. Cannot be null or empty.</param>
+        /// <param name="messageType">The type/severity of the message.</param>
+        /// <param name="iconSrc">The optional icon source URL for the message. Use empty string if no icon is needed.</param>
+        /// <param name="priority">The priority of the message. Use values from <see cref="PagePriority"/> for consistency.</param>
+        public PageMessage(string heading, string message, PageMessageType messageType, string iconSrc, int priority)
+        {
+            this.Heading = heading;
+            this.Message = message;
+            this.MessageType = messageType;
+            this.IconSrc = iconSrc;
+            this.Priority = priority;
+        }
+
+        /// <summary>
+        /// Gets or sets the heading text for the message.
+        /// </summary>
+        /// <value>
+        /// A string containing the heading text that will be displayed prominently.
+        /// This should be a concise summary of the message.
+        /// </value>
+        public string Heading { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message text content.
+        /// </summary>
+        /// <value>
+        /// A string containing the detailed message content that will be displayed to the user.
+        /// This can contain HTML markup for formatting.
+        /// </value>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type/severity of the message.
+        /// </summary>
+        /// <value>
+        /// A <see cref="MessageType"/> value indicating the severity or type of the message.
+        /// This affects how the message is styled and displayed to the user.
+        /// </value>
+        public PageMessageType MessageType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional icon source URL for the message.
+        /// </summary>
+        /// <value>
+        /// A string containing the URL or path to an icon image, or an empty string if no icon is needed.
+        /// The icon will be displayed alongside the message to provide visual context.
+        /// </value>
+        public string IconSrc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the priority of the message (lower number = higher priority).
+        /// </summary>
+        /// <value>
+        /// An integer representing the display priority of the message.
+        /// Messages with lower priority numbers will be displayed before those with higher numbers.
+        /// Use constants from <see cref="PagePriority"/> for consistent priority values.
+        /// </value>
+        public int Priority { get; set; }
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Pages/PageMessageType.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/PageMessageType.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Pages
+{
+    /// <summary>
+    /// Defines the types and severity levels for page messages.
+    /// Message types determine how messages are styled and presented to users.
+    /// </summary>
+    /// <remarks>
+    /// These enumeration values are used to categorize messages by their purpose and severity.
+    /// The UI layer typically uses these values to apply appropriate styling, colors, and icons
+    /// to provide visual context to users about the nature of the message.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Success message for completed operations
+    /// var successMsg = new PageMessage("Operation Complete", "Data saved successfully", MessageType.Success, "", PagePriority.Default);
+    ///
+    /// // Warning message for potential issues
+    /// var warningMsg = new PageMessage("Warning", "This action cannot be undone", MessageType.Warning, "", PagePriority.Default);
+    ///
+    /// // Error message for failed operations
+    /// var errorMsg = new PageMessage("Error", "Failed to save data", MessageType.Error, "", PagePriority.Default);
+    ///
+    /// // Informational message for general notifications
+    /// var infoMsg = new PageMessage("Notice", "System maintenance scheduled", MessageType.Info, "", PagePriority.Default);
+    /// </code>
+    /// </example>
+    public enum PageMessageType
+    {
+        /// <summary>
+        /// Success message type.
+        /// Used for messages indicating successful completion of operations.
+        /// Typically displayed with green styling and success icons.
+        /// </summary>
+        /// <example>
+        /// Use for: Data saved, user created, operation completed, etc.
+        /// </example>
+        Success = 0,
+
+        /// <summary>
+        /// Warning message type.
+        /// Used for messages indicating potential issues or important notices that require user attention.
+        /// Typically displayed with yellow/orange styling and warning icons.
+        /// </summary>
+        /// <example>
+        /// Use for: Validation warnings, deprecation notices, cautionary information, etc.
+        /// </example>
+        Warning = 1,
+
+        /// <summary>
+        /// Error message type.
+        /// Used for messages indicating failed operations or critical issues.
+        /// Typically displayed with red styling and error icons.
+        /// </summary>
+        /// <example>
+        /// Use for: Validation errors, operation failures, system errors, etc.
+        /// </example>
+        Error = 2,
+
+        /// <summary>
+        /// Informational message type.
+        /// Used for general notifications and informational content.
+        /// Typically displayed with blue styling and info icons.
+        /// </summary>
+        /// <example>
+        /// Use for: General notifications, tips, system status updates, etc.
+        /// </example>
+        Info = 3,
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Pages/PageMeta.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/PageMeta.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Pages
+{
+    /// <summary>
+    /// Represents a meta tag with priority information for inclusion in the HTML head section.
+    /// Meta tags provide metadata about the HTML document and are used by search engines and browsers.
+    /// </summary>
+    /// <remarks>
+    /// This class is used to store meta tag information that will be rendered in the HTML head section.
+    /// Priority determines the order in which meta tags are rendered, with lower numbers having higher priority.
+    /// Common priority values are defined in <see cref="PagePriority"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Create a description meta tag with page priority
+    /// var descriptionMeta = new PriorityMeta(
+    ///     "description",
+    ///     "This is the page description for SEO purposes.",
+    ///     PagePriority.Page);
+    ///
+    /// // Create a keywords meta tag with default priority
+    /// var keywordsMeta = new PriorityMeta(
+    ///     "keywords",
+    ///     "DNN, CMS, content management",
+    ///     PagePriority.Default);
+    ///
+    /// // Create a viewport meta tag with site priority
+    /// var viewportMeta = new PriorityMeta(
+    ///     "viewport",
+    ///     "width=device-width, initial-scale=1.0",
+    ///     PagePriority.Site);
+    /// </code>
+    /// </example>
+    public class PageMeta
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageMeta"/> class.
+        /// </summary>
+        /// <param name="name">The name attribute of the meta tag. Cannot be null or empty.</param>
+        /// <param name="content">The content attribute of the meta tag. Cannot be null.</param>
+        /// <param name="priority">The priority of the meta tag (lower number = higher priority). Use values from <see cref="PagePriority"/> for consistency.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when name or content is null.</exception>
+        /// <exception cref="System.ArgumentException">Thrown when name is empty.</exception>
+        public PageMeta(string name, string content, int priority)
+        {
+            this.Name = name;
+            this.Content = content;
+            this.Priority = priority;
+        }
+
+        /// <summary>
+        /// Gets or sets the name attribute of the meta tag.
+        /// </summary>
+        /// <value>
+        /// A string containing the name attribute value for the meta tag.
+        /// Common values include "description", "keywords", "author", "viewport", etc.
+        /// This will be rendered as: &lt;meta name="[Name]" content="[Content]" /&gt;.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content attribute of the meta tag.
+        /// </summary>
+        /// <value>
+        /// A string containing the content attribute value for the meta tag.
+        /// This contains the actual metadata information associated with the name attribute.
+        /// The content should be appropriate for the specified name attribute.
+        /// </value>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the priority of the meta tag (lower number = higher priority).
+        /// </summary>
+        /// <value>
+        /// An integer representing the rendering priority of the meta tag in the HTML head section.
+        /// Meta tags with lower priority numbers will be rendered before those with higher numbers.
+        /// Use constants from <see cref="PagePriority"/> for consistent priority values.
+        /// </value>
+        public int Priority { get; set; }
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Pages/PagePriority.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/PagePriority.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Pages
+{
+    /// <summary>
+    /// Defines standard priority values for page content ordering.
+    /// Lower numbers indicate higher priority and will be processed/rendered first.
+    /// </summary>
+    /// <remarks>
+    /// These constants provide a standardized way to assign priorities to page content such as
+    /// scripts, styles, meta tags, and messages. Using these predefined values ensures consistent
+    /// ordering across the application and makes the code more maintainable.
+    ///
+    /// Priority processing order:
+    /// 1. Site-level content (priority 10)
+    /// 2. Page-level content (priority 20)
+    /// 3. Default content (priority 100)
+    /// 4. Module-level content (priority 200).
+    /// </remarks>
+    public class PagePriority
+    {
+        /// <summary>
+        /// Site-level priority (value: 10).
+        /// Used for framework scripts, core styles, and other fundamental site-wide content
+        /// that should be loaded before any other content.
+        /// </summary>
+        public const int Site = 10;
+
+        /// <summary>
+        /// Page-level priority (value: 20).
+        /// Used for page-specific content that should be loaded after site-level content
+        /// but before default and module content.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Page-specific JavaScript
+        /// pageService.AddToHead(new PriorityItem("&lt;script src=\"page-analytics.js\"&gt;&lt;/script&gt;", PagePriority.Page));
+        ///
+        /// // Page-specific meta description
+        /// pageService.AddMeta(new PriorityMeta("description", "Page-specific description", PagePriority.Page));
+        /// </code>
+        /// </example>
+        public const int Page = 20;
+
+        /// <summary>
+        /// Default priority (value: 100).
+        /// Used as the standard priority when no specific priority is needed.
+        /// Most content should use this priority unless there's a specific ordering requirement.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Standard content without specific ordering requirements
+        /// pageService.AddMessage(new PriorityMessage("Info", "General information", MessageType.Info, "", PagePriority.Default));
+        ///
+        /// // Regular meta tags
+        /// pageService.AddMeta(new PriorityMeta("author", "John Doe", PagePriority.Default));
+        /// </code>
+        /// </example>
+        public const int Default = 100;
+
+        /// <summary>
+        /// Module-level priority (value: 200).
+        /// Used for module-specific content that should be loaded after all other content.
+        /// This ensures that module content doesn't interfere with core functionality.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Module-specific success message
+        /// pageService.AddMessage(new PriorityMessage("Success", "Module operation completed", MessageType.Success, "", PagePriority.Module));
+        /// </code>
+        /// </example>
+        public const int Module = 200;
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Pages/PageTag.cs
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/PageTag.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Abstractions.Pages
+{
+    /// <summary>
+    /// Represents a string item with priority information for inclusion in page content.
+    /// This class is used for HTML tags, scripts, styles, and other string-based content that needs priority-based ordering.
+    /// </summary>
+    /// <remarks>
+    /// This class is commonly used for HTML tags that need to be injected into different sections of a page
+    /// (head, body top, body end) with specific priority ordering. Priority determines the order in which
+    /// items are rendered.
+    /// Common priority values are defined in <see cref="PagePriority"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Create a script tag with high priority for the head section
+    /// var scriptTag = new PriorityItem(
+    ///     "&lt;script src=\"/js/framework.js\"&gt;&lt;/script&gt;",
+    ///     PagePriority.Site);
+    ///
+    /// // Create a style tag with module priority
+    /// var styleTag = new PriorityItem(
+    ///     "&lt;link rel=\"stylesheet\" href=\"/css/module.css\" /&gt;",
+    ///     PagePriority.Module);
+    ///
+    /// // Create a meta tag with page priority
+    /// var metaTag = new PriorityItem(
+    ///     "&lt;meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" /&gt;",
+    ///     PagePriority.Page);
+    /// </code>
+    /// </example>
+    public class PageTag
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageTag"/> class.
+        /// </summary>
+        /// <param name="value">The string value of the item. Cannot be null.</param>
+        /// <param name="priority">The priority of the item . Use values from <see cref="PagePriority"/> for consistency.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when value is null.</exception>
+        public PageTag(string value, int priority)
+        {
+            this.Value = value;
+            this.Priority = priority;
+        }
+
+        /// <summary>
+        /// Gets or sets the string value of the item.
+        /// </summary>
+        /// <value>
+        /// A string containing the content to be rendered. This is typically HTML content such as
+        /// script tags, link tags, meta tags, or other HTML elements. The content should be properly
+        /// formatted HTML that is valid for the intended injection location.
+        /// </value>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets the priority of the item.
+        /// </summary>
+        /// <value>
+        /// An integer representing the rendering priority of the item.
+        /// Items with lower priority numbers will be rendered before those with higher numbers.
+        /// Use constants from <see cref="PagePriority"/> for consistent priority values:
+        /// - <see cref="PagePriority.Site"/> (10): Framework and site-level content
+        /// - <see cref="PagePriority.Page"/> (20): Page-specific content
+        /// - <see cref="PagePriority.Default"/> (100): Default priority for most content
+        /// - <see cref="PagePriority.Module"/> (200): Module-specific content.
+        /// </value>
+        public int Priority { get; set; }
+    }
+}

--- a/DNN Platform/DotNetNuke.Abstractions/Pages/readme.md
+++ b/DNN Platform/DotNetNuke.Abstractions/Pages/readme.md
@@ -1,0 +1,68 @@
+### Enhancement: Priority-based IPageService for page metadata, head tags, and messages
+
+#### Summary
+Add a simple, priority-driven API for setting page title/description/keywords/canonical URL, injecting head tags and meta tags, and collecting user-visible messages. This formalizes page composition logic and decouples it from the rendering pipeline, supporting both the current WebForms pipeline and the new MVC pipeline.
+
+#### Motivation
+- **Unify page composition**: Provide a single abstraction for metadata, head elements, and messages across pipelines.
+- **Deterministic ordering**: Ensure consistent output using explicit priorities.
+- **Progress toward MVC/Core**: Keeps page state management out of WebForms, easing the hybrid transition.
+- **Testability**: A small, mockable surface that’s easy to unit test.
+
+#### Scope
+- Interfaces and models:
+  - `IPageService`
+  - `PageMessage`, `PageMessageType`
+  - `PageMeta`
+  - `PageTag`
+  - `PagePriority`
+
+
+#### Proposed API (already defined)
+- **Title/SEO**
+  - `void SetTitle(string value, int priority = PagePriority.Default)`
+  - `void SetDescription(string value, int priority = PagePriority.Default)`
+  - `void SetKeyWords(string value, int priority = PagePriority.Default)`
+  - `void SetCanonicalLinkUrl(string value, int priority = PagePriority.Default)`
+  - `string GetTitle()`, `string GetDescription()`, `string GetKeyWords()`, `string GetCanonicalLinkUrl()`
+- **Head content**
+  - `void AddToHead(PageTag tagItem)`
+  - `List<PageTag> GetHeadTags()`
+  - `void AddMeta(PageMeta metaItem)`
+  - `List<PageMeta> GetMetaTags()`
+- **Messages**
+  - `void AddMessage(PageMessage messageItem)`
+  - `List<PageMessage> GetMessages()`
+- **Maintenance**
+  - `void Clear()`
+- **Priority model**
+  - `PagePriority.Site = 10`, `PagePriority.Page = 20`, `PagePriority.Default = 100`, `PagePriority.Module = 200`
+- **Message model**
+  - `PageMessageType`: `Success`, `Warning`, `Error`, `Info`
+  - `PageMessage`: `Heading`, `Message`, `MessageType`, `IconSrc`, `Priority`
+- **Meta/head models**
+  - `PageMeta`: `Name`, `Content`, `Priority`
+  - `PageTag`: `Value`, `Priority`
+
+#### Example usage
+```csharp
+pageService.SetTitle("Products", PagePriority.Page);
+pageService.SetDescription("Browse our product catalog.", PagePriority.Page);
+pageService.SetCanonicalLinkUrl("https://www.mysite.com/products", PagePriority.Page);
+
+pageService.AddMeta(new PageMeta("viewport", "width=device-width, initial-scale=1.0", PagePriority.Site));
+pageService.AddToHead(new PageTag("<link rel=\"stylesheet\" href=\"/css/catalog.css\" />", PagePriority.Page));
+
+pageService.AddMessage(new PageMessage(
+    "Saved", "Your product was updated.", PageMessageType.Success, "", PagePriority.Default));
+```
+
+#### Rendering contract (follow-up implementation)
+- The renderer (WebForms skin, MVC layout) must:
+  - Pick the highest-priority values for title/description/keywords/canonical link.
+  - Render `GetMetaTags()` and `GetHeadTags()` in ascending `Priority` order.
+  - Render `GetMessages()` in ascending `Priority` order, with styling determined by `PageMessageType`.
+
+
+
+

--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -890,6 +890,8 @@
     <Compile Include="Services\OutputCache\Providers\FileResponseFilter.cs" />
     <Compile Include="Services\OutputCache\Providers\MemoryProvider.cs" />
     <Compile Include="Services\OutputCache\Providers\MemoryResponseFilter.cs" />
+    <Compile Include="Services\Pages\PageExtensions.cs" />
+    <Compile Include="Services\Pages\PageService.cs" />
     <Compile Include="Services\Registration\IRegistrationProfileController.cs" />
     <Compile Include="Services\Registration\RegistrationProfileController.cs" />
     <Compile Include="Services\Search\Controllers\BaseResultController.cs" />

--- a/DNN Platform/Library/Services/Pages/PageExtensions.cs
+++ b/DNN Platform/Library/Services/Pages/PageExtensions.cs
@@ -1,0 +1,152 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Services.Pages
+{
+    using DotNetNuke.Abstractions.Pages;
+    using DotNetNuke.UI.Skins.Controls;
+
+    /// <summary>
+    /// Extension methods for <see cref="IPageService"/> that provide convenient overloads with simple parameters.
+    /// These methods create the appropriate priority objects internally for easier usage.
+    /// </summary>
+    public static class PageExtensions
+    {
+        /// <summary>
+        /// Adds a tag to the header of the page using simple parameters.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="tag">The HTML tag to add to the head section.</param>
+        /// <param name="priority">The priority of this tag. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddToHead(this IPageService pageService, string tag, int priority = PagePriority.Default)
+        {
+            var priorityItem = new PageTag(tag, priority);
+            pageService.AddToHead(priorityItem);
+        }
+
+        /// <summary>
+        /// Adds a meta tag using simple parameters.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="name">The name attribute of the meta tag.</param>
+        /// <param name="content">The content attribute of the meta tag.</param>
+        /// <param name="priority">The priority of this meta tag. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddMeta(this IPageService pageService, string name, string content, int priority = PagePriority.Default)
+        {
+            var priorityMeta = new PageMeta(name, content, priority);
+            pageService.AddMeta(priorityMeta);
+        }
+
+        /// <summary>
+        /// Adds a message using simple parameters with default message type.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the message.</param>
+        /// <param name="message">The message text content.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddMessage(this IPageService pageService, string heading, string message, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, PageMessageType.Info, string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Adds a message using simple parameters with specified message type.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the message.</param>
+        /// <param name="message">The message text content.</param>
+        /// <param name="messageType">The type/severity of the message.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddMessage(this IPageService pageService, string heading, string message, PageMessageType messageType, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, messageType, string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Adds a message using simple parameters with specified message type and icon.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the message.</param>
+        /// <param name="message">The message text content.</param>
+        /// <param name="messageType">The type/severity of the message.</param>
+        /// <param name="iconSrc">The optional icon source URL for the message.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddMessage(this IPageService pageService, string heading, string message, PageMessageType messageType, string iconSrc, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, messageType, iconSrc ?? string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Adds a success message using simple parameters.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the success message.</param>
+        /// <param name="message">The success message text content.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddSuccessMessage(this IPageService pageService, string heading, string message, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, PageMessageType.Success, string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Adds an error message using simple parameters.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the error message.</param>
+        /// <param name="message">The error message text content.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddErrorMessage(this IPageService pageService, string heading, string message, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, PageMessageType.Error, string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Adds a warning message using simple parameters.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the warning message.</param>
+        /// <param name="message">The warning message text content.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddWarningMessage(this IPageService pageService, string heading, string message, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, PageMessageType.Warning, string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Adds an informational message using simple parameters.
+        /// </summary>
+        /// <param name="pageService">The page service instance.</param>
+        /// <param name="heading">The heading text for the info message.</param>
+        /// <param name="message">The info message text content.</param>
+        /// <param name="priority">The priority of this message. Defaults to <see cref="PagePriority.Default"/>.</param>
+        public static void AddInfoMessage(this IPageService pageService, string heading, string message, int priority = PagePriority.Default)
+        {
+            var priorityMessage = new PageMessage(heading, message, PageMessageType.Info, string.Empty, priority);
+            pageService.AddMessage(priorityMessage);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="PageMessageType"/> to a <see cref="ModuleMessage.ModuleMessageType"/>.
+        /// </summary>
+        /// <param name="priorityMessage">The <see cref="PageMessageType"/> to convert.</param>
+        /// <returns>The <see cref="ModuleMessage.ModuleMessageType"/>.</returns>
+        public static ModuleMessage.ModuleMessageType ToModuleMessageType(this PageMessageType priorityMessage)
+        {
+            return priorityMessage switch
+            {
+                PageMessageType.Success => ModuleMessage.ModuleMessageType.GreenSuccess,
+                PageMessageType.Warning => ModuleMessage.ModuleMessageType.YellowWarning,
+                PageMessageType.Error => ModuleMessage.ModuleMessageType.RedError,
+                PageMessageType.Info => ModuleMessage.ModuleMessageType.BlueInfo,
+                _ => ModuleMessage.ModuleMessageType.GreenSuccess,
+            };
+        }
+    }
+}

--- a/DNN Platform/Library/Services/Pages/PageService.cs
+++ b/DNN Platform/Library/Services/Pages/PageService.cs
@@ -1,0 +1,272 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Services.Pages
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using DotNetNuke.Abstractions.Pages;
+
+    /// <summary>
+    /// Provides services for managing page-level elements including meta tags, head tags, messages, and SEO properties.
+    /// This service supports priority-based management where higher priority values take precedence.
+    /// </summary>
+    /// <remarks>
+    /// The PageService manages various page-level elements:
+    /// - Page metadata (title, description, keywords) with priority-based overrides
+    /// - Custom head tags for additional HTML head content
+    /// - Meta tags for SEO and page information
+    /// - Page messages for user notifications
+    /// Priority system: Higher priority values (e.g., 200) will override lower priority values (e.g., 100).
+    /// Default priority is 100 for most operations.
+    /// </remarks>
+    public class PageService : IPageService
+    {
+        /// <summary>
+        /// Collection of head tags to be included in the HTML head section, ordered by priority.
+        /// </summary>
+        private readonly List<PageTag> headTags = new List<PageTag>();
+
+        /// <summary>
+        /// Collection of meta tags for SEO and page information, ordered by priority.
+        /// </summary>
+        private readonly List<PageMeta> metaTags = new List<PageMeta>();
+
+        /// <summary>
+        /// Collection of page messages for user notifications, ordered by priority.
+        /// </summary>
+        private readonly List<PageMessage> messages = new List<PageMessage>();
+
+        /// <summary>
+        /// The current page title with the highest priority.
+        /// </summary>
+        private PageTag title;
+
+        /// <summary>
+        /// The current page description with the highest priority.
+        /// </summary>
+        private PageTag description;
+
+        /// <summary>
+        /// The current page keywords with the highest priority.
+        /// </summary>
+        private PageTag keywords;
+
+        /// <summary>
+        /// The current page canonical link URL with the highest priority.
+        /// </summary>
+        private PageTag canonicalLinkUrl;
+
+        /// <summary>
+        /// Adds a message to the page's message collection.
+        /// </summary>
+        /// <param name="messageItem">The message item to add to the page. Cannot be null.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="messageItem"/> is null.</exception>
+        /// <remarks>
+        /// Messages are used to display notifications, alerts, or informational content to users.
+        /// They are ordered by priority when retrieved, with lower priority values appearing first.
+        /// </remarks>
+        public void AddMessage(PageMessage messageItem)
+        {
+            if (messageItem == null)
+            {
+                throw new ArgumentNullException(nameof(messageItem));
+            }
+
+            this.messages.Add(messageItem);
+        }
+
+        /// <summary>
+        /// Adds a meta tag to the page's meta tag collection.
+        /// </summary>
+        /// <param name="metaItem">The meta tag item to add to the page. Cannot be null.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="metaItem"/> is null.</exception>
+        /// <remarks>
+        /// Meta tags provide metadata about the HTML document and are typically used for SEO,
+        /// social media sharing, and browser behavior. They are rendered in the HTML head section
+        /// and ordered by priority when retrieved.
+        /// </remarks>
+        public void AddMeta(PageMeta metaItem)
+        {
+            if (metaItem == null)
+            {
+                throw new ArgumentNullException(nameof(metaItem));
+            }
+
+            this.metaTags.Add(metaItem);
+        }
+
+        /// <summary>
+        /// Adds a custom tag to the page's HTML head section.
+        /// </summary>
+        /// <param name="tagItem">The tag item to add to the head section. Cannot be null.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="tagItem"/> is null.</exception>
+        /// <remarks>
+        /// Head tags allow you to include custom HTML elements in the page's head section,
+        /// such as custom CSS links, JavaScript files, or other HTML elements.
+        /// Tags are ordered by priority when retrieved, with lower priority values appearing first.
+        /// </remarks>
+        public void AddToHead(PageTag tagItem)
+        {
+            if (tagItem == null)
+            {
+                throw new ArgumentNullException(nameof(tagItem));
+            }
+
+            this.headTags.Add(tagItem);
+        }
+
+        /// <summary>
+        /// Sets the page description with the specified priority.
+        /// </summary>
+        /// <param name="value">The description text for the page.</param>
+        /// <param name="priority">The priority level for this description. Higher values take precedence. Default is 100.</param>
+        /// <remarks>
+        /// The page description is typically used in meta tags for SEO purposes and may appear
+        /// in search engine results. Only the description with the highest priority will be used.
+        /// If multiple descriptions have the same priority, the last one set will be used.
+        /// </remarks>
+        public void SetDescription(string value, int priority = 100)
+        {
+            this.SetHighestPriorityValue(ref this.description, value, priority);
+        }
+
+        /// <summary>
+        /// Sets the page keywords with the specified priority.
+        /// </summary>
+        /// <param name="value">The keywords for the page, typically comma-separated.</param>
+        /// <param name="priority">The priority level for these keywords. Higher values take precedence. Default is 100.</param>
+        /// <remarks>
+        /// Page keywords are used for SEO purposes and help categorize the page content.
+        /// Only the keywords with the highest priority will be used.
+        /// If multiple keyword sets have the same priority, the last one set will be used.
+        /// </remarks>
+        public void SetKeyWords(string value, int priority = 100)
+        {
+            this.SetHighestPriorityValue(ref this.keywords, value, priority);
+        }
+
+        /// <summary>
+        /// Sets the page title with the specified priority.
+        /// </summary>
+        /// <param name="value">The title text for the page.</param>
+        /// <param name="priority">The priority level for this title. Higher values take precedence. Default is 100.</param>
+        /// <remarks>
+        /// The page title appears in the browser tab, search engine results, and when sharing on social media.
+        /// Only the title with the highest priority will be used.
+        /// If multiple titles have the same priority, the last one set will be used.
+        /// </remarks>
+        public void SetTitle(string value, int priority = 100)
+        {
+            this.SetHighestPriorityValue(ref this.title, value, priority);
+        }
+
+        /// <summary>
+        /// Sets the page canonical link URL with the specified priority.
+        /// </summary>
+        /// <param name="value">The canonical link URL for the page.</param>
+        /// <param name="priority">The priority level for this canonical link URL. Higher values take precedence. Default is 100.</param>
+        public void SetCanonicalLinkUrl(string value, int priority = 100)
+        {
+            this.SetHighestPriorityValue(ref this.canonicalLinkUrl, value, priority);
+        }
+
+        /// <summary>
+        /// Gets the current canonical link URL value with highest priority.
+        /// </summary>
+        /// <returns>The canonical link URL value or null if not set.</returns>
+        public string GetCanonicalLinkUrl()
+        {
+            return this.canonicalLinkUrl?.Value;
+        }
+
+        /// <summary>
+        /// Gets the current title value with highest priority.
+        /// </summary>
+        /// <returns>The title value or null if not set.</returns>
+        public string GetTitle()
+        {
+            return this.title?.Value;
+        }
+
+        /// <summary>
+        /// Gets the current description value with highest priority.
+        /// </summary>
+        /// <returns>The description value or null if not set.</returns>
+        public string GetDescription()
+        {
+            return this.description?.Value;
+        }
+
+        /// <summary>
+        /// Gets the current keywords value with highest priority.
+        /// </summary>
+        /// <returns>The keywords value or null if not set.</returns>
+        public string GetKeyWords()
+        {
+            return this.keywords?.Value;
+        }
+
+        /// <summary>
+        /// Gets all head tags ordered by priority (lowest priority first).
+        /// </summary>
+        /// <returns>List of head tags ordered by priority.</returns>
+        public List<PageTag> GetHeadTags()
+        {
+            return this.headTags.OrderBy(x => x.Priority).ToList();
+        }
+
+        /// <summary>
+        /// Gets all meta tags ordered by priority (lowest priority first).
+        /// </summary>
+        /// <returns>List of meta tags ordered by priority.</returns>
+        public List<PageMeta> GetMetaTags()
+        {
+            return this.metaTags.OrderBy(x => x.Priority).ToList();
+        }
+
+        /// <summary>
+        /// Gets all messages ordered by priority (lowest priority first).
+        /// </summary>
+        /// <returns>List of messages ordered by priority.</returns>
+        public List<PageMessage> GetMessages()
+        {
+            return this.messages.OrderBy(x => x.Priority).ToList();
+        }
+
+        /// <summary>
+        /// Clears all stored page data. Useful for testing or resetting state.
+        /// </summary>
+        public void Clear()
+        {
+            this.title = null;
+            this.description = null;
+            this.keywords = null;
+            this.headTags.Clear();
+            this.metaTags.Clear();
+            this.messages.Clear();
+        }
+
+        /// <summary>
+        /// Sets the highest priority value for a PageTag field.
+        /// </summary>
+        /// <param name="currentItem">Reference to the current PageTag field to potentially update.</param>
+        /// <param name="value">The new value to set.</param>
+        /// <param name="priority">The priority of the new value.</param>
+        /// <remarks>
+        /// This method implements the priority-based override system. It only updates the current item
+        /// if the new priority is higher than the existing priority, or if no item is currently set.
+        /// This ensures that higher priority values always take precedence.
+        /// </remarks>
+        private void SetHighestPriorityValue(ref PageTag currentItem, string value, int priority)
+        {
+            if (currentItem == null || priority > currentItem.Priority)
+            {
+                currentItem = new PageTag(value, priority);
+            }
+        }
+    }
+}

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke
@@ -10,6 +10,7 @@ namespace DotNetNuke
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Abstractions.Modules;
+    using DotNetNuke.Abstractions.Pages;
     using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Abstractions.Portals.Templates;
     using DotNetNuke.Abstractions.Prompt;
@@ -47,6 +48,7 @@ namespace DotNetNuke
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Services.Mail.OAuth;
     using DotNetNuke.Services.Mobile;
+    using DotNetNuke.Services.Pages;
     using DotNetNuke.Services.Personalization;
     using DotNetNuke.Services.Search.Controllers;
     using DotNetNuke.Services.Search.Internals;
@@ -90,6 +92,7 @@ namespace DotNetNuke
             services.AddScoped<IPortalAliasService, PortalAliasController>();
 
             services.AddScoped<IPermissionDefinitionService, PermissionController>();
+            services.AddScoped<IPageService, PageService>();
 
             services.AddTransient<IFileSystemUtils, FileSystemUtilsProvider>();
             services.AddTransient<ISmtpOAuthController, SmtpOAuthController>();

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -17,6 +17,7 @@ namespace DotNetNuke.Framework
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Logging;
+    using DotNetNuke.Abstractions.Pages;
     using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
@@ -59,11 +60,12 @@ namespace DotNetNuke.Framework
         private readonly IHostSettingsService hostSettingsService;
         private readonly IEventLogger eventLogger;
         private readonly IPortalSettingsController portalSettingsController;
+        private readonly IPageService pageService;
 
         /// <summary>Initializes a new instance of the <see cref="DefaultPage"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.2. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public DefaultPage()
-            : this(null, null, null, null, null, null, null, null, null)
+            : this(null, null, null, null, null, null, null, null, null, null)
         {
         }
 
@@ -77,7 +79,8 @@ namespace DotNetNuke.Framework
         /// <param name="eventLogger">The event logger.</param>
         /// <param name="portalController">The portal controller.</param>
         /// <param name="portalSettingsController">The portal settings controller.</param>
-        public DefaultPage(INavigationManager navigationManager, IApplicationInfo appInfo, IApplicationStatusInfo appStatus, IModuleControlPipeline moduleControlPipeline, IHostSettings hostSettings, IHostSettingsService hostSettingsService, IEventLogger eventLogger, IPortalController portalController, IPortalSettingsController portalSettingsController)
+        /// <param name="pageService">The page service.</param>
+        public DefaultPage(INavigationManager navigationManager, IApplicationInfo appInfo, IApplicationStatusInfo appStatus, IModuleControlPipeline moduleControlPipeline, IHostSettings hostSettings, IHostSettingsService hostSettingsService, IEventLogger eventLogger, IPortalController portalController, IPortalSettingsController portalSettingsController, IPageService pageService)
             : base(portalController, appStatus, hostSettings)
         {
             this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
@@ -88,6 +91,7 @@ namespace DotNetNuke.Framework
             this.hostSettingsService = hostSettingsService ?? Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettingsService>();
             this.eventLogger = eventLogger ?? Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>();
             this.portalSettingsController = portalSettingsController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IPortalSettingsController>();
+            this.pageService = pageService ?? Globals.GetCurrentServiceProvider().GetRequiredService<IPageService>();
         }
 
         public string CurrentSkinPath => ((PortalSettings)HttpContext.Current.Items["PortalSettings"]).ActiveTab.SkinPath;
@@ -284,6 +288,8 @@ namespace DotNetNuke.Framework
                 }
             }
 
+            this.pageService.SetCanonicalLinkUrl(this.CanonicalLinkUrl, PagePriority.Page);
+
             // add CSS links
             ClientResourceManager.RegisterDefaultStylesheet(this, string.Concat(Globals.ApplicationPath, "/Resources/Shared/stylesheets/dnndefault/10.0.0/default.css"));
             ClientResourceManager.RegisterStyleSheet(this, string.Concat(ctlSkin.SkinPath, "skin.css"), FileOrder.Css.SkinCss);
@@ -337,6 +343,10 @@ namespace DotNetNuke.Framework
             this.metaPanel.Visible = !UrlUtils.InPopUp();
             if (!UrlUtils.InPopUp())
             {
+                this.Title = this.pageService.GetTitle();
+                this.Description = this.pageService.GetDescription();
+                this.KeyWords = this.pageService.GetKeyWords();
+
                 this.MetaGenerator.Content = this.Generator;
                 this.MetaGenerator.Visible = !string.IsNullOrEmpty(this.Generator);
                 this.MetaAuthor.Content = this.PortalSettings.PortalName;
@@ -352,6 +362,7 @@ namespace DotNetNuke.Framework
                 this.Page.Response.AddHeader("X-UA-Compatible", this.PortalSettings.AddCompatibleHttpHeader);
             }
 
+            this.CanonicalLinkUrl = this.pageService.GetCanonicalLinkUrl();
             if (!string.IsNullOrEmpty(this.CanonicalLinkUrl))
             {
                 // Add Canonical <link> using the primary alias
@@ -361,6 +372,40 @@ namespace DotNetNuke.Framework
 
                 // Add the HtmlLink to the Head section of the page.
                 this.Page.Header.Controls.Add(canonicalLink);
+            }
+
+            foreach (var item in this.pageService.GetHeadTags())
+            {
+                this.Page.Header.Controls.Add(new LiteralControl(item.Value));
+            }
+
+            foreach (var item in this.pageService.GetMetaTags())
+            {
+                this.Page.Header.Controls.Add(new Meta() { Name = item.Name, Content = item.Content });
+            }
+
+            foreach (var item in this.pageService.GetMessages())
+            {
+                ModuleMessage.ModuleMessageType moduleMessageType = ModuleMessage.ModuleMessageType.BlueInfo;
+
+                switch (item.MessageType)
+                {
+                    case PageMessageType.Success:
+                        moduleMessageType = ModuleMessage.ModuleMessageType.GreenSuccess;
+                        break;
+                    case PageMessageType.Warning:
+                        moduleMessageType = ModuleMessage.ModuleMessageType.YellowWarning;
+                        break;
+                    case PageMessageType.Error:
+                        moduleMessageType = ModuleMessage.ModuleMessageType.RedError;
+                        break;
+                    case PageMessageType.Info:
+                    default:
+                        moduleMessageType = ModuleMessage.ModuleMessageType.BlueInfo;
+                        break;
+                }
+
+                Skin.AddPageMessage(this, item.Heading, item.Message, moduleMessageType);
             }
         }
 
@@ -567,6 +612,8 @@ namespace DotNetNuke.Framework
                 this.Description = this.PortalSettings.Description;
             }
 
+            this.pageService.SetDescription(this.Description, PagePriority.Page);
+
             // META keywords
             if (!string.IsNullOrEmpty(this.PortalSettings.ActiveTab.KeyWords))
             {
@@ -576,6 +623,8 @@ namespace DotNetNuke.Framework
             {
                 this.KeyWords = this.PortalSettings.KeyWords;
             }
+
+            this.pageService.SetKeyWords(this.KeyWords, PagePriority.Page);
 
             // META copyright
             if (!string.IsNullOrEmpty(this.PortalSettings.FooterText))
@@ -618,6 +667,8 @@ namespace DotNetNuke.Framework
                 string versionString = $" ({this.appInfo.Status} Version: {this.appInfo.Version})";
                 this.Title += versionString;
             }
+
+            this.pageService.SetTitle(this.Title, PagePriority.Page);
 
             // register css variables
             var cssVariablesStyleSheet = this.GetCssVariablesStylesheet();


### PR DESCRIPTION
#### Summary
Add a simple, priority-driven API for setting page title/description/keywords/canonical URL, injecting head tags and meta tags, and collecting user-visible messages. This formalizes page composition logic and decouples it from the rendering pipeline, supporting both the current WebForms pipeline and the new MVC pipeline.

#### Motivation
- **Unify page composition**: Provide a single abstraction for metadata, head elements, and messages across pipelines.
- **Deterministic ordering**: Ensure consistent output using explicit priorities.
- **Progress toward MVC/Core**: Keeps page state management out of WebForms, easing the hybrid transition.
- **Testability**: A small, mockable surface that’s easy to unit test.

#### Scope
- Interfaces and models:
  - `IPageService`
  - `PageMessage`, `PageMessageType`
  - `PageMeta`
  - `PageTag`
  - `PagePriority`


#### Proposed API (already defined)
- **Title/SEO**
  - `void SetTitle(string value, int priority = PagePriority.Default)`
  - `void SetDescription(string value, int priority = PagePriority.Default)`
  - `void SetKeyWords(string value, int priority = PagePriority.Default)`
  - `void SetCanonicalLinkUrl(string value, int priority = PagePriority.Default)`
  - `string GetTitle()`, `string GetDescription()`, `string GetKeyWords()`, `string GetCanonicalLinkUrl()`
- **Head content**
  - `void AddToHead(PageTag tagItem)`
  - `List<PageTag> GetHeadTags()`
  - `void AddMeta(PageMeta metaItem)`
  - `List<PageMeta> GetMetaTags()`
- **Messages**
  - `void AddMessage(PageMessage messageItem)`
  - `List<PageMessage> GetMessages()`
- **Maintenance**
  - `void Clear()`
- **Priority model**
  - `PagePriority.Site = 10`, `PagePriority.Page = 20`, `PagePriority.Default = 100`, `PagePriority.Module = 200`
- **Message model**
  - `PageMessageType`: `Success`, `Warning`, `Error`, `Info`
  - `PageMessage`: `Heading`, `Message`, `MessageType`, `IconSrc`, `Priority`
- **Meta/head models**
  - `PageMeta`: `Name`, `Content`, `Priority`
  - `PageTag`: `Value`, `Priority`

#### Example usage
```csharp
pageService.SetTitle("Products", PagePriority.Page);
pageService.SetDescription("Browse our product catalog.", PagePriority.Page);
pageService.SetCanonicalLinkUrl("https://www.mysite.com/products", PagePriority.Page);

pageService.AddMeta(new PageMeta("viewport", "width=device-width, initial-scale=1.0", PagePriority.Site));
pageService.AddToHead(new PageTag("<link rel=\"stylesheet\" href=\"/css/catalog.css\" />", PagePriority.Page));

pageService.AddMessage(new PageMessage(
    "Saved", "Your product was updated.", PageMessageType.Success, "", PagePriority.Default));
```

#### Rendering contract
- The renderer (WebForms skin, MVC layout) must:
  - Pick the highest-priority values for title/description/keywords/canonical link.
  - Render `GetMetaTags()` and `GetHeadTags()` in ascending `Priority` order.
  - Render `GetMessages()` in ascending `Priority` order, with styling determined by `PageMessageType`.

 Fixes #6737