### PR TITLE
Fixed a build issue with new typescript sample projects

### DIFF
--- a/DNN Platform/Modules/Samples/Dnn.ContactList.Spa/Dnn.ContactList.Spa.csproj
+++ b/DNN Platform/Modules/Samples/Dnn.ContactList.Spa/Dnn.ContactList.Spa.csproj
@@ -17,6 +17,9 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <BaseOutputPath>.\bin</BaseOutputPath>
     <AssetTargetFallback>netstandard2.0</AssetTargetFallback>
+    <!-- Disable TypeScript compilation in MSBuild - handled by npm/yarn -->
+    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+    <EnableTypeScriptChecking>false</EnableTypeScriptChecking>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />

--- a/DNN Platform/Modules/Samples/Dnn.ContactList.SpaReact/Dnn.ContactList.SpaReact.csproj
+++ b/DNN Platform/Modules/Samples/Dnn.ContactList.SpaReact/Dnn.ContactList.SpaReact.csproj
@@ -17,6 +17,9 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <BaseOutputPath>.\bin</BaseOutputPath>
     <AssetTargetFallback>netstandard2.0</AssetTargetFallback>
+    <!-- Disable TypeScript compilation in MSBuild - handled by npm/yarn -->
+    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+    <EnableTypeScriptChecking>false</EnableTypeScriptChecking>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />


### PR DESCRIPTION
The new typescript based sample projects are built using our existing yarn process. However building DNN in modern Visual Studio (2022-2026) if you have typescript workload installed made the project build twice and VS was not really knowing what to do and failed.

This prevents VisualStudio/MsBuild to try and compile the typescript in the project, leaving it to our existing yarn process only.
