### PR TITLE
Fixed an issue where site file management was not create on localized portal import/creation

### DIFF
--- a/DNN Platform/Website/Portals/_default/Blank Website.template
+++ b/DNN Platform/Website/Portals/_default/Blank Website.template
@@ -2766,7 +2766,7 @@
       <sitemappriority>0.5</sitemappriority>
       <skinsrc />
       <startdate>0001-01-01T00:00:00</startdate>
-      <name>[Tab.WebsiteAdministration.Name.Text]</name>
+      <name>Admin</name>
       <title>[Tab.WebsiteAdministration.Title.Text]</title>
       <url type="Normal" />
       <tabpermissions>

--- a/DNN Platform/Website/Portals/_default/Default Website.template
+++ b/DNN Platform/Website/Portals/_default/Default Website.template
@@ -3176,7 +3176,7 @@
       <sitemappriority>0.5</sitemappriority>
       <skinsrc />
       <startdate>0001-01-01T00:00:00</startdate>
-      <name>[Tab.WebsiteAdministration.Name.Text]</name>
+      <name>Admin</name>
       <title>[Tab.WebsiteAdministration.Title.Text]</title>
       <url type="Normal" />
       <tabpermissions>


### PR DESCRIPTION
Closes #6874

The crux of the issue is that for historical reasons "Admin" is a special page that needs too keep that specific name, we can localize the title but we need to keep that exact name. By changing parents to Admin in the templates, it appears to fix the issue reported.

#6939 might still have something good in it that I will try and take a look later on...
