### PR TITLE
Allow building from source without git repo

### DIFF
--- a/Build/Tasks/SetVersion.cs
+++ b/Build/Tasks/SetVersion.cs
@@ -8,6 +8,7 @@ namespace DotNetNuke.Build.Tasks
 
     using Cake.Common.Diagnostics;
     using Cake.Common.Tools.GitVersion;
+    using Cake.Core;
     using Cake.Frosting;
 
     using Dnn.CakeUtils;
@@ -22,29 +23,25 @@ namespace DotNetNuke.Build.Tasks
         {
             if (context.Settings.Version == "auto")
             {
-                context.Version = context.GitVersion();
-                context.BuildNumber = context.Version.FullSemVer;
+                try
+                {
+                    context.Version = context.GitVersion();
+                    context.BuildNumber = context.Version.FullSemVer;
+                }
+                catch (CakeException)
+                {
+                    if (context.IsRunningInCI)
+                    {
+                        throw;
+                    }
+
+                    context.Warning("Unable to get version from Git, using version from SolutionInfo.cs");
+                    SetManualVersion(context, "off");
+                }
             }
             else
             {
-                context.Version = new GitVersion();
-                var assemblyInfo = new AssemblyInfo("SolutionInfo.cs");
-                var requestedVersion = context.Settings.Version == "off"
-                                           ? assemblyInfo.GetVersion()
-                                           : new Version(context.Settings.Version);
-                context.Version.Major = requestedVersion.Major;
-                context.Version.Minor = requestedVersion.Minor;
-                context.Version.Patch = requestedVersion.Build;
-                context.Version.InformationalVersion = requestedVersion.ToString(3) + " Custom build";
-                context.Version.MajorMinorPatch = requestedVersion.ToString(3);
-                context.Version.FullSemVer = requestedVersion.ToString(3);
-                if (requestedVersion.Revision != -1)
-                {
-                    context.Version.CommitsSinceVersionSource = requestedVersion.Revision;
-                    context.Version.InformationalVersion = requestedVersion.ToString(4) + " Custom build";
-                }
-
-                context.BuildNumber = requestedVersion.ToString(3);
+                SetManualVersion(context, context.Settings.Version);
             }
 
             context.Information(JsonConvert.SerializeObject(context.Version));
@@ -65,6 +62,28 @@ namespace DotNetNuke.Build.Tasks
             context.Information("Product Version : " + context.ProductVersion);
             context.Information("Build Number : " + context.BuildNumber);
             context.Information("The build Id is : " + context.BuildId);
+        }
+
+        private static void SetManualVersion(Context context, string settingsVersion)
+        {
+            context.Version = new GitVersion();
+            var assemblyInfo = new AssemblyInfo("SolutionInfo.cs");
+            var requestedVersion = settingsVersion == "off"
+                ? assemblyInfo.GetVersion()
+                : new Version(context.Settings.Version);
+            context.Version.Major = requestedVersion.Major;
+            context.Version.Minor = requestedVersion.Minor;
+            context.Version.Patch = requestedVersion.Build;
+            context.Version.InformationalVersion = requestedVersion.ToString(3) + " Custom build";
+            context.Version.MajorMinorPatch = requestedVersion.ToString(3);
+            context.Version.FullSemVer = requestedVersion.ToString(3);
+            if (requestedVersion.Revision != -1)
+            {
+                context.Version.CommitsSinceVersionSource = requestedVersion.Revision;
+                context.Version.InformationalVersion = requestedVersion.ToString(4) + " Custom build";
+            }
+
+            context.BuildNumber = requestedVersion.ToString(3);
         }
     }
 }


### PR DESCRIPTION
## Summary
I received a question from someone that had downloaded the source and then tried to follow the [build instructions](https://github.com/dnnsoftware/Dnn.Platform/blob/develop/.github/BUILD.md). However, the build uses GitVersion, and so fails if the source code is downloaded instead of cloned via Git. This PR catches that error and uses the current version in source instead in that scenario.