### PR TITLE
Async support for MVC controllers.

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Mvc/AsyncMvcHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/AsyncMvcHostControl.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+namespace DotNetNuke.Web.Mvc
+{
+    using System;
+    using System.Globalization;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Web;
+    using System.Web.UI;
+
+    using DotNetNuke.Services.Exceptions;
+    using DotNetNuke.UI.Modules;
+    using DotNetNuke.Web.Mvc.Routing;
+
+    public class AsyncMvcHostControl : MvcHostControl, IAsyncModuleControl
+    {
+        public AsyncMvcHostControl()
+            : base()
+        {
+        }
+
+        public AsyncMvcHostControl(string controlKey)
+            : base(controlKey)
+        {
+        }
+
+        protected override void OnInitInternal(EventArgs e)
+        {
+            if (this.ExecuteModuleImmediately)
+            {
+                this.Page.RegisterAsyncTask(new PageAsyncTask(this.ExecuteModuleAsync));
+            }
+        }
+
+        protected override void OnPreRenderInternal(EventArgs e)
+        {
+            this.Page.RegisterAsyncTask(new PageAsyncTask(this.OnPreRenderAsync));
+        }
+
+        protected async Task ExecuteModuleAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                HttpContextBase httpContext = new HttpContextWrapper(HttpContext.Current);
+
+                var moduleExecutionEngine = GetModuleExecutionEngine();
+
+                this.Result = await moduleExecutionEngine.ExecuteModuleAsync(this.GetModuleRequestContext(httpContext), cancellationToken);
+
+                this.ModuleActions = this.LoadActions(this.Result);
+
+                httpContext.SetModuleRequestResult(this.Result);
+            }
+            catch (Exception exc)
+            {
+                Exceptions.ProcessModuleLoadException(this, exc);
+            }
+        }
+
+        private Task OnPreRenderAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (this.Result == null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                var mvcString = RenderModule(this.Result);
+                if (!string.IsNullOrEmpty(Convert.ToString(mvcString, CultureInfo.InvariantCulture)))
+                {
+                    this.Controls.Add(new LiteralControl(Convert.ToString(mvcString, CultureInfo.InvariantCulture)));
+                }
+            }
+            catch (Exception exc)
+            {
+                Exceptions.ProcessModuleLoadException(this, exc);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web.Mvc/AsyncMvcHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/AsyncMvcHostControl.cs
@@ -36,6 +36,7 @@ namespace DotNetNuke.Web.Mvc
 
         protected override void OnPreRenderInternal(EventArgs e)
         {
+            // We need to defer execution to after the async task registered in OnInitInternal above, which will only get executed at the WebForms async point, just before PreRenderComplete.
             this.Page.RegisterAsyncTask(new PageAsyncTask(this.OnPreRenderAsync));
         }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/AsyncMvcSettingsControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/AsyncMvcSettingsControl.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Web.Mvc
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.UI.Modules;
+
+    public class AsyncMvcSettingsControl : AsyncMvcHostControl, IAsyncSettingsControl
+    {
+        public AsyncMvcSettingsControl()
+            : base("Settings")
+        {
+            this.ExecuteModuleImmediately = false;
+        }
+
+        /// <inheritdoc/>
+        public void LoadSettings()
+        {
+            throw new NotSupportedException("Async controls need to call LoadSettingsAsync.");
+        }
+
+        /// <inheritdoc/>
+        public Task LoadSettingsAsync(CancellationToken cancellationToken)
+        {
+            return this.ExecuteModuleAsync(cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public void UpdateSettings()
+        {
+            throw new NotSupportedException("Async controls need to call UpdateSettingsAsync.");
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateSettingsAsync(CancellationToken cancellationToken)
+        {
+            await this.ExecuteModuleAsync(cancellationToken);
+
+            ModuleController.Instance.UpdateModule(this.ModuleContext.Configuration);
+        }
+    }
+}

--- a/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcHandler.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/DnnMvcHandler.cs
@@ -4,6 +4,8 @@
 namespace DotNetNuke.Web.Mvc
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Web;
     using System.Web.Mvc;
     using System.Web.Routing;
@@ -26,7 +28,7 @@ namespace DotNetNuke.Web.Mvc
 
     using Microsoft.Extensions.DependencyInjection;
 
-    public class DnnMvcHandler : IHttpHandler, IRequiresSessionState
+    public class DnnMvcHandler : HttpTaskAsyncHandler, IRequiresSessionState
     {
         public static readonly string MvcVersionHeaderName = "X-AspNetMvc-Version";
 
@@ -41,19 +43,13 @@ namespace DotNetNuke.Web.Mvc
 
         public RequestContext RequestContext { get; private set; }
 
-        /// <inheritdoc />
-        bool IHttpHandler.IsReusable => this.IsReusable;
-
         internal ControllerBuilder ControllerBuilder
         {
             get => this.controllerBuilder ??= ControllerBuilder.Current;
             set => this.controllerBuilder = value;
         }
 
-        protected virtual bool IsReusable => false;
-
-        /// <inheritdoc />
-        void IHttpHandler.ProcessRequest(HttpContext httpContext)
+        public override async Task ProcessRequestAsync(HttpContext context)
         {
             SetThreadCulture();
             MembershipModule.AuthenticateRequest(
@@ -65,10 +61,12 @@ namespace DotNetNuke.Web.Mvc
                 Globals.GetCurrentServiceProvider().GetRequiredService<IHostSettings>(),
                 this.RequestContext.HttpContext,
                 allowUnknownExtensions: true);
-            this.ProcessRequest(httpContext);
+
+            var httpContextBase = new HttpContextWrapper(context);
+            await this.ProcessRequestAsync(httpContextBase, httpContextBase.Response.ClientDisconnectedToken);
         }
 
-        protected internal virtual void ProcessRequest(HttpContextBase httpContext)
+        protected internal virtual async Task ProcessRequestAsync(HttpContextBase httpContext, CancellationToken cancellationToken)
         {
             try
             {
@@ -76,19 +74,13 @@ namespace DotNetNuke.Web.Mvc
 
                 // Check if the controller supports IDnnController
                 var moduleResult =
-                    moduleExecutionEngine.ExecuteModule(this.GetModuleRequestContext(httpContext));
+                    await moduleExecutionEngine.ExecuteModuleAsync(this.GetModuleRequestContext(httpContext), cancellationToken);
                 httpContext.SetModuleRequestResult(moduleResult);
                 this.RenderModule(moduleResult);
             }
             finally
             {
             }
-        }
-
-        protected virtual void ProcessRequest(HttpContext httpContext)
-        {
-            HttpContextBase httpContextBase = new HttpContextWrapper(httpContext);
-            this.ProcessRequest(httpContextBase);
         }
 
         private static void SetThreadCulture()

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionFilters/ModuleActionItemsAttribute.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionFilters/ModuleActionItemsAttribute.cs
@@ -26,6 +26,47 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionFilters
         public override void OnActionExecuting(ActionExecutingContext filterContext)
         {
             var controller = filterContext.Controller as IDnnController;
+            var result = this.InvokeMethod(filterContext, controller, false);
+            if (result is ModuleActionCollection moduleActions)
+            {
+                controller.ModuleActions = moduleActions;
+            }
+        }
+
+        public async Task OnActionExecutingAsync(ActionExecutingContext filterContext)
+        {
+            var controller = filterContext.Controller as IDnnController;
+            var result = this.InvokeMethod(filterContext, controller, true);
+            if (result is ModuleActionCollection moduleActions)
+            {
+                controller.ModuleActions = moduleActions;
+            }
+            else if (result is Task<ModuleActionCollection> taskResult)
+            {
+                controller.ModuleActions = await taskResult;
+            }
+        }
+
+        private static MethodInfo GetMethod(Type type, string methodName, bool supportsAsync)
+        {
+            var method = type.GetMethod(methodName);
+
+            if (method == null)
+            {
+                throw new NotImplementedException($"The expected method to get the module actions cannot be found. Type: {type.FullName}, Method: {methodName}");
+            }
+
+            var returnType = method.ReturnType;
+            if (returnType == typeof(ModuleActionCollection) || (supportsAsync && returnType == typeof(Task<ModuleActionCollection>)))
+            {
+                return method;
+            }
+
+            throw new InvalidOperationException("The method must return an object of type ModuleActionCollection");
+        }
+
+        private object InvokeMethod(ActionExecutingContext filterContext, IDnnController controller, bool supportsAsync)
+        {
             Type type;
             string methodName;
 
@@ -56,35 +97,9 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionFilters
                 methodName = this.MethodName;
             }
 
-            var method = GetMethod(type, methodName, controller.IsAsync);
+            var method = GetMethod(type, methodName, supportsAsync);
 
-            var result = method.Invoke(instance, null);
-            if (result is ModuleActionCollection moduleActions)
-            {
-                controller.ModuleActions = moduleActions;
-            }
-            else if (result is Task<ModuleActionCollection> taskResult)
-            {
-                controller.ModuleActionsAsync = taskResult;
-            }
-        }
-
-        private static MethodInfo GetMethod(Type type, string methodName, bool supportsAsync)
-        {
-            var method = type.GetMethod(methodName);
-
-            if (method == null)
-            {
-                throw new NotImplementedException($"The expected method to get the module actions cannot be found. Type: {type.FullName}, Method: {methodName}");
-            }
-
-            var returnType = method.ReturnType;
-            if (returnType == typeof(ModuleActionCollection) || (supportsAsync && returnType == typeof(Task<ModuleActionCollection>)))
-            {
-                return method;
-            }
-
-            throw new InvalidOperationException("The method must return an object of type ModuleActionCollection");
+            return method.Invoke(instance, null);
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionFilters/ModuleActionItemsAttribute.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionFilters/ModuleActionItemsAttribute.cs
@@ -7,6 +7,7 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionFilters
     using System;
     using System.Globalization;
     using System.Reflection;
+    using System.Threading.Tasks;
     using System.Web.Mvc;
 
     using DotNetNuke.Entities.Modules.Actions;
@@ -55,12 +56,20 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionFilters
                 methodName = this.MethodName;
             }
 
-            var method = GetMethod(type, methodName);
+            var method = GetMethod(type, methodName, controller.IsAsync);
 
-            controller.ModuleActions = method.Invoke(instance, null) as ModuleActionCollection;
+            var result = method.Invoke(instance, null);
+            if (result is ModuleActionCollection moduleActions)
+            {
+                controller.ModuleActions = moduleActions;
+            }
+            else if (result is Task<ModuleActionCollection> taskResult)
+            {
+                controller.ModuleActionsAsync = taskResult;
+            }
         }
 
-        private static MethodInfo GetMethod(Type type, string methodName)
+        private static MethodInfo GetMethod(Type type, string methodName, bool supportsAsync)
         {
             var method = type.GetMethod(methodName);
 
@@ -69,13 +78,13 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionFilters
                 throw new NotImplementedException($"The expected method to get the module actions cannot be found. Type: {type.FullName}, Method: {methodName}");
             }
 
-            var returnType = method.ReturnType.FullName;
-            if (returnType != "DotNetNuke.Entities.Modules.Actions.ModuleActionCollection")
+            var returnType = method.ReturnType;
+            if (returnType == typeof(ModuleActionCollection) || (supportsAsync && returnType == typeof(Task<ModuleActionCollection>)))
             {
-                throw new InvalidOperationException("The method must return an object of type ModuleActionCollection");
+                return method;
             }
 
-            return method;
+            throw new InvalidOperationException("The method must return an object of type ModuleActionCollection");
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnPartialViewResult.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnPartialViewResult.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionResults
 
             if (this.View == null)
             {
-                result = this.ViewEngineCollection.FindPartialView(context, this.ViewName);
+                result = this.FindView(context);
                 this.View = result.View;
             }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnViewResult.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ActionResults/DnnViewResult.cs
@@ -27,7 +27,7 @@ namespace DotNetNuke.Web.Mvc.Framework.ActionResults
 
             if (this.View == null)
             {
-                result = this.ViewEngineCollection.FindView(context, this.ViewName, this.MasterName);
+                result = this.FindView(context);
                 this.View = result.View;
             }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
@@ -73,12 +73,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
         /// <inheritdoc />
         public ModuleActionCollection ModuleActions { get; set; }
 
-        /// <inheritdoc/>
-        public Task<ModuleActionCollection> ModuleActionsAsync { get; set; }
-
-        /// <inheritdoc/>
-        public bool IsAsync { get; set; }
-
         /// <inheritdoc />
         public ModuleInstanceContext ModuleContext { get; set; }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/DnnController.cs
@@ -7,6 +7,7 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Text;
+    using System.Threading.Tasks;
     using System.Web.Mvc;
     using System.Web.Routing;
     using System.Web.UI;
@@ -71,6 +72,12 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
 
         /// <inheritdoc />
         public ModuleActionCollection ModuleActions { get; set; }
+
+        /// <inheritdoc/>
+        public Task<ModuleActionCollection> ModuleActionsAsync { get; set; }
+
+        /// <inheritdoc/>
+        public bool IsAsync { get; set; }
 
         /// <inheritdoc />
         public ModuleInstanceContext ModuleContext { get; set; }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/IDnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/IDnnController.cs
@@ -5,7 +5,6 @@
 namespace DotNetNuke.Web.Mvc.Framework.Controllers
 {
     using System.Diagnostics.CodeAnalysis;
-    using System.Threading.Tasks;
     using System.Web.Mvc;
     using System.Web.UI;
 
@@ -24,10 +23,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
         string LocalResourceFile { get; set; }
 
         ModuleActionCollection ModuleActions { get; set; }
-
-        Task<ModuleActionCollection> ModuleActionsAsync { get; set; }
-
-        bool IsAsync { get; set; }
 
         ModuleInstanceContext ModuleContext { get; set; }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/IDnnController.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Controllers/IDnnController.cs
@@ -5,6 +5,7 @@
 namespace DotNetNuke.Web.Mvc.Framework.Controllers
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading.Tasks;
     using System.Web.Mvc;
     using System.Web.UI;
 
@@ -23,6 +24,10 @@ namespace DotNetNuke.Web.Mvc.Framework.Controllers
         string LocalResourceFile { get; set; }
 
         ModuleActionCollection ModuleActions { get; set; }
+
+        Task<ModuleActionCollection> ModuleActionsAsync { get; set; }
+
+        bool IsAsync { get; set; }
 
         ModuleInstanceContext ModuleContext { get; set; }
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/IModuleExecutionEngine.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/IModuleExecutionEngine.cs
@@ -5,10 +5,14 @@
 namespace DotNetNuke.Web.Mvc.Framework.Modules
 {
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     public interface IModuleExecutionEngine
     {
         ModuleRequestResult ExecuteModule(ModuleRequestContext moduleRequestContext);
+
+        Task<ModuleRequestResult> ExecuteModuleAsync(ModuleRequestContext moduleRequestContext, CancellationToken cancellationToken);
 
         void ExecuteModuleResult(ModuleRequestResult moduleResult, TextWriter writer);
     }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -168,7 +168,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
             {
                 // Check if the controller supports IDnnController
                 var moduleController = controller as IDnnController;
-                moduleController.IsAsync = true;
 
                 // If we couldn't adapt it, we fail.  We can't support IController implementations directly :(
                 // Because we need to retrieve the ActionResult without executing it, IController won't cut it
@@ -176,6 +175,8 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
                 {
                     throw new InvalidOperationException("Could Not Construct Controller");
                 }
+
+                moduleController.IsAsync = true;
 
                 moduleController.ValidateRequest = false;
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -168,6 +168,7 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
             {
                 // Check if the controller supports IDnnController
                 var moduleController = controller as IDnnController;
+                moduleController.IsAsync = true;
 
                 // If we couldn't adapt it, we fail.  We can't support IController implementations directly :(
                 // Because we need to retrieve the ActionResult without executing it, IController won't cut it
@@ -182,24 +183,24 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
 
                 moduleController.ModuleContext = context.ModuleContext;
 
-                moduleController.LocalResourceFile = string.Format(
-                    "~/DesktopModules/MVC/{0}/{1}/{2}.resx",
-                    context.ModuleContext.Configuration.DesktopModule.FolderName,
-                    Localization.LocalResourceDirectory,
-                    controllerName);
+                moduleController.LocalResourceFile =
+                    $"~/DesktopModules/MVC/{context.ModuleContext.Configuration.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{controllerName}.resx";
 
                 moduleController.ViewEngineCollectionEx = this.ViewEngines;
+
+                if (controller is not IAsyncController asyncController)
+                {
+                    // the base System.Web.Mvc.Controller class implements IAsyncController so this should normally never happen.
+                    throw new NotSupportedException("Synchronous only Controller implementation is not supported.");
+                }
 
                 // Execute the controller and capture the result
                 // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
                 // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
-                if (moduleController is IAsyncController asyncController)
+                await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
+                if (moduleController.ModuleActionsAsync != null)
                 {
-                    await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
-                }
-                else
-                {
-                    moduleController.Execute(this.RequestContext);
+                    moduleController.ModuleActions = await moduleController.ModuleActionsAsync;
                 }
 
                 var result = moduleController.ResultOfLastExecute;

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -6,8 +6,12 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
     using System;
     using System.Globalization;
     using System.Reflection;
+    using System.Runtime.Remoting.Contexts;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Web;
     using System.Web.Mvc;
+    using System.Web.Mvc.Async;
     using System.Web.Routing;
 
     using DotNetNuke.Common;
@@ -121,6 +125,83 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
                 // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
                 // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
                 moduleController.Execute(this.RequestContext);
+                var result = moduleController.ResultOfLastExecute;
+
+                // Return the final result
+                return new ModuleRequestResult
+                {
+                    ActionResult = result,
+                    ControllerContext = moduleController.ControllerContext,
+                    ModuleActions = moduleController.ModuleActions,
+                    ModuleContext = context.ModuleContext,
+                    ModuleApplication = this,
+                };
+            }
+            finally
+            {
+                this.ControllerFactory.ReleaseController(controller);
+            }
+        }
+
+        public virtual async Task<ModuleRequestResult> ExecuteRequestAsync(ModuleRequestContext context, CancellationToken cancellationToken)
+        {
+            this.EnsureInitialized();
+            this.RequestContext = this.RequestContext ?? new RequestContext(context.HttpContext, context.RouteData);
+            var currentContext = HttpContext.Current;
+            if (currentContext != null)
+            {
+                var isRequestValidationEnabled = ValidationUtility.IsValidationEnabled(currentContext);
+                if (isRequestValidationEnabled == true)
+                {
+                    ValidationUtility.EnableDynamicValidation(currentContext);
+                }
+            }
+
+            this.AddVersionHeader(this.RequestContext.HttpContext);
+            this.RemoveOptionalRoutingParameters();
+
+            var controllerName = this.RequestContext.RouteData.GetRequiredString("controller");
+
+            // Construct the controller using the ControllerFactory
+            var controller = this.ControllerFactory.CreateController(this.RequestContext, controllerName);
+            try
+            {
+                // Check if the controller supports IDnnController
+                var moduleController = controller as IDnnController;
+
+                // If we couldn't adapt it, we fail.  We can't support IController implementations directly :(
+                // Because we need to retrieve the ActionResult without executing it, IController won't cut it
+                if (moduleController == null)
+                {
+                    throw new InvalidOperationException("Could Not Construct Controller");
+                }
+
+                moduleController.ValidateRequest = false;
+
+                moduleController.DnnPage = context.DnnPage;
+
+                moduleController.ModuleContext = context.ModuleContext;
+
+                moduleController.LocalResourceFile = string.Format(
+                    "~/DesktopModules/MVC/{0}/{1}/{2}.resx",
+                    context.ModuleContext.Configuration.DesktopModule.FolderName,
+                    Localization.LocalResourceDirectory,
+                    controllerName);
+
+                moduleController.ViewEngineCollectionEx = this.ViewEngines;
+
+                // Execute the controller and capture the result
+                // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
+                // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
+                if (moduleController is IAsyncController asyncController)
+                {
+                    await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
+                }
+                else
+                {
+                    moduleController.Execute(this.RequestContext);
+                }
+
                 var result = moduleController.ResultOfLastExecute;
 
                 // Return the final result

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -6,7 +6,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
     using System;
     using System.Globalization;
     using System.Reflection;
-    using System.Runtime.Remoting.Contexts;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web;
@@ -176,8 +175,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
                     throw new InvalidOperationException("Could Not Construct Controller");
                 }
 
-                moduleController.IsAsync = true;
-
                 moduleController.ValidateRequest = false;
 
                 moduleController.DnnPage = context.DnnPage;
@@ -199,10 +196,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
                 // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
                 // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
                 await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
-                if (moduleController.ModuleActionsAsync != null)
-                {
-                    moduleController.ModuleActions = await moduleController.ModuleActionsAsync;
-                }
 
                 var result = moduleController.ResultOfLastExecute;
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -167,6 +167,7 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
             {
                 // Check if the controller supports IDnnController
                 var moduleController = controller as IDnnController;
+                moduleController.IsAsync = true;
 
                 // If we couldn't adapt it, we fail.  We can't support IController implementations directly :(
                 // Because we need to retrieve the ActionResult without executing it, IController won't cut it
@@ -181,24 +182,24 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
 
                 moduleController.ModuleContext = context.ModuleContext;
 
-                moduleController.LocalResourceFile = string.Format(
-                    "~/DesktopModules/MVC/{0}/{1}/{2}.resx",
-                    context.ModuleContext.Configuration.DesktopModule.FolderName,
-                    Localization.LocalResourceDirectory,
-                    controllerName);
+                moduleController.LocalResourceFile =
+                    $"~/DesktopModules/MVC/{context.ModuleContext.Configuration.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{controllerName}.resx";
 
                 moduleController.ViewEngineCollectionEx = this.ViewEngines;
+
+                if (controller is not IAsyncController asyncController)
+                {
+                    // the base System.Web.Mvc.Controller class implements IAsyncController so this should normally never happen.
+                    throw new NotSupportedException("Synchronous only Controller implementation is not supported.");
+                }
 
                 // Execute the controller and capture the result
                 // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
                 // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
-                if (moduleController is IAsyncController asyncController)
+                await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
+                if (moduleController.ModuleActionsAsync != null)
                 {
-                    await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
-                }
-                else
-                {
-                    moduleController.Execute(this.RequestContext);
+                    moduleController.ModuleActions = await moduleController.ModuleActionsAsync;
                 }
 
                 var result = moduleController.ResultOfLastExecute;

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -6,8 +6,12 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
     using System;
     using System.Globalization;
     using System.Reflection;
+    using System.Runtime.Remoting.Contexts;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Web;
     using System.Web.Mvc;
+    using System.Web.Mvc.Async;
     using System.Web.Routing;
 
     using DotNetNuke.Common;
@@ -120,6 +124,83 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
                 // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
                 // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
                 moduleController.Execute(this.RequestContext);
+                var result = moduleController.ResultOfLastExecute;
+
+                // Return the final result
+                return new ModuleRequestResult
+                {
+                    ActionResult = result,
+                    ControllerContext = moduleController.ControllerContext,
+                    ModuleActions = moduleController.ModuleActions,
+                    ModuleContext = context.ModuleContext,
+                    ModuleApplication = this,
+                };
+            }
+            finally
+            {
+                this.ControllerFactory.ReleaseController(controller);
+            }
+        }
+
+        public virtual async Task<ModuleRequestResult> ExecuteRequestAsync(ModuleRequestContext context, CancellationToken cancellationToken)
+        {
+            this.EnsureInitialized();
+            this.RequestContext = this.RequestContext ?? new RequestContext(context.HttpContext, context.RouteData);
+            var currentContext = HttpContext.Current;
+            if (currentContext != null)
+            {
+                var isRequestValidationEnabled = ValidationUtility.IsValidationEnabled(currentContext);
+                if (isRequestValidationEnabled == true)
+                {
+                    ValidationUtility.EnableDynamicValidation(currentContext);
+                }
+            }
+
+            this.AddVersionHeader(this.RequestContext.HttpContext);
+            this.RemoveOptionalRoutingParameters();
+
+            var controllerName = this.RequestContext.RouteData.GetRequiredString("controller");
+
+            // Construct the controller using the ControllerFactory
+            var controller = this.ControllerFactory.CreateController(this.RequestContext, controllerName);
+            try
+            {
+                // Check if the controller supports IDnnController
+                var moduleController = controller as IDnnController;
+
+                // If we couldn't adapt it, we fail.  We can't support IController implementations directly :(
+                // Because we need to retrieve the ActionResult without executing it, IController won't cut it
+                if (moduleController == null)
+                {
+                    throw new InvalidOperationException("Could Not Construct Controller");
+                }
+
+                moduleController.ValidateRequest = false;
+
+                moduleController.DnnPage = context.DnnPage;
+
+                moduleController.ModuleContext = context.ModuleContext;
+
+                moduleController.LocalResourceFile = string.Format(
+                    "~/DesktopModules/MVC/{0}/{1}/{2}.resx",
+                    context.ModuleContext.Configuration.DesktopModule.FolderName,
+                    Localization.LocalResourceDirectory,
+                    controllerName);
+
+                moduleController.ViewEngineCollectionEx = this.ViewEngines;
+
+                // Execute the controller and capture the result
+                // if our ActionFilter is executed after the ActionResult has triggered an Exception the filter
+                // MUST explicitly flip the ExceptionHandled bit otherwise the view will not render
+                if (moduleController is IAsyncController asyncController)
+                {
+                    await Task.Factory.FromAsync(asyncController.BeginExecute, asyncController.EndExecute, this.RequestContext, null);
+                }
+                else
+                {
+                    moduleController.Execute(this.RequestContext);
+                }
+
                 var result = moduleController.ResultOfLastExecute;
 
                 // Return the final result

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleApplication.cs
@@ -167,7 +167,6 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
             {
                 // Check if the controller supports IDnnController
                 var moduleController = controller as IDnnController;
-                moduleController.IsAsync = true;
 
                 // If we couldn't adapt it, we fail.  We can't support IController implementations directly :(
                 // Because we need to retrieve the ActionResult without executing it, IController won't cut it
@@ -175,6 +174,8 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
                 {
                     throw new InvalidOperationException("Could Not Construct Controller");
                 }
+
+                moduleController.IsAsync = true;
 
                 moduleController.ValidateRequest = false;
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleExecutionEngine.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ModuleExecutionEngine.cs
@@ -6,6 +6,8 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
 {
     using System;
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     using DotNetNuke.Common;
     using DotNetNuke.Web.Mvc.Framework.ActionResults;
@@ -21,6 +23,19 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
             {
                 // Run the module
                 return moduleRequestContext.ModuleApplication.ExecuteRequest(moduleRequestContext);
+            }
+
+            return null;
+        }
+
+        public async Task<ModuleRequestResult> ExecuteModuleAsync(ModuleRequestContext moduleRequestContext, CancellationToken cancellationToken)
+        {
+            Requires.NotNull("moduleRequestContext", moduleRequestContext);
+
+            if (moduleRequestContext.ModuleApplication != null)
+            {
+                // Run the module
+                return await moduleRequestContext.ModuleApplication.ExecuteRequestAsync(moduleRequestContext, cancellationToken);
             }
 
             return null;

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ResultCapturingActionInvoker.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ResultCapturingActionInvoker.cs
@@ -7,8 +7,9 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
     using System;
     using System.Collections.Generic;
     using System.Web.Mvc;
+    using System.Web.Mvc.Async;
 
-    public class ResultCapturingActionInvoker : ControllerActionInvoker
+    public class ResultCapturingActionInvoker : AsyncControllerActionInvoker
     {
         public ActionResult ResultOfLastInvoke { get; set; }
 
@@ -16,6 +17,13 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
         protected override ActionExecutedContext InvokeActionMethodWithFilters(ControllerContext controllerContext, IList<IActionFilter> filters, ActionDescriptor actionDescriptor, IDictionary<string, object> parameters)
         {
             var context = base.InvokeActionMethodWithFilters(controllerContext, filters, actionDescriptor, parameters);
+            this.ResultOfLastInvoke = context.Result;
+            return context;
+        }
+
+        protected override ActionExecutedContext EndInvokeActionMethodWithFilters(IAsyncResult asyncResult)
+        {
+            var context = base.EndInvokeActionMethodWithFilters(asyncResult);
             this.ResultOfLastInvoke = context.Result;
             return context;
         }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ResultCapturingActionInvoker.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/Modules/ResultCapturingActionInvoker.cs
@@ -6,12 +6,54 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
     using System.Web.Mvc;
     using System.Web.Mvc.Async;
+
+    using DotNetNuke.Web.Mvc.Framework.ActionFilters;
 
     public class ResultCapturingActionInvoker : AsyncControllerActionInvoker
     {
         public ActionResult ResultOfLastInvoke { get; set; }
+
+        /// <inheritdoc />
+        protected override IAsyncResult BeginInvokeActionMethodWithFilters(ControllerContext controllerContext, IList<IActionFilter> filters, ActionDescriptor actionDescriptor, IDictionary<string, object> parameters, AsyncCallback callback, object state)
+        {
+            var moduleActionsFilter = filters.OfType<ModuleActionItemsAttribute>().ToList();
+            if (moduleActionsFilter.Count == 0)
+            {
+                return base.BeginInvokeActionMethodWithFilters(controllerContext, filters, actionDescriptor, parameters, callback, state);
+            }
+
+            var tcs = new TaskCompletionSource<bool>(state);
+            var filterContext = new ActionExecutingContext(controllerContext, actionDescriptor, parameters);
+            var task = Task.CompletedTask;
+            foreach (var filter in moduleActionsFilter)
+            {
+                task = task.ContinueWith(_ => filter.OnActionExecutingAsync(filterContext));
+            }
+
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                }
+                else if (t.IsCanceled)
+                {
+                    tcs.TrySetCanceled();
+                }
+                else
+                {
+                    tcs.TrySetResult(true);
+                }
+
+                IAsyncResult BeginDelegate(AsyncCallback innerCallback, object innerState) => base.BeginInvokeActionMethodWithFilters(controllerContext, [.. filters.Where(f => f is not ModuleActionItemsAttribute)], actionDescriptor, parameters, innerCallback, innerState);
+                return Task.Factory.FromAsync(BeginDelegate, ar => callback(ar), state);
+            });
+            return tcs.Task;
+        }
 
         /// <inheritdoc />
         protected override ActionExecutedContext InvokeActionMethodWithFilters(ControllerContext controllerContext, IList<IActionFilter> filters, ActionDescriptor actionDescriptor, IDictionary<string, object> parameters)
@@ -21,6 +63,7 @@ namespace DotNetNuke.Web.Mvc.Framework.Modules
             return context;
         }
 
+        /// <inheritdoc />
         protected override ActionExecutedContext EndInvokeActionMethodWithFilters(IAsyncResult asyncResult)
         {
             var context = base.EndInvokeActionMethodWithFilters(asyncResult);

--- a/DNN Platform/DotNetNuke.Web.Mvc/Framework/ViewEngineCollectionExt.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Framework/ViewEngineCollectionExt.cs
@@ -49,7 +49,7 @@ namespace DotNetNuke.Web.Mvc.Framework
                 var parameters = new object[]
                 {
                     new Func<IViewEngine, ViewEngineResult>(e => e.FindView(controllerContext, viewName, masterName, false)),
-                    false,
+                    true, // allow SearchedLocations tracking to improve error messages up the stack.
                 };
                 var cacheArg = new CacheItemArgs(cacheKey, 120, CacheItemPriority.Default, "Find", viewEngineCollection, parameters);
 
@@ -79,7 +79,7 @@ namespace DotNetNuke.Web.Mvc.Framework
                 var parameters = new object[]
                 {
                     new Func<IViewEngine, ViewEngineResult>(e => e.FindPartialView(controllerContext, partialViewName, false)),
-                    false,
+                    true, // allow SearchedLocations tracking to improve error messages up the stack.
                 };
                 var cacheArg = new CacheItemArgs(cacheKey, 120, CacheItemPriority.Default, "Find", viewEngineCollection, parameters);
 

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcHostControl.cs
@@ -6,6 +6,8 @@ namespace DotNetNuke.Web.Mvc
     using System;
     using System.Globalization;
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Web;
     using System.Web.Mvc;
     using System.Web.Routing;
@@ -72,6 +74,26 @@ namespace DotNetNuke.Web.Mvc
             }
         }
 
+        protected async Task ExecuteModuleAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                HttpContextBase httpContext = new HttpContextWrapper(HttpContext.Current);
+
+                var moduleExecutionEngine = this.GetModuleExecutionEngine();
+
+                this.result = await moduleExecutionEngine.ExecuteModuleAsync(this.GetModuleRequestContext(httpContext), cancellationToken);
+
+                this.ModuleActions = this.LoadActions(this.result);
+
+                httpContext.SetModuleRequestResult(this.result);
+            }
+            catch (Exception exc)
+            {
+                Exceptions.ProcessModuleLoadException(this, exc);
+            }
+        }
+
         /// <inheritdoc />
         protected override void OnInit(EventArgs e)
         {
@@ -79,7 +101,7 @@ namespace DotNetNuke.Web.Mvc
 
             if (this.ExecuteModuleImmediately)
             {
-                this.ExecuteModule();
+                this.Page.RegisterAsyncTask(new PageAsyncTask(this.ExecuteModuleAsync));
             }
         }
 
@@ -87,11 +109,16 @@ namespace DotNetNuke.Web.Mvc
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);
+            this.Page.RegisterAsyncTask(new PageAsyncTask(this.OnPreRenderAsync));
+        }
+
+        private Task OnPreRenderAsync(CancellationToken cancellationToken)
+        {
             try
             {
                 if (this.result == null)
                 {
-                    return;
+                    return Task.CompletedTask;
                 }
 
                 var mvcString = RenderModule(this.result);
@@ -104,6 +131,8 @@ namespace DotNetNuke.Web.Mvc
             {
                 Exceptions.ProcessModuleLoadException(this, exc);
             }
+
+            return Task.CompletedTask;
         }
 
         private static ModuleApplication GetModuleApplication(

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcHostControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcHostControl.cs
@@ -6,8 +6,6 @@ namespace DotNetNuke.Web.Mvc
     using System;
     using System.Globalization;
     using System.IO;
-    using System.Threading;
-    using System.Threading.Tasks;
     using System.Web;
     using System.Web.Mvc;
     using System.Web.Routing;
@@ -31,27 +29,51 @@ namespace DotNetNuke.Web.Mvc
     /// <summary>WebForms control for hosting an MVC module control.</summary>
     public class MvcHostControl : ModuleControlBase, IActionable
     {
-        private ModuleRequestResult result;
-        private string controlKey;
-
         /// <summary>Initializes a new instance of the <see cref="MvcHostControl"/> class.</summary>
         public MvcHostControl()
         {
-            this.controlKey = string.Empty;
+            this.ControlKey = string.Empty;
         }
 
         /// <summary>Initializes a new instance of the <see cref="MvcHostControl"/> class.</summary>
         /// <param name="controlKey">The module control key.</param>
         public MvcHostControl(string controlKey)
         {
-            this.controlKey = controlKey;
+            this.ControlKey = controlKey;
         }
 
         /// <inheritdoc />
-        public ModuleActionCollection ModuleActions { get; private set; }
+        public ModuleActionCollection ModuleActions { get; protected set; }
+
+        protected ModuleRequestResult Result { get; set; }
+
+        protected string ControlKey { get; set; }
 
         /// <summary>Gets or sets a value indicating whether the module controller should execute immediately (i.e. during <see cref="Control.OnInit"/> rather than <see cref="ISettingsControl.LoadSettings"/>).</summary>
         protected bool ExecuteModuleImmediately { get; set; } = true;
+
+        protected static IModuleExecutionEngine GetModuleExecutionEngine()
+        {
+            var moduleExecutionEngine = ComponentFactory.GetComponent<IModuleExecutionEngine>();
+
+            if (moduleExecutionEngine == null)
+            {
+                moduleExecutionEngine = new ModuleExecutionEngine();
+                ComponentFactory.RegisterComponentInstance<IModuleExecutionEngine>(moduleExecutionEngine);
+            }
+
+            return moduleExecutionEngine;
+        }
+
+        protected static MvcHtmlString RenderModule(ModuleRequestResult moduleResult)
+        {
+            using var writer = new StringWriter(CultureInfo.CurrentCulture);
+            var moduleExecutionEngine = ComponentFactory.GetComponent<IModuleExecutionEngine>();
+
+            moduleExecutionEngine.ExecuteModuleResult(moduleResult, writer);
+
+            return MvcHtmlString.Create(writer.ToString());
+        }
 
         /// <summary>Runs and renders the MVC action.</summary>
         protected void ExecuteModule()
@@ -62,31 +84,11 @@ namespace DotNetNuke.Web.Mvc
 
                 var moduleExecutionEngine = GetModuleExecutionEngine();
 
-                this.result = moduleExecutionEngine.ExecuteModule(this.GetModuleRequestContext(httpContext));
+                this.Result = moduleExecutionEngine.ExecuteModule(this.GetModuleRequestContext(httpContext));
 
-                this.ModuleActions = this.LoadActions(this.result);
+                this.ModuleActions = this.LoadActions(this.Result);
 
-                httpContext.SetModuleRequestResult(this.result);
-            }
-            catch (Exception exc)
-            {
-                Exceptions.ProcessModuleLoadException(this, exc);
-            }
-        }
-
-        protected async Task ExecuteModuleAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                HttpContextBase httpContext = new HttpContextWrapper(HttpContext.Current);
-
-                var moduleExecutionEngine = this.GetModuleExecutionEngine();
-
-                this.result = await moduleExecutionEngine.ExecuteModuleAsync(this.GetModuleRequestContext(httpContext), cancellationToken);
-
-                this.ModuleActions = this.LoadActions(this.result);
-
-                httpContext.SetModuleRequestResult(this.result);
+                httpContext.SetModuleRequestResult(this.Result);
             }
             catch (Exception exc)
             {
@@ -98,10 +100,14 @@ namespace DotNetNuke.Web.Mvc
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
+            this.OnInitInternal(e);
+        }
 
+        protected virtual void OnInitInternal(EventArgs e)
+        {
             if (this.ExecuteModuleImmediately)
             {
-                this.Page.RegisterAsyncTask(new PageAsyncTask(this.ExecuteModuleAsync));
+                this.ExecuteModule();
             }
         }
 
@@ -109,19 +115,19 @@ namespace DotNetNuke.Web.Mvc
         protected override void OnPreRender(EventArgs e)
         {
             base.OnPreRender(e);
-            this.Page.RegisterAsyncTask(new PageAsyncTask(this.OnPreRenderAsync));
+            this.OnPreRenderInternal(e);
         }
 
-        private Task OnPreRenderAsync(CancellationToken cancellationToken)
+        protected virtual void OnPreRenderInternal(EventArgs e)
         {
             try
             {
-                if (this.result == null)
+                if (this.Result == null)
                 {
-                    return Task.CompletedTask;
+                    return;
                 }
 
-                var mvcString = RenderModule(this.result);
+                var mvcString = RenderModule(this.Result);
                 if (!string.IsNullOrEmpty(Convert.ToString(mvcString, CultureInfo.InvariantCulture)))
                 {
                     this.Controls.Add(new LiteralControl(Convert.ToString(mvcString, CultureInfo.InvariantCulture)));
@@ -131,8 +137,78 @@ namespace DotNetNuke.Web.Mvc
             {
                 Exceptions.ProcessModuleLoadException(this, exc);
             }
+        }
 
-            return Task.CompletedTask;
+        protected ModuleRequestContext GetModuleRequestContext(HttpContextBase httpContext)
+        {
+            var module = this.ModuleContext.Configuration;
+
+            // TODO DesktopModuleControllerAdapter usage is temporary in order to make method testable
+            var desktopModule = DesktopModuleControllerAdapter.Instance.GetDesktopModule(module.DesktopModuleID, module.PortalID);
+            var defaultControl = ModuleControlControllerAdapter.Instance.GetModuleControlByControlKey(string.Empty, module.ModuleDefID);
+
+            var defaultRouteData = ModuleRoutingProvider.Instance().GetRouteData(null, defaultControl);
+
+            var moduleApplication = GetModuleApplication(
+                httpContext.GetScope().ServiceProvider.GetRequiredService<IBusinessControllerProvider>(),
+                desktopModule,
+                defaultRouteData);
+
+            RouteData routeData;
+
+            var queryString = httpContext.Request.QueryString;
+
+            if (string.IsNullOrEmpty(this.ControlKey))
+            {
+                this.ControlKey = queryString.GetValueOrDefault("ctl", string.Empty);
+            }
+
+            var moduleId = Null.NullInteger;
+            if (queryString["moduleid"] != null)
+            {
+                if (!int.TryParse(queryString["moduleid"], out moduleId))
+                {
+                    moduleId = Null.NullInteger;
+                }
+            }
+
+            if (moduleId != this.ModuleContext.ModuleId && string.IsNullOrEmpty(this.ControlKey))
+            {
+                // Set default routeData for module that is not the "selected" module
+                routeData = defaultRouteData;
+            }
+            else
+            {
+                var control = ModuleControlControllerAdapter.Instance.GetModuleControlByControlKey(this.ControlKey, module.ModuleDefID);
+                routeData = ModuleRoutingProvider.Instance().GetRouteData(httpContext, control);
+            }
+
+            var moduleRequestContext = new ModuleRequestContext
+            {
+                DnnPage = this.Page,
+                HttpContext = httpContext,
+                ModuleContext = this.ModuleContext,
+                ModuleApplication = moduleApplication,
+                RouteData = routeData,
+            };
+
+            return moduleRequestContext;
+        }
+
+        protected ModuleActionCollection LoadActions(ModuleRequestResult requestResult)
+        {
+            var actions = new ModuleActionCollection();
+
+            if (requestResult.ModuleActions != null)
+            {
+                foreach (ModuleAction action in requestResult.ModuleActions)
+                {
+                    action.ID = this.ModuleContext.GetNextActionID();
+                    actions.Add(action);
+                }
+            }
+
+            return actions;
         }
 
         private static ModuleApplication GetModuleApplication(
@@ -162,101 +238,6 @@ namespace DotNetNuke.Web.Mvc
                 ModuleName = desktopModule.ModuleName,
                 FolderPath = desktopModule.FolderName,
             };
-        }
-
-        private static IModuleExecutionEngine GetModuleExecutionEngine()
-        {
-            var moduleExecutionEngine = ComponentFactory.GetComponent<IModuleExecutionEngine>();
-
-            if (moduleExecutionEngine == null)
-            {
-                moduleExecutionEngine = new ModuleExecutionEngine();
-                ComponentFactory.RegisterComponentInstance<IModuleExecutionEngine>(moduleExecutionEngine);
-            }
-
-            return moduleExecutionEngine;
-        }
-
-        private static MvcHtmlString RenderModule(ModuleRequestResult moduleResult)
-        {
-            using var writer = new StringWriter(CultureInfo.CurrentCulture);
-            var moduleExecutionEngine = ComponentFactory.GetComponent<IModuleExecutionEngine>();
-
-            moduleExecutionEngine.ExecuteModuleResult(moduleResult, writer);
-
-            return MvcHtmlString.Create(writer.ToString());
-        }
-
-        private ModuleRequestContext GetModuleRequestContext(HttpContextBase httpContext)
-        {
-            var module = this.ModuleContext.Configuration;
-
-            // TODO DesktopModuleControllerAdapter usage is temporary in order to make method testable
-            var desktopModule = DesktopModuleControllerAdapter.Instance.GetDesktopModule(module.DesktopModuleID, module.PortalID);
-            var defaultControl = ModuleControlControllerAdapter.Instance.GetModuleControlByControlKey(string.Empty, module.ModuleDefID);
-
-            var defaultRouteData = ModuleRoutingProvider.Instance().GetRouteData(null, defaultControl);
-
-            var moduleApplication = GetModuleApplication(
-                httpContext.GetScope().ServiceProvider.GetRequiredService<IBusinessControllerProvider>(),
-                desktopModule,
-                defaultRouteData);
-
-            RouteData routeData;
-
-            var queryString = httpContext.Request.QueryString;
-
-            if (string.IsNullOrEmpty(this.controlKey))
-            {
-                this.controlKey = queryString.GetValueOrDefault("ctl", string.Empty);
-            }
-
-            var moduleId = Null.NullInteger;
-            if (queryString["moduleid"] != null)
-            {
-                if (!int.TryParse(queryString["moduleid"], out moduleId))
-                {
-                    moduleId = Null.NullInteger;
-                }
-            }
-
-            if (moduleId != this.ModuleContext.ModuleId && string.IsNullOrEmpty(this.controlKey))
-            {
-                // Set default routeData for module that is not the "selected" module
-                routeData = defaultRouteData;
-            }
-            else
-            {
-                var control = ModuleControlControllerAdapter.Instance.GetModuleControlByControlKey(this.controlKey, module.ModuleDefID);
-                routeData = ModuleRoutingProvider.Instance().GetRouteData(httpContext, control);
-            }
-
-            var moduleRequestContext = new ModuleRequestContext
-            {
-                DnnPage = this.Page,
-                HttpContext = httpContext,
-                ModuleContext = this.ModuleContext,
-                ModuleApplication = moduleApplication,
-                RouteData = routeData,
-            };
-
-            return moduleRequestContext;
-        }
-
-        private ModuleActionCollection LoadActions(ModuleRequestResult requestResult)
-        {
-            var actions = new ModuleActionCollection();
-
-            if (requestResult.ModuleActions != null)
-            {
-                foreach (ModuleAction action in requestResult.ModuleActions)
-                {
-                    action.ID = this.ModuleContext.GetNextActionID();
-                    actions.Add(action);
-                }
-            }
-
-            return actions;
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcHttpModule.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcHttpModule.cs
@@ -11,7 +11,6 @@ namespace DotNetNuke.Web.Mvc
     using System.Web;
     using System.Web.Helpers;
     using System.Web.Mvc;
-    using System.Web.Routing;
     using System.Xml;
 
     using DotNetNuke.Abstractions.Application;
@@ -23,7 +22,6 @@ namespace DotNetNuke.Web.Mvc
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Framework.Reflections;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Web.Mvc.Framework;
     using DotNetNuke.Web.Mvc.Framework.Modules;

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcModuleControlFactory.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcModuleControlFactory.cs
@@ -23,12 +23,22 @@ namespace DotNetNuke.Web.Mvc
         /// <inheritdoc />
         public override Control CreateControl(TemplateControl containerControl, string controlKey, string controlSrc)
         {
+            if (IsAsyncControl(controlSrc))
+            {
+                return new AsyncMvcHostControl(controlKey);
+            }
+
             return new MvcHostControl(controlKey);
         }
 
         /// <inheritdoc />
         public override Control CreateModuleControl(TemplateControl containerControl, ModuleInfo moduleConfiguration)
         {
+            if (IsAsyncControl(moduleConfiguration.ModuleControl.ControlSrc))
+            {
+                return new AsyncMvcHostControl();
+            }
+
             return new MvcHostControl();
         }
 
@@ -37,9 +47,9 @@ namespace DotNetNuke.Web.Mvc
         {
             ModuleControlBase moduleControl = base.CreateModuleControl(moduleConfiguration);
 
-            var segments = moduleConfiguration.ModuleControl.ControlSrc.Replace(".mvc", string.Empty).Split('/');
+            var segments = moduleConfiguration.ModuleControl.ControlSrc.Split('/');
 
-            moduleControl.LocalResourceFile = $"~/DesktopModules/MVC/{moduleConfiguration.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{segments[0]}.resx";
+            moduleControl.LocalResourceFile = $"~/DesktopModules/MVC/{moduleConfiguration.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{(segments.Length == 2 ? segments[0] : segments[1])}.resx";
 
             return moduleControl;
         }
@@ -47,7 +57,18 @@ namespace DotNetNuke.Web.Mvc
         /// <inheritdoc />
         public override Control CreateSettingsControl(TemplateControl containerControl, ModuleInfo moduleConfiguration, string controlSrc)
         {
+            if (IsAsyncControl(controlSrc))
+            {
+                return new AsyncMvcSettingsControl();
+            }
+
             return new MvcSettingsControl();
+        }
+
+        private static bool IsAsyncControl(string controlSrc)
+        {
+            var segments = controlSrc.Split('/');
+            return segments.Length == 4 && segments[2].Equals("async", System.StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcSettingsControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcSettingsControl.cs
@@ -4,10 +4,13 @@
 
 namespace DotNetNuke.Web.Mvc
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.UI.Modules;
 
-    public class MvcSettingsControl : MvcHostControl, ISettingsControl
+    public class MvcSettingsControl : MvcHostControl, IAsyncSettingsControl
     {
         public MvcSettingsControl()
             : base("Settings")
@@ -18,13 +21,31 @@ namespace DotNetNuke.Web.Mvc
         /// <inheritdoc />
         public void LoadSettings()
         {
+            // TODO: This should now throw as control needs to always be executed asynchronously.
+            // throw new NotSupportedException();
             this.ExecuteModule();
         }
 
         /// <inheritdoc />
+        public Task LoadSettingsAsync(CancellationToken cancellationToken)
+        {
+            return this.ExecuteModuleAsync(cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public void UpdateSettings()
         {
+            // TODO: This should now throw as control needs to always be executed asynchronously.
+            // throw new NotSupportedException();
             this.ExecuteModule();
+
+            ModuleController.Instance.UpdateModule(this.ModuleContext.Configuration);
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateSettingsAsync(CancellationToken cancellationToken)
+        {
+            await this.ExecuteModuleAsync(cancellationToken);
 
             ModuleController.Instance.UpdateModule(this.ModuleContext.Configuration);
         }

--- a/DNN Platform/DotNetNuke.Web.Mvc/MvcSettingsControl.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/MvcSettingsControl.cs
@@ -4,13 +4,10 @@
 
 namespace DotNetNuke.Web.Mvc
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.UI.Modules;
 
-    public class MvcSettingsControl : MvcHostControl, IAsyncSettingsControl
+    public class MvcSettingsControl : MvcHostControl, ISettingsControl
     {
         public MvcSettingsControl()
             : base("Settings")
@@ -21,31 +18,13 @@ namespace DotNetNuke.Web.Mvc
         /// <inheritdoc />
         public void LoadSettings()
         {
-            // TODO: This should now throw as control needs to always be executed asynchronously.
-            // throw new NotSupportedException();
             this.ExecuteModule();
         }
 
         /// <inheritdoc />
-        public Task LoadSettingsAsync(CancellationToken cancellationToken)
-        {
-            return this.ExecuteModuleAsync(cancellationToken);
-        }
-
-        /// <inheritdoc/>
         public void UpdateSettings()
         {
-            // TODO: This should now throw as control needs to always be executed asynchronously.
-            // throw new NotSupportedException();
             this.ExecuteModule();
-
-            ModuleController.Instance.UpdateModule(this.ModuleContext.Configuration);
-        }
-
-        /// <inheritdoc/>
-        public async Task UpdateSettingsAsync(CancellationToken cancellationToken)
-        {
-            await this.ExecuteModuleAsync(cancellationToken);
 
             ModuleController.Instance.UpdateModule(this.ModuleContext.Configuration);
         }

--- a/DNN Platform/DotNetNuke.Web.Mvc/Routing/StandardModuleRoutingProvider.cs
+++ b/DNN Platform/DotNetNuke.Web.Mvc/Routing/StandardModuleRoutingProvider.cs
@@ -61,7 +61,13 @@ namespace DotNetNuke.Web.Mvc.Routing
             string routeNamespace = string.Empty;
             string routeControllerName;
             string routeActionName;
-            if (segments.Length == 3)
+            if (segments.Length == 4)
+            {
+                routeNamespace = segments[0];
+                routeControllerName = segments[1];
+                routeActionName = segments[3];
+            }
+            else if (segments.Length == 3)
             {
                 routeNamespace = segments[0];
                 routeControllerName = segments[1];

--- a/DNN Platform/Library/UI/Containers/ActionBase.cs
+++ b/DNN Platform/Library/UI/Containers/ActionBase.cs
@@ -111,6 +111,24 @@ namespace DotNetNuke.UI.Containers
         /// <param name="actionID">The id of the action.</param>
         protected void ProcessAction(string actionID)
         {
+            if (this.ModuleControl is IAsyncModuleControl)
+            {
+                this.Page.RegisterAsyncTask(new PageAsyncTask(ct => this.ProcessActionInternalAsync(actionID, ct)));
+            }
+            else
+            {
+                this.ProcessActionInternal(actionID);
+            }
+        }
+
+        protected Task ProcessActionInternalAsync(string actionID, CancellationToken cancellationToken)
+        {
+            this.ProcessActionInternal(actionID);
+            return Task.CompletedTask;
+        }
+
+        protected void ProcessActionInternal(string actionID)
+        {
             if (int.TryParse(actionID, out var output))
             {
                 ModuleAction action = this.Actions.GetActionByID(output);
@@ -128,16 +146,26 @@ namespace DotNetNuke.UI.Containers
         /// <param name="e">The event arguments.</param>
         protected override void OnLoad(EventArgs e)
         {
-            if (this.ModuleControl != null)
+            if (this.ModuleControl is IAsyncModuleControl)
             {
                 // We need to defer accesing this.Actions as it could only be accesible after the WebForms async point.
                 this.Page.RegisterAsyncTask(new PageAsyncTask(this.LoadActionsAsync));
+            }
+            else
+            {
+                this.LoadActions();
             }
 
             base.OnLoad(e);
         }
 
         private Task LoadActionsAsync(CancellationToken cancellationToken)
+        {
+            this.LoadActions();
+            return Task.CompletedTask;
+        }
+
+        private void LoadActions()
         {
             try
             {
@@ -147,8 +175,6 @@ namespace DotNetNuke.UI.Containers
             {
                 Exceptions.ProcessModuleLoadException(this, exc);
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/DNN Platform/Library/UI/Containers/ActionBase.cs
+++ b/DNN Platform/Library/UI/Containers/ActionBase.cs
@@ -113,6 +113,7 @@ namespace DotNetNuke.UI.Containers
         {
             if (this.ModuleControl is IAsyncModuleControl)
             {
+                // We need to defer accesing this.Actions as it could only be accesible after the WebForms async point.
                 this.Page.RegisterAsyncTask(new PageAsyncTask(ct => this.ProcessActionInternalAsync(actionID, ct)));
             }
             else

--- a/DNN Platform/Library/UI/Containers/ActionBase.cs
+++ b/DNN Platform/Library/UI/Containers/ActionBase.cs
@@ -5,6 +5,8 @@ namespace DotNetNuke.UI.Containers
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Web.UI;
 
     using DotNetNuke.Abstractions.Logging;
@@ -126,13 +128,19 @@ namespace DotNetNuke.UI.Containers
         /// <param name="e">The event arguments.</param>
         protected override void OnLoad(EventArgs e)
         {
+            if (this.ModuleControl != null)
+            {
+                // We need to defer accesing this.Actions as it could only be accesible after the WebForms async point.
+                this.Page.RegisterAsyncTask(new PageAsyncTask(this.LoadActionsAsync));
+            }
+
+            base.OnLoad(e);
+        }
+
+        private Task LoadActionsAsync(CancellationToken cancellationToken)
+        {
             try
             {
-                if (this.ModuleControl == null)
-                {
-                    return;
-                }
-
                 this.ActionRoot.Actions.AddRange(this.Actions);
             }
             catch (Exception exc)
@@ -140,7 +148,7 @@ namespace DotNetNuke.UI.Containers
                 Exceptions.ProcessModuleLoadException(this, exc);
             }
 
-            base.OnLoad(e);
+            return Task.CompletedTask;
         }
     }
 }

--- a/DNN Platform/Library/UI/Modules/IAsyncSettingsControl.cs
+++ b/DNN Platform/Library/UI/Modules/IAsyncSettingsControl.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.UI.Modules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>IAsyncSettingsControl provides a common Interface for Module Settings Controls that need to execute async work.</summary>
+    public interface IAsyncSettingsControl : ISettingsControl
+    {
+        /// <summary>Loads the module settings asynchronously.</summary>
+        /// <param name="cancellationToken">cancellationToken.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task LoadSettingsAsync(CancellationToken cancellationToken);
+
+        /// <summary>Updates the module settings asynchronously.</summary>
+        /// <param name="cancellationToken">cancellationToken.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task UpdateSettingsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/DNN Platform/Library/UI/Modules/IModuleControl.cs
+++ b/DNN Platform/Library/UI/Modules/IModuleControl.cs
@@ -23,4 +23,8 @@ namespace DotNetNuke.UI.Modules
         /// <summary>Gets or sets the local resource localization file for the control.</summary>
         string LocalResourceFile { get; set; }
     }
+
+    public interface IAsyncModuleControl
+    {
+    }
 }

--- a/DNN Platform/Library/UI/Modules/ModuleControlFactory.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleControlFactory.cs
@@ -162,9 +162,9 @@ namespace DotNetNuke.UI.Modules
             switch (extension)
             {
                 case ".mvc":
-                    var segments = moduleConfiguration.ModuleControl.ControlSrc.Replace(".mvc", string.Empty).Split('/');
+                    var segments = moduleConfiguration.ModuleControl.ControlSrc.Split('/');
 
-                    moduleControl.LocalResourceFile = $"~/DesktopModules/MVC/{moduleConfiguration.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{segments[0]}.resx";
+                    moduleControl.LocalResourceFile = $"~/DesktopModules/MVC/{moduleConfiguration.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{(segments.Length == 2 ? segments[0] : segments[1])}.resx";
                     break;
                 default:
                     moduleControl.LocalResourceFile = moduleConfiguration.ModuleControl.ControlSrc.Replace(Path.GetFileName(moduleConfiguration.ModuleControl.ControlSrc), string.Empty) +

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -511,13 +511,10 @@ namespace DotNetNuke.UI.Modules
             if (actionable != null)
             {
                 // Async module controls populate ModuleActions only after their async task executes.
-                // Leave this.actions as null so the Actions getter retries once results are available.
                 if (this.moduleControl is IAsyncModuleControl && actionable.ModuleActions == null)
                 {
-                    this.actions = null;
-
-                    // TODO: Should we throw instead to be able to identify code that tries to call it too early?
-                    return;
+                    throw new InvalidOperationException("Too early to access the ModuleActions. For async controls, ModuleActions collection is available only after the framework executes the `Page.ExecuteRegisteredAsyncTasks()`. " +
+                        "More specifically, you have to either register an async task using `Page.RegisterAsyncTask()` or use any of the sync events starting from PreRenderComplete to access them.");
                 }
 
                 this.moduleSpecificActions = new ModuleAction(this.GetNextActionID(), Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);

--- a/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
+++ b/DNN Platform/Library/UI/Modules/ModuleInstanceContext.cs
@@ -510,6 +510,16 @@ namespace DotNetNuke.UI.Modules
             var actionable = this.moduleControl as IActionable;
             if (actionable != null)
             {
+                // Async module controls populate ModuleActions only after their async task executes.
+                // Leave this.actions as null so the Actions getter retries once results are available.
+                if (this.moduleControl is IAsyncModuleControl && actionable.ModuleActions == null)
+                {
+                    this.actions = null;
+
+                    // TODO: Should we throw instead to be able to identify code that tries to call it too early?
+                    return;
+                }
+
                 this.moduleSpecificActions = new ModuleAction(this.GetNextActionID(), Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile), string.Empty, string.Empty, string.Empty);
 
                 ModuleActionCollection moduleActions = actionable.ModuleActions;

--- a/DNN Platform/Website/Default.aspx.cs
+++ b/DNN Platform/Website/Default.aspx.cs
@@ -630,9 +630,9 @@ namespace DotNetNuke.Framework
                     switch (extension)
                     {
                         case ".mvc":
-                            var segments = slaveModule.ModuleControl.ControlSrc.Replace(".mvc", string.Empty).Split('/');
+                            var segments = slaveModule.ModuleControl.ControlSrc.Split('/');
                             control.LocalResourceFile =
-                                $"~/DesktopModules/MVC/{slaveModule.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{segments[0]}.resx";
+                                $"~/DesktopModules/MVC/{slaveModule.DesktopModule.FolderName}/{Localization.LocalResourceDirectory}/{(segments.Length == 2 ? segments[0] : segments[1])}.resx";
                             break;
                         default:
                             var controlFileName = Path.GetFileName(slaveModule.ModuleControl.ControlSrc);

--- a/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -156,7 +156,14 @@ namespace DotNetNuke.Admin.Containers
                     this.clientResourceController.RegisterScript("~/admin/menus/ModuleActions/dnnQuickSettings.js");
                 }
 
-                this.Page.RegisterAsyncTask(new PageAsyncTask(this.ProcessActionsAsync));
+                if (this.ModuleControl is IAsyncModuleControl)
+                {
+                    this.Page.RegisterAsyncTask(new PageAsyncTask(this.ProcessActionsAsync));
+                }
+                else
+                {
+                    this.ProcessActions();
+                }
             }
             catch (Exception exc)
             {
@@ -177,11 +184,17 @@ namespace DotNetNuke.Admin.Containers
 
         private Task ProcessActionsAsync(CancellationToken cancellationToken)
         {
+            this.ProcessActions();
+            return Task.CompletedTask;
+        }
+
+        private void ProcessActions()
+        {
             try
             {
                 if (!this.ActionRoot.Visible)
                 {
-                    return Task.CompletedTask;
+                    return;
                 }
 
                 // Add Menu Items
@@ -245,19 +258,11 @@ namespace DotNetNuke.Admin.Containers
             {
                 Exceptions.ProcessModuleLoadException(this, exc);
             }
-
-            return Task.CompletedTask;
         }
 
         private void ActionButton_Click(object sender, EventArgs e)
         {
-            this.Page.RegisterAsyncTask(new PageAsyncTask(ct => this.ActionButton_ClickAsync(sender, e, ct)));
-        }
-
-        private Task ActionButton_ClickAsync(object sender, EventArgs e, CancellationToken cancellationToken)
-        {
             this.ProcessAction(this.Request.Params["__EVENTARGUMENT"]);
-            return Task.CompletedTask;
         }
     }
 }

--- a/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -158,6 +158,7 @@ namespace DotNetNuke.Admin.Containers
 
                 if (this.ModuleControl is IAsyncModuleControl)
                 {
+                    // We need to defer accesing this.Actions as it could only be accesible after the WebForms async point.
                     this.Page.RegisterAsyncTask(new PageAsyncTask(this.ProcessActionsAsync));
                 }
                 else

--- a/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
+++ b/DNN Platform/Website/admin/Menus/ModuleActions/ModuleActions.ascx.cs
@@ -6,6 +6,8 @@ namespace DotNetNuke.Admin.Containers
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using System.Web.Script.Serialization;
     using System.Web.UI;
 
@@ -154,65 +156,7 @@ namespace DotNetNuke.Admin.Containers
                     this.clientResourceController.RegisterScript("~/admin/menus/ModuleActions/dnnQuickSettings.js");
                 }
 
-                if (this.ActionRoot.Visible)
-                {
-                    // Add Menu Items
-                    foreach (ModuleAction rootAction in this.ActionRoot.Actions)
-                    {
-                        // Process Children
-                        var actions = new List<ModuleAction>();
-                        foreach (ModuleAction action in rootAction.Actions)
-                        {
-                            if (action.Visible)
-                            {
-                                if ((this.EditMode && Globals.IsAdminControl() == false) ||
-                                    (action.Secure != SecurityAccessLevel.Anonymous && action.Secure != SecurityAccessLevel.View))
-                                {
-                                    if (!action.Icon.Contains("://")
-                                            && !action.Icon.StartsWith("/", StringComparison.Ordinal)
-                                            && !action.Icon.StartsWith("~/", StringComparison.Ordinal))
-                                    {
-                                        action.Icon = "~/images/" + action.Icon;
-                                    }
-
-                                    if (action.Icon.StartsWith("~/", StringComparison.Ordinal))
-                                    {
-                                        action.Icon = Globals.ResolveUrl(action.Icon);
-                                    }
-
-                                    actions.Add(action);
-
-                                    if (string.IsNullOrEmpty(action.Url))
-                                    {
-                                        this.validIDs.Add(action.ID);
-                                    }
-                                }
-                            }
-                        }
-
-                        var oSerializer = new JavaScriptSerializer();
-                        if (rootAction.Title == Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile))
-                        {
-                            this.AdminActionsJSON = oSerializer.Serialize(actions);
-                        }
-                        else
-                        {
-                            if (rootAction.Title == Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile))
-                            {
-                                this.CustomActionsJSON = oSerializer.Serialize(actions);
-                            }
-                            else
-                            {
-                                this.SupportsMove = actions.Count > 0;
-                                this.Panes = oSerializer.Serialize(this.PortalSettings.ActiveTab.Panes);
-                            }
-                        }
-                    }
-
-                    this.IsShared = this.ModuleContext.Configuration.AllTabs
-                        || PortalGroupController.Instance.IsModuleShared(this.ModuleContext.ModuleId, PortalController.Instance.GetPortal(this.PortalSettings.PortalId))
-                        || TabController.Instance.GetTabsByModuleID(this.ModuleContext.ModuleId).Count > 1;
-                }
+                this.Page.RegisterAsyncTask(new PageAsyncTask(this.ProcessActionsAsync));
             }
             catch (Exception exc)
             {
@@ -220,7 +164,7 @@ namespace DotNetNuke.Admin.Containers
             }
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         protected override void Render(HtmlTextWriter writer)
         {
             base.Render(writer);
@@ -231,9 +175,89 @@ namespace DotNetNuke.Admin.Containers
             }
         }
 
+        private Task ProcessActionsAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (!this.ActionRoot.Visible)
+                {
+                    return Task.CompletedTask;
+                }
+
+                // Add Menu Items
+                foreach (ModuleAction rootAction in this.ActionRoot.Actions)
+                {
+                    // Process Children
+                    var actions = new List<ModuleAction>();
+                    foreach (ModuleAction action in rootAction.Actions)
+                    {
+                        if (action.Visible)
+                        {
+                            if ((this.EditMode && Globals.IsAdminControl() == false) ||
+                                (action.Secure != SecurityAccessLevel.Anonymous && action.Secure != SecurityAccessLevel.View))
+                            {
+                                if (!action.Icon.Contains("://")
+                                        && !action.Icon.StartsWith("/", StringComparison.Ordinal)
+                                        && !action.Icon.StartsWith("~/", StringComparison.Ordinal))
+                                {
+                                    action.Icon = "~/images/" + action.Icon;
+                                }
+
+                                if (action.Icon.StartsWith("~/", StringComparison.Ordinal))
+                                {
+                                    action.Icon = Globals.ResolveUrl(action.Icon);
+                                }
+
+                                actions.Add(action);
+
+                                if (string.IsNullOrEmpty(action.Url))
+                                {
+                                    this.validIDs.Add(action.ID);
+                                }
+                            }
+                        }
+                    }
+
+                    var oSerializer = new JavaScriptSerializer();
+                    if (rootAction.Title == Localization.GetString("ModuleGenericActions.Action", Localization.GlobalResourceFile))
+                    {
+                        this.AdminActionsJSON = oSerializer.Serialize(actions);
+                    }
+                    else
+                    {
+                        if (rootAction.Title == Localization.GetString("ModuleSpecificActions.Action", Localization.GlobalResourceFile))
+                        {
+                            this.CustomActionsJSON = oSerializer.Serialize(actions);
+                        }
+                        else
+                        {
+                            this.SupportsMove = actions.Count > 0;
+                            this.Panes = oSerializer.Serialize(this.PortalSettings.ActiveTab.Panes);
+                        }
+                    }
+                }
+
+                this.IsShared = this.ModuleContext.Configuration.AllTabs
+                    || PortalGroupController.Instance.IsModuleShared(this.ModuleContext.ModuleId, PortalController.Instance.GetPortal(this.PortalSettings.PortalId))
+                    || TabController.Instance.GetTabsByModuleID(this.ModuleContext.ModuleId).Count > 1;
+            }
+            catch (Exception exc)
+            {
+                Exceptions.ProcessModuleLoadException(this, exc);
+            }
+
+            return Task.CompletedTask;
+        }
+
         private void ActionButton_Click(object sender, EventArgs e)
         {
+            this.Page.RegisterAsyncTask(new PageAsyncTask(ct => this.ActionButton_ClickAsync(sender, e, ct)));
+        }
+
+        private Task ActionButton_ClickAsync(object sender, EventArgs e, CancellationToken cancellationToken)
+        {
             this.ProcessAction(this.Request.Params["__EVENTARGUMENT"]);
+            return Task.CompletedTask;
         }
     }
 }

--- a/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
+++ b/DNN Platform/Website/admin/Modules/Modulesettings.ascx.cs
@@ -12,6 +12,7 @@ namespace DotNetNuke.Modules.Admin.Modules
     using System.Linq;
     using System.Text;
     using System.Threading;
+    using System.Threading.Tasks;
     using System.Web.UI;
 
     using DotNetNuke.Abstractions;
@@ -320,7 +321,25 @@ namespace DotNetNuke.Modules.Admin.Modules
                     {
                         // Get the module settings from the PortalSettings and pass the
                         // two settings hashtables to the sub control to process
-                        this.SettingsControl.LoadSettings();
+                        if (this.SettingsControl is IAsyncSettingsControl asyncSettingsControl)
+                        {
+                            this.Page.RegisterAsyncTask(new PageAsyncTask(async cancellationToken =>
+                            {
+                                try
+                                {
+                                    await asyncSettingsControl.LoadSettingsAsync(cancellationToken);
+                                }
+                                catch (Exception exc)
+                                {
+                                    Exceptions.ProcessModuleLoadException(this, exc);
+                                }
+                            }));
+                        }
+                        else
+                        {
+                            this.SettingsControl.LoadSettings();
+                        }
+
                         this.specificSettingsTab.Visible = true;
                         this.fsSpecific.Visible = true;
                     }
@@ -506,12 +525,33 @@ namespace DotNetNuke.Modules.Admin.Modules
                     this.Module.AllModules = this.chkAllModules.Checked;
                     ModuleController.Instance.UpdateModule(this.Module);
 
+                    var executeAsync = false;
+
                     // Update Custom Settings
                     if (this.SettingsControl != null)
                     {
                         try
                         {
-                            this.SettingsControl.UpdateSettings();
+                            if (this.SettingsControl is IAsyncSettingsControl asyncSettingsControl)
+                            {
+                                executeAsync = true;
+                                this.Page.RegisterAsyncTask(new PageAsyncTask(async cancellationToken =>
+                                {
+                                    try
+                                    {
+                                        await asyncSettingsControl.UpdateSettingsAsync(cancellationToken);
+                                        Continuation();
+                                    }
+                                    catch (Exception exc)
+                                    {
+                                        Exceptions.ProcessModuleLoadException(this, exc);
+                                    }
+                                }));
+                            }
+                            else
+                            {
+                                this.SettingsControl.UpdateSettings();
+                            }
                         }
                         catch (ThreadAbortException exc)
                         {
@@ -525,70 +565,78 @@ namespace DotNetNuke.Modules.Admin.Modules
                         }
                     }
 
-                    // These Module Copy/Move statements must be
-                    // at the end of the Update as the Controller code assumes all the
-                    // Updates to the Module have been carried out.
-
-                    // Check if the Module is to be Moved to a new Tab
-                    if (!this.chkAllTabs.Checked)
+                    if (!executeAsync)
                     {
-                        var newTabId = int.Parse(this.cboTab.SelectedValue);
-                        if (this.TabId != newTabId)
-                        {
-                            // First check if there already is an instance of the module on the target page
-                            var tmpModule = ModuleController.Instance.GetModule(this.moduleId, newTabId, false);
-                            if (tmpModule == null)
-                            {
-                                // Move module
-                                ModuleController.Instance.MoveModule(this.moduleId, this.TabId, newTabId, Globals.glbDefaultPane);
-                            }
-                            else
-                            {
-                                // Warn user
-                                Skin.AddModuleMessage(this, Localization.GetString("ModuleExists", this.LocalResourceFile), ModuleMessage.ModuleMessageType.RedError);
-                                return;
-                            }
-                        }
+                        Continuation();
                     }
 
-                    // Check if Module is to be Added/Removed from all Tabs
-                    if (allTabsChanged)
+                    void Continuation()
                     {
-                        var listTabs = TabController.GetPortalTabs(this.hostSettings, this.appStatus, this.PortalSettings.PortalId, Null.NullInteger, false, true);
-                        if (this.chkAllTabs.Checked)
+                        // These Module Copy/Move statements must be
+                        // at the end of the Update as the Controller code assumes all the
+                        // Updates to the Module have been carried out.
+
+                        // Check if the Module is to be Moved to a new Tab
+                        if (!this.chkAllTabs.Checked)
                         {
-                            if (!this.chkNewTabs.Checked)
+                            var newTabId = int.Parse(this.cboTab.SelectedValue);
+                            if (this.TabId != newTabId)
                             {
-                                foreach (var destinationTab in listTabs)
+                                // First check if there already is an instance of the module on the target page
+                                var tmpModule = ModuleController.Instance.GetModule(this.moduleId, newTabId, false);
+                                if (tmpModule == null)
                                 {
-                                    var module = ModuleController.Instance.GetModule(this.moduleId, destinationTab.TabID, false);
-                                    if (module != null)
+                                    // Move module
+                                    ModuleController.Instance.MoveModule(this.moduleId, this.TabId, newTabId, Globals.glbDefaultPane);
+                                }
+                                else
+                                {
+                                    // Warn user
+                                    Skin.AddModuleMessage(this, Localization.GetString("ModuleExists", this.LocalResourceFile), ModuleMessage.ModuleMessageType.RedError);
+                                    return;
+                                }
+                            }
+                        }
+
+                        // Check if Module is to be Added/Removed from all Tabs
+                        if (allTabsChanged)
+                        {
+                            var listTabs = TabController.GetPortalTabs(this.hostSettings, this.appStatus, this.PortalSettings.PortalId, Null.NullInteger, false, true);
+                            if (this.chkAllTabs.Checked)
+                            {
+                                if (!this.chkNewTabs.Checked)
+                                {
+                                    foreach (var destinationTab in listTabs)
                                     {
-                                        if (module.IsDeleted)
+                                        var module = ModuleController.Instance.GetModule(this.moduleId, destinationTab.TabID, false);
+                                        if (module != null)
                                         {
-                                            ModuleController.Instance.RestoreModule(module);
+                                            if (module.IsDeleted)
+                                            {
+                                                ModuleController.Instance.RestoreModule(module);
+                                            }
                                         }
-                                    }
-                                    else
-                                    {
-                                        if (!this.PortalSettings.ContentLocalizationEnabled || (this.Module.CultureCode == destinationTab.CultureCode))
+                                        else
                                         {
-                                            ModuleController.Instance.CopyModule(this.Module, destinationTab, this.Module.PaneName, true);
+                                            if (!this.PortalSettings.ContentLocalizationEnabled || (this.Module.CultureCode == destinationTab.CultureCode))
+                                            {
+                                                ModuleController.Instance.CopyModule(this.Module, destinationTab, this.Module.PaneName, true);
+                                            }
                                         }
                                     }
                                 }
                             }
+                            else
+                            {
+                                ModuleController.Instance.DeleteAllModules(this.moduleId, this.TabId, listTabs, true, false, false);
+                            }
                         }
-                        else
-                        {
-                            ModuleController.Instance.DeleteAllModules(this.moduleId, this.TabId, listTabs, true, false, false);
-                        }
-                    }
 
-                    if (!this.DoNotRedirectOnUpdate)
-                    {
-                        // Navigate back to admin page
-                        this.Response.Redirect(this.ReturnURL, true);
+                        if (!this.DoNotRedirectOnUpdate)
+                        {
+                            // Navigate back to admin page
+                            this.Response.Redirect(this.ReturnURL, true);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #4647

## Summary
Creates a secondary variant of the MvcHostControl that is executed asynchronously during the page execution.
To avoid any breaking changes to the execution of the existing MVC controls, the control has to opt-in / be marked as requiring asynchronous execution. To do that the control needs to be declared with a ControlSrc in the form of `{ControllerNamespace}/{ControllerName}/async/{ActionName}.mvc` instead of the `{ControllerNamespace}/{ControllerName}/{ActionName}.mvc` that existing MVC module controls are defined as.

Apart from the action itself, the retrieval of the ModuleActions (`Get{0}Actions` method) supports `Task<ModuleActionCollection>` for asynchronous execution as well.

A few of the methods had to be made `protected` and as such code had to be re-ordered to comply with StyleCop rules. As a result, it may initially appear that more code than expected was modified.

Other small fixes:
+ Fix selection of ControllerName from the segments of the ControlSrc when it has a length greater than 2 when assigning the value for `moduleControl.LocalResourceFile`.
+ MVC: Improve error messages when view template is not found by writing out the SearchedLocations (something that I think ASP.NET does by default).

There is one TODO left in ModuleInstanceContext.cs, and as it states I am not sure if that should return or throw, Throwing, with a good message explaining the issue, would probably help more than the NullReferenceException that would end up being thrown by existing code that would most likely directly iterate over the list received from the method call.

This is also a place where a breaking change could be expected in 3rd party skins or other extensions that try to synchronously read the `ModuleInstanceContext.Actions` (list of admin ModuleActions) for asynchronous controls.