### PR TITLE
Fix search SKO issues

### DIFF
--- a/DNN Platform/Website/admin/Skins/Search.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Search.ascx.cs
@@ -354,7 +354,7 @@ namespace DotNetNuke.UI.Skins.Controls
                         }
                         else
                         {
-                            this.Response.Redirect(this.navigationManager.NavigateURL(searchTabId, "Search=" + WebUtility.UrlEncode(searchText)));
+                            this.Response.Redirect(this.navigationManager.NavigateURL(searchTabId, string.Empty, "search=" + WebUtility.UrlEncode(searchText)));
                         }
 
                         break;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
The Search Them Object Search button does not point you to the correct URL. See #6712 

The issue is this:
On this line https://github.com/dnnsoftware/Dnn.Platform/blob/2ca5bd49d256168a5479c7a9e040e204390ee155/DNN%20Platform/Website/admin/Skins/Search.ascx.cs#L357

Uses https://github.com/dnnsoftware/Dnn.Platform/blob/2ca5bd49d256168a5479c7a9e040e204390ee155/DNN%20Platform/DotNetNuke.Abstractions/INavigationManager.cs#L41

Where the second parameter is a controlkey string, resulting in the /ctl/search url reported in the Issue as the QS parameter is interpreted as Control Key.

I changed this to use 

https://github.com/dnnsoftware/Dnn.Platform/blob/2ca5bd49d256168a5479c7a9e040e204390ee155/DNN%20Platform/DotNetNuke.Abstractions/INavigationManager.cs#L48

BTW,  also changed "Search" to "search" as that's what will be in the resulting url.


Fixes #6712
