### PR TITLE
Add GitHub Actions job to deploy to NuGet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ env:
   RELEASE_MODE: "Beta"
   RUN_TESTS: "true"
 
-permissions:
-  checks: write
-  pull-requests: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -57,6 +53,9 @@ jobs:
   build-and-validate:
     name: "Build and Validate"
     runs-on: "windows-2025-vs2026"
+    permissions:
+      checks: write
+      pull-requests: write
     defaults:
       run:
         shell: "pwsh"
@@ -128,6 +127,7 @@ jobs:
           action_fail: true
 
       - name: "Publish Artifacts"
+        id: "publish-artifacts-step"
         uses: "actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f" # v7.0.0
         if: ${{ !cancelled() }}
         with:
@@ -142,3 +142,32 @@ jobs:
         env:
           GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+
+    outputs:
+      artifact-id: ${{ steps.publish-artifacts-step.outputs.artifact-id }}
+
+  deploy-to-nuget:
+    name: "Deploy to NuGet"
+    needs: ["build-and-validate"]
+    environment: "nuget.org"
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+    defaults:
+      run:
+        shell: "pwsh"
+    steps:
+      - name: "Download Artifacts"
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-and-validate.outputs.artifact-id }}
+
+      - name: "NuGet login (OIDC → temp API key)"
+        uses: "NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544" # v1
+        id: "nuget-login"
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: "NuGet Push"
+        run: "dotnet nuget push *.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json"


### PR DESCRIPTION
## Summary
This PR adds a second job to the GitHub Actions workflow for CI. It only runs when the build is manually triggered, and it uses an [environment](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments) to gate its running until approved. It's setup to use [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing), which still needs to be setup on the NuGet side (currently configured to use `MitchelSellers` as the NuGet user via an environment secret).

### Alternatives Considered
Instead of tacking this on to the end of each CI request, it could be a separate workflow that builds everything again (maybe triggered on creating a release), or a manual workflow that requires specifying an artifact ID.