### PR TITLE
Fixed an issue where CodeDom would be disabled post-upgrade

### DIFF
--- a/DNN Platform/Components/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dnn
+++ b/DNN Platform/Components/Microsoft.CodeDom.Providers.DotNetCompilerPlatform/Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dnn
@@ -33,6 +33,14 @@
             </uninstall>
           </config>
         </component>
+        <component type="Assembly">
+          <assemblies>
+            <assembly Action="UnRegister">
+              <path>bin</path>
+              <name>Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</name>
+            </assembly>
+          </assemblies>
+        </component>
         <component type="Cleanup" version="10.00.00">
           <files>
             <file>
@@ -194,7 +202,9 @@
                   <node path="/configuration/system.codedom" action="update" targetpath="/configuration/system.codedom/compilers" collision="ignore">
                     <compilers></compilers>
                   </node>
-                  <node path="/configuration/system.codedom/compilers" action="update" key="extension" collision="overwrite">
+                  <node path="/configuration/system.codedom/compilers/compiler[@extension='.cs']" action="remove" />
+                  <node path="/configuration/system.codedom/compilers/compiler[@extension='.vb']" action="remove" />
+                  <node path="/configuration/system.codedom/compilers" action="add">
                     <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701;612;618" />
                     <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
                   </node>


### PR DESCRIPTION
Fixes https://github.com/dnnsoftware/Dnn.Platform/issues/7213
A two step process was put in place to disable CodeDom compilation before its upgrade and re-enable it aftewards. This was implemented in https://github.com/dnnsoftware/Dnn.Platform/pull/6455

However when upgrading from-to the same version, something did not go right and no changes were detected upon the last step of that process. With this PR the change detection appears to be fixed and the web.config saves after the second XmlMerge.

I have tested upgrades from 10.2.4 and 10.3.0 as well as a clean install and the web.config is fine after each of those scenarios.

This PR includes the changes from https://github.com/dnnsoftware/Dnn.Platform/pull/7221 as I could not build without it, so merging the other first will make this one easier to review.