### PR TITLE
Add merge_group triggers for PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ on:
     branches:
       - "develop"
       - "release/*"
+  merge_group:
+    types:
+      - "checks_requested"
   workflow_dispatch:
     inputs:
       CAKE_TARGET:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,10 @@
 ﻿name: "Dependency Review"
 
 on: 
-  - pull_request
+  pull_request:
+  merge_group:
+      types:
+      - "checks_requested"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
+    types:
+      - "checks_requested"
 
 permissions: {}
 


### PR DESCRIPTION
Required checks don't run once they're added to the merge queue