### PR TITLE
Update env variables from `workflow_dispatch` inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       run:
         shell: "pwsh"
     steps:
+      - name: "Setup Environment Variables"
+        run: |
+          "CAKE_TARGET=${{ inputs.CAKE_TARGET || env.CAKE_TARGET }}" >> $env:GITHUB_ENV;
+          "CAKE_VERBOSITY=${{ inputs.CAKE_VERBOSITY || env.CAKE_VERBOSITY }}" >> $env:GITHUB_ENV;
+          "RELEASE_MODE=${{ inputs.RELEASE_MODE || env.RELEASE_MODE }}" >> $env:GITHUB_ENV;
+          "RUN_TESTS=${{ inputs.RUN_TESTS || env.RUN_TESTS }}" >> $env:GITHUB_ENV;
+
       - name: "Checkout"
         uses: "actions/checkout@v6.0.2"
 


### PR DESCRIPTION
GitHub Actions allows [defining inputs when manually triggering a build](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_dispatchinputs). However, these values are available only via [the `inputs` context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#inputs-context), which does not exist when the workflow runs due to another trigger.

Specifically, this meant that our current workflow does not actually use the manual input, only the defaults, since it just looks in the `env` context, instead of the `inputs` context.

Therefore, this PR adds a new step to [update the `env` context](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-environment-variable) with either the `inputs` value or the default.

Based on https://github.com/orgs/community/discussions/26322#discussioncomment-11553893