### PR TITLE
Remove StyleCop.Analyzers reference from DotNetNuke.WebControls

### DIFF
--- a/DNN Platform/Controls/DotNetNuke.WebControls/DotNetNuke.WebControls.vbproj
+++ b/DNN Platform/Controls/DotNetNuke.WebControls/DotNetNuke.WebControls.vbproj
@@ -18,13 +18,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="StyleCop.Analyzers">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup>
 		<Reference Include="Microsoft.VisualBasic" />
 		<Reference Include="System.Web" />
 		<Reference Include="System.Design" />


### PR DESCRIPTION
This was added globally in #7006