### PR TITLE
Bump HtmlSanitizer

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="AngleSharp.Css" />
     <PackageReference Include="BouncyCastle.Cryptography" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-j92c-7v7g-gj3f" />
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="Lucene.Net.Contrib" />
     <PackageReference Include="MailKit" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Dnn.CakeUtils" Version="2.1.4" />
     <PackageVersion Include="Dnn.ClientDependency" Version="1.10.0" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.69.0" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.1.878-beta" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.1.968-beta" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />
     <PackageVersion Include="Lucene.Net.Contrib" Version="3.0.3" />
     <PackageVersion Include="MailKit" Version="4.16.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,7 +64,7 @@
     <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageVersion Include="QuickIO.NET" Version="2.6.2" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.2" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="TestStack.Dossier" Version="4.0.0" />
     <PackageVersion Include="Verify.NUnit" Version="31.13.2" />


### PR DESCRIPTION
## Summary
In order to avoid NU1902 error, this PR bumps HtmlSanitizer (which requires bumping System.Collections.Immutable).

Locally, this caused issues with the source generator, pushing this to CI to see if it's a local only issue.