### PR TITLE
Use CI-aware helpers from Cake

### DIFF
--- a/Build/Context.cs
+++ b/Build/Context.cs
@@ -4,9 +4,11 @@
 namespace DotNetNuke.Build
 {
     using System;
+    using System.Globalization;
     using System.IO;
 
     using Cake.Common;
+    using Cake.Common.Build;
     using Cake.Common.Diagnostics;
     using Cake.Common.IO;
     using Cake.Common.IO.Paths;
@@ -63,7 +65,11 @@ namespace DotNetNuke.Build
                 this.Settings = LoadSettings(context, settingsFile);
                 this.WriteSettings(context, settingsFile);
 
-                this.BuildId = context.EnvironmentVariable("BUILD_BUILDID") ?? "0";
+                this.BuildId = context.AzurePipelines().IsRunningOnAzurePipelines
+                    ? context.AzurePipelines().Environment.Build.Id.ToString(CultureInfo.InvariantCulture)
+                    : context.GitHubActions().IsRunningOnGitHubActions
+                        ? context.GitHubActions().Environment.Workflow.RunId
+                        : "0";
                 context.Information($"BuildId: {this.BuildId}");
                 this.BuildNumber = string.Empty;
                 this.ProductVersion = string.Empty;

--- a/Build/Tasks/CreateGitHubPullRequest.cs
+++ b/Build/Tasks/CreateGitHubPullRequest.cs
@@ -14,6 +14,7 @@ namespace DotNetNuke.Build.Tasks
     using System.Text.RegularExpressions;
 
     using Cake.Common;
+    using Cake.Common.Build;
     using Cake.Common.Diagnostics;
     using Cake.Core;
     using Cake.Core.IO;
@@ -61,7 +62,11 @@ namespace DotNetNuke.Build.Tasks
                 return;
             }
 
-            var sourceBranch = context.EnvironmentVariable("BUILD_SOURCEBRANCH") ?? string.Empty;
+            var sourceBranch = context.AzurePipelines().IsRunningOnAzurePipelines
+                ? context.AzurePipelines().Environment.Repository.SourceBranch
+                : context.GitHubActions().IsRunningOnGitHubActions
+                    ? context.GitHubActions().Environment.Workflow.Ref
+                    : string.Empty;
             context.Information("CreateGitHubPullRequest: BUILD_SOURCEBRANCH is '{0}'.", sourceBranch);
             if (!IsTargetedBranch(sourceBranch))
             {
@@ -78,8 +83,11 @@ namespace DotNetNuke.Build.Tasks
             }
 
             // owner/repo – e.g. "dnnsoftware/Dnn.Platform"
-            var repoSlug = context.EnvironmentVariable("BUILD_REPOSITORY_NAME")
-                           ?? throw new CakeException("BUILD_REPOSITORY_NAME environment variable is not set.");
+            var repoSlug = context.AzurePipelines().IsRunningOnAzurePipelines
+                ? context.AzurePipelines().Environment.Repository.RepoName
+                : context.GitHubActions().IsRunningOnGitHubActions
+                    ? context.GitHubActions().Environment.Workflow.Repository
+                    : throw new CakeException("BUILD_REPOSITORY_NAME environment variable is not set.");
 
             var parts = repoSlug.Split('/');
             if (parts.Length != 2)


### PR DESCRIPTION
## Summary
The Cake build reads some environment variables to get context during CI. This needed to be updated to read different variables for GitHub Actions. This PR uses Cake's built-in helpers to read that info from the correct source.