### PR TITLE
Get ServicesFramework instance from DI container

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/DnnWebViewPage.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/DnnWebViewPage.cs
@@ -4,15 +4,33 @@
 
 namespace DotNetNuke.Web.Mvc.Framework
 {
+    using System;
     using System.Web.Mvc;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Framework;
     using DotNetNuke.Web.Mvc.Helpers;
 
     using Microsoft.Extensions.DependencyInjection;
 
     public abstract class DnnWebViewPage : WebViewPage
     {
+        private readonly IServicesFramework servicesFramework;
+
+        /// <summary>Initializes a new instance of the <see cref="DnnWebViewPage"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
+        protected DnnWebViewPage()
+            : this(null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnWebViewPage"/> class.</summary>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        protected DnnWebViewPage(IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
+        }
+
         public DnnHelper<object> Dnn { get; set; }
 
         public new DnnHtmlHelper<object> Html { get; set; }
@@ -23,7 +41,7 @@ namespace DotNetNuke.Web.Mvc.Framework
         public override void InitHelpers()
         {
             this.Ajax = new AjaxHelper<object>(this.ViewContext, this);
-            this.Html = new DnnHtmlHelper<object>(this.ViewContext, this);
+            this.Html = new DnnHtmlHelper<object>(this.ViewContext, this, this.servicesFramework);
             this.Url = new DnnUrlHelper(this.ViewContext);
             this.Dnn = ActivatorUtilities.CreateInstance<DnnHelper<object>>(Globals.GetCurrentServiceProvider(), this.ViewContext, this);
         }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/DnnWebViewPage{TModel}.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/DnnWebViewPage{TModel}.cs
@@ -3,15 +3,33 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Web.Mvc.Framework
 {
+    using System;
     using System.Web.Mvc;
 
     using DotNetNuke.Common;
+    using DotNetNuke.Framework;
     using DotNetNuke.Web.Mvc.Helpers;
 
     using Microsoft.Extensions.DependencyInjection;
 
     public abstract class DnnWebViewPage<TModel> : WebViewPage<TModel>
     {
+        private readonly IServicesFramework servicesFramework;
+
+        /// <summary>Initializes a new instance of the <see cref="DnnWebViewPage{TModel}"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
+        protected DnnWebViewPage()
+            : this(null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnWebViewPage{TModel}"/> class.</summary>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        protected DnnWebViewPage(IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
+        }
+
         public DnnHelper<TModel> Dnn { get; set; }
 
         public new DnnHtmlHelper<TModel> Html { get; set; }
@@ -22,7 +40,7 @@ namespace DotNetNuke.Web.Mvc.Framework
         public override void InitHelpers()
         {
             this.Ajax = new AjaxHelper<TModel>(this.ViewContext, this);
-            this.Html = new DnnHtmlHelper<TModel>(this.ViewContext, this);
+            this.Html = new DnnHtmlHelper<TModel>(this.ViewContext, this, this.servicesFramework);
             this.Url = new DnnUrlHelper(this.ViewContext);
             this.Dnn = ActivatorUtilities.CreateInstance<DnnHelper<TModel>>(Globals.GetCurrentServiceProvider(), this.ViewContext, this);
         }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelper.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelper.cs
@@ -11,17 +11,32 @@ namespace DotNetNuke.Web.Mvc.Helpers
     using System.Web.Mvc;
     using System.Web.Routing;
 
+    using DotNetNuke.Common;
     using DotNetNuke.Framework;
     using DotNetNuke.UI.Modules;
     using DotNetNuke.Web.Mvc.Framework.Controllers;
 
+    using Microsoft.Extensions.DependencyInjection;
+
     public class DnnHtmlHelper
     {
+        private readonly IServicesFramework servicesFramework;
+
         /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper"/> class.</summary>
         /// <param name="viewContext">The view context.</param>
         /// <param name="viewDataContainer">The ViewData container.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer)
-            : this(viewContext, viewDataContainer, RouteTable.Routes)
+            : this(viewContext, viewDataContainer, (IServicesFramework)null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper"/> class.</summary>
+        /// <param name="viewContext">The view context.</param>
+        /// <param name="viewDataContainer">The ViewData container.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer, IServicesFramework servicesFramework)
+            : this(viewContext, viewDataContainer, RouteTable.Routes, servicesFramework)
         {
         }
 
@@ -29,15 +44,36 @@ namespace DotNetNuke.Web.Mvc.Helpers
         /// <param name="viewContext">The view context.</param>
         /// <param name="viewDataContainer">The ViewData container.</param>
         /// <param name="routeCollection">The route collection.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer, RouteCollection routeCollection)
-            : this(new HtmlHelper(viewContext, viewDataContainer, routeCollection))
+            : this(viewContext, viewDataContainer, routeCollection, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper"/> class.</summary>
+        /// <param name="viewContext">The view context.</param>
+        /// <param name="viewDataContainer">The ViewData container.</param>
+        /// <param name="routeCollection">The route collection.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer, RouteCollection routeCollection, IServicesFramework servicesFramework)
+            : this(new HtmlHelper(viewContext, viewDataContainer, routeCollection), servicesFramework)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper"/> class.</summary>
         /// <param name="htmlHelper">The HtmlHelper to wrap.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         protected DnnHtmlHelper(HtmlHelper htmlHelper)
+            : this(htmlHelper, null)
         {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper"/> class.</summary>
+        /// <param name="htmlHelper">The HtmlHelper to wrap.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        protected DnnHtmlHelper(HtmlHelper htmlHelper, IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
             this.HtmlHelper = htmlHelper;
 
             var controller = htmlHelper.ViewContext.Controller as IDnnController;
@@ -64,10 +100,9 @@ namespace DotNetNuke.Web.Mvc.Helpers
 
         internal HtmlHelper HtmlHelper { get; set; }
 
-        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Breaking change")]
         public MvcHtmlString AntiForgeryToken()
         {
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             return new MvcHtmlString(string.Empty);
         }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelper{TModel}.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Helpers/DnnHtmlHelper{TModel}.cs
@@ -4,16 +4,29 @@
 
 namespace DotNetNuke.Web.Mvc.Helpers
 {
+    using System;
     using System.Web.Mvc;
     using System.Web.Routing;
+
+    using DotNetNuke.Framework;
 
     public class DnnHtmlHelper<TModel> : DnnHtmlHelper
     {
         /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper{TModel}"/> class.</summary>
         /// <param name="viewContext">The view context.</param>
         /// <param name="viewDataContainer">The ViewData container.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer)
-            : this(viewContext, viewDataContainer, RouteTable.Routes)
+            : this(viewContext, viewDataContainer, (IServicesFramework)null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper{TModel}"/> class.</summary>
+        /// <param name="viewContext">The view context.</param>
+        /// <param name="viewDataContainer">The ViewData container.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer, IServicesFramework servicesFramework)
+            : this(viewContext, viewDataContainer, RouteTable.Routes, servicesFramework)
         {
         }
 
@@ -21,8 +34,19 @@ namespace DotNetNuke.Web.Mvc.Helpers
         /// <param name="viewContext">The view context.</param>
         /// <param name="viewDataContainer">The ViewData container.</param>
         /// <param name="routeCollection">The route collection.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer, RouteCollection routeCollection)
-            : base(new HtmlHelper<TModel>(viewContext, viewDataContainer, routeCollection))
+            : this(viewContext, viewDataContainer, routeCollection, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnHtmlHelper{TModel}"/> class.</summary>
+        /// <param name="viewContext">The view context.</param>
+        /// <param name="viewDataContainer">The ViewData container.</param>
+        /// <param name="routeCollection">The route collection.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnHtmlHelper(ViewContext viewContext, IViewDataContainer viewDataContainer, RouteCollection routeCollection, IServicesFramework servicesFramework)
+            : base(new HtmlHelper<TModel>(viewContext, viewDataContainer, routeCollection), servicesFramework)
         {
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnDropDownList.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnDropDownList.cs
@@ -31,6 +31,7 @@ namespace DotNetNuke.Web.UI.WebControls
 
         private readonly Lazy<DnnDropDownListOptions> options = new Lazy<DnnDropDownListOptions>(() => new DnnDropDownListOptions());
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
 
         private DnnGenericHiddenField<DnnDropDownListState> stateControl;
         private HtmlAnchor selectedValue;
@@ -38,15 +39,17 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnDropDownList"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
         public DnnDropDownList()
-            : this(null)
+            : this(null, null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnDropDownList"/> class.</summary>
         /// <param name="clientResourceController">The client resource controller.</param>
-        public DnnDropDownList(IClientResourceController clientResourceController)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnDropDownList(IClientResourceController clientResourceController, IServicesFramework servicesFramework)
         {
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Occurs when the selection from the list control changes between posts to the server.</summary>
@@ -261,7 +264,7 @@ namespace DotNetNuke.Web.UI.WebControls
         {
             base.OnInit(e);
             this.StateControl.Value = string.Empty; // for state persistence (stateControl)
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
         }
 
         /// <inheritdoc />

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFileDropDownList.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFileDropDownList.cs
@@ -13,6 +13,7 @@ namespace DotNetNuke.Web.UI.WebControls
     using DotNetNuke.Abstractions.ClientResources;
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Framework;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.Common;
@@ -27,14 +28,15 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnFileDropDownList"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
         public DnnFileDropDownList()
-            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>())
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>(), Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>())
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnFileDropDownList"/> class.</summary>
         /// <param name="clientResourceController">The client resource controller.</param>
-        public DnnFileDropDownList(IClientResourceController clientResourceController)
-            : base(clientResourceController)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnFileDropDownList(IClientResourceController clientResourceController, IServicesFramework servicesFramework)
+            : base(clientResourceController, servicesFramework)
         {
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFilePickerUploader.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFilePickerUploader.cs
@@ -59,6 +59,7 @@ namespace DotNetNuke.Web.UI.WebControls
         private const string MyFileName = "filepickeruploader.ascx";
         private readonly IApplicationStatusInfo appStatus;
         private readonly IEventLogger eventLogger;
+        private readonly IServicesFramework servicesFramework;
         private int? portalId;
         private string fileFilter;
         private string folderPath = string.Empty;
@@ -67,17 +68,19 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnFilePickerUploader"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IApplicationStatusInfo. Scheduled removal in v12.0.0.")]
         public DnnFilePickerUploader()
-            : this(null, null)
+            : this(null, null, null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnFilePickerUploader"/> class.</summary>
         /// <param name="appStatus">The application status.</param>
         /// <param name="eventLogger">The event logger.</param>
-        public DnnFilePickerUploader(IApplicationStatusInfo appStatus, IEventLogger eventLogger)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnFilePickerUploader(IApplicationStatusInfo appStatus, IEventLogger eventLogger, IServicesFramework servicesFramework)
         {
             this.appStatus = appStatus ?? Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>();
             this.eventLogger = eventLogger ?? Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Gets or sets a value indicating whether to use the user's personal folder.</summary>
@@ -239,7 +242,7 @@ namespace DotNetNuke.Web.UI.WebControls
             this.LoadFolders();
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, PortalSettings.Current, CommonJs.jQueryFileUpload);
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, PortalSettings.Current, CommonJs.DnnPlugins);
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
         }
 
         /// <inheritdoc />

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFileUpload.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFileUpload.cs
@@ -32,12 +32,13 @@ namespace DotNetNuke.Web.UI.WebControls
         private readonly IClientResourceController clientResourceController;
         private readonly IApplicationStatusInfo appStatus;
         private readonly IEventLogger eventLogger;
+        private readonly IServicesFramework servicesFramework;
         private readonly Lazy<DnnFileUploadOptions> options;
 
         /// <summary>Initializes a new instance of the <see cref="DnnFileUpload"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
         public DnnFileUpload()
-            : this(null, null, null, null, null)
+            : this(null, null, null, null, null, null)
         {
         }
 
@@ -47,11 +48,13 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <param name="eventLogger">The event logger.</param>
         /// <param name="hostSettings">The host settings.</param>
         /// <param name="cryptographyProvider">The cryptography provider.</param>
-        public DnnFileUpload(IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IHostSettings hostSettings, ICryptographyProvider cryptographyProvider)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnFileUpload(IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IHostSettings hostSettings, ICryptographyProvider cryptographyProvider, IServicesFramework servicesFramework)
         {
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
             this.appStatus = appStatus ?? Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>();
             this.eventLogger = eventLogger ?? Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
             this.options = new Lazy<DnnFileUploadOptions>(() => new DnnFileUploadOptions(hostSettings, this.appStatus, cryptographyProvider));
         }
 
@@ -114,7 +117,7 @@ namespace DotNetNuke.Web.UI.WebControls
         {
             base.OnInit(e);
 
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, PortalSettings.Current, CommonJs.jQueryFileUpload);
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFolderDropDownList.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnFolderDropDownList.cs
@@ -14,6 +14,7 @@ namespace DotNetNuke.Web.UI.WebControls
     using DotNetNuke.Common;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Framework;
     using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.Common;
@@ -28,14 +29,15 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnFolderDropDownList"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
         public DnnFolderDropDownList()
-            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>())
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>(), Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>())
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnFolderDropDownList"/> class.</summary>
         /// <param name="clientResourceController">The client resource controller.</param>
-        public DnnFolderDropDownList(IClientResourceController clientResourceController)
-            : base(clientResourceController)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnFolderDropDownList(IClientResourceController clientResourceController, IServicesFramework servicesFramework)
+            : base(clientResourceController, servicesFramework)
         {
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnPageDropDownList.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnPageDropDownList.cs
@@ -18,6 +18,7 @@ namespace DotNetNuke.Web.UI.WebControls
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Framework;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.UI.WebControls.Extensions;
 
@@ -30,14 +31,15 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnPageDropDownList"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
         public DnnPageDropDownList()
-            : this(null)
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>(), Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>())
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnPageDropDownList"/> class.</summary>
         /// <param name="clientResourceController">The client resource controller.</param>
-        public DnnPageDropDownList(IClientResourceController clientResourceController)
-            : base(clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>())
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnPageDropDownList(IClientResourceController clientResourceController, IServicesFramework servicesFramework)
+            : base(clientResourceController, servicesFramework)
         {
         }
 

--- a/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnPortalPageDropDownList.cs
+++ b/DNN Platform/DotNetNuke.Web/UI/WebControls/DnnPortalPageDropDownList.cs
@@ -15,6 +15,7 @@ namespace DotNetNuke.Web.UI.WebControls
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Framework;
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.UI.WebControls.Extensions;
 
@@ -29,14 +30,15 @@ namespace DotNetNuke.Web.UI.WebControls
         /// <summary>Initializes a new instance of the <see cref="DnnPortalPageDropDownList"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IApplicationStatusInfo. Scheduled removal in v12.0.0.")]
         public DnnPortalPageDropDownList()
-            : this(null)
+            : this(Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>(), Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>())
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnPortalPageDropDownList"/> class.</summary>
         /// <param name="clientResourceController">The client resource controller.</param>
-        public DnnPortalPageDropDownList(IClientResourceController clientResourceController)
-            : base(clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>())
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnPortalPageDropDownList(IClientResourceController clientResourceController, IServicesFramework servicesFramework)
+            : base(clientResourceController, servicesFramework)
         {
         }
 

--- a/DNN Platform/Library/Framework/ServicesFrameworkInternal.cs
+++ b/DNN Platform/Library/Framework/ServicesFrameworkInternal.cs
@@ -4,18 +4,12 @@
 
 namespace DotNetNuke.Framework
 {
-    using System;
-
     using DotNetNuke.Common;
 
     using Microsoft.Extensions.DependencyInjection;
 
-    internal class ServicesFrameworkInternal : ServiceLocator<IServiceFrameworkInternals, ServicesFrameworkInternal>
+    internal class ServicesFrameworkInternal
     {
-        /// <inheritdoc />
-        protected override Func<IServiceFrameworkInternals> GetFactory()
-        {
-            return static () => ActivatorUtilities.GetServiceOrCreateInstance<ServicesFrameworkImpl>(Globals.DependencyProvider);
-        }
+        public static IServiceFrameworkInternals Instance => ActivatorUtilities.GetServiceOrCreateInstance<ServicesFrameworkImpl>(Globals.GetCurrentServiceProvider());
     }
 }

--- a/DNN Platform/Library/Security/Permissions/Controls/PermissionsGrid.cs
+++ b/DNN Platform/Library/Security/Permissions/Controls/PermissionsGrid.cs
@@ -27,6 +27,8 @@ namespace DotNetNuke.Security.Permissions.Controls
     using DotNetNuke.Web.Client;
     using DotNetNuke.Web.Client.ClientResourceManagement;
 
+    using Microsoft.Extensions.DependencyInjection;
+
     using Globals = DotNetNuke.Common.Globals;
 
     /// <summary>A base class for permissions grid controls.</summary>
@@ -48,6 +50,7 @@ namespace DotNetNuke.Security.Permissions.Controls
         [SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Justification = "Breaking change")]
         protected DataGrid userPermissionsGrid;
 
+        private readonly IServicesFramework servicesFramework;
         private readonly int unAuthUsersRoleId = int.Parse(Globals.glbRoleUnauthUser, CultureInfo.InvariantCulture);
         private readonly int allUsersRoleId = int.Parse(Globals.glbRoleAllUsers, CultureInfo.InvariantCulture);
 
@@ -66,8 +69,17 @@ namespace DotNetNuke.Security.Permissions.Controls
         private HiddenField roleField;
 
         /// <summary>Initializes a new instance of the <see cref="PermissionsGrid"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public PermissionsGrid()
+            : this(null)
         {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="PermissionsGrid"/> class.</summary>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public PermissionsGrid(IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
             this.dtUserPermissions = new DataTable();
             this.dtRolePermissions = new DataTable();
         }
@@ -589,7 +601,7 @@ namespace DotNetNuke.Security.Permissions.Controls
         {
             base.OnInit(e);
 
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             ClientResourceManager.RegisterScript(this.Page, "~/Resources/Shared/Components/Tokeninput/jquery.tokeninput.js");
             ClientResourceManager.RegisterScript(this.Page, "~/js/dnn.permissiongrid.js");

--- a/DNN Platform/Library/Services/Tokens/PropertyAccess/AntiForgeryTokenPropertyAccess.cs
+++ b/DNN Platform/Library/Services/Tokens/PropertyAccess/AntiForgeryTokenPropertyAccess.cs
@@ -4,13 +4,33 @@
 
 namespace DotNetNuke.Services.Tokens
 {
+    using System;
     using System.Globalization;
 
+    using DotNetNuke.Common;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Framework;
 
+    using Microsoft.Extensions.DependencyInjection;
+
     public class AntiForgeryTokenPropertyAccess : IPropertyAccess
     {
+        private readonly IServicesFramework servicesFramework;
+
+        /// <summary>Initializes a new instance of the <see cref="AntiForgeryTokenPropertyAccess"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
+        public AntiForgeryTokenPropertyAccess()
+            : this(null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="AntiForgeryTokenPropertyAccess"/> class.</summary>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public AntiForgeryTokenPropertyAccess(IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
+        }
+
         /// <inheritdoc />
         public CacheLevel Cacheability
         {
@@ -20,7 +40,7 @@ namespace DotNetNuke.Services.Tokens
         /// <inheritdoc />
         public string GetProperty(string propertyName, string format, CultureInfo formatProvider, UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound)
         {
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             return string.Empty;
         }

--- a/DNN Platform/Library/Startup.cs
+++ b/DNN Platform/Library/Startup.cs
@@ -35,6 +35,7 @@ namespace DotNetNuke
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Framework;
     using DotNetNuke.Framework.JavaScriptLibraries;
     using DotNetNuke.Framework.Reflections;
     using DotNetNuke.Instrumentation;
@@ -108,6 +109,7 @@ namespace DotNetNuke
             services.AddTransient<ITabVersionBuilder, TabVersionBuilder>();
             services.AddTransient<ISearchController, SearchControllerImpl>();
             services.AddTransient<IFolderMappingController, FolderMappingController>(_ => new FolderMappingController());
+            services.AddTransient<IServicesFramework, ServicesFrameworkImpl>(ActivatorUtilities.GetServiceOrCreateInstance<ServicesFrameworkImpl>);
 
             // TODO: LocalizationProvider can be overridden via the ComponentFactory, need to be able to get an instance registered via ComponentFactory without creating a dependency loop
             services.AddTransient<ILocalizationProvider, LocalizationProvider>();

--- a/DNN Platform/Library/UI/Modules/Html5/Html5HostControl.cs
+++ b/DNN Platform/Library/UI/Modules/Html5/Html5HostControl.cs
@@ -25,13 +25,14 @@ namespace DotNetNuke.UI.Modules.Html5
     {
         private readonly string html5File;
         private readonly IBusinessControllerProvider businessControllerProvider;
+        private readonly IServicesFramework servicesFramework;
         private string fileContent;
 
         /// <summary>Initializes a new instance of the <see cref="Html5HostControl"/> class.</summary>
         /// <param name="html5File">The path to the HTML file.</param>
         [Obsolete("Deprecated in DotNetNuke 10.0.0. Please use overload with IBusinessControllerProvider. Scheduled removal in v12.0.0.")]
         public Html5HostControl(string html5File)
-            : this(html5File, null)
+            : this(html5File, null, null)
         {
             this.html5File = html5File;
         }
@@ -39,10 +40,21 @@ namespace DotNetNuke.UI.Modules.Html5
         /// <summary>Initializes a new instance of the <see cref="Html5HostControl"/> class.</summary>
         /// <param name="html5File">The path to the HTML file.</param>
         /// <param name="businessControllerProvider">The business controller provider.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Html5HostControl(string html5File, IBusinessControllerProvider businessControllerProvider)
+            : this(html5File, businessControllerProvider, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Html5HostControl"/> class.</summary>
+        /// <param name="html5File">The path to the HTML file.</param>
+        /// <param name="businessControllerProvider">The business controller provider.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public Html5HostControl(string html5File, IBusinessControllerProvider businessControllerProvider, IServicesFramework servicesFramework)
         {
             this.html5File = html5File;
             this.businessControllerProvider = businessControllerProvider ?? Globals.GetCurrentServiceProvider().GetRequiredService<IBusinessControllerProvider>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         /// <inheritdoc />
@@ -77,7 +89,7 @@ namespace DotNetNuke.UI.Modules.Html5
             }
 
             // Register for Services Framework
-            ServicesFramework.Instance.RequestAjaxScriptSupport();
+            this.servicesFramework.RequestAjaxScriptSupport();
         }
 
         /// <inheritdoc />

--- a/DNN Platform/Library/UI/Skins/Skin.cs
+++ b/DNN Platform/Library/UI/Skins/Skin.cs
@@ -80,6 +80,7 @@ namespace DotNetNuke.UI.Skins
         private readonly IHostSettings hostSettings;
         private readonly IHostSettingsService hostSettingsService;
         private readonly IJavaScriptLibraryHelper javaScript;
+        private readonly IServicesFramework servicesFramework;
         private readonly ModuleCommunicate communicator = new ModuleCommunicate();
         private ArrayList actionEventListeners;
         private Control controlPanel;
@@ -95,6 +96,7 @@ namespace DotNetNuke.UI.Skins
         /// <summary>Initializes a new instance of the <see cref="Skin"/> class.</summary>
         /// <param name="moduleControlPipeline">The module control pipeline.</param>
         /// <param name="navigationManager">The navigation manager.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Skin(IModuleControlPipeline moduleControlPipeline, INavigationManager navigationManager)
             : this(moduleControlPipeline, navigationManager, null, null, null)
         {
@@ -106,6 +108,7 @@ namespace DotNetNuke.UI.Skins
         /// <param name="hostSettings">The host settings.</param>
         /// <param name="hostSettingsService">The host settings service.</param>
         /// <param name="javaScript">The JavaScript library helper.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Skin(IModuleControlPipeline moduleControlPipeline, INavigationManager navigationManager, IHostSettings hostSettings, IHostSettingsService hostSettingsService, IJavaScriptLibraryHelper javaScript)
             : this(moduleControlPipeline, navigationManager, hostSettings, hostSettingsService, javaScript, null)
         {
@@ -118,7 +121,21 @@ namespace DotNetNuke.UI.Skins
         /// <param name="hostSettingsService">The host settings service.</param>
         /// <param name="javaScript">The JavaScript library helper.</param>
         /// <param name="moduleInjectionManager">The module injection manager.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         internal Skin(IModuleControlPipeline moduleControlPipeline, INavigationManager navigationManager, IHostSettings hostSettings, IHostSettingsService hostSettingsService, IJavaScriptLibraryHelper javaScript, ModuleInjectionManager moduleInjectionManager)
+            : this(moduleControlPipeline, navigationManager, hostSettings, hostSettingsService, javaScript, moduleInjectionManager, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Skin"/> class.</summary>
+        /// <param name="moduleControlPipeline">The module control pipeline.</param>
+        /// <param name="navigationManager">The navigation manager.</param>
+        /// <param name="hostSettings">The host settings.</param>
+        /// <param name="hostSettingsService">The host settings service.</param>
+        /// <param name="javaScript">The JavaScript library helper.</param>
+        /// <param name="moduleInjectionManager">The module injection manager.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        internal Skin(IModuleControlPipeline moduleControlPipeline, INavigationManager navigationManager, IHostSettings hostSettings, IHostSettingsService hostSettingsService, IJavaScriptLibraryHelper javaScript, ModuleInjectionManager moduleInjectionManager, IServicesFramework servicesFramework)
         {
             this.ModuleControlPipeline = moduleControlPipeline ?? Globals.GetCurrentServiceProvider().GetRequiredService<IModuleControlPipeline>();
             this.NavigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
@@ -126,6 +143,7 @@ namespace DotNetNuke.UI.Skins
             this.hostSettingsService = hostSettingsService ?? Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettingsService>();
             this.javaScript = javaScript ?? Globals.GetCurrentServiceProvider().GetRequiredService<IJavaScriptLibraryHelper>();
             this.moduleInjectionManager = moduleInjectionManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<ModuleInjectionManager>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Gets a Dictionary of Panes.</summary>
@@ -524,8 +542,8 @@ namespace DotNetNuke.UI.Skins
 
                 if (UserController.Instance.GetCurrentUserInfo().IsSuperUser)
                 {
-                    ServicesFramework.Instance.RequestAjaxScriptSupport();
-                    ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+                    this.servicesFramework.RequestAjaxScriptSupport();
+                    this.servicesFramework.RequestAjaxAntiForgerySupport();
 
                     this.javaScript.RequestRegistration(CommonJs.jQueryUI);
                     JavaScript.RegisterClientReference(this.Page, ClientAPI.ClientNamespaceReferences.dnn_dom);
@@ -552,7 +570,7 @@ namespace DotNetNuke.UI.Skins
                 AddPageMessage(this, string.Empty, HttpContextSource.Current.Items[OnInitMessage].ToString(), messageType, string.Empty);
 
                 this.javaScript.RequestRegistration(CommonJs.DnnPlugins);
-                ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+                this.servicesFramework.RequestAjaxAntiForgerySupport();
             }
 
             // Process the Panes attributes

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNCountryAutocompleteControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNCountryAutocompleteControl.cs
@@ -8,30 +8,52 @@ namespace DotNetNuke.UI.WebControls
     using System.Web.UI;
     using System.Web.UI.WebControls;
 
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Lists;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Framework;
     using DotNetNuke.Framework.JavaScriptLibraries;
     using DotNetNuke.Web.Client.ClientResourceManagement;
 
+    using Microsoft.Extensions.DependencyInjection;
+
     [ToolboxData("<{0}:DnnCountryAutocompleteControl runat=server></{0}:DnnCountryAutocompleteControl>")]
     public class DnnCountryAutocompleteControl : EditControl
     {
+        private readonly IServicesFramework servicesFramework;
         private TextBox countryName;
 
         private HiddenField countryId;
 
         /// <summary>Initializes a new instance of the <see cref="DnnCountryAutocompleteControl"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DnnCountryAutocompleteControl()
+            : this((IServicesFramework)null)
         {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnCountryAutocompleteControl"/> class.</summary>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnCountryAutocompleteControl(IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
             this.Init += this.DnnCountryRegionControl_Init;
         }
 
         /// <summary>Initializes a new instance of the <see cref="DnnCountryAutocompleteControl"/> class.</summary>
         /// <param name="type">A string representing the <see cref="Type"/> being edited.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DnnCountryAutocompleteControl(string type)
+            : this(type, null)
         {
-            this.Init += this.DnnCountryRegionControl_Init;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DnnCountryAutocompleteControl"/> class.</summary>
+        /// <param name="type">A string representing the <see cref="Type"/> being edited.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DnnCountryAutocompleteControl(string type, IServicesFramework servicesFramework)
+            : this(servicesFramework)
+        {
             this.SystemType = type;
         }
 
@@ -158,7 +180,7 @@ namespace DotNetNuke.UI.WebControls
 
         private void DnnCountryRegionControl_Init(object sender, System.EventArgs e)
         {
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             ClientResourceManager.RegisterScript(this.Page, "~/Resources/Shared/components/CountriesRegions/dnn.CountriesRegions.js");
             ClientResourceManager.RegisterFeatureStylesheet(this.Page, "~/Resources/Shared/components/CountriesRegions/dnn.CountriesRegions.css");
             JavaScript.RequestRegistration(CommonJs.jQuery);

--- a/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNRegionEditControl.cs
+++ b/DNN Platform/Library/UI/WebControls/PropertyEditor/Edit Controls/DNN Edit Controls/DNNRegionEditControl.cs
@@ -12,6 +12,7 @@ namespace DotNetNuke.UI.WebControls
     using System.Web.UI.HtmlControls;
     using System.Web.UI.WebControls;
 
+    using DotNetNuke.Common;
     using DotNetNuke.Common.Lists;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
@@ -20,6 +21,8 @@ namespace DotNetNuke.UI.WebControls
     using DotNetNuke.Services.Localization;
     using DotNetNuke.Web.Client.ClientResourceManagement;
 
+    using Microsoft.Extensions.DependencyInjection;
+
     /// <summary>
     /// The DNNRegionEditControl control provides a standard UI component for editing
     /// Regions.
@@ -27,6 +30,7 @@ namespace DotNetNuke.UI.WebControls
     [ToolboxData("<{0}:DNNRegionEditControl runat=server></{0}:DNNRegionEditControl>")]
     public class DNNRegionEditControl : EditControl
     {
+        private readonly IServicesFramework servicesFramework;
         private DropDownList regions;
 
         private TextBox region;
@@ -36,16 +40,34 @@ namespace DotNetNuke.UI.WebControls
         private List<ListEntryInfo> listEntries;
 
         /// <summary>Initializes a new instance of the <see cref="DNNRegionEditControl"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DNNRegionEditControl()
+            : this((IServicesFramework)null)
         {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DNNRegionEditControl"/> class.</summary>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DNNRegionEditControl(IServicesFramework servicesFramework)
+        {
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
             this.Init += this.DnnRegionControl_Init;
         }
 
         /// <summary>Initializes a new instance of the <see cref="DNNRegionEditControl"/> class.</summary>
         /// <param name="type">A string representing the <see cref="Type"/> being edited.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public DNNRegionEditControl(string type)
+            : this(type, null)
         {
-            this.Init += this.DnnRegionControl_Init;
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DNNRegionEditControl"/> class.</summary>
+        /// <param name="type">A string representing the <see cref="Type"/> being edited.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public DNNRegionEditControl(string type, IServicesFramework servicesFramework)
+            : this(servicesFramework)
+        {
             this.SystemType = type;
         }
 
@@ -237,7 +259,7 @@ namespace DotNetNuke.UI.WebControls
 
         private void DnnRegionControl_Init(object sender, System.EventArgs e)
         {
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             ClientResourceManager.RegisterScript(this.Page, "~/Resources/Shared/components/CountriesRegions/dnn.CountriesRegions.js");
             ClientResourceManager.RegisterFeatureStylesheet(this.Page, "~/Resources/Shared/components/CountriesRegions/dnn.CountriesRegions.css");
             JavaScript.RequestRegistration(CommonJs.jQuery);

--- a/DNN Platform/Modules/CoreMessaging/Subscriptions.ascx.cs
+++ b/DNN Platform/Modules/CoreMessaging/Subscriptions.ascx.cs
@@ -27,17 +27,35 @@ namespace DotNetNuke.Modules.CoreMessaging
     using DotNetNuke.UI.Modules;
     using Microsoft.Extensions.DependencyInjection;
 
-    /// <summary>Implementes the logic of the Subscription view.</summary>
+    /// <summary>Implements the logic of the Subscription view.</summary>
     public partial class Subscriptions : UserControl
     {
         private const string SharedResources = "~/DesktopModules/CoreMessaging/App_LocalResources/SharedResources.resx";
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
+
+        /// <summary>Initializes a new instance of the <see cref="Subscriptions"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.0. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
+        public Subscriptions()
+            : this(null, null)
+        {
+        }
 
         /// <summary>Initializes a new instance of the <see cref="Subscriptions"/> class.</summary>
         /// <param name="clientResourceController">The client resources controller.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Subscriptions(IClientResourceController clientResourceController)
+            : this(clientResourceController, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Subscriptions"/> class.</summary>
+        /// <param name="clientResourceController">The client resources controller.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public Subscriptions(IClientResourceController clientResourceController, IServicesFramework servicesFramework)
         {
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Gets or sets the module context.</summary>
@@ -86,7 +104,7 @@ namespace DotNetNuke.Modules.CoreMessaging
         {
             base.OnLoad(e);
 
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             if (this.Request.IsAuthenticated)
             {

--- a/DNN Platform/Modules/CoreMessaging/View.ascx.cs
+++ b/DNN Platform/Modules/CoreMessaging/View.ascx.cs
@@ -27,6 +27,7 @@ namespace DotNetNuke.Modules.CoreMessaging
         private readonly IJavaScriptLibraryHelper javaScript;
         private readonly IPortalController portalController;
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
 
         /// <summary>Initializes a new instance of the <see cref="View"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.0.2. Please use overload with IPortalController. Scheduled removal in v12.0.0.")]
@@ -47,11 +48,23 @@ namespace DotNetNuke.Modules.CoreMessaging
         /// <param name="javaScript">The JavaScript library helper.</param>
         /// <param name="portalController">The portal controller.</param>
         /// <param name="clientResourceController">The client resources controller.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public View(IJavaScriptLibraryHelper javaScript, IPortalController portalController, IClientResourceController clientResourceController)
+            : this(javaScript, portalController, clientResourceController, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="View"/> class.</summary>
+        /// <param name="javaScript">The JavaScript library helper.</param>
+        /// <param name="portalController">The portal controller.</param>
+        /// <param name="clientResourceController">The client resources controller.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public View(IJavaScriptLibraryHelper javaScript, IPortalController portalController, IClientResourceController clientResourceController, IServicesFramework servicesFramework)
         {
             this.javaScript = javaScript ?? this.DependencyProvider.GetRequiredService<IJavaScriptLibraryHelper>();
             this.portalController = portalController ?? this.DependencyProvider.GetRequiredService<IPortalController>();
             this.clientResourceController = clientResourceController ?? this.DependencyProvider.GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? this.DependencyProvider.GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Gets the user id from the request parameters.</summary>
@@ -106,8 +119,8 @@ namespace DotNetNuke.Modules.CoreMessaging
                 UI.Skins.Skin.AddModuleMessage(this, Localization.GetString("PermissionsNotProperlySet", this.LocalResourceFile), ModuleMessage.ModuleMessageType.YellowWarning);
             }
 
-            ServicesFramework.Instance.RequestAjaxScriptSupport();
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxScriptSupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             this.javaScript.RequestRegistration(CommonJs.DnnPlugins);
             this.javaScript.RequestRegistration(CommonJs.Knockout);
             this.clientResourceController.RegisterScript("~/DesktopModules/CoreMessaging/Scripts/CoreMessaging.js");

--- a/DNN Platform/Modules/Groups/List.ascx.cs
+++ b/DNN Platform/Modules/Groups/List.ascx.cs
@@ -15,10 +15,22 @@ namespace DotNetNuke.Modules.Groups
     /// <summary>Display the group list.</summary>
     public partial class List : GroupsModuleBase
     {
+        private readonly IServicesFramework servicesFramework;
+
         /// <summary>Initializes a new instance of the <see cref="List"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public List()
+            : this(null, null)
         {
-            this._navigationManager = this.DependencyProvider.GetRequiredService<INavigationManager>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="List"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public List(INavigationManager navigationManager, IServicesFramework servicesFramework)
+        {
+            this._navigationManager = navigationManager ?? this.DependencyProvider.GetRequiredService<INavigationManager>();
+            this.servicesFramework = servicesFramework ?? this.DependencyProvider.GetRequiredService<IServicesFramework>();
         }
 
         [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Breaking Change")]
@@ -28,7 +40,7 @@ namespace DotNetNuke.Modules.Groups
 
         protected void Page_Load(object sender, EventArgs e)
         {
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             this.panelSearch.Visible = this.GroupListSearchEnabled;
 

--- a/DNN Platform/Modules/Journal/View.ascx.cs
+++ b/DNN Platform/Modules/Journal/View.ascx.cs
@@ -74,11 +74,12 @@ namespace DotNetNuke.Modules.Journal
         private readonly IClientResourceController clientResourceController;
         private readonly IApplicationStatusInfo appStatus;
         private readonly IEventLogger eventLogger;
+        private readonly IServicesFramework servicesFramework;
 
         /// <summary>Initializes a new instance of the <see cref="View"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
         public View()
-            : this(null, null, null, null)
+            : this(null, null, null, null, null)
         {
         }
 
@@ -87,12 +88,14 @@ namespace DotNetNuke.Modules.Journal
         /// <param name="clientResourceController">The client resource controller.</param>
         /// <param name="appStatus">The application status.</param>
         /// <param name="eventLogger">The event logger.</param>
-        public View(INavigationManager navigationManager, IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public View(INavigationManager navigationManager, IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IServicesFramework servicesFramework)
         {
             this.navigationManager = navigationManager ?? this.DependencyProvider.GetRequiredService<INavigationManager>();
             this.clientResourceController = clientResourceController ?? this.DependencyProvider.GetRequiredService<IClientResourceController>();
             this.appStatus = appStatus ?? this.DependencyProvider.GetRequiredService<IApplicationStatusInfo>();
             this.eventLogger = eventLogger ?? this.DependencyProvider.GetRequiredService<IEventLogger>();
+            this.servicesFramework = servicesFramework ?? this.DependencyProvider.GetRequiredService<IServicesFramework>();
             this.MaxUploadSize = Config.GetMaxUploadSize(this.appStatus);
         }
 
@@ -100,7 +103,7 @@ namespace DotNetNuke.Modules.Journal
         {
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.DnnPlugins);
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.jQueryFileUpload);
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.Knockout);
 
             this.clientResourceController.RegisterScript("~/DesktopModules/Journal/Scripts/journal.js");

--- a/DNN Platform/Modules/MemberDirectory/View.ascx.cs
+++ b/DNN Platform/Modules/MemberDirectory/View.ascx.cs
@@ -28,6 +28,7 @@ namespace DotNetNuke.Modules.MemberDirectory
         private readonly IClientResourceController clientResourceController;
         private readonly IApplicationStatusInfo appStatus;
         private readonly IEventLogger eventLogger;
+        private readonly IServicesFramework servicesFramework;
 
         /// <summary>Initializes a new instance of the <see cref="View"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
@@ -39,11 +40,13 @@ namespace DotNetNuke.Modules.MemberDirectory
         /// <param name="clientResourceController">The client resource controller.</param>
         /// <param name="appStatus">The application status.</param>
         /// <param name="eventLogger">The event logger.</param>
-        public View(IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public View(IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IServicesFramework servicesFramework)
         {
             this.clientResourceController = clientResourceController;
             this.appStatus = appStatus;
             this.eventLogger = eventLogger;
+            this.servicesFramework = servicesFramework;
         }
 
         /// <inheritdoc />
@@ -127,7 +130,7 @@ namespace DotNetNuke.Modules.MemberDirectory
         /// <inheritdoc />
         protected override void OnInit(EventArgs e)
         {
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.DnnPlugins);
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.jQueryFileUpload);
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.Knockout);

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Framework/ServicesFrameworkTests.cs
@@ -5,6 +5,9 @@ namespace DotNetNuke.Tests.Core.Framework
 {
     using System;
 
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Abstractions.ClientResources;
+    using DotNetNuke.Abstractions.Logging;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Framework;
     using DotNetNuke.Tests.Utilities.Fakes;
@@ -37,20 +40,23 @@ namespace DotNetNuke.Tests.Core.Framework
         [Test]
         public void RequestingAjaxAntiForgeryIsNoted()
         {
-            // Arrange
+            var servicesFramework = new ServicesFrameworkImpl(
+                Mock.Of<IClientResourceController>(),
+                Mock.Of<IApplicationStatusInfo>(),
+                Mock.Of<IEventLogger>());
+            servicesFramework.RequestAjaxAntiForgerySupport();
 
-            // Act
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
-
-            // Assert
-            Assert.That(ServicesFrameworkInternal.Instance.IsAjaxAntiForgerySupportRequired, Is.True);
+            Assert.That(servicesFramework.IsAjaxAntiForgerySupportRequired, Is.True);
         }
 
         [Test]
         public void NoAjaxAntiForgeryRequestMeansNotRequired()
         {
-            // Assert
-            Assert.That(ServicesFrameworkInternal.Instance.IsAjaxAntiForgerySupportRequired, Is.False);
+            var servicesFramework = new ServicesFrameworkImpl(
+                Mock.Of<IClientResourceController>(),
+                Mock.Of<IApplicationStatusInfo>(),
+                Mock.Of<IEventLogger>());
+            Assert.That(servicesFramework.IsAjaxAntiForgerySupportRequired, Is.False);
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Helpers/DnnHtmlHelperTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Web.Mvc/Helpers/DnnHtmlHelperTests.cs
@@ -12,6 +12,7 @@ namespace DotNetNuke.Tests.Web.Mvc.Helpers
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.ClientResources;
     using DotNetNuke.Abstractions.Logging;
+    using DotNetNuke.Framework;
     using DotNetNuke.Tests.Utilities.Fakes;
     using DotNetNuke.Tests.Web.Mvc.Fakes;
     using DotNetNuke.UI.Modules;
@@ -87,7 +88,7 @@ namespace DotNetNuke.Tests.Web.Mvc.Helpers
             var viewDataContainer = new Mock<IViewDataContainer>();
 
             // Act,Assert
-            Assert.Throws<ArgumentNullException>(() => new DnnHtmlHelper(new ViewContext(), viewDataContainer.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new DnnHtmlHelper(new ViewContext(), viewDataContainer.Object, null, Mock.Of<IServicesFramework>()));
         }
 
         [Test]
@@ -97,7 +98,7 @@ namespace DotNetNuke.Tests.Web.Mvc.Helpers
             var viewDataContainer = new Mock<IViewDataContainer>();
 
             // Act,Assert
-            Assert.Throws<ArgumentNullException>(() => new DnnHtmlHelper<Dog>(new ViewContext(), viewDataContainer.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new DnnHtmlHelper<Dog>(new ViewContext(), viewDataContainer.Object, null, Mock.Of<IServicesFramework>()));
         }
 
         [Test]

--- a/DNN Platform/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
+++ b/DNN Platform/Website/DesktopModules/Admin/SearchResults/SearchResults.ascx.cs
@@ -32,10 +32,12 @@ namespace DotNetNuke.Modules.SearchResults
 
         private readonly IJavaScriptLibraryHelper javaScript;
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
         private IList<string> searchContentSources;
         private IList<int> searchPortalIds;
 
         /// <summary>Initializes a new instance of the <see cref="SearchResults"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public SearchResults()
             : this(null, null)
         {
@@ -44,10 +46,21 @@ namespace DotNetNuke.Modules.SearchResults
         /// <summary>Initializes a new instance of the <see cref="SearchResults"/> class.</summary>
         /// <param name="javaScript">The JavaScript library helper.</param>
         /// <param name="clientResourceController">The client resources controller.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public SearchResults(IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController)
+            : this(javaScript, clientResourceController, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="SearchResults"/> class.</summary>
+        /// <param name="javaScript">The JavaScript library helper.</param>
+        /// <param name="clientResourceController">The client resources controller.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public SearchResults(IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController, IServicesFramework servicesFramework)
         {
             this.javaScript = javaScript ?? Globals.GetCurrentServiceProvider().GetRequiredService<IJavaScriptLibraryHelper>();
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         protected string SearchTerm
@@ -360,7 +373,7 @@ namespace DotNetNuke.Modules.SearchResults
         {
             base.OnLoad(e);
 
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             this.javaScript.RequestRegistration(CommonJs.DnnPlugins);
             this.clientResourceController.RegisterScript("~/Resources/Shared/scripts/dnn.searchBox.js");
             this.clientResourceController.RegisterStylesheet("~/Resources/Shared/stylesheets/dnn.searchBox.css", Abstractions.ClientResources.FileOrder.Css.ModuleCss);

--- a/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -35,11 +35,12 @@ namespace DotNetNuke.Admin.Containers
         private readonly IModuleControlPipeline moduleControlPipeline;
         private readonly IJavaScriptLibraryHelper javaScript;
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
 
         /// <summary>Initializes a new instance of the <see cref="ModuleActions"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IEventLogger. Scheduled removal in v12.0.0.")]
         public ModuleActions()
-            : this(null, null, null, null)
+            : this(null, null, null, null, null)
         {
         }
 
@@ -49,7 +50,7 @@ namespace DotNetNuke.Admin.Containers
         /// <param name="clientResourceController">The client resources controller.</param>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IEventLogger. Scheduled removal in v12.0.0.")]
         public ModuleActions(IModuleControlPipeline moduleControlPipeline, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController)
-            : this(null, moduleControlPipeline, javaScript, clientResourceController)
+            : this(null, moduleControlPipeline, javaScript, clientResourceController, null)
         {
         }
 
@@ -58,12 +59,14 @@ namespace DotNetNuke.Admin.Containers
         /// <param name="moduleControlPipeline">The module control pipeline.</param>
         /// <param name="javaScript">The JavaScript library helper.</param>
         /// <param name="clientResourceController">The client resources controller.</param>
-        public ModuleActions(IEventLogger eventLogger, IModuleControlPipeline moduleControlPipeline, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public ModuleActions(IEventLogger eventLogger, IModuleControlPipeline moduleControlPipeline, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController, IServicesFramework servicesFramework)
             : base(eventLogger)
         {
             this.moduleControlPipeline = moduleControlPipeline ?? Globals.GetCurrentServiceProvider().GetRequiredService<IModuleControlPipeline>();
             this.javaScript = javaScript ?? Globals.GetCurrentServiceProvider().GetRequiredService<IJavaScriptLibraryHelper>();
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         protected string AdminText => Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile);
@@ -108,7 +111,7 @@ namespace DotNetNuke.Admin.Containers
             this.clientResourceController.RegisterStylesheet("~/Resources/Shared/stylesheets/dnnicons/css/dnnicon.min.css", FileOrder.Css.ModuleCss);
             this.clientResourceController.RegisterScript("~/admin/menus/ModuleActions/ModuleActions.js");
 
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
         }
 
         /// <inheritdoc />

--- a/DNN Platform/Website/admin/Skins/Search.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Search.ascx.cs
@@ -13,6 +13,7 @@ namespace DotNetNuke.UI.Skins.Controls
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Icons;
     using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Framework;
     using DotNetNuke.Framework.JavaScriptLibraries;
     using DotNetNuke.Services.ClientDependency;
     using DotNetNuke.Services.Localization;
@@ -29,6 +30,7 @@ namespace DotNetNuke.UI.Skins.Controls
 
         private readonly INavigationManager navigationManager;
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
 
         private bool enableWildSearch = true;
         private string siteIconURL;
@@ -41,6 +43,7 @@ namespace DotNetNuke.UI.Skins.Controls
         private string webURL;
 
         /// <summary>Initializes a new instance of the <see cref="Search"/> class.</summary>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Search()
             : this(null, null)
         {
@@ -49,10 +52,21 @@ namespace DotNetNuke.UI.Skins.Controls
         /// <summary>Initializes a new instance of the <see cref="Search"/> class.</summary>
         /// <param name="navigationManager">The navigation manager.</param>
         /// <param name="clientResourceController">The client resources controller.</param>
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Search(INavigationManager navigationManager, IClientResourceController clientResourceController)
+            : this(navigationManager, clientResourceController, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Search"/> class.</summary>
+        /// <param name="navigationManager">The navigation manager.</param>
+        /// <param name="clientResourceController">The client resources controller.</param>
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public Search(INavigationManager navigationManager, IClientResourceController clientResourceController, IServicesFramework servicesFramework)
         {
             this.navigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         public string SeeMoreText
@@ -385,7 +399,7 @@ namespace DotNetNuke.UI.Skins.Controls
         {
             base.OnLoad(e);
 
-            Framework.ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
             this.clientResourceController.RegisterStylesheet("~/Resources/Search/SearchSkinObjectPreview.css", FileOrder.Css.ModuleCss);
             this.clientResourceController.RegisterScript("~/Resources/Search/SearchSkinObjectPreview.js");
 

--- a/DNN Platform/Website/admin/Skins/Toast.ascx.cs
+++ b/DNN Platform/Website/admin/Skins/Toast.ascx.cs
@@ -32,17 +32,26 @@ namespace DotNetNuke.UI.Skins.Controls
         private readonly INavigationManager navigationManager;
         private readonly IJavaScriptLibraryHelper javaScript;
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
 
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Toast()
             : this(null, null, null)
         {
         }
 
+        [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IServicesFramework. Scheduled removal in v12.0.0.")]
         public Toast(INavigationManager navigationManager, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController)
+            : this(navigationManager, javaScript, clientResourceController, null)
+        {
+        }
+
+        public Toast(INavigationManager navigationManager, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController, IServicesFramework servicesFramework)
         {
             this.navigationManager = navigationManager ?? Globals.GetCurrentServiceProvider().GetRequiredService<INavigationManager>();
             this.javaScript = javaScript ?? Globals.GetCurrentServiceProvider().GetRequiredService<IJavaScriptLibraryHelper>();
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         protected string ServiceModuleName { get; private set; }
@@ -81,7 +90,7 @@ namespace DotNetNuke.UI.Skins.Controls
             base.OnLoad(e);
 
             this.javaScript.RequestRegistration(CommonJs.jQueryUI);
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             this.clientResourceController.RegisterScript("~/Resources/Shared/components/Toast/jquery.toastmessage.js", FileOrder.Js.jQuery);
             this.clientResourceController.RegisterStylesheet("~/Resources/Shared/components/Toast/jquery.toastmessage.css", FileOrder.Css.DefaultCss);

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Controllers/ContentEditorManager.cs
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/Controllers/ContentEditorManager.cs
@@ -62,12 +62,13 @@ namespace Dnn.EditBar.UI.Controllers
         private readonly IHostSettings hostSettings;
         private readonly IUserController userController;
         private readonly IHostSettingsService hostSettingsService;
+        private readonly IServicesFramework servicesFramework;
         private bool supportAjax = true;
 
         /// <summary>Initializes a new instance of the <see cref="ContentEditorManager"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IClientResourceController. Scheduled removal in v12.0.0.")]
         public ContentEditorManager()
-            : this(null, null, null, null, null, null, null)
+            : this(null, null, null, null, null, null, null, null)
         {
         }
 
@@ -79,7 +80,8 @@ namespace Dnn.EditBar.UI.Controllers
         /// <param name="hostSettings">The host settings.</param>
         /// <param name="userController">The user controller.</param>
         /// <param name="hostSettingsService">The host settings service.</param>
-        public ContentEditorManager(IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IPortalController portalController, IHostSettings hostSettings, IUserController userController, IHostSettingsService hostSettingsService)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public ContentEditorManager(IClientResourceController clientResourceController, IApplicationStatusInfo appStatus, IEventLogger eventLogger, IPortalController portalController, IHostSettings hostSettings, IUserController userController, IHostSettingsService hostSettingsService, IServicesFramework servicesFramework)
         {
             this.clientResourceController = clientResourceController ?? HttpContextSource.Current.GetScope().ServiceProvider.GetRequiredService<IClientResourceController>();
             this.appStatus = appStatus ?? HttpContextSource.Current.GetScope().ServiceProvider.GetRequiredService<IApplicationStatusInfo>();
@@ -88,6 +90,7 @@ namespace Dnn.EditBar.UI.Controllers
             this.hostSettings = hostSettings ?? HttpContextSource.Current.GetScope().ServiceProvider.GetRequiredService<IHostSettings>();
             this.userController = userController ?? HttpContextSource.Current.GetScope().ServiceProvider.GetRequiredService<IUserController>();
             this.hostSettingsService = hostSettingsService ?? HttpContextSource.Current.GetScope().ServiceProvider.GetRequiredService<IHostSettingsService>();
+            this.servicesFramework = servicesFramework ?? HttpContextSource.Current.GetScope().ServiceProvider.GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Gets or sets the skin.</summary>
@@ -346,7 +349,7 @@ namespace Dnn.EditBar.UI.Controllers
             this.clientResourceController.RegisterScript(Path.Combine(ControlFolder, "ContentEditorManager/Js/ModuleService.js"));
             this.clientResourceController.RegisterScript(Path.Combine(ControlFolder, "ContentEditorManager/Js/ContentEditor.js"));
             this.clientResourceController.RegisterStylesheet(Path.Combine(ControlFolder, "ContentEditorManager/Styles/ContentEditor.css"), (FileOrder.Css)CssFileOrder);
-            ServicesFramework.Instance.RequestAjaxScriptSupport();
+            this.servicesFramework.RequestAjaxScriptSupport();
 
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.DnnPlugins);
 
@@ -360,7 +363,7 @@ namespace Dnn.EditBar.UI.Controllers
         private void RegisterEditBarResources()
         {
             JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.jQuery);
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             ClientAPI.RegisterClientVariable(this.Page, "editbar_isAdmin", this.IsAdmin().ToString(), true);
 

--- a/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/HttpModules/EditBarModule.cs
+++ b/Dnn.AdminExperience/EditBar/Dnn.EditBar.UI/HttpModules/EditBarModule.cs
@@ -20,6 +20,7 @@ namespace Dnn.EditBar.UI.HttpModules
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Framework;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.UI.Skins.EventListeners;
 
@@ -123,8 +124,9 @@ namespace Dnn.EditBar.UI.HttpModules
                     var portalController = scope.ServiceProvider.GetRequiredService<IPortalController>();
                     var userController = scope.ServiceProvider.GetRequiredService<IUserController>();
                     var hostSettingsService = scope.ServiceProvider.GetRequiredService<IHostSettingsService>();
+                    var servicesFramework = scope.ServiceProvider.GetRequiredService<IServicesFramework>();
 
-                    e.Skin.Page.Form.Controls.Add(new ContentEditorManager(clientResourceController, appStatus, eventLogger, portalController, this.hostSettings, userController, hostSettingsService) { Skin = e.Skin, });
+                    e.Skin.Page.Form.Controls.Add(new ContentEditorManager(clientResourceController, appStatus, eventLogger, portalController, this.hostSettings, userController, hostSettingsService, servicesFramework) { Skin = e.Skin, });
                 }
             }
         }

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/UserControls/PersonaBarContainer.ascx.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/UserControls/PersonaBarContainer.ascx.cs
@@ -40,11 +40,12 @@ namespace Dnn.PersonaBar.UI.UserControls
         private readonly IHostSettings hostSettings;
         private readonly IJavaScriptLibraryHelper javaScript;
         private readonly IClientResourceController clientResourceController;
+        private readonly IServicesFramework servicesFramework;
 
         /// <summary>Initializes a new instance of the <see cref="PersonaBarContainer"/> class.</summary>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IEventLogger. Scheduled removal in v12.0.0.")]
         public PersonaBarContainer()
-            : this(null, null, null, null, null)
+            : this(null, null, null, null, null, null, null, null)
         {
         }
 
@@ -56,7 +57,7 @@ namespace Dnn.PersonaBar.UI.UserControls
         /// <param name="clientResourceController">The client resources controller.</param>
         [Obsolete("Deprecated in DotNetNuke 10.2.2. Please use overload with IEventLogger. Scheduled removal in v12.0.0.")]
         public PersonaBarContainer(IPersonaBarContainer personaBarContainer, IPersonaBarController personaBarController, IHostSettings hostSettings, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController)
-            : this(null, null, personaBarContainer, personaBarController, hostSettings, javaScript, clientResourceController)
+            : this(null, null, personaBarContainer, personaBarController, hostSettings, javaScript, clientResourceController, null)
         {
         }
 
@@ -68,7 +69,8 @@ namespace Dnn.PersonaBar.UI.UserControls
         /// <param name="hostSettings">The host settings.</param>
         /// <param name="javaScript">The JavaScript library helper.</param>
         /// <param name="clientResourceController">The client resources controller.</param>
-        public PersonaBarContainer(IEventLogger eventLogger, IPermissionDefinitionService permissionDefinitionService, IPersonaBarContainer personaBarContainer, IPersonaBarController personaBarController, IHostSettings hostSettings, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController)
+        /// <param name="servicesFramework">The web API service framework.</param>
+        public PersonaBarContainer(IEventLogger eventLogger, IPermissionDefinitionService permissionDefinitionService, IPersonaBarContainer personaBarContainer, IPersonaBarController personaBarController, IHostSettings hostSettings, IJavaScriptLibraryHelper javaScript, IClientResourceController clientResourceController, IServicesFramework servicesFramework)
             : base(eventLogger ?? Globals.GetCurrentServiceProvider().GetRequiredService<IEventLogger>(), permissionDefinitionService ?? Globals.GetCurrentServiceProvider().GetRequiredService<IPermissionDefinitionService>())
         {
             this.personaBarContainer = personaBarContainer ?? Globals.GetCurrentServiceProvider().GetRequiredService<IPersonaBarContainer>();
@@ -76,6 +78,7 @@ namespace Dnn.PersonaBar.UI.UserControls
             this.hostSettings = hostSettings ?? Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettings>();
             this.javaScript = javaScript ?? Globals.GetCurrentServiceProvider().GetRequiredService<IJavaScriptLibraryHelper>();
             this.clientResourceController = clientResourceController ?? Globals.GetCurrentServiceProvider().GetRequiredService<IClientResourceController>();
+            this.servicesFramework = servicesFramework ?? Globals.GetCurrentServiceProvider().GetRequiredService<IServicesFramework>();
         }
 
         /// <summary>Gets a JSON representation of <see cref="IPersonaBarContainer.GetConfiguration"/>.</summary>
@@ -144,7 +147,7 @@ namespace Dnn.PersonaBar.UI.UserControls
             this.javaScript.RequestRegistration(CommonJs.DnnPlugins); // We need to add the Dnn JQuery plugins because the Edit Bar removes the Control Panel from the page
             this.javaScript.RequestRegistration(CommonJs.KnockoutMapping);
 
-            ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
+            this.servicesFramework.RequestAjaxAntiForgerySupport();
 
             this.clientResourceController.RegisterScript("~/Resources/Shared/Components/Tokeninput/jquery.tokeninput.js");
             this.clientResourceController.RegisterStylesheet("~/Resources/Shared/Components/Tokeninput/Themes/token-input-facebook.css");


### PR DESCRIPTION
## Summary
This PR removes usages of `ServicesFramework.Instance`, instead opting to use DI to resolved `IServicesFramework`. This resolves https://github.com/dnnsoftware/Dnn.Platform/issues/6954. Note, however, that https://github.com/dnnsoftware/Dnn.Platform/pull/6964 is still needed for 3rd party usages.