### PR TITLE
Made RenderingVersion property public in SkinObjectBase

### DIFF
--- a/DNN Platform/Library/UI/Skins/SkinObjectBase.cs
+++ b/DNN Platform/Library/UI/Skins/SkinObjectBase.cs
@@ -36,6 +36,6 @@ namespace DotNetNuke.UI.Skins
         /// <remarks>
         /// This allows opting-in into new more modern rendering behaviors.
         /// </remarks>
-        protected int RenderingVersion { get; set; }
+        public int RenderingVersion { get; set; }
     }
 }


### PR DESCRIPTION
Made RenderingVersion property public in SkinObjectBase

From feedback in https://github.com/dnnsoftware/Dnn.Platform/pull/6972#pullrequestreview-3760775458 and after testing, the property does need to be public so it can be set from an ascx file.