### PR TITLE
Fix task scheduler editor date mismatch

### DIFF
--- a/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/src/components/scheduler/schedulerEditor/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/TaskScheduler.Web/src/components/scheduler/schedulerEditor/index.jsx
@@ -281,7 +281,7 @@ class SchedulerEditor extends Component {
             return <History pageSize={5} scheduleId={props.scheduleId} title={resx.get("HistoryModalTitle")} />;
         }
 
-        if (props.scheduleItemDetail !== undefined || props.id === "add") {
+        if ((props.scheduleItemDetail !== undefined && props.scheduleItemDetail.ScheduleID === props.scheduleId) || props.id === "add") {
             const columnOne = <div className="container" key="columnOne">
                 <div className="editor-row divider">
                     <SingleLineInputWithError


### PR DESCRIPTION
## Summary
- Fix Task Scheduler editor to only render date in "Schedule Start Date/Time" picker for the selected schedule.

## Issue
Fixes #6978

## Release note
- Fix Task Scheduler editor to only render date in "Schedule Start Date/Time" picker for the selected schedule.

## Testing steps

1. log in as host
2. to go Setting > Scheduler
3. select Scheduler tab
4. click "pencil" next to any task
5. select any future date from "Schedule Start Date/Time" picker (remember the date)
6. click "Update"
7. click "pencil" next to some OTHER task
8. should show blank or some other date in the "Schedule Start Date/Time" picker
9. change dates / click around / make sure correct dates are shown in "Schedule Start Date/Time" picker