### PR TITLE
Fix bug report version using RC

### DIFF
--- a/Build/Tasks/CreateGitHubPullRequest.cs
+++ b/Build/Tasks/CreateGitHubPullRequest.cs
@@ -302,7 +302,7 @@ namespace DotNetNuke.Build.Tasks
                 select new { release, version, isReleaseCandidate, };
             releases = releases.ToList();
 
-            var latestStable = releases.FirstOrDefault();
+            var latestStable = releases.FirstOrDefault(r => !r.isReleaseCandidate);
 
             context.Information(
                 "Latest stable release: {0}",


### PR DESCRIPTION
## Summary
#7236 introduced an issue where the bug-report version was set to the latest release, rather than the latest stable release.