### PR TITLE
Prevent the installBlocker lock file to be removed by subsequent requests during Upgrade or Install.

### DIFF
--- a/DNN Platform/Website/Install/Install.aspx.cs
+++ b/DNN Platform/Website/Install/Install.aspx.cs
@@ -224,6 +224,7 @@ namespace DotNetNuke.Services.Install
             }
             else
             {
+                bool cleanupLocker = false;
                 try
                 {
                     var synchConnectionString = new SynchConnectionStringStep();
@@ -259,6 +260,7 @@ namespace DotNetNuke.Services.Install
                                 return;
                             }
 
+                            cleanupLocker = true;
                             RegisterInstallBegining();
                         }
 
@@ -314,7 +316,10 @@ namespace DotNetNuke.Services.Install
                 }
                 finally
                 {
-                    RegisterInstallEnd();
+                    if (cleanupLocker)
+                    {
+                        RegisterInstallEnd();
+                    }
                 }
             }
         }
@@ -352,6 +357,7 @@ namespace DotNetNuke.Services.Install
 
         private void UpgradeApplication()
         {
+            bool cleanupLocker = false;
             try
             {
                 if (Upgrade.Upgrade.RemoveInvalidAntiForgeryCookie())
@@ -377,6 +383,7 @@ namespace DotNetNuke.Services.Install
                         return;
                     }
 
+                    cleanupLocker = true;
                     RegisterInstallBegining();
                 }
 
@@ -498,7 +505,10 @@ namespace DotNetNuke.Services.Install
             }
             finally
             {
-                RegisterInstallEnd();
+                if (cleanupLocker)
+                {
+                    RegisterInstallEnd();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #6859

## Summary
Uses a `cleanupLocker` boolean that gets set just before calling `RegisterInstallBegining` to control whether the locker gets cleaned up by the finally block. This prevents early returning code that is meant for any arbitrary requests made during the installation/upgrade process to remove the lock prematurely.