### PR TITLE
Don't blow up when sending email without portal

### DIFF
--- a/DNN Platform/Library/Services/Mail/CoreMailProvider.cs
+++ b/DNN Platform/Library/Services/Mail/CoreMailProvider.cs
@@ -46,6 +46,10 @@ namespace DotNetNuke.Services.Mail
             this.hostSettings = hostSettings ?? Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettings>();
         }
 
+        private static int CurrentPortalId => PortalSettings.Current?.PortalId ?? Null.NullInteger;
+
+        private static string CurrentPortalName => PortalSettings.Current?.PortalName ?? string.Empty;
+
         /// <inheritdoc />
         public override string SendMail(MailInfo mailInfo, SmtpInfo smtpInfo = null)
         {
@@ -116,7 +120,7 @@ namespace DotNetNuke.Services.Mail
                 return null;
             }
 
-            if (!string.IsNullOrWhiteSpace(mailSettings.GetServer(PortalSettings.Current.PortalId)))
+            if (!string.IsNullOrWhiteSpace(mailSettings.GetServer(CurrentPortalId)))
             {
                 return null;
             }
@@ -131,15 +135,14 @@ namespace DotNetNuke.Services.Mail
                 return smtpInfo;
             }
 
-            var currentPortalId = PortalSettings.Current.PortalId;
             return new SmtpInfo
                    {
-                       Server = mailSettings.GetServer(currentPortalId),
-                       Authentication = mailSettings.GetAuthentication(currentPortalId),
-                       Username = mailSettings.GetUsername(currentPortalId),
-                       Password = mailSettings.GetPassword(currentPortalId),
-                       EnableSSL = mailSettings.GetSecureConnectionEnabled(currentPortalId),
-                       AuthProvider = mailSettings.GetAuthProvider(currentPortalId),
+                       Server = mailSettings.GetServer(CurrentPortalId),
+                       Authentication = mailSettings.GetAuthentication(CurrentPortalId),
+                       Username = mailSettings.GetUsername(CurrentPortalId),
+                       Password = mailSettings.GetPassword(CurrentPortalId),
+                       EnableSSL = mailSettings.GetSecureConnectionEnabled(CurrentPortalId),
+                       AuthProvider = mailSettings.GetAuthProvider(CurrentPortalId),
                    };
         }
 
@@ -200,7 +203,7 @@ namespace DotNetNuke.Services.Mail
 
                     if (string.IsNullOrEmpty(senderDisplayName))
                     {
-                        senderDisplayName = mailSettings.IsPortalEnabled(PortalSettings.Current.PortalId) ? PortalSettings.Current.PortalName : hostSettings.HostTitle;
+                        senderDisplayName = mailSettings.IsPortalEnabled(CurrentPortalId) ? CurrentPortalName : hostSettings.HostTitle;
                         needUpdateSender = true;
                     }
 
@@ -213,7 +216,7 @@ namespace DotNetNuke.Services.Mail
                 {
                     mailMessage.Sender = new MailAddress(
                         smtpInfo.Username,
-                        mailSettings.IsPortalEnabled(PortalSettings.Current.PortalId) ? PortalSettings.Current.PortalName : hostSettings.HostTitle);
+                        mailSettings.IsPortalEnabled(CurrentPortalId) ? CurrentPortalName : hostSettings.HostTitle);
                 }
             }
 

--- a/DNN Platform/Library/Services/Mail/MailKitMailProvider.cs
+++ b/DNN Platform/Library/Services/Mail/MailKitMailProvider.cs
@@ -64,6 +64,10 @@ namespace DotNetNuke.Services.Mail
         /// <inheritdoc />
         public override bool SupportsOAuth => true;
 
+        private static int CurrentPortalId => PortalSettings.Current?.PortalId ?? Null.NullInteger;
+
+        private static string CurrentPortalName => PortalSettings.Current?.PortalName ?? string.Empty;
+
         /// <inheritdoc />
         public override string SendMail(MailInfo mailInfo, SmtpInfo smtpInfo = null)
         {
@@ -140,22 +144,21 @@ namespace DotNetNuke.Services.Mail
         private static (string Host, int Port, string ErrorMessage) ParseSmtpServer(IMailSettings mailSettings, ref SmtpInfo smtpInfo)
         {
             var port = 25;
-            var currentPortalId = PortalSettings.Current.PortalId;
             if (smtpInfo == null || string.IsNullOrEmpty(smtpInfo.Server))
             {
-                if (string.IsNullOrWhiteSpace(mailSettings.GetServer(currentPortalId)))
+                if (string.IsNullOrWhiteSpace(mailSettings.GetServer(CurrentPortalId)))
                 {
                     return (null, port, "SMTP Server not configured");
                 }
 
                 smtpInfo = new SmtpInfo
                            {
-                               Server = mailSettings.GetServer(currentPortalId),
-                               Authentication = mailSettings.GetAuthentication(currentPortalId),
-                               Username = mailSettings.GetUsername(currentPortalId),
-                               Password = mailSettings.GetPassword(currentPortalId),
-                               EnableSSL = mailSettings.GetSecureConnectionEnabled(currentPortalId),
-                               AuthProvider = mailSettings.GetAuthProvider(currentPortalId),
+                               Server = mailSettings.GetServer(CurrentPortalId),
+                               Authentication = mailSettings.GetAuthentication(CurrentPortalId),
+                               Username = mailSettings.GetUsername(CurrentPortalId),
+                               Password = mailSettings.GetPassword(CurrentPortalId),
+                               EnableSSL = mailSettings.GetSecureConnectionEnabled(CurrentPortalId),
+                               AuthProvider = mailSettings.GetAuthProvider(CurrentPortalId),
                            };
             }
 
@@ -260,7 +263,7 @@ namespace DotNetNuke.Services.Mail
 
                     if (string.IsNullOrEmpty(senderDisplayName))
                     {
-                        senderDisplayName = mailSettings.IsPortalEnabled(PortalSettings.Current.PortalId) ? PortalSettings.Current.PortalName : hostSettings.HostTitle;
+                        senderDisplayName = mailSettings.IsPortalEnabled(CurrentPortalId) ? CurrentPortalName : hostSettings.HostTitle;
                         needUpdateSender = true;
                     }
 
@@ -274,7 +277,7 @@ namespace DotNetNuke.Services.Mail
                 else if (smtpInfo.Username.Contains("@"))
                 {
                     mailMessage.Sender = ParseAddressWithDisplayName(
-                        displayName: mailSettings.IsPortalEnabled(PortalSettings.Current.PortalId) ? PortalSettings.Current.PortalName : hostSettings.HostTitle,
+                        displayName: mailSettings.IsPortalEnabled(CurrentPortalId) ? CurrentPortalName : hostSettings.HostTitle,
                         address: smtpInfo.Username);
                 }
             }
@@ -336,9 +339,9 @@ namespace DotNetNuke.Services.Mail
             }
 
             var portalId = Null.NullInteger;
-            if (this.mailSettings.IsPortalEnabled(PortalSettings.Current.PortalId))
+            if (this.mailSettings.IsPortalEnabled(CurrentPortalId))
             {
-                portalId = PortalSettings.Current.PortalId;
+                portalId = CurrentPortalId;
             }
 
             return (authProvider, portalId);


### PR DESCRIPTION
Fixes #7052

This PR causes the mail providers to fall back to a portal ID of `-1` if `PortalSettings.Current` is `null`. This prevents a `NullReferenceException`.

Ideally, there would be a way to specify a portal when sending an email from a scheduled task. We could add a property to `MailInfo` to support that scenario.