### PR TITLE
Fixed an issue where language flags would not show in Site Settings

### DIFF
--- a/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/Flag/index.jsx
+++ b/Dnn.AdminExperience/ClientSide/Dnn.React.Common/src/Flag/index.jsx
@@ -42,11 +42,11 @@ function Flag({ culture = "", onClick, title }) {
 
     useEffect(() => {
         try {
-            setFlagUrl(require(`./img/flags/${culture}.png`).default);
+            setFlagUrl(require(`./img/flags/${culture}.png`));
             setIsFallback(false);
         } catch {
             try {
-                setFlagUrl(require("./img/flags/none.png").default);
+                setFlagUrl(require("./img/flags/none.png"));
                 setIsFallback(true);
             } catch {
                 setFlagUrl(undefined);


### PR DESCRIPTION
#7116 had a fix for the language icons in Site Settings, it worked for a dev build but apparently failed at runtime. This PR should fix it but I will test the CI build before confirming...

Relates to #7114 