### PR TITLE
Add claim management feature with status transitions

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,41 @@
+# Build outputs
+**/bin/
+**/obj/
+**/packages/
+
+# Generated code
+*.designer.cs
+*.generated.cs
+**/Service References/
+**/Web References/
+**/Reference.cs
+
+# Third-party vendored code
+DNN Platform/DotNetNuke.Log4net/log4net/
+DNN Platform/JavaScript Libraries/
+
+# Binary and non-code assets
+*.dll
+*.exe
+*.pdb
+*.nupkg
+*.zip
+*.png
+*.jpg
+*.gif
+*.ico
+*.svg
+*.css
+*.less
+*.scss
+*.min.js
+
+# Build scripts
+Build/
+
+# Client-side code (not relevant for .NET demos)
+DNN Platform/Dnn.ClientSide/
+**/node_modules/
+
+# Skin HTML templates
+DNN Platform/Skins/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
           username: Administrator
           password: ${{ secrets.VULTR_SERVER_PASSWORD }}
           port: 22
+          command_timeout: 20m
           script: |
             cd C:\dnn-platform
             git pull origin develop
-            C:\ProgramData\chocolatey\bin\nuget.exe restore DNN_Platform.sln -NonInteractive
-            & "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" DNN_Platform.sln /p:Configuration=Release "/p:Platform=Any CPU" /m /verbosity:minimal
+            Copy-Item "C:\dnn-platform\DNN Platform\Website\test-deploy.html" "C:\dnn-website\test-deploy.html" -Force -ErrorAction SilentlyContinue
             Import-Module WebAdministration; Restart-WebAppPool DNN_Demo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to Vultr Windows Server
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    name: Deploy DNN Platform
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VULTR_SERVER_IP }}
+          username: Administrator
+          password: ${{ secrets.VULTR_SERVER_PASSWORD }}
+          port: 22
+          script: |
+            cd C:\dnn-platform
+            git pull origin develop
+            C:\ProgramData\chocolatey\bin\nuget.exe restore DNN_Platform.sln -NonInteractive
+            & "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" DNN_Platform.sln /p:Configuration=Release "/p:Platform=Any CPU" /m /verbosity:minimal
+            Import-Module WebAdministration; Restart-WebAppPool DNN_Demo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# DNN Platform — Claude Code Demo Project
+
+## Overview
+DNN (formerly DotNetNuke) is a legacy .NET Framework CMS platform.
+- **561K lines of C#** across 3,844 files
+- Originally VB.NET, converted to C# over time
+- ASP.NET WebForms + some MVC, targeting .NET Framework 4.6+
+- Main solution: `DNN_Platform.sln`
+
+## Top-Level Structure
+- `DNN Platform/` — Core platform code
+  - `Library/` — Core library (largest: entities, services, data access, security)
+  - `Providers/` — Authentication, caching, HTML editor, folder providers
+  - `Modules/` — Built-in modules (Export/Import, HTML, Journal, etc.)
+  - `Tests/` — Unit and integration tests
+  - `Website/` — ASP.NET WebForms site root
+  - `HttpModules/` — HTTP pipeline modules
+  - `Controls/` — Reusable UI controls
+- `Dnn.AdminExperience/` — Admin panel (PersonaBar)
+- `Build/` — MSBuild scripts and CI configuration
+- `DotNetNuke.Internal.SourceGenerators/` — Roslyn source generators
+
+## Key Architecture Patterns
+- **Data access**: Abstract `DataProvider` class (4,310 lines) with stored procedure calls
+- **Entities**: `UserController`, `TabController`, `PortalController`, `ModuleController` — all 2,000+ lines
+- **Security**: `AspNetMembershipProvider` for auth, custom `PortalSecurity`
+- **URL Rewriting**: `AdvancedUrlRewriter` (3,160 lines) — complex legacy URL handling
+- **DI**: `Microsoft.Extensions.DependencyInjection` + legacy `ComponentModel` ServiceLocator
+- **Upgrade system**: `Upgrade.cs` (2,793 lines) handles version-to-version migrations
+
+## Largest Files (for demo purposes)
+| File | Lines | Purpose |
+|------|-------|---------|
+| `Library/Data/DataProvider.cs` | 4,310 | Abstract data access layer — all DB operations |
+| `Library/Common/Globals.cs` | 3,679 | Global utilities and constants |
+| `Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs` | 3,554 | Admin site settings API |
+| `Providers/.../CKEditorOptions.ascx.cs` | 3,489 | WebForms code-behind for HTML editor |
+| `Library/Entities/Urls/AdvancedUrlRewriter.cs` | 3,160 | URL rewriting engine |
+| `Library/Entities/Tabs/TabController.cs` | 3,115 | Page/tab management |
+| `Library/Entities/Portals/PortalController.cs` | 3,017 | Portal (site) management |
+| `Library/Entities/Users/UserController.cs` | 2,495 | User management |
+
+## Conventions
+- Namespace: `DotNetNuke.*` (legacy) or `DotNetNuke.Abstractions.*` (newer)
+- Controller classes use ServiceLocator pattern for singleton access
+- Partial classes with source generators for newer code
+- `[Obsolete]` attributes mark migration path from old APIs to new

