### PR TITLE
Add box-shadow to sticky header

### DIFF
--- a/DNN Platform/Skins/Aperture/src/scss/sections/_header.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/sections/_header.scss
@@ -5,7 +5,7 @@
     position: sticky;
     top: 0;
     z-index: 1000;
-    box-shadow: .4rem .2rem .3rem 0rem var(--dnn-color-foreground-dark);
+    box-shadow: 0 4px 4px -2px rgba(var(--dnn-color-foreground-r), var(--dnn-color-foreground-g), var(--dnn-color-foreground-b), 0.3);)
     .eyebrow-bar {
         background-color: colors.color('tertiary');
         padding: .5rem 0;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #6755

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
**Header separation on scroll**  
   Adds a subtle box-shadow to the header when scrolling to improve visual separation from the page content.  
   This prevents the header from visually blending into the content below while preserving the existing layout and behavior.