### PR TITLE
Fix install wizard not working with hash in URL

### DIFF
--- a/DNN Platform/Website/Install/InstallWizard.aspx
+++ b/DNN Platform/Website/Install/InstallWizard.aspx
@@ -675,7 +675,10 @@
                                     if (valid.Item1) {
                                         $('#<%= lblDatabaseInfoMsg.ClientID %>').removeClass("promptMessage");
                                         //Restart app to refresh config from web.config
-                                        window.location.replace(window.location + "?culture=" + $("#PageLocale")[0].value + "&initiateinstall");
+                                        var installUrl = new URL(window.location);
+                                        installUrl.searchParams.set("culture", $("#PageLocale")[0].value);
+                                        installUrl.searchParams.set("initiateinstall", '1');
+                                        window.location.replace(installUrl);
                                     } else {
                                         $("#databaseError").show();
                                         $('#<%= lblDatabaseInfoMsg.ClientID %>').removeClass("promptMessage");

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -626,13 +626,13 @@ namespace DotNetNuke.Services.Install
                 File.CreateText(StatusFile).Close();
             }
 
-            if (HttpContext.Current.Request.RawUrl.EndsWith("&initiateinstall"))
+            if (HttpContext.Current.Request.RawUrl.EndsWith("&initiateinstall=1"))
             {
                 var synchConnectionString = new SynchConnectionStringStep();
                 synchConnectionString.Execute();
-                this.Response.Redirect(HttpContext.Current.Request.RawUrl.Replace("&initiateinstall", "&executeinstall"), true);
+                this.Response.Redirect(HttpContext.Current.Request.RawUrl.Replace("&initiateinstall=1", "&executeinstall=1"), true);
             }
-            else if (HttpContext.Current.Request.RawUrl.EndsWith("&executeinstall"))
+            else if (HttpContext.Current.Request.RawUrl.EndsWith("&executeinstall=1"))
             {
                 try
                 {
@@ -642,7 +642,7 @@ namespace DotNetNuke.Services.Install
                 catch (Exception)
                 {
                     // Redirect back to first page
-                    this.Response.Redirect(HttpContext.Current.Request.RawUrl.Replace("&executeinstall", string.Empty), true);
+                    this.Response.Redirect(HttpContext.Current.Request.RawUrl.Replace("&executeinstall=1", string.Empty), true);
                 }
             }
             else if (!this.Page.IsPostBack)

--- a/DNN Platform/Website/Install/InstallWizard.aspx.designer.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.designer.cs
@@ -777,7 +777,7 @@ namespace DotNetNuke.Services.Install
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputHidden @__dnnVariable;
+        protected global::System.Web.UI.HtmlControls.HtmlInputHidden __dnnVariable;
 
         /// <summary>
         /// PageLocale control.


### PR DESCRIPTION
## Summary
I noticed that the install wizard fails to advance if there is a hash in the URL (I had my local dev site pointed to `https://dnn.local/#learn` and then reset the dev site and ended up with `#learn` on the Install Wizard URL). The script in InstallWizard appends the query string to the current URL, so it gets lost in the hash if the hash is present.