### PR TITLE
Fix CSP tests not running

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.ContentSecurityPolicy/DotNetNuke.Tests.ContentSecurityPolicy.csproj
+++ b/DNN Platform/Tests/DotNetNuke.Tests.ContentSecurityPolicy/DotNetNuke.Tests.ContentSecurityPolicy.csproj
@@ -7,6 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn),SA0001</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RootNamespace>DotNetNuke.ContentSecurityPolicy.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DNN_Platform.sln
+++ b/DNN_Platform.sln
@@ -631,7 +631,7 @@ Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "Dnn.ClientSide", "DNN Platf
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.ContentSecurityPolicy", "DNN Platform\DotNetNuke.ContentSecurityPolicy\DotNetNuke.ContentSecurityPolicy.csproj", "{33C9571D-E3AF-46FC-DC75-9CA082BBDC3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.ContentSecurityPolicy.Tests", "DNN Platform\Tests\DotNetNuke.Tests.ContentSecurityPolicy\DotNetNuke.ContentSecurityPolicy.Tests.csproj", "{66524EA5-0C3A-5159-DA42-2063DD4EB949}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Tests.ContentSecurityPolicy", "DNN Platform\Tests\DotNetNuke.Tests.ContentSecurityPolicy\DotNetNuke.Tests.ContentSecurityPolicy.csproj", "{66524EA5-0C3A-5159-DA42-2063DD4EB949}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetNuke.Web.Client.ResourceManager", "DNN Platform\DotNetNuke.Web.Client.ResourceManager\DotNetNuke.Web.Client.ResourceManager.csproj", "{039BAFBD-E2DB-40C4-B565-C27467D9B5E1}"
 EndProject


### PR DESCRIPTION
## Summary
The new ContentSecurityPolicy project has tests, but they aren't named in a way that the build automatically picks them up.