### PR TITLE
Bump Microsoft.SqlServer.SqlManagementObjects from 180.10.0 to 181.12.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" />
-    <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="180.10.0" />
+    <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.12.0" />
     <PackageVersion Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageVersion Include="Microsoft.Web.Infrastructure" Version="2.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
This is only used by tests, not distributed with DNN
