### PR TITLE
Resolve CA1874 warnings about Regex.IsMatch

### DIFF
--- a/DNN Platform/DotNetNuke.Web/InternalServices/FileUploadController.cs
+++ b/DNN Platform/DotNetNuke.Web/InternalServices/FileUploadController.cs
@@ -392,7 +392,7 @@ namespace DotNetNuke.Web.InternalServices
                                     fileName = Path.GetFileName(fileName);
                                 }
 
-                                if (!Globals.FileEscapingRegex.Match(fileName).Success)
+                                if (!Globals.FileEscapingRegex.IsMatch(fileName))
                                 {
                                     stream = item.ReadAsStreamAsync().Result;
                                 }

--- a/DNN Platform/HttpModules/UrlRewrite/BasicUrlRewriter.cs
+++ b/DNN Platform/HttpModules/UrlRewrite/BasicUrlRewriter.cs
@@ -78,7 +78,7 @@ namespace DotNetNuke.HttpModules.UrlRewrite
             // the application should always use the exact relative location of the resource it is requesting
             var strURL = request.Url.AbsolutePath;
             var strDoubleDecodeURL = server.UrlDecode(server.UrlDecode(request.RawUrl)) ?? string.Empty;
-            if (Globals.FileEscapingRegex.Match(strURL).Success || Globals.FileEscapingRegex.Match(strDoubleDecodeURL).Success)
+            if (Globals.FileEscapingRegex.IsMatch(strURL) || Globals.FileEscapingRegex.IsMatch(strDoubleDecodeURL))
             {
                 DotNetNuke.Services.Exceptions.Exceptions.ProcessHttpException(request);
             }

--- a/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
+++ b/DNN Platform/Library/Entities/Urls/AdvancedUrlRewriter.cs
@@ -2188,7 +2188,7 @@ namespace DotNetNuke.Entities.Urls
             // the application should always use the exact relative location of the resource it is requesting
             var strURL = request.Url.AbsolutePath;
             var strDoubleDecodeURL = server.UrlDecode(server.UrlDecode(request.Url.AbsolutePath)) ?? string.Empty;
-            if (UrlSlashesRegex.Match(strURL).Success || UrlSlashesRegex.Match(strDoubleDecodeURL).Success)
+            if (UrlSlashesRegex.IsMatch(strURL) || UrlSlashesRegex.IsMatch(strDoubleDecodeURL))
             {
                 throw new HttpException(404, "Not Found");
             }

--- a/DNN Platform/Library/Services/Mail/Mail.cs
+++ b/DNN Platform/Library/Services/Mail/Mail.cs
@@ -45,7 +45,7 @@ namespace DotNetNuke.Services.Mail
             }
 
             pattern = string.IsNullOrEmpty(pattern) ? Globals.glbEmailRegEx : pattern;
-            return Regex.Match(email, pattern).Success;
+            return Regex.IsMatch(email, pattern);
         }
 
         public static void SendEmail(string fromAddress, string toAddress, string subject, string body)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ExtensionsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/ExtensionsController.cs
@@ -1534,7 +1534,7 @@ namespace Dnn.PersonaBar.Extensions.Services
                                     fileName = Path.GetFileName(fileName);
                                 }
 
-                                if (!Globals.FileEscapingRegex.Match(fileName).Success)
+                                if (!Globals.FileEscapingRegex.IsMatch(fileName))
                                 {
                                     stream = item.ReadAsStreamAsync().Result;
                                 }

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
@@ -3471,7 +3471,7 @@ namespace Dnn.PersonaBar.SiteSettings.Services
             var objListController = new ListController();
             string strDataType = objListController.GetListEntryInfo("DataType", definition.DataType).Value;
             Regex propertyNameRegex = new Regex("^[a-zA-Z0-9]+$");
-            if (!propertyNameRegex.Match(definition.PropertyName).Success)
+            if (!propertyNameRegex.IsMatch(definition.PropertyName))
             {
                 isValid = false;
                 httpPropertyValidationError = this.Request.CreateErrorResponse(


### PR DESCRIPTION
## Summary
A new wild code analysis rule has appeared!

This PR resolves [CA1874: Use 'Regex.IsMatch'](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1874).