### PR TITLE
Made package.json files to use only Major.Minor.Patch versioning

### DIFF
--- a/Build/Tasks/SetPackageVersions.cs
+++ b/Build/Tasks/SetPackageVersions.cs
@@ -32,15 +32,15 @@ namespace DotNetNuke.Build.Tasks
             // Set all package.json in Admin Experience to the current version and to consume the current (local) version of dnn-react-common.
             foreach (var file in packages)
             {
-                context.Information($"Updating {file} to version {context.Version.SemVer}");
+                context.Information($"Updating {file} to version {context.Version.MajorMinorPatch}");
                 context.ReplaceRegexInFiles(
                     file.ToString(),
                     @"""version"": "".*""",
-                    $@"""version"": ""{context.Version.SemVer}""");
+                    $@"""version"": ""{context.Version.MajorMinorPatch}""");
                 context.ReplaceRegexInFiles(
                     file.ToString(),
                     @"""@dnnsoftware\/dnn-react-common"": "".*""",
-                    $@"""@dnnsoftware/dnn-react-common"": ""{context.Version.SemVer}""");
+                    $@"""@dnnsoftware/dnn-react-common"": ""{context.Version.MajorMinorPatch}""");
             }
         }
     }


### PR DESCRIPTION
Made package.json files to use only Major.Minor.Patch versioning. This should also reduce the PR noise to update github per builds.

This is a release management task, as per our policy, we are self-approving it. 