### PR TITLE
Fix RTL resource detection by resolving virtual path to physical path

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client.ResourceManager/ClientResourceController.cs
+++ b/DNN Platform/DotNetNuke.Web.Client.ResourceManager/ClientResourceController.cs
@@ -241,7 +241,12 @@ namespace DotNetNuke.Web.Client.ResourceManager
 
                     var ext = Path.GetExtension(resource.ResolvedPath);
                     var rtlResolvedPath = Path.ChangeExtension(resource.ResolvedPath, ".rtl" + ext);
-                    if (!File.Exists(this.appStatus.ApplicationMapPath + rtlResolvedPath))
+                    var cleanRtlResolvedPath = rtlResolvedPath.TrimStart('~').Replace("/", "\\");
+                    var physicalPath = Path.Combine(
+                        this.appStatus.ApplicationMapPath,
+                        cleanRtlResolvedPath.TrimStart('\\'));
+
+                    if (!File.Exists(physicalPath))
                     {
                         return resource;
                     }


### PR DESCRIPTION
### Summary
Fixes an issue where RTL-specific resources were not detected correctly because
`File.Exists` was being called with a virtual path.

### Details
- Converts RTL resolved paths from virtual (`~/...`) to physical paths
- Uses `Path.Combine` to safely build the physical file system path
- Ensures RTL resources are only swapped when the corresponding `.rtl` file exists

### Impact
- RTL styles/scripts are now correctly loaded when available
- No behavior change for LTR cultures or CDN/external resources

### Notes
This change only affects local resources and preserves existing CDN logic.
