### PR TITLE
Add Zizmor for GitHub Actions auditing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     labels:
       - "Type: Build/Release"
       - "Type: Maintenance"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -15,6 +17,8 @@ updates:
     labels:
       - "javascript"
       - "Type: Maintenance"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "dotnet-sdk"
     directory: "/"
@@ -24,6 +28,8 @@ updates:
     labels:
       - ".NET"
       - "Type: Maintenance"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "nuget"
     directory: "/"
@@ -65,3 +71,5 @@ updates:
       CodeAnalysis:
         patterns:
           - "Microsoft.CodeAnalysis.*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/browserslist-update-db.yml
+++ b/.github/workflows/browserslist-update-db.yml
@@ -18,6 +18,7 @@ jobs:
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Configure git"
         run: |
           # Setup for commiting using built-in token. See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

--- a/.github/workflows/browserslist-update-db.yml
+++ b/.github/workflows/browserslist-update-db.yml
@@ -14,8 +14,8 @@ jobs:
   update-browserslist-database:
     runs-on: "ubuntu-latest"
     permissions:
-      contents: "write"
-      pull-requests: "write"
+      contents: "write" # creates a commmit for the pull request
+      pull-requests: "write" # creates a pull request if there's an update
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2

--- a/.github/workflows/browserslist-update-db.yml
+++ b/.github/workflows/browserslist-update-db.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: "read"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-browserslist-database:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/browserslist-update-db.yml
+++ b/.github/workflows/browserslist-update-db.yml
@@ -4,8 +4,7 @@ on:
   schedule:
     - cron: "0 2 1,15 * *"
 
-permissions:
-  contents: "read"
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/browserslist-update-db.yml
+++ b/.github/workflows/browserslist-update-db.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   update-browserslist-database:
+    name: "Update Browserslist database"
     runs-on: "ubuntu-latest"
     permissions:
       contents: "write" # creates a commmit for the pull request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   RUN_TESTS: "true"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: "read"
+permissions: {}
 
 on:
   push:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,15 @@
 ﻿name: "Dependency Review"
-on: ["pull_request"]
+
+on: 
+  - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: "read"
+
 jobs:
   dependency-review:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,12 +7,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: "read"
+permissions: {}
 
 jobs:
   dependency-review:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2

--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: "Checkout Repo"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Compress Images"
         id: "compress_images"

--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -1,4 +1,5 @@
 name: "Compress images"
+
 on:
   pull_request: # PRs with image (but we can't push changes back to other forks)
     paths:
@@ -7,14 +8,23 @@ on:
       - "**.png"
       - "**.webp"
       - "**.avif"
+
   push:
     branches:
       - development # merging PRs from other forks (will open a new PR)
+
   workflow_dispatch: # on demand
+
   schedule:
     - cron: "0 0 * * 0" # every Sunday at midnight
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: "read"
+
 jobs:
   build:
     if: | # Only run on main repo on and PRs that match the main repo.

--- a/.github/workflows/image-actions.yml
+++ b/.github/workflows/image-actions.yml
@@ -22,8 +22,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: "read"
+permissions: {}
 
 jobs:
   build:
@@ -33,6 +32,8 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     name: "calibreapp/image-actions"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
     steps:
       - name: "Checkout Repo"
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -24,10 +24,8 @@ jobs:
     runs-on: "ubuntu-latest"
     if: ${{ github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request' }}
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: "write"
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: "write"
+      security-events: "write" # Needed to upload the results to code-scanning dashboard.
+      id-token: "write" # Needed to publish results and get a badge (see publish_results below).
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -12,8 +12,7 @@ on:
     branches:
     - develop
 
-# Declare default permissions as read only.
-permissions: "read-all"
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -9,10 +9,15 @@ on:
   schedule:
     - cron: "45 10 * * 0"
   push:
-    branches: ["develop"]
+    branches:
+    - develop
 
 # Declare default permissions as read only.
 permissions: "read-all"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analysis:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - "**"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     name: Run zizmor 🌈

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  secrets-outside-env:
+    config:
+      allow:
+        - SCORECARD_TOKEN

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,7 +2,7 @@ compressionLevel: mixed
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 1440
+npmMinimalAgeGate: "1d"
 
 npmPreapprovedPackages:
   - "@dnncommunity/dnn-elements"


### PR DESCRIPTION
## Summary
This PR adds an action to run [Zimzor](https://docs.zizmor.sh/) to lint GitHub Actions workflows for security concerns.