### PR TITLE
Fix GitVersion not able to read history from repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v6.0.2"
+        with:
+          fetch-depth: 0 # include all history for GitVersion
 
       # Built-in caching is broken for Yarn, using setup-node twice
       # See https://github.com/actions/setup-node/issues/531#issuecomment-3335630863


### PR DESCRIPTION
## Summary
The default git checkout does not include history, so GitVersion was not able to determine the correct version. This PR includes all history when performing `git checkout` so that it works as expected.