### PR TITLE
Corrected `requestLengthDiskThreshold` to use MS default of `80`

### DIFF
--- a/DNN Platform/Tests/App.config
+++ b/DNN Platform/Tests/App.config
@@ -114,7 +114,7 @@
       <forms name=".DOTNETNUKE" protection="All" timeout="60" cookieless="UseCookies" />
     </authentication>
     <!-- allow large file uploads -->
-    <httpRuntime shutdownTimeout="120" executionTimeout="900" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="81920" />
+    <httpRuntime shutdownTimeout="120" executionTimeout="900" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="80" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain="" />
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application. 

--- a/DNN Platform/Website/Install/Config/10.02.00.config
+++ b/DNN Platform/Website/Install/Config/10.02.00.config
@@ -4,5 +4,6 @@
       <!-- Can be set to true to allow the image handler to display text passed in the querystring. -->
       <add key="AllowDnnUpgradeUpload" value="false" />
     </node>
+    <node path="/configuration/system.web/httpRuntime" action="updateattribute"  name="requestLengthDiskThreshold" value="80" />
   </nodes>
 </configuration>

--- a/DNN Platform/Website/development.config
+++ b/DNN Platform/Website/development.config
@@ -159,7 +159,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="80" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.

--- a/DNN Platform/Website/release.config
+++ b/DNN Platform/Website/release.config
@@ -160,7 +160,7 @@
     </authentication>
     -->
     <!-- allow large file uploads -->
-    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="81920" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
+    <httpRuntime targetFramework="4.7.2" shutdownTimeout="120" executionTimeout="1200" useFullyQualifiedRedirectUrl="true" maxRequestLength="28672" requestLengthDiskThreshold="80" maxUrlLength="2048" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false"  requestValidationMode="2.0" fcnMode="Single" />
     <httpCookies httpOnlyCookies="true" requireSSL="false" domain=""/>
     <!--  GLOBALIZATION
     This section sets the globalization settings of the application.


### PR DESCRIPTION
## Summary
Resolves #6816 

As mentioned in the above issue comments, the MS documentation is wrong.  A PR has been submitted by @mitchelsellers to correct the MS documentation.  This PR changes the `requestLengthDiskThreshold` value back to `80` (which means 80KB).  The way it was prior, nothing would ever get written to disk (no chunking) because the value was actually 80MB due to the incorrect documented unit for this attribute.  Instead uploads would be held in memory until the full upload is complete and then written to disk at the end.  This change will allow 80KB chunks to be written to disk during the uploads (freeing up memory).

Our suspicion is this has caused quite a few issues lately with module installations close to 28MB (e.g., 24MB) running out of memory and preventing installation.  Also, upgrades in Azure seem to be experiencing similar issues.