### PR TITLE
Fixed an issue where the themes list were no longer vertical in Pages module

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Appearance/Gallery/Gallery.jsx
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Appearance/Gallery/Gallery.jsx
@@ -48,7 +48,7 @@ class Gallery extends Component {
                     autoHeight
                     autoHeightMin={0}
                     autoHeightMax={480}>
-                    <div style={{width}}>
+                    <div style={{width}} className="flex-container">
                         {this.props.children}
                     </div>
                 </Scrollbars>

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Appearance/Gallery/style.module.less
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Appearance/Gallery/style.module.less
@@ -7,4 +7,8 @@
         background-color: @gallery;
         border: solid 1px @mercury;
     }
+
+    .flex-container{
+        display: flex;
+    }
 }

--- a/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Appearance/style.module.less
+++ b/Dnn.AdminExperience/ClientSide/Pages.Web/src/components/Appearance/style.module.less
@@ -1,5 +1,6 @@
 @import "~@dnnsoftware/dnn-react-common/styles/index";
 :local(.moduleContainer) {
+    padding: 0;
     & > .dnn-grid-cell {
         margin-bottom: 20px;
     }


### PR DESCRIPTION
I can't for the life of me remember where this was discussed, but in 10.3.1 the list of themes/layouts/containers was no longer listed horizontally but showed up as a long vertical list.

This PR fixes that.