### PR TITLE
Use Unix timestamp as cdv in debug mode

### DIFF
--- a/DNN Platform/DotNetNuke.Web.Client.ResourceManager/ClientResourceController.cs
+++ b/DNN Platform/DotNetNuke.Web.Client.ResourceManager/ClientResourceController.cs
@@ -283,7 +283,9 @@ namespace DotNetNuke.Web.Client.ResourceManager
                 });
             }
 
-            return string.Join(string.Empty, sortedList.Select(resource => resource.Render(this.crmVersion, this.hostSettings.CdnEnabled, applicationPath)));
+            var crmVersion = this.hostSettings.DebugMode ? DateTimeOffset.UtcNow.ToUnixTimeSeconds() : this.crmVersion;
+
+            return string.Join(string.Empty, sortedList.Select(resource => resource.Render(unchecked((int)crmVersion), this.hostSettings.CdnEnabled, applicationPath)));
         }
 
         private List<T> AddResource<T>(List<T> resources, T resource)

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Security/App_LocalResources/Security.resx
@@ -634,7 +634,7 @@
     <value>Show Critical Errors on Screen</value>
   </data>
   <data name="plDebugMode.Help" xml:space="preserve">
-    <value>Check this box to run the installation in "debug mode". This causes various parts of the application to write more verbose error logs etc. Note: This may lead to performance degradation.</value>
+    <value>Check this box to run the installation in "debug mode". This causes various parts of the application to write more verbose error logs etc. It also switches the CDV value to a timestamp, meaning the client browser will continuously download new versions of client resources (stylesheets, fonts and javascript files). Note: This may lead to performance degradation.</value>
   </data>
   <data name="plDebugMode.Text" xml:space="preserve">
     <value>Debug Mode</value>

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.Library/Containers/PersonaBarContainer.cs
@@ -114,7 +114,7 @@ namespace Dnn.PersonaBar.Library.Containers
             var menuStructure = this.personaBarController.GetMenu(portalSettings, user);
 
             settings.Add("applicationPath", Globals.ApplicationPath);
-            settings.Add("buildNumber", this.hostSettings.CrmVersion.ToString(CultureInfo.InvariantCulture));
+            settings.Add("buildNumber", this.hostSettings.DebugMode ? DateTimeOffset.UtcNow.ToUnixTimeSeconds() : this.hostSettings.CrmVersion.ToString(CultureInfo.InvariantCulture));
             settings.Add("userId", user.UserID);
             settings.Add("avatarUrl", Globals.ResolveUrl(Utilities.GetProfileAvatar(user)));
             settings.Add("culture", Thread.CurrentThread.CurrentUICulture.Name);


### PR DESCRIPTION
Addresses #7296

When in debug mode (Security > More > More Security Settings) the CDV nr will be replaced with the unix timestamp in seconds.