### PR TITLE
Pin Microsoft.Data.OData to 5.8.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,8 @@
     <!-- NOTE: this version also needs to be managed in DotNetNuke.Internal.SourceGenerators.csproj -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.Data.OData" Version="5.8.4" />
+    <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
[Version 5.8.2](https://www.nuget.org/packages/Microsoft.Data.OData/5.8.2) is being brought in by [WindowsAzure.Storage](https://www.nuget.org/packages/WindowsAzure.Storage), but has https://github.com/advisories/GHSA-mv2r-q4g5-j8q5. The presence of this vulnerability is [blocking other PRs](https://github.com/dnnsoftware/Dnn.Platform/actions/runs/25928055793/job/76214529685?pr=7274).

However, [its latest version (5.8.5)](https://www.nuget.org/packages/Microsoft.Data.OData/5.8.5) is deprecated due to "critical bugs" https://github.com/OData/odata.net/issues/2452. [Version 5.8.4](https://www.nuget.org/packages/Microsoft.Data.OData/5.8.4) appears to be the best choice.

Ultimately, we need to transition from [WindowsAzure.Storage](https://www.nuget.org/packages/WindowsAzure.Storage) (which is what's bringing in [Microsoft.Data.OData](https://www.nuget.org/packages/Microsoft.Data.OData)) to [Azure.Storage.Common](https://www.nuget.org/packages/Azure.Storage.Common). A shorter-term fix is to upgrade WindowsAzure.Storage from 8.3.0 to 9.x, which does not have the OData dependency.