### PR TITLE
Fix CKEditor Browser missing scripts

### DIFF
--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx
@@ -9,13 +9,15 @@
     <meta name="language" content="en" />
     <title id="title" runat="server">DNNConnect.CKEditorProvider.FileBrowser</title>
     <asp:Placeholder id="favicon" runat="server"></asp:Placeholder>
-    <asp:PlaceHolder runat="server" ID="ClientDependencyHeadCss" />
+      <dnncrm:DnnResources runat="server" Provider="DnnPageHeaderProvider" />
+      <asp:PlaceHolder runat="server" ID="ClientDependencyHeadCss" />
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadJs" />
   </head>
   <body>
     <form id="fBrowser" method="post" runat="server">
+      <dnncrm:DnnResources runat="server" Provider="DnnBodyProvider" />
       <asp:PlaceHolder ID="BodySCRIPTS" runat="server" />
-      <asp:ScriptManager ID="scriptManager1" runat="server"></asp:ScriptManager>
+      <asp:ScriptManager runat="server" />
       <div id="BrowserContainer">
       <h1><asp:Label id="lblModus" runat="server"></asp:Label></h1>
       <hr />
@@ -374,6 +376,8 @@
       </div>
       </asp:Panel>
       <!-- / Loading screen -->
+
+      <dnncrm:DnnResources runat="server" Provider="DnnFormBottomProvider" />
       <asp:PlaceHolder runat="server" ID="ClientResourcesFormBottom" />
     </form>
     <script type="text/javascript">
@@ -436,12 +440,6 @@
     </script>
   
     <asp:PlaceHolder runat="server" id="ClientResourceIncludes" />
-
-    <dnncrm:ClientResourceLoader runat="server" id="ClientResourceLoader">
-      <Paths>
-        <dnncrm:ClientResourcePath Name="SharedScripts" Path="~/Resources/Shared/Scripts/" />
-      </Paths>
-    </dnncrm:ClientResourceLoader>
   </body>
 </html>
 

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.cs
@@ -1671,9 +1671,6 @@ public partial class Browser : PageBase
         this.FoldersTree.SelectedNodeChanged += this.FoldersTree_NodeClick;
 
         this.FilesList.ItemCommand += this.FilesList_ItemCommand;
-
-        this.ClientResourceLoader.DataBind();
-        this.ClientResourceLoader.PreRender += (_, _) => JavaScript.Register(this.hostSettings, this.hostSettingsService, this.appStatus, this.eventLogger, this.portalSettings, this.Page);
     }
 
     /// <summary>Load Favicon from Current Portal Home Directory.</summary>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.designer.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Browser/Browser.aspx.designer.cs
@@ -56,13 +56,6 @@ namespace DNNConnect.CKEditorProvider.Browser
         /// </remarks>
         protected global::System.Web.UI.WebControls.PlaceHolder BodySCRIPTS;
 
-        /// <summary>scriptManager1 control.</summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.ScriptManager scriptManager1;
-
         /// <summary>lblModus control.</summary>
         /// <remarks>
         /// Auto-generated field.
@@ -706,12 +699,5 @@ namespace DNNConnect.CKEditorProvider.Browser
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.PlaceHolder ClientResourceIncludes;
-
-        /// <summary>ClientResourceLoader control.</summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::DotNetNuke.Web.Client.ClientResourceManagement.ClientResourceLoader ClientResourceLoader;
     }
 }

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Options.aspx
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Options.aspx
@@ -8,6 +8,8 @@
     <meta name="language" content="en" />
     <title>CKEditor Options</title>
     <asp:PlaceHolder id="favicon" runat="server"></asp:PlaceHolder>
+
+    <dnncrm:DnnResources runat="server" Provider="DnnPageHeaderProvider" />
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadCss" />
     <asp:PlaceHolder runat="server" ID="ClientDependencyHeadJs" />
     <script type="text/javascript">
@@ -25,17 +27,14 @@
   </head>
   <body>
     <form id="ckOptionsForm" runat="server">
+      <dnncrm:DnnResources runat="server" Provider="DnnBodyProvider" />
       <asp:PlaceHolder ID="BodySCRIPTS" runat="server" />
       <asp:PlaceHolder id="phControls" runat="server" />
+      
+      <dnncrm:DnnResources runat="server" Provider="DnnFormBottomProvider" />
       <asp:PlaceHolder runat="server" ID="ClientResourcesFormBottom" />
     </form>
   
     <asp:PlaceHolder runat="server" id="ClientResourceIncludes" />
-
-    <dnncrm:ClientResourceLoader runat="server" id="ClientResourceLoader">
-      <Paths>
-        <dnncrm:ClientResourcePath Name="SharedScripts" Path="~/Resources/Shared/Scripts/" />
-      </Paths>
-    </dnncrm:ClientResourceLoader>
   </body>
 </html>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Options.aspx.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Options.aspx.cs
@@ -207,9 +207,6 @@ namespace DNNConnect.CKEditorProvider
         private void InitializeComponent()
         {
             this.curPortalSettings = this.GetPortalSettings();
-
-            this.ClientResourceLoader.DataBind();
-            this.ClientResourceLoader.PreRender += (sender, args) => JavaScript.Register(this.Page);
         }
 
         /// <summary>Load Favicon from Current Portal Home Directory.</summary>

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Options.aspx.designer.cs
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/Options.aspx.designer.cs
@@ -69,12 +69,5 @@ namespace DNNConnect.CKEditorProvider
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.PlaceHolder ClientResourceIncludes;
-
-        /// <summary>ClientResourceLoader control.</summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::DotNetNuke.Web.Client.ClientResourceManagement.ClientResourceLoader ClientResourceLoader;
     }
 }


### PR DESCRIPTION
The two `aspx` pages used by the CKEditor provider integrated the old CRM controls, and needed to be transitioned to the new CDF as of DNN 10.2.0.

Fixes #6931