### PR TITLE
Fix Simple Web Farm Caching Provider not getting packaged

### DIFF
--- a/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.csproj
+++ b/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputPath>bin/Providers</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <TargetFramework>net48</TargetFramework>
     <Deterministic>true</Deterministic>
     <LangVersion>latest</LangVersion>

--- a/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/Provider.build
+++ b/DNN Platform/Providers/CachingProviders/DotNetNuke.Providers.Caching.SimpleWebFarmCachingProvider/Provider.build
@@ -11,7 +11,7 @@
     <InstallPath>$(WebsiteInstallPath)\Provider</InstallPath>
   </PropertyGroup>
   <Import Project="$(BuildScriptsPath)\Package.Targets" />
-  <Target Name="AfterBuild" DependsOnTargets="DebugProject;Package">
+  <Target Name="CopyAndPackage" BeforeTargets="Build" DependsOnTargets="DebugProject;Package">
   </Target>
   <Target Name="DebugProject" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Copy SourceFiles="$(MSBuildProjectDirectory)/bin$(Providers)/$(AssemblyName).dll" DestinationFolder="$(WebsitePath)/bin$(Providers)" />

--- a/DNN Platform/Providers/FolderProviders/Provider.build
+++ b/DNN Platform/Providers/FolderProviders/Provider.build
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <Import Project="$(BuildScriptsPath)\Package.Targets" />
   <Target Name="CopyAndPackage" BeforeTargets="Build" DependsOnTargets="GetFiles;DebugProject;Package" />
-    <Target Name="GetFiles">
+  <Target Name="GetFiles">
     <ItemGroup>
       <TextFiles Include="*.txt" Exclude="license.txt;releasenotes.txt" />
       <Views Include="AzureFolderProvider/*.ascx" />


### PR DESCRIPTION
## Summary
Fixes #7170.

There were two issues. The first is that the project was using `<Target Name="AfterBuild" DependsOnTargets="Package" />` in order to run the `Package` task after the `Build` task. However, this no longer works in SDK-style projects (because these auto-generate a different `AfterBuild` task). The correct way to add a task into the pipeline is to use `BeforeTargets="Build"`, instead of relying on a conventional target name. Somehow that had been fixed for all other projects but got missed in this one.

The second issue that, once the project was actually trying to package itself (or to copy DLLs to the website output during a Debug build), it was failing to find the DLLs, because, again, SDK-style projects use a different default output path, and so that needed to be overridden.

Thanks @dimarobert for tracking this down and starting the fix!