### PR TITLE
Re-introduced "role" JWT claim to attempt to limit impact of breaking change

### DIFF
--- a/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/LoginResultData.cs
+++ b/DNN Platform/Dnn.AuthServices.Jwt/Components/Entity/LoginResultData.cs
@@ -29,5 +29,10 @@ namespace Dnn.AuthServices.Jwt.Components.Entity
         /// <summary>Gets or sets any error message.</summary>
         [JsonIgnore]
         public string Error { get; set; }
+
+        /// <summary>Gets deprecation warnings about the JWT token format (included in all responses).</summary>
+        [JsonProperty("deprecationNotice")]
+        public string DeprecationNotice =>
+            "The role claim format in JWT tokens is deprecated. Please use http://schemas.microsoft.com/ws/2008/06/identity/claims/role instead. The legacy role claim will be removed in DNN Platform v12.0.0.";
     }
 }


### PR DESCRIPTION
In #6356 a dependency update made an unintentional breaking change. Instead of the classic "role" claim we now give a "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" claim for roles.

JWT in itself has no specs for roles or claims which is left to whatever implementation is targeted like OIDC, OAuth, etc.

In DNN context it is a simple JWT but we do provide roles and the new package enum values uses Microsoft "standard" values that have been around in the Microsoft ecosystem since .Net Framework 4.5 and still lives all the way up to .Net 10.

I am not sure if we should support our old "role" claim forever or the Microsoft claim as there are 0 specs about "role". IETF does have a spec about "roles" so if we would change it to that spec, it would still be a breaking change.

What this PR does is provide both the old (<=9.13.9) behavior of "role" as well as the new Microsoft way which may be better known in the .Net ecosystem. It also adds a deprecation note on both the plain and encrypted token to try and bring attention to this breaking change with the old way being obsolete and removed in v12.

Closes #6829

<img width="1894" height="589" alt="image" src="https://github.com/user-attachments/assets/28370378-03c0-46da-86dc-3a2a33647a81" />