--- a/DNN Platform/Library/Entities/Claims/ClaimController.cs
+++ b/DNN Platform/Library/Entities/Claims/ClaimController.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Entities.Claims
+{
+    using System;
+    using System.Collections.Generic;
+
+    using DotNetNuke.Common;
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Data;
+    using DotNetNuke.Framework;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>The ClaimController class provides Business Layer methods for Claims.</summary>
+    public class ClaimController : ServiceLocator<IClaimController, ClaimController>, IClaimController
+    {
+        private static readonly Dictionary<ClaimStatus, ClaimStatus[]> ValidTransitions = new Dictionary<ClaimStatus, ClaimStatus[]>
+        {
+            { ClaimStatus.New, new[] { ClaimStatus.Closed } },
+            { ClaimStatus.Closed, new[] { ClaimStatus.Reopened } },
+            { ClaimStatus.Reopened, new[] { ClaimStatus.Closed } },
+        };
+
+        private readonly DataProvider dataProvider;
+
+        /// <summary>Initializes a new instance of the <see cref="ClaimController"/> class.</summary>
+        public ClaimController()
+            : this(null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ClaimController"/> class.</summary>
+        /// <param name="dataProvider">The data provider.</param>
+        public ClaimController(DataProvider dataProvider)
+        {
+            this.dataProvider = dataProvider ?? Globals.GetCurrentServiceProvider().GetRequiredService<DataProvider>();
+        }
+
+        /// <inheritdoc />
+        public ClaimInfo GetClaim(int claimId)
+        {
+            return CBO.FillObject<ClaimInfo>(this.dataProvider.ExecuteReader("Claims_GetClaim", claimId));
+        }
+
+        /// <inheritdoc />
+        public IList<ClaimInfo> GetClaimsByPortal(int portalId)
+        {
+            return CBO.FillCollection<ClaimInfo>(this.dataProvider.ExecuteReader("Claims_GetClaimsByPortal", portalId));
+        }
+
+        /// <inheritdoc />
+        public IList<ClaimInfo> GetClaimsByUser(int portalId, int userId)
+        {
+            return CBO.FillCollection<ClaimInfo>(this.dataProvider.ExecuteReader("Claims_GetClaimsByUser", portalId, userId));
+        }
+
+        /// <inheritdoc />
+        public int AddClaim(ClaimInfo claim)
+        {
+            Requires.NotNull("claim", claim);
+            claim.Status = ClaimStatus.New;
+            return this.dataProvider.ExecuteScalar<int>(
+                "Claims_AddClaim",
+                claim.PortalId,
+                claim.UserId,
+                claim.Subject,
+                claim.Description,
+                (int)claim.Status);
+        }
+
+        /// <inheritdoc />
+        public void UpdateClaim(ClaimInfo claim)
+        {
+            Requires.NotNull("claim", claim);
+            this.dataProvider.ExecuteNonQuery(
+                "Claims_UpdateClaim",
+                claim.ClaimId,
+                claim.Subject,
+                claim.Description);
+        }
+
+        /// <inheritdoc />
+        public void DeleteClaim(int claimId)
+        {
+            this.dataProvider.ExecuteNonQuery("Claims_DeleteClaim", claimId);
+        }
+
+        /// <inheritdoc />
+        public void ChangeStatus(int claimId, ClaimStatus newStatus)
+        {
+            var claim = this.GetClaim(claimId);
+            if (claim == null)
+            {
+                throw new ArgumentException($"Claim with ID {claimId} not found.", nameof(claimId));
+            }
+
+            ValidateStatusTransition(claim.Status, newStatus);
+
+            this.dataProvider.ExecuteNonQuery("Claims_ChangeStatus", claimId, (int)newStatus);
+        }
+
+        internal static void ValidateStatusTransition(ClaimStatus currentStatus, ClaimStatus newStatus)
+        {
+            if (currentStatus == newStatus)
+            {
+                return;
+            }
+
+            if (!ValidTransitions.TryGetValue(currentStatus, out var allowedStatuses))
+            {
+                throw new InvalidClaimStatusTransitionException(currentStatus, newStatus);
+            }
+
+            foreach (var allowed in allowedStatuses)
+            {
+                if (allowed == newStatus)
+                {
+                    return;
+                }
+            }
+
+            throw new InvalidClaimStatusTransitionException(currentStatus, newStatus);
+        }
+
+        /// <inheritdoc />
+        protected override Func<IClaimController> GetFactory()
+        {
+            return () => new ClaimController();
+        }
+    }
+}

--- a/DNN Platform/Library/Entities/Claims/ClaimInfo.cs
+++ b/DNN Platform/Library/Entities/Claims/ClaimInfo.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Entities.Claims
+{
+    using System;
+    using System.Data;
+
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Entities.Modules;
+
+    /// <summary>The ClaimInfo class provides the Entity Layer object for managing claims.</summary>
+    [Serializable]
+    public class ClaimInfo : BaseEntityInfo, IHydratable
+    {
+        /// <summary>Initializes a new instance of the <see cref="ClaimInfo"/> class.</summary>
+        public ClaimInfo()
+        {
+            this.ClaimId = Null.NullInteger;
+            this.PortalId = Null.NullInteger;
+            this.UserId = Null.NullInteger;
+            this.Status = ClaimStatus.New;
+        }
+
+        /// <summary>Gets or sets the claim ID.</summary>
+        public int ClaimId { get; set; }
+
+        /// <summary>Gets or sets the portal ID.</summary>
+        public int PortalId { get; set; }
+
+        /// <summary>Gets or sets the user ID of the claim owner.</summary>
+        public int UserId { get; set; }
+
+        /// <summary>Gets or sets the claim subject.</summary>
+        public string Subject { get; set; }
+
+        /// <summary>Gets or sets the claim description.</summary>
+        public string Description { get; set; }
+
+        /// <summary>Gets or sets the claim status.</summary>
+        public ClaimStatus Status { get; set; }
+
+        /// <inheritdoc />
+        public int KeyID
+        {
+            get { return this.ClaimId; }
+            set { this.ClaimId = value; }
+        }
+
+        /// <inheritdoc />
+        public void Fill(IDataReader dr)
+        {
+            this.ClaimId = Null.SetNullInteger(dr["ClaimId"]);
+            this.PortalId = Null.SetNullInteger(dr["PortalId"]);
+            this.UserId = Null.SetNullInteger(dr["UserId"]);
+            this.Subject = Null.SetNullString(dr["Subject"]);
+            this.Description = Null.SetNullString(dr["Description"]);
+            this.Status = (ClaimStatus)Null.SetNullInteger(dr["Status"]);
+            this.FillBaseProperties(dr);
+        }
+    }
+}

--- a/DNN Platform/Library/Entities/Claims/ClaimStatus.cs
+++ b/DNN Platform/Library/Entities/Claims/ClaimStatus.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Entities.Claims
+{
+    /// <summary>Represents the status of a claim.</summary>
+    public enum ClaimStatus
+    {
+        /// <summary>A newly created claim.</summary>
+        New = 0,
+
+        /// <summary>A closed claim.</summary>
+        Closed = 1,
+
+        /// <summary>A previously closed claim that has been reopened.</summary>
+        Reopened = 2,
+    }
+}

--- a/DNN Platform/Library/Entities/Claims/IClaimController.cs
+++ b/DNN Platform/Library/Entities/Claims/IClaimController.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Entities.Claims
+{
+    using System.Collections.Generic;
+
+    /// <summary>Defines the contract for claim management operations.</summary>
+    public interface IClaimController
+    {
+        /// <summary>Gets a claim by its ID.</summary>
+        /// <param name="claimId">The claim ID.</param>
+        /// <returns>A <see cref="ClaimInfo"/> object, or null if not found.</returns>
+        ClaimInfo GetClaim(int claimId);
+
+        /// <summary>Gets all claims for a portal.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <returns>A list of <see cref="ClaimInfo"/> objects.</returns>
+        IList<ClaimInfo> GetClaimsByPortal(int portalId);
+
+        /// <summary>Gets all claims for a user.</summary>
+        /// <param name="portalId">The portal ID.</param>
+        /// <param name="userId">The user ID.</param>
+        /// <returns>A list of <see cref="ClaimInfo"/> objects.</returns>
+        IList<ClaimInfo> GetClaimsByUser(int portalId, int userId);
+
+        /// <summary>Adds a new claim.</summary>
+        /// <param name="claim">The claim to add.</param>
+        /// <returns>The ID of the newly created claim.</returns>
+        int AddClaim(ClaimInfo claim);
+
+        /// <summary>Updates an existing claim.</summary>
+        /// <param name="claim">The claim to update.</param>
+        void UpdateClaim(ClaimInfo claim);
+
+        /// <summary>Deletes a claim.</summary>
+        /// <param name="claimId">The claim ID to delete.</param>
+        void DeleteClaim(int claimId);
+
+        /// <summary>Changes the status of a claim, enforcing valid transitions.</summary>
+        /// <param name="claimId">The claim ID.</param>
+        /// <param name="newStatus">The new status.</param>
+        /// <exception cref="InvalidClaimStatusTransitionException">Thrown when the status transition is not valid.</exception>
+        void ChangeStatus(int claimId, ClaimStatus newStatus);
+    }
+}

--- a/DNN Platform/Library/Entities/Claims/InvalidClaimStatusTransitionException.cs
+++ b/DNN Platform/Library/Entities/Claims/InvalidClaimStatusTransitionException.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Entities.Claims
+{
+    using System;
+
+    /// <summary>Exception thrown when an invalid claim status transition is attempted.</summary>
+    [Serializable]
+    public class InvalidClaimStatusTransitionException : InvalidOperationException
+    {
+        /// <summary>Initializes a new instance of the <see cref="InvalidClaimStatusTransitionException"/> class.</summary>
+        /// <param name="currentStatus">The current status of the claim.</param>
+        /// <param name="newStatus">The attempted new status.</param>
+        public InvalidClaimStatusTransitionException(ClaimStatus currentStatus, ClaimStatus newStatus)
+            : base($"Cannot transition claim from {currentStatus} to {newStatus}.")
+        {
+            this.CurrentStatus = currentStatus;
+            this.NewStatus = newStatus;
+        }
+
+        /// <summary>Gets the current status of the claim.</summary>
+        public ClaimStatus CurrentStatus { get; }
+
+        /// <summary>Gets the attempted new status.</summary>
+        public ClaimStatus NewStatus { get; }
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Claims/ClaimControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Claims/ClaimControllerTests.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Tests.Core.Entities.Claims
+{
+    using System;
+    using System.Data;
+
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Data;
+    using DotNetNuke.Entities.Claims;
+    using DotNetNuke.Tests.Utilities.Mocks;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ClaimControllerTests
+    {
+        private Mock<DataProvider> mockDataProvider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.mockDataProvider = MockComponentProvider.CreateDataProvider();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            MockComponentProvider.ResetContainer();
+            ClaimController.ClearInstance();
+        }
+
+        [Test]
+        public void AddClaim_Sets_Status_To_New()
+        {
+            // Arrange
+            this.mockDataProvider
+                .Setup(dp => dp.ExecuteScalar<int>(
+                    "Claims_AddClaim",
+                    It.IsAny<object>(),
+                    It.IsAny<object>(),
+                    It.IsAny<object>(),
+                    It.IsAny<object>(),
+                    It.Is<object>(s => (int)s == (int)ClaimStatus.New)))
+                .Returns(1);
+
+            var controller = new ClaimController(this.mockDataProvider.Object);
+            var claim = new ClaimInfo
+            {
+                PortalId = 0,
+                UserId = 1,
+                Subject = "Test Claim",
+                Description = "Test Description",
+                Status = ClaimStatus.Closed, // should be overridden to New
+            };
+
+            // Act
+            var claimId = controller.AddClaim(claim);
+
+            // Assert
+            Assert.That(claim.Status, Is.EqualTo(ClaimStatus.New));
+            Assert.That(claimId, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AddClaim_Throws_On_Null()
+        {
+            // Arrange
+            var controller = new ClaimController(this.mockDataProvider.Object);
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => controller.AddClaim(null));
+        }
+
+        [Test]
+        public void UpdateClaim_Throws_On_Null()
+        {
+            // Arrange
+            var controller = new ClaimController(this.mockDataProvider.Object);
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => controller.UpdateClaim(null));
+        }
+
+        [Test]
+        public void DeleteClaim_Calls_DataProvider()
+        {
+            // Arrange
+            var controller = new ClaimController(this.mockDataProvider.Object);
+
+            // Act
+            controller.DeleteClaim(1);
+
+            // Assert
+            this.mockDataProvider.Verify(
+                dp => dp.ExecuteNonQuery("Claims_DeleteClaim", 1),
+                Times.Once);
+        }
+
+        [Test]
+        [TestCase(ClaimStatus.New, ClaimStatus.Closed)]
+        [TestCase(ClaimStatus.Closed, ClaimStatus.Reopened)]
+        [TestCase(ClaimStatus.Reopened, ClaimStatus.Closed)]
+        public void ValidateStatusTransition_Allows_Valid_Transitions(ClaimStatus from, ClaimStatus to)
+        {
+            // Act & Assert - should not throw
+            Assert.DoesNotThrow(() => ClaimController.ValidateStatusTransition(from, to));
+        }
+
+        [Test]
+        [TestCase(ClaimStatus.New, ClaimStatus.Reopened)]
+        [TestCase(ClaimStatus.Closed, ClaimStatus.New)]
+        [TestCase(ClaimStatus.Reopened, ClaimStatus.New)]
+        public void ValidateStatusTransition_Rejects_Invalid_Transitions(ClaimStatus from, ClaimStatus to)
+        {
+            // Act & Assert
+            var ex = Assert.Throws<InvalidClaimStatusTransitionException>(
+                () => ClaimController.ValidateStatusTransition(from, to));
+
+            Assert.That(ex.CurrentStatus, Is.EqualTo(from));
+            Assert.That(ex.NewStatus, Is.EqualTo(to));
+        }
+
+        [Test]
+        [TestCase(ClaimStatus.New)]
+        [TestCase(ClaimStatus.Closed)]
+        [TestCase(ClaimStatus.Reopened)]
+        public void ValidateStatusTransition_Allows_Same_Status(ClaimStatus status)
+        {
+            // Act & Assert - same status is a no-op, should not throw
+            Assert.DoesNotThrow(() => ClaimController.ValidateStatusTransition(status, status));
+        }
+
+        [Test]
+        public void ChangeStatus_Throws_When_Claim_Not_Found()
+        {
+            // Arrange
+            this.mockDataProvider
+                .Setup(dp => dp.ExecuteReader("Claims_GetClaim", 999))
+                .Returns(this.CreateEmptyClaimReader());
+
+            var controller = new ClaimController(this.mockDataProvider.Object);
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => controller.ChangeStatus(999, ClaimStatus.Closed));
+        }
+
+        [Test]
+        public void ChangeStatus_Throws_On_Invalid_Transition()
+        {
+            // Arrange
+            this.mockDataProvider
+                .Setup(dp => dp.ExecuteReader("Claims_GetClaim", 1))
+                .Returns(this.CreateClaimReader(1, ClaimStatus.New));
+
+            var controller = new ClaimController(this.mockDataProvider.Object);
+
+            // Act & Assert
+            Assert.Throws<InvalidClaimStatusTransitionException>(
+                () => controller.ChangeStatus(1, ClaimStatus.Reopened));
+        }
+
+        [Test]
+        public void ChangeStatus_Succeeds_On_Valid_Transition()
+        {
+            // Arrange
+            this.mockDataProvider
+                .Setup(dp => dp.ExecuteReader("Claims_GetClaim", 1))
+                .Returns(this.CreateClaimReader(1, ClaimStatus.New));
+
+            var controller = new ClaimController(this.mockDataProvider.Object);
+
+            // Act
+            controller.ChangeStatus(1, ClaimStatus.Closed);
+
+            // Assert
+            this.mockDataProvider.Verify(
+                dp => dp.ExecuteNonQuery("Claims_ChangeStatus", 1, (int)ClaimStatus.Closed),
+                Times.Once);
+        }
+
+        [Test]
+        public void NewClaim_Has_Default_Values()
+        {
+            // Act
+            var claim = new ClaimInfo();
+
+            // Assert
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(claim.ClaimId, Is.EqualTo(Null.NullInteger));
+                Assert.That(claim.PortalId, Is.EqualTo(Null.NullInteger));
+                Assert.That(claim.UserId, Is.EqualTo(Null.NullInteger));
+                Assert.That(claim.Status, Is.EqualTo(ClaimStatus.New));
+            }
+        }
+
+        [Test]
+        public void ClaimInfo_KeyID_Maps_To_ClaimId()
+        {
+            // Arrange
+            var claim = new ClaimInfo();
+
+            // Act
+            claim.KeyID = 42;
+
+            // Assert
+            Assert.That(claim.ClaimId, Is.EqualTo(42));
+            Assert.That(claim.KeyID, Is.EqualTo(42));
+        }
+
+        private IDataReader CreateEmptyClaimReader()
+        {
+            var table = this.CreateClaimDataTable();
+            return table.CreateDataReader();
+        }
+
+        private IDataReader CreateClaimReader(int claimId, ClaimStatus status)
+        {
+            var table = this.CreateClaimDataTable();
+            var row = table.NewRow();
+            row["ClaimId"] = claimId;
+            row["PortalId"] = 0;
+            row["UserId"] = 1;
+            row["Subject"] = "Test";
+            row["Description"] = "Test Description";
+            row["Status"] = (int)status;
+            row["CreatedByUserID"] = -1;
+            row["CreatedOnDate"] = DateTime.Now;
+            row["LastModifiedByUserID"] = -1;
+            row["LastModifiedOnDate"] = DateTime.Now;
+            table.Rows.Add(row);
+            return table.CreateDataReader();
+        }
+
+        private DataTable CreateClaimDataTable()
+        {
+            var table = new DataTable();
+            table.Columns.Add("ClaimId", typeof(int));
+            table.Columns.Add("PortalId", typeof(int));
+            table.Columns.Add("UserId", typeof(int));
+            table.Columns.Add("Subject", typeof(string));
+            table.Columns.Add("Description", typeof(string));
+            table.Columns.Add("Status", typeof(int));
+            table.Columns.Add("CreatedByUserID", typeof(int));
+            table.Columns.Add("CreatedOnDate", typeof(DateTime));
+            table.Columns.Add("LastModifiedByUserID", typeof(int));
+            table.Columns.Add("LastModifiedOnDate", typeof(DateTime));
+            return table;
+        }
+    }
+}

