### PR TITLE
Get ContentEditorManager dependencies from request scope

### DIFF
--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/HttpModules/EditBarModule.cs
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/HttpModules/EditBarModule.cs
@@ -18,66 +18,35 @@ namespace Dnn.EditBar.UI.HttpModules
     using DotNetNuke.Common.Extensions;
     using DotNetNuke.Entities.Controllers;
     using DotNetNuke.Entities.Host;
-    using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
-    using DotNetNuke.Security.Permissions;
-    using DotNetNuke.Services.Cryptography;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.UI.Skins.EventListeners;
-    using DotNetNuke.Web.Client.ResourceManager;
 
     using Microsoft.Extensions.DependencyInjection;
 
-    using ICryptographyProvider = DotNetNuke.Abstractions.Security.ICryptographyProvider;
-
+    /// <summary>An HTTP module which injects the <see cref="ContentEditorManager"/> control on requests that may need to contain the Edit Bar.</summary>
     public class EditBarModule : IHttpModule
     {
         private static readonly object LockAppStarted = new object();
         private static bool hasAppStarted;
 
         private readonly IHostSettings hostSettings;
-        private readonly IClientResourceController clientResourceController;
-        private readonly IApplicationStatusInfo appStatus;
-        private readonly IEventLogger eventLogger;
-        private readonly IPortalController portalController;
-        private readonly IUserController userController;
-        private readonly IHostSettingsService hostSettingsService;
 
         /// <summary>Initializes a new instance of the <see cref="EditBarModule"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IHostSettings. Scheduled removal in v12.0.0.")]
         public EditBarModule()
-            : this(null, null, null, null, null, null, null)
+            : this(null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="EditBarModule"/> class.</summary>
         /// <param name="hostSettings">The host settings.</param>
-        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IHostSettings. Scheduled removal in v12.0.0.")]
         public EditBarModule(IHostSettings hostSettings)
-            : this(hostSettings, null, null, null, null, null, null)
-        {
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="EditBarModule"/> class.</summary>
-        /// <param name="hostSettings">The host settings.</param>
-        /// <param name="clientResourceController">The client resource controller.</param>
-        /// <param name="appStatus">The application status.</param>
-        /// <param name="eventLogger">The event logger.</param>
-        /// <param name="portalController">The portal controller.</param>
-        /// <param name="userController">The user controller.</param>
-        /// <param name="hostSettingsService">The host settings service.</param>
-        public EditBarModule(IHostSettings hostSettings, IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IPortalController portalController, IUserController userController, IHostSettingsService hostSettingsService)
         {
             if (hostSettings is not null)
             {
                 this.hostSettings = hostSettings;
-                this.clientResourceController = clientResourceController;
-                this.appStatus = appStatus;
-                this.eventLogger = eventLogger;
-                this.portalController = portalController;
-                this.userController = userController;
-                this.hostSettingsService = hostSettingsService;
             }
             else
             {
@@ -85,30 +54,20 @@ namespace Dnn.EditBar.UI.HttpModules
                 if (scope is not null)
                 {
                     this.hostSettings = scope.ServiceProvider.GetRequiredService<IHostSettings>();
-                    this.clientResourceController = scope.ServiceProvider.GetRequiredService<IClientResourceController>();
-                    this.appStatus = scope.ServiceProvider.GetRequiredService<IApplicationStatusInfo>();
-                    this.eventLogger = scope.ServiceProvider.GetRequiredService<IEventLogger>();
-                    this.portalController = scope.ServiceProvider.GetRequiredService<IPortalController>();
-                    this.userController = scope.ServiceProvider.GetRequiredService<IUserController>();
-                    this.hostSettingsService = scope.ServiceProvider.GetRequiredService<IHostSettingsService>();
                 }
                 else
                 {
+                    this.hostSettings = new HostSettings(
+                        new HostController(
 #pragma warning disable CS0618 // Type or member is obsolete
-                    this.eventLogger = new EventLogController();
+                            new EventLogController(),
 #pragma warning restore CS0618 // Type or member is obsolete
-                    this.hostSettings = new HostSettings(new HostController(this.eventLogger, new Lazy<IPortalController>(() => PortalController.Instance)));
-                    this.appStatus = new ApplicationStatusInfo(new Application());
-                    this.clientResourceController = new ClientResourceController(this.hostSettings, this.appStatus);
-#pragma warning disable CS0618 // Type or member is obsolete
-                    this.portalController = new PortalController(new BusinessControllerProvider(null), this.hostSettings, this.appStatus, this.eventLogger, CryptographyProvider.Instance() as ICryptographyProvider, new PermissionController(this.eventLogger));
-#pragma warning restore CS0618 // Type or member is obsolete
-                    this.userController = new UserController();
-                    this.hostSettingsService = new HostController(this.eventLogger, new Lazy<IPortalController>(() => this.portalController));
+                            new Lazy<IPortalController>(() => PortalController.Instance)));
                 }
             }
         }
 
+        /// <inheritdoc />
         [SuppressMessage("Microsoft.Naming", "CA1725:ParameterNamesShouldMatchBaseDeclaration", Justification = "Breaking change")]
         public void Init(HttpApplication application)
         {
@@ -129,6 +88,7 @@ namespace Dnn.EditBar.UI.HttpModules
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
         }
@@ -156,7 +116,15 @@ namespace Dnn.EditBar.UI.HttpModules
             {
                 if (PortalSettings.Current.UserId > 0)
                 {
-                    e.Skin.Page.Form.Controls.Add(new ContentEditorManager(this.clientResourceController, this.appStatus, this.eventLogger, this.portalController, this.hostSettings, this.userController, this.hostSettingsService) { Skin = e.Skin, });
+                    var scope = HttpContextSource.Current.GetScope();
+                    var clientResourceController = scope.ServiceProvider.GetRequiredService<IClientResourceController>();
+                    var appStatus = scope.ServiceProvider.GetRequiredService<IApplicationStatusInfo>();
+                    var eventLogger = scope.ServiceProvider.GetRequiredService<IEventLogger>();
+                    var portalController = scope.ServiceProvider.GetRequiredService<IPortalController>();
+                    var userController = scope.ServiceProvider.GetRequiredService<IUserController>();
+                    var hostSettingsService = scope.ServiceProvider.GetRequiredService<IHostSettingsService>();
+
+                    e.Skin.Page.Form.Controls.Add(new ContentEditorManager(clientResourceController, appStatus, eventLogger, portalController, this.hostSettings, userController, hostSettingsService) { Skin = e.Skin, });
                 }
             }
         }


### PR DESCRIPTION
## Summary
In DNN 10.2.2 RC1, the edit bar does not display in edit mode. There is an error in the console about `dnn.ContentEditorManager` being undefined, which points to [`ContentEditor.js`](https://github.com/dnnsoftware/Dnn.Platform/blob/fd590cf8208d3c0e93de6a8ef0cc0e4c9afd11dc/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ContentEditor.js) not being registered by [`ContentEditorManager`](https://github.com/dnnsoftware/Dnn.Platform/blob/0115d33b6ba769916049308e87a462dae2829488/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Controllers/ContentEditorManager.cs#L347).

This line was successfully running, but when the scripts were rendered on the page, the script was not in the list of requested scripts. This is because the `IClientResourceController` passed to the constructor of `ContentEditorManager` did not come from the current request scope, but was [created when `EditBarModule` was instantiated](https://github.com/dnnsoftware/Dnn.Platform/blob/03ee406ad582ecdd2a334d55b5a8d74f011fa901/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/HttpModules/EditBarModule.cs#L72-L109) was instantiated (due to timing issues with DI support in `IHttpModule` implementations).

The solution in this PR is to get the dependencies from the request scope when needed, rather than using constructor injection.