### PR TITLE
Allow `ApiTokenAuthorize` attributes at class level

### DIFF
--- a/DNN Platform/DotNetNuke.Web/Api/ApiTokenAuthorizeAttribute.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/ApiTokenAuthorizeAttribute.cs
@@ -10,14 +10,10 @@ namespace DotNetNuke.Web.Api
     using DotNetNuke.Web.Api.Auth.ApiTokens;
     using DotNetNuke.Web.Api.Auth.ApiTokens.Models;
 
-    /// <summary>
-    /// Attribute to authorize apis based on the api token used.
-    /// </summary>
+    /// <summary>Attribute to authorize apis based on the api token used.</summary>
     public class ApiTokenAuthorizeAttribute : AuthorizeAttributeBase, IOverrideDefaultAuthLevel
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApiTokenAuthorizeAttribute"/> class.
-        /// </summary>
+        /// <summary>Initializes a new instance of the <see cref="ApiTokenAuthorizeAttribute"/> class.</summary>
         /// <param name="key">The Key to authenticate api.</param>
         /// <param name="resourceFile">The resource file for the token api.</param>
         /// <param name="scope">The required api token scope.</param>
@@ -28,29 +24,21 @@ namespace DotNetNuke.Web.Api
             this.Scope = scope;
         }
 
-        /// <summary>
-        /// Gets or sets the Key for the api token.
-        /// </summary>
-        public string Key { get; set; } = string.Empty;
+        /// <summary>Gets or sets the Key for the api token.</summary>
+        public string Key { get; set; }
 
-        /// <summary>
-        /// Gets or sets the resource file for the api token.
-        /// </summary>
-        public string ResourceFile { get; set; } = string.Empty;
+        /// <summary>Gets or sets the resource file for the api token.</summary>
+        public string ResourceFile { get; set; }
 
-        /// <summary>
-        /// Gets or sets the required api token scope.
-        /// </summary>
-        public ApiTokenScope Scope { get; set; } = ApiTokenScope.User;
+        /// <summary>Gets or sets the required api token scope.</summary>
+        public ApiTokenScope Scope { get; set; }
 
         [Dependency]
         private IApiTokenController ApiTokenController { get; set; }
 
-        /// <summary>
-        /// Check if the request is authorized.
-        /// </summary>
+        /// <summary>Check if the request is authorized.</summary>
         /// <param name="context">The authentication filter context.</param>
-        /// <returns>True if authorized, false otherwise.</returns>
+        /// <returns><see langword="true"/> if authorized, <see langword="false"/> otherwise.</returns>
         public override bool IsAuthorized(AuthFilterContext context)
         {
             var token = this.ApiTokenController.GetCurrentThreadApiToken();

--- a/DNN Platform/DotNetNuke.Web/Api/Auth/ApiTokens/ApiTokenController.cs
+++ b/DNN Platform/DotNetNuke.Web/Api/Auth/ApiTokens/ApiTokenController.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Web.Api.Auth.ApiTokens
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Reflection;
     using System.Security.Cryptography;
     using System.Text;
     using System.Web;
@@ -99,17 +100,19 @@ namespace DotNetNuke.Web.Api.Auth.ApiTokens
         {
             var res = new SortedDictionary<string, ApiTokenAttribute>();
             var typeLocator = new TypeLocator();
-            var attributes = typeLocator.GetAllMatchingTypes(
-                t => t is { IsClass: true, IsAbstract: false, IsVisible: true, })
-                .SelectMany(x => x.GetMethods())
-                .SelectMany(m => m.GetCustomAttributes(typeof(ApiTokenAuthorizeAttribute), false))
-                .Cast<ApiTokenAuthorizeAttribute>()
-                .Where(a => a.Scope <= scope);
+            var attributes =
+                from type in typeLocator.GetAllMatchingTypes(t => t is { IsClass: true, IsAbstract: false, IsVisible: true, })
+                let typeAttributes = type.GetCustomAttributes<ApiTokenAuthorizeAttribute>(inherit: false)
+                from method in type.GetMethods()
+                let methodAttributes = method.GetCustomAttributes<ApiTokenAuthorizeAttribute>(inherit: false)
+                from attribute in typeAttributes.Concat(methodAttributes)
+                where attribute.Scope <= scope
+                select attribute;
 
             foreach (var attr in attributes)
             {
                 var key = attr.Key.ToLowerInvariant();
-                var k = attr.Scope.ToString() + key;
+                var k = $"{attr.Scope}{key}";
                 if (!res.ContainsKey(k))
                 {
                     var name = DotNetNuke.Services.Localization.Localization.GetString(attr.Key + ".Text", attr.ResourceFile, locale);


### PR DESCRIPTION
## Summary
This PR update the API Token authorization system to support defining API token access for an entire web API controller, in addition to the current system of defining the APIs only for individual actions (i.e. for classes in addition to methods).