### PR TITLE
Add CDV cache buster argument to Persona Bar loads

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
@@ -1,29 +1,28 @@
 'use strict';
 define(['jquery', 'purify.min'], function ($, DOMPurify) {
-    var initializedModules = {};
+    const initializedModules = {};
     return {
         init: function (config) {
-            var loadTempl;
-            var setDialogClass;
-
-            loadTempl = function (folder, template, wrapper, params, self, cb) {
-                var callbackInit, moduleFolder, scriptFolder, templateSuffix, cssSuffix, initMethod, moduleJs, loadMethod;
-
+            const loadTempl = function (folder, template, wrapper, params, self, cb) {
                 if (!initializedModules[template]) {
-                    templateSuffix = '.html';
-                    cssSuffix = '.css';
-                    initMethod = 'init';
-                    moduleFolder = folder ? 'modules/' + folder + '/' : '';
-                    scriptFolder = moduleFolder ? moduleFolder + 'scripts/' : 'scripts/';
-                    var requiredArray = ['../../' + scriptFolder + template, 'text!../../' + moduleFolder + template + templateSuffix];
-                    requiredArray.push('css!../../' + moduleFolder + 'css/' + template + cssSuffix);
+                    const cacheBust = `cdv=${config.buildNumber}`;
+                    const templateSuffix = `.html?${cacheBust}`;
+                    const cssSuffix = `.css?${cacheBust}`;
+                    const initMethod = 'init';
+                    const moduleFolder = folder ? `modules/${folder}/` : '';
+                    const scriptFolder = moduleFolder ? `${moduleFolder}scripts/` : 'scripts/';
+                    const requiredArray = [
+                        `../../${scriptFolder}${template}`,
+                        `text!../../${moduleFolder}${template}${templateSuffix}`,
+                        `css!../../${moduleFolder}css/${template}${cssSuffix}`
+                    ];
 
                     window.require(requiredArray, function (module, html) {
                         if (module === undefined) return;
 
                         wrapper.html(html);
 
-                        // Create objects or Initicialize objects and store
+                        // Create objects or Initialize objects and store
                         if (module.type === 'Class') {
                             initializedModules[template] = new module(wrapper, self, params, cb);
                         } else {
@@ -32,10 +31,10 @@ define(['jquery', 'purify.min'], function ($, DOMPurify) {
                         }
                     });
                 } else {
-                    moduleJs = initializedModules[template];
+                    const moduleJs = initializedModules[template];
                     if (typeof moduleJs.load !== 'function') return;
 
-                    loadMethod = 'load';
+                    const loadMethod = 'load';
 
                     if (moduleJs.type === 'Class') {
                         moduleJs.load(moduleJs, params, cb);
@@ -45,7 +44,7 @@ define(['jquery', 'purify.min'], function ($, DOMPurify) {
                 }
             };
 
-            setDialogClass = function (dialog) {
+            const setDialogClass = function (dialog) {
                 if (dialog.parent().find('.socialpanel:visible .dnn-persona-bar-page').hasClass('full-width')) {
                     dialog.addClass('full-width-mode');
                 }
@@ -60,12 +59,12 @@ define(['jquery', 'purify.min'], function ($, DOMPurify) {
                 },
 
                 loadTemplate: function (folder, template, wrapper, params, cb) {
-                    var self = this;
+                    const self = this;
                     loadTempl(folder, template, wrapper, params, self, cb, false);
                 },
 
                 loadResx: function (cb) {
-                    var self = this;
+                    const self = this;
 
                     self.sf.moduleRoot = 'personaBar';
                     self.sf.controller = 'localization';
@@ -99,9 +98,9 @@ define(['jquery', 'purify.min'], function ($, DOMPurify) {
                 },
 
                 asyncParallel: function (deferreds, callback) {
-                    var i = deferreds.length;
+                    let i = deferreds.length;
                     if (i === 0) callback();
-                    var call = function () {
+                    const call = function () {
                         i--;
                         if (i === 0) {
                             callback();
@@ -114,8 +113,8 @@ define(['jquery', 'purify.min'], function ($, DOMPurify) {
                 },
 
                 asyncWaterfall: function (deferreds, callback) {
-                    var call = function () {
-                        var deferred = deferreds.shift();
+                    const call = function () {
+                        const deferred = deferreds.shift();
                         if (!deferred) {
                             callback();
                             return;


### PR DESCRIPTION
Fixes #7066

## Summary
In 10.2.3, some of the Persona Bar extensions were [migrated from webpack to Rsbuild](https://github.com/dnnsoftware/Dnn.Platform/pull/6837). One of the consequences of this change is that the CSS for those modules moved out of the JS bundle into a CSS file. Specifically, in 10.2.2, `/DesktopModules/Admin/Dnn.PersonaBar/Modules/Dnn.Servers/css/Servers.css` was empty, whereas in 10.2.3 it's 20kb (and `/DesktopModules/Admin/Dnn.PersonaBar/Modules/Dnn.Servers/scripts/bundles/servers-bundle.js` went from 592kb to 506kb).

Previously, the webpack runtime dynamically loaded that CSS, now it is loaded externally by DNN via its Persona Bar infrastructure. For each Persona Bar component it loads, DNN looks for a file sharing the name of the component in a `css` directory, so `css/Servers.css` gets loaded automatically in 10.2.3 and everything works as expected.

However, the way that the CSS file is requested causes it to be cached by the browser. So, in the upgrade scenario, the old empty `Servers.css` is served instead of the new version that has content. Because the Persona Bar is dynamically loaded in an `iframe`, even doing a hard refresh in the browser does not clear this cache (but using browser dev tools with caching disabled does). Therefore, this PR adds a cache buster parameter to those CSS requests.