### PR TITLE
Enhance font-weight for bold elements in SCSS

### DIFF
--- a/DNN Platform/Skins/Aperture/src/scss/_base.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/_base.scss
@@ -105,6 +105,11 @@ code {
   line-height: 1;
 }
 
+b,
+strong {
+  font-weight: bolder;
+}
+
 sup,
 sub {
   vertical-align: baseline;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #6755 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
This PR fixes an issue where `<strong>` and `<b>` elements were not rendered as bold in the Aperture theme.

A global reset rule was inheriting the full `font` property for these elements, which unintentionally removed the browser default bold behavior and caused them to render with the same font weight as their parent.

An explicit override using:


`b, strong { font-weight: bolder; }`

restores the expected semantic behavior by matching standard user-agent styling, without hard-coding a specific font weight or impacting layout and typography elsewhere.