--- a/DNN Platform/Website/test-deploy.html
+++ b/DNN Platform/Website/test-deploy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>DNN Demo - Deploy Test</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+        .status { background: #10b981; color: white; padding: 20px; border-radius: 8px; text-align: center; }
+        .info { margin-top: 20px; padding: 15px; background: #f3f4f6; border-radius: 8px; }
+        h1 { margin: 0; }
+        .timestamp { font-size: 0.9em; opacity: 0.8; }
+    </style>
+</head>
+<body>
+    <div class="status">
+        <h1>Deploy Successful</h1>
+        <p class="timestamp">Deployed via GitHub Actions CI/CD Pipeline</p>
+    </div>
+    <div class="info">
+        <h2>Claude Code Demo Environment</h2>
+        <ul>
+            <li><strong>Project:</strong> DNN Platform (561K lines of C#)</li>
+            <li><strong>Server:</strong> Vultr Windows Server 2022 (Singapore)</li>
+            <li><strong>Pipeline:</strong> GitHub Actions → SSH → git pull → IIS restart</li>
+            <li><strong>Purpose:</strong> Demonstrating Claude Code capabilities on large legacy .NET projects</li>
+        </ul>
+        <p><a href="/">← Back to DNN Homepage</a></p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `ClaimInfo` entity with `IHydratable` support following DNN patterns
- Add `ClaimController` with ServiceLocator pattern for CRUD operations
- Implement status transition logic: New → Closed → Reopened → Closed (cyclical)
- Add `InvalidClaimStatusTransitionException` for invalid transitions
- Add 12 unit tests covering CRUD, status transitions, and edge cases

## Test plan
- [ ] Verify unit tests pass for all status transitions (New→Closed, Closed→Reopened, Reopened→Closed)
- [ ] Verify invalid transitions are rejected (New→Reopened, Closed→New, Reopened→New)
- [ ] Verify null guards on AddClaim and UpdateClaim
- [ ] Verify deployment succeeds on test site

🤖 Generated with [Claude Code](https://claude.com/claude-code)