### PR TITLE
Bumped MailKit and MimeKit from 4.10.0 to 4.16.0

### DIFF
--- a/DNN Platform/Components/MailKit/MailKit.dnn
+++ b/DNN Platform/Components/MailKit/MailKit.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DotNetNuke.MailKit" type="Library" version="4.10.0.0">
+    <package name="DotNetNuke.MailKit" type="Library" version="4.16.0.0">
       <friendlyName>MailKit Components</friendlyName>
       <description>Libraries required for MailKit.</description>
       <dependencies/>
@@ -12,7 +12,7 @@
       </owner>
       <license src="License.txt"/>
       <releaseNotes>
-        This package includes MailKit assembly version 4.10.0 and MimeKit assembly version 4.10.0.
+        This package includes MailKit assembly version 4.16.0 and MimeKit assembly version 4.16.0.
         Please go to http://www.mimekit.com/ to view release notes on this particular version.</releaseNotes>
       <components>
         <component type="Assembly">
@@ -20,27 +20,27 @@
             <assembly>
               <path>bin</path>
               <name>MailKit.dll</name>
-              <version>4.10.0.0</version>
+              <version>4.16.0.0</version>
             </assembly>
             <assembly>
               <path>bin</path>
               <name>MimeKit.dll</name>
-              <version>4.10.0.0</version>
+              <version>4.16.0.0</version>
             </assembly>
             <assembly>
               <path>bin</path>
               <name>BouncyCastle.Cryptography.dll</name>
-              <version>2.5.0.6119</version>
+              <version>2.6.2.46322</version>
             </assembly>
             <assembly>
               <path>bin</path>
               <name>System.Buffers.dll</name>
-              <version>4.600.24.56208</version>
+              <version>4.600.125.16908</version>
             </assembly>
             <assembly>
               <path>bin</path>
               <name>System.Memory.dll</name>
-              <version>4.600.24.56208</version>
+              <version>4.600.325.20307</version>
             </assembly>
             <assembly>
               <path>bin</path>
@@ -50,7 +50,7 @@
             <assembly>
               <path>bin</path>
               <name>System.Formats.Asn1.dll</name>
-              <version>9.0.124.61010</version>
+              <version>8.0.724.31311</version>
             </assembly>
             <assembly>
               <path>bin</path>

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.03.01.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.03.01.SqlDataProvider
@@ -1,0 +1,9 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.03.02.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.03.02.SqlDataProvider
@@ -1,0 +1,9 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/

--- a/DNN Platform/Website/web.config
+++ b/DNN Platform/Website/web.config
@@ -45,11 +45,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="MimeKit" publicKeyToken="bede1c8a46c66814" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.10.0.0" newVersion="4.10.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.16.0.0" newVersion="4.16.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="MailKit" publicKeyToken="4e064fe7c44a8f1b" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.16.0.0" newVersion="4.16.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="HtmlSanitizer" Version="9.1.878-beta" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />
     <PackageVersion Include="Lucene.Net.Contrib" Version="3.0.3" />
-    <PackageVersion Include="MailKit" Version="4.8.0" />
+    <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="Microsoft.ApplicationBlocks.Data" Version="2.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.3.0" />
@@ -49,7 +49,7 @@
     <PackageVersion Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageVersion Include="Microsoft.Web.Infrastructure" Version="2.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MimeKit" Version="4.15.1" />
+    <PackageVersion Include="MimeKit" Version="4.16.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -14,5 +14,5 @@ using System.Reflection;
 [assembly: AssemblyCopyright("DNN Platform is copyright 2002-2026 by .NET Foundation. All Rights Reserved.")]
 [assembly: AssemblyTrademark("DNN")]
 [assembly: AssemblyVersion("10.3.2")]
-[assembly: AssemblyFileVersion("10.3.2.16")]
-[assembly: AssemblyInformationalVersion("10.3.2-alpha.16+Branch.develop.Sha.4aac525e610f56ce7e0cc9a6cc72c949c8496da6")]
+[assembly: AssemblyFileVersion("10.3.2.0")]
+[assembly: AssemblyInformationalVersion("10.3.2 Custom build")]


### PR DESCRIPTION
Bumps MailKit and MimeKit from 4.10.0 to 4.16.0
This should resolve the current build failures to to a security advisory on MailKit side.