### PR TITLE
Fix broken upgrades using install package

### DIFF
--- a/DNN Platform/Website/App_Data/Upgrade/upgrade.json
+++ b/DNN Platform/Website/App_Data/Upgrade/upgrade.json
@@ -1,13 +1,13 @@
 ﻿{
   "minimumDnnVersion": "10.02.00",
   "upgradeExclude": [
-    "/favicon.ico",
-    "/Robots.txt",
-    "/web.config",
-    "/App_Data/Database.mdf",
-    "/App_Data/Database_log.LDF",
-    "/bin/Providers/DotNetNuke.Providers.AspNetClientCapabilityProvider.dll",
-    "/Config/DotNetNuke.config",
-    "/Install/InstallWizard.aspx"
+    "favicon.ico",
+    "Robots.txt",
+    "web.config",
+    "App_Data/Database.mdf",
+    "App_Data/Database_log.LDF",
+    "bin/Providers/DotNetNuke.Providers.AspNetClientCapabilityProvider.dll",
+    "Config/DotNetNuke.config",
+    "Install/InstallWizard.aspx"
   ]
 }


### PR DESCRIPTION
If you currently upload an install package to the upgrade module it will break your installation when you try to upgrade. This is because the exclude file list was containing a leading slash which meant nothing matched and all files got copied over including the web.config. This PR fixes that error.