### PR TITLE
Suppress HtmlSanitizer upgrade

### DIFF
--- a/DNN Platform/Library/DotNetNuke.Library.csproj
+++ b/DNN Platform/Library/DotNetNuke.Library.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="AngleSharp.Css" />
     <PackageReference Include="BouncyCastle.Cryptography" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-j92c-7v7g-gj3f" />
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="MailKit" />
     <PackageReference Include="Microsoft.AspNet.WebPages" />


### PR DESCRIPTION
For 10.2.2, let's suppress the warning about https://github.com/advisories/GHSA-j92c-7v7g-gj3f, since it doesn't apply to our usage. We'll have to decide whether to include #6968 in 10.3.0 or 11.0.0.