### PR TITLE
Updated HtmlSanitizer

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -642,7 +642,7 @@ namespace DotNetNuke.Services.Upgrade
                 foreach (string file in files)
                 {
                     // Execute if script is a provider script
-                    if (file.Contains("." + DefaultProvider, StringComparison.OrdinalIgnoreCase))
+                    if (file.IndexOf("." + DefaultProvider, StringComparison.OrdinalIgnoreCase) >= 0)
                     {
                         ExecuteScript(file, true);
 
@@ -666,7 +666,7 @@ namespace DotNetNuke.Services.Upgrade
         public static void ExecuteScript(string file)
         {
             // Execute if script is a provider script
-            if (file.Contains("." + DefaultProvider, StringComparison.OrdinalIgnoreCase))
+            if (file.IndexOf("." + DefaultProvider, StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 ExecuteScript(file, true);
             }
@@ -956,7 +956,7 @@ namespace DotNetNuke.Services.Upgrade
                                     settingValue = settingValue.Substring(0, settingValue.IndexOf("/", StringComparison.Ordinal));
 
                                     // Remove port number
-                                    if (settingValue.Contains(":", StringComparison.Ordinal))
+                                    if (settingValue.IndexOf(":", StringComparison.Ordinal) >= 0)
                                     {
                                         settingValue = settingValue.Substring(0, settingValue.IndexOf(":", StringComparison.Ordinal));
                                     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Dnn.CakeUtils" Version="2.1.0" />
     <PackageVersion Include="Dnn.ClientDependency" Version="1.10.0" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.69.0" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.1.878-beta" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.1.893-beta" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />
     <PackageVersion Include="MailKit" Version="4.8.0" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
@@ -32,7 +32,7 @@
     <PackageVersion Include="Microsoft.AspNet.WebPages.WebData" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
@@ -57,7 +57,7 @@
     <PackageVersion Include="QuickIO.NET" Version="2.6.2" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.2" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.2" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="TestStack.Dossier" Version="4.0.0" />
     <PackageVersion Include="Verify.NUnit" Version="31.8.0" />

--- a/DotNetNuke.Internal.SourceGenerators/DotNetNuke.Internal.SourceGenerators.csproj
+++ b/DotNetNuke.Internal.SourceGenerators/DotNetNuke.Internal.SourceGenerators.csproj
@@ -13,21 +13,23 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>bin/$(Configuration)/$(TargetFramework)/DotNetNuke.Internal.SourceGenerators.xml</DocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaced usage of string.Contains with string.IndexOf for compatibility with older .NET versions in Upgrade.cs. Updated NuGet package versions for HtmlSanitizer, Microsoft.CodeAnalysis.CSharp, and System.Collections.Immutable. Added MSBuild properties and explicit package versions in DotNetNuke.Internal.SourceGenerators.csproj to improve build configuration and compatibility.

