### PR TITLE
Harmonized support for portal settings in portal templates

### DIFF
--- a/DNN Platform/Library/Entities/Portals/Templates/PortalTemplateExporter.cs
+++ b/DNN Platform/Library/Entities/Portals/Templates/PortalTemplateExporter.cs
@@ -288,6 +288,72 @@ namespace DotNetNuke.Entities.Portals.Templates
                 writer.WriteElementString("showquickmoduleaddmenu", setting);
             }
 
+            settingsDictionary.TryGetValue("AllowJsInModuleHeaders", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("allowjsinmoduleheaders", setting);
+            }
+
+            settingsDictionary.TryGetValue("AllowJsInModuleFooters", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("allowjsinmodulefooters", setting);
+            }
+
+            settingsDictionary.TryGetValue("AllowUserUICulture", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("allowuseruiculture", setting);
+            }
+
+            settingsDictionary.TryGetValue("EnableBrowserLanguage", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("enablebrowserlanguage", setting);
+            }
+
+            settingsDictionary.TryGetValue("SitemapCacheDays", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("sitemapcachedays", setting);
+            }
+
+            settingsDictionary.TryGetValue("SitemapExcludePriority", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("sitemapexcludepriority", setting);
+            }
+
+            settingsDictionary.TryGetValue("SitemmpIncludeHidden", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("sitemapincludehidden", setting);
+            }
+
+            settingsDictionary.TryGetValue("SitemapLevelMode", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("sitemaplevelmode", setting);
+            }
+
+            settingsDictionary.TryGetValue("SitemapMinPriority", out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("sitemapminpriority", setting);
+            }
+
+            settingsDictionary.TryGetValue(PortalTemplateImporter.HtmlTextAutoSaveEnabled, out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("enableautosave", setting);
+            }
+
+            settingsDictionary.TryGetValue(PortalTemplateImporter.HtmlTextTimeToAutoSave, out setting);
+            if (!string.IsNullOrEmpty(setting))
+            {
+                writer.WriteElementString("timetoautosave", setting);
+            }
+
             // End Portal Settings
             writer.WriteEndElement();
         }

--- a/DNN Platform/Library/Entities/Portals/Templates/PortalTemplateImporter.cs
+++ b/DNN Platform/Library/Entities/Portals/Templates/PortalTemplateImporter.cs
@@ -931,6 +931,16 @@ namespace DotNetNuke.Entities.Portals.Templates
             {
                 PortalController.UpdatePortalSetting(portalId, "ShowQuickModuleAddMenu", XmlUtils.GetNodeValue(nodeSettings, "showquickmoduleaddmenu", string.Empty));
             }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "allowjsinmoduleheaders", string.Empty)))
+            {
+                PortalController.UpdatePortalSetting(portalId, "AllowJsInModuleHeaders", XmlUtils.GetNodeValue(nodeSettings, "allowjsinmoduleheaders", string.Empty));
+            }
+
+            if (!string.IsNullOrEmpty(XmlUtils.GetNodeValue(nodeSettings, "allowjsinmodulefooters", string.Empty)))
+            {
+                PortalController.UpdatePortalSetting(portalId, "AllowJsInModuleFooters", XmlUtils.GetNodeValue(nodeSettings, "allowjsinmodulefooters", string.Empty));
+            }
         }
 
         private static void ParseRoleGroups(IEventLogger eventLogger, XPathNavigator nav, int portalID, int administratorId)

--- a/DNN Platform/Website/Portals/_default/Blank Website.template
+++ b/DNN Platform/Website/Portals/_default/Blank Website.template
@@ -32,6 +32,8 @@
     <sitemapincludehidden>False</sitemapincludehidden>
     <sitemaplevelmode>False</sitemaplevelmode>
     <sitemapminpriority>0.2</sitemapminpriority>
+    <allowjsinmoduleheaders>False</allowjsinmoduleheaders>
+    <allowjsinmodulefooters>False</allowjsinmodulefooters>
   </settings>
   <profiledefinitions>
     <profiledefinition>

--- a/DNN Platform/Website/Portals/_default/Default Website.template
+++ b/DNN Platform/Website/Portals/_default/Default Website.template
@@ -32,6 +32,8 @@
     <sitemapincludehidden>False</sitemapincludehidden>
     <sitemaplevelmode>False</sitemaplevelmode>
     <sitemapminpriority>0.2</sitemapminpriority>
+    <allowjsinmoduleheaders>False</allowjsinmoduleheaders>
+    <allowjsinmodulefooters>False</allowjsinmodulefooters>
   </settings>
   <profiledefinitions>
     <profiledefinition>


### PR DESCRIPTION
There are 4 parts to portal templates
- The actual .template files themselves
- The XSD validation
- The code that handles portal template exports
- The code that handles portal template imports

Over the years there has been som offset in keeping those in sync and we have effectivelly xml that does nothing even though the xsd says they are a supported feature.

This brings the import/export on par with the definition.

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
