### PR TITLE
Better support for empty elements in manifest.

### DIFF
--- a/DNN Platform/Library/Common/Utilities/XmlUtils.cs
+++ b/DNN Platform/Library/Common/Utilities/XmlUtils.cs
@@ -787,6 +787,22 @@ namespace DotNetNuke.Common.Utilities
             return functionReturnValue;
         }
 
+        public static bool TryReadEndElement(XmlReader reader)
+        {
+            while (reader.NodeType == XmlNodeType.Whitespace)
+            {
+                reader.Read();
+            }
+
+            if (reader.NodeType == XmlNodeType.EndElement)
+            {
+                reader.ReadEndElement();
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>Creates an <see cref="XPathExpression"/> with variable arguments.</summary>
         /// <param name="xpath">The XPath expression that includes variables, e.g. <c>//root/data[@name=$resourceKeyName]/value</c>.</param>
         /// <param name="arguments">A collection of variable names and values.</param>

--- a/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
@@ -266,82 +266,81 @@ namespace DotNetNuke.Entities.Modules
                     continue;
                 }
 
-                if (reader.NodeType == XmlNodeType.Element && reader.Name == "moduleDefinitions" && !reader.IsEmptyElement)
+                switch (reader)
                 {
-                    this.ReadModuleDefinitions(reader);
-                }
-                else if (reader.NodeType == XmlNodeType.Element && reader.Name == "supportedFeatures" && !reader.IsEmptyElement)
-                {
-                    this.ReadSupportedFeatures(reader);
-                }
-                else if (reader.NodeType == XmlNodeType.Element && reader.Name == "shareable" && !reader.IsEmptyElement)
-                {
-                    this.ReadModuleSharing(reader);
-                }
-                else if (reader.NodeType == XmlNodeType.Element && reader.Name == "page" && !reader.IsEmptyElement)
-                {
-                    this.ReadPageInfo(reader);
-                }
-                else
-                {
-                    switch (reader.Name)
-                    {
-                        case "desktopModule":
-                            break;
-                        case "moduleName":
-                            this.ModuleName = reader.ReadElementContentAsString();
-                            break;
-                        case "friendlyName":
-                            this.FriendlyName = reader.ReadElementContentAsString();
-                            break;
-                        case "description":
-                            this.Description = reader.ReadElementContentAsString();
-                            break;
-                        case "foldername":
-                            this.FolderName = reader.ReadElementContentAsString();
-                            break;
-                        case "businessControllerClass":
-                            this.BusinessControllerClass = reader.ReadElementContentAsString();
-                            break;
-                        case "codeSubDirectory":
-                            this.CodeSubDirectory = reader.ReadElementContentAsString();
-                            break;
-                        case "page":
-                            this.ReadPageInfo(reader);
+                    case { NodeType: XmlNodeType.Element, Name: "moduleDefinitions", IsEmptyElement: false, }:
+                        this.ReadModuleDefinitions(reader);
+                        break;
+                    case { NodeType: XmlNodeType.Element, Name: "supportedFeatures", IsEmptyElement: false, }:
+                        this.ReadSupportedFeatures(reader);
+                        break;
+                    case { NodeType: XmlNodeType.Element, Name: "shareable", IsEmptyElement: false, }:
+                        this.ReadModuleSharing(reader);
+                        break;
+                    case { NodeType: XmlNodeType.Element, Name: "page", IsEmptyElement: false, }:
+                        this.ReadPageInfo(reader);
+                        break;
+                    default:
+                        switch (reader.Name)
+                        {
+                            case "desktopModule":
+                                break;
+                            case "moduleName":
+                                this.ModuleName = reader.ReadElementContentAsString();
+                                break;
+                            case "friendlyName":
+                                this.FriendlyName = reader.ReadElementContentAsString();
+                                break;
+                            case "description":
+                                this.Description = reader.ReadElementContentAsString();
+                                break;
+                            case "foldername":
+                                this.FolderName = reader.ReadElementContentAsString();
+                                break;
+                            case "businessControllerClass":
+                                this.BusinessControllerClass = reader.ReadElementContentAsString();
+                                break;
+                            case "codeSubDirectory":
+                                this.CodeSubDirectory = reader.ReadElementContentAsString();
+                                break;
+                            case "page":
+                                this.ReadPageInfo(reader);
 
-                            if (this.Page.HasAdminPage())
-                            {
-                                this.AdminPage = this.Page.Name;
-                            }
+                                if (this.Page.HasAdminPage())
+                                {
+                                    this.AdminPage = this.Page.Name;
+                                }
 
-                            if (this.Page.HasHostPage())
-                            {
-                                this.HostPage = this.Page.Name;
-                            }
+                                if (this.Page.HasHostPage())
+                                {
+                                    this.HostPage = this.Page.Name;
+                                }
 
-                            break;
-                        case "isAdmin":
-                            if (bool.TryParse(reader.ReadElementContentAsString(), out var isAdmin))
-                            {
-                                this.IsAdmin = isAdmin;
-                            }
+                                break;
+                            case "isAdmin":
+                                if (bool.TryParse(reader.ReadElementContentAsString(), out var isAdmin))
+                                {
+                                    this.IsAdmin = isAdmin;
+                                }
 
-                            break;
-                        case "isPremium":
-                            if (bool.TryParse(reader.ReadElementContentAsString(), out var isPremium))
-                            {
-                                this.IsPremium = isPremium;
-                            }
+                                break;
+                            case "isPremium":
+                                if (bool.TryParse(reader.ReadElementContentAsString(), out var isPremium))
+                                {
+                                    this.IsPremium = isPremium;
+                                }
 
-                            break;
-                        default:
-                            if (reader.NodeType == XmlNodeType.Element && !string.IsNullOrEmpty(reader.Name))
-                            {
-                                reader.ReadElementContentAsString();
-                            }
+                                break;
+                            default:
+                                if (reader.NodeType == XmlNodeType.Element && !string.IsNullOrEmpty(reader.Name))
+                                {
+                                    reader.ReadElementContentAsString();
+                                }
 
-                            break;
-                    }
+                                break;
+                        }
+
+                        break;
                 }
             }
         }
@@ -350,7 +349,7 @@ namespace DotNetNuke.Entities.Modules
         /// <param name="writer">The XmlWriter to use.</param>
         public void WriteXml(XmlWriter writer)
         {
-            // Write start of main elemenst
+            // Write start of main elements
             writer.WriteStartElement("desktopModule");
 
             // write out properties
@@ -389,10 +388,7 @@ namespace DotNetNuke.Entities.Modules
             writer.WriteEndElement();
 
             // Write admin/host page info.
-            if (this.Page != null)
-            {
-                this.Page.WriteXml(writer);
-            }
+            this.Page?.WriteXml(writer);
 
             // Module sharing
             if (this.Shareable != ModuleSharing.Unknown)
@@ -432,7 +428,7 @@ namespace DotNetNuke.Entities.Modules
         private void ClearFeature(DesktopModuleSupportedFeature feature)
         {
             // And with the 1's complement of Feature to Clear the Feature flag
-            this.SupportedFeatures = this.SupportedFeatures & ~((int)feature);
+            this.SupportedFeatures &= ~(int)feature;
         }
 
         /// <summary>Gets a Feature from the Features.</summary>
@@ -470,10 +466,8 @@ namespace DotNetNuke.Entities.Modules
         {
             reader.ReadStartElement("supportedFeatures");
 
-            // support for empty <supportedFeatures></supportedFeatures>
-            if (reader.NodeType == XmlNodeType.EndElement)
+            if (XmlUtils.TryReadEndElement(reader))
             {
-                reader.ReadEndElement();
                 return;
             }
 
@@ -532,10 +526,8 @@ namespace DotNetNuke.Entities.Modules
         {
             reader.ReadStartElement("moduleDefinitions");
 
-            // support for empty <moduleDefinitions></moduleDefinitions>
-            if (reader.NodeType == XmlNodeType.EndElement)
+            if (XmlUtils.TryReadEndElement(reader))
             {
-                reader.ReadEndElement();
                 return;
             }
 
@@ -546,7 +538,7 @@ namespace DotNetNuke.Entities.Modules
                 // Create new ModuleDefinition object
                 var moduleDefinition = new ModuleDefinitionInfo();
 
-                // Load it from the Xml
+                // Load it from the XML
                 moduleDefinition.ReadXml(reader);
 
                 // Add to the collection
@@ -559,7 +551,7 @@ namespace DotNetNuke.Entities.Modules
         {
             this.Page = new PageInfo();
 
-            // Load it from the Xml
+            // Load it from the XML
             this.Page.ReadXml(reader.ReadSubtree());
 
             if (this.Page.HasAdminPage())

--- a/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
+++ b/DNN Platform/Library/Entities/Modules/DesktopModuleInfo.cs
@@ -468,8 +468,16 @@ namespace DotNetNuke.Entities.Modules
         /// <param name="reader">The XmlReader to use.</param>
         private void ReadSupportedFeatures(XmlReader reader)
         {
-            this.SupportedFeatures = 0;
             reader.ReadStartElement("supportedFeatures");
+
+            // support for empty <supportedFeatures></supportedFeatures>
+            if (reader.NodeType == XmlNodeType.EndElement)
+            {
+                reader.ReadEndElement();
+                return;
+            }
+
+            this.SupportedFeatures = 0;
             do
             {
                 if (reader.HasAttributes)
@@ -523,6 +531,14 @@ namespace DotNetNuke.Entities.Modules
         private void ReadModuleDefinitions(XmlReader reader)
         {
             reader.ReadStartElement("moduleDefinitions");
+
+            // support for empty <moduleDefinitions></moduleDefinitions>
+            if (reader.NodeType == XmlNodeType.EndElement)
+            {
+                reader.ReadEndElement();
+                return;
+            }
+
             do
             {
                 reader.ReadStartElement("moduleDefinition");

--- a/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
+++ b/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
@@ -237,10 +237,8 @@ namespace DotNetNuke.Security.Roles
         {
             reader.ReadStartElement("roles");
 
-            // support for empty <roles></roles>
-            if (reader.NodeType == XmlNodeType.EndElement)
+            if (XmlUtils.TryReadEndElement(reader))
             {
-                reader.ReadEndElement();
                 return;
             }
 

--- a/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
+++ b/DNN Platform/Library/Security/Roles/RoleGroupInfo.cs
@@ -236,6 +236,14 @@ namespace DotNetNuke.Security.Roles
         private void ReadRoles(XmlReader reader)
         {
             reader.ReadStartElement("roles");
+
+            // support for empty <roles></roles>
+            if (reader.NodeType == XmlNodeType.EndElement)
+            {
+                reader.ReadEndElement();
+                return;
+            }
+
             this.roles = new Dictionary<string, RoleInfo>();
             do
             {

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/DesktopModuleInfoTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/DesktopModuleInfoTests.cs
@@ -6,10 +6,12 @@ namespace DotNetNuke.Tests.Core.Entities.Modules;
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Xml;
 
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
+using DotNetNuke.Security;
 
 using NUnit.Framework;
 
@@ -19,7 +21,7 @@ public class DesktopModuleInfoTests
     [Test]
     public void ReadXml_WithUpgradeable_ReadsOneSupportedFeature()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -30,17 +32,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.True);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.False);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsUpgradeable));
+            Assert.That(desktopModule.IsUpgradeable, Is.True);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsUpgradeable));
         }
     }
 
     [Test]
     public void ReadXml_WithPortable_ReadsOneSupportedFeature()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -51,17 +53,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.True);
-            Assert.That(roleGroup.IsSearchable, Is.False);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.True);
+            Assert.That(desktopModule.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable));
         }
     }
 
     [Test]
     public void ReadXml_WithSearchable_ReadsOneSupportedFeature()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -72,17 +74,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.True);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.True);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable));
         }
     }
 
     [Test]
     public void ReadXml_WithSearchableAndPortable_ReadsTwoSupportedFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -94,17 +96,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.True);
-            Assert.That(roleGroup.IsSearchable, Is.True);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable + (int)DesktopModuleSupportedFeature.IsPortable));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.True);
+            Assert.That(desktopModule.IsSearchable, Is.True);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable + (int)DesktopModuleSupportedFeature.IsPortable));
         }
     }
 
     [Test]
     public void ReadXml_WithSearchableAndUpgradeable_ReadsTwoSupportedFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -116,16 +118,16 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.True);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.True);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable + (int)DesktopModuleSupportedFeature.IsUpgradeable));
+            Assert.That(desktopModule.IsUpgradeable, Is.True);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.True);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable + (int)DesktopModuleSupportedFeature.IsUpgradeable));
         }
     }
 
     [Test] public void ReadXml_WithPortableAndUpgradeable_ReadsTwoSupportedFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -137,16 +139,16 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.True);
-            Assert.That(roleGroup.IsPortable, Is.True);
-            Assert.That(roleGroup.IsSearchable, Is.False);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable + (int)DesktopModuleSupportedFeature.IsUpgradeable));
+            Assert.That(desktopModule.IsUpgradeable, Is.True);
+            Assert.That(desktopModule.IsPortable, Is.True);
+            Assert.That(desktopModule.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable + (int)DesktopModuleSupportedFeature.IsUpgradeable));
         }
     }
 
     [Test] public void ReadXml_WithAllThreeFeatures_ReadsThreeSupportedFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -159,17 +161,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.IsUpgradeable, Is.True);
-            Assert.That(roleGroup.IsPortable, Is.True);
-            Assert.That(roleGroup.IsSearchable, Is.True);
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable + (int)DesktopModuleSupportedFeature.IsUpgradeable + (int)DesktopModuleSupportedFeature.IsSearchable));
+            Assert.That(desktopModule.IsUpgradeable, Is.True);
+            Assert.That(desktopModule.IsPortable, Is.True);
+            Assert.That(desktopModule.IsSearchable, Is.True);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable + (int)DesktopModuleSupportedFeature.IsUpgradeable + (int)DesktopModuleSupportedFeature.IsSearchable));
         }
     }
 
     [Test]
     public void ReadXml_WithEmptySupportedFeatures_DoesNotInitializeFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures></supportedFeatures>
@@ -178,17 +180,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.False);
         }
     }
 
     [Test]
     public void ReadXml_WithEmptySupportedFeaturesIncludingWhiteSpace_DoesNotInitializeFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures>
@@ -198,17 +200,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.False);
         }
     }
 
     [Test]
     public void ReadXml_WithNoSupportedFeatures_DoesNotInitializeFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
             </desktopModule>
@@ -216,17 +218,17 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.False);
         }
     }
 
     [Test]
     public void ReadXml_WithSelfClosingSupportedFeatures_DoesNotInitializeFeatures()
     {
-        var roleGroup = ReadXml(
+        var desktopModule = ReadXml(
             """
             <desktopModule>
                 <supportedFeatures />
@@ -235,10 +237,113 @@ public class DesktopModuleInfoTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
-            Assert.That(roleGroup.IsUpgradeable, Is.False);
-            Assert.That(roleGroup.IsPortable, Is.False);
-            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(desktopModule.IsUpgradeable, Is.False);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.False);
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSelfClosingSupportedFeatures_ReadsRemainingInformationCorrectly()
+    {
+        var desktopModule = ReadXml(
+            """
+            <desktopModule>
+                <moduleName>Console</moduleName>
+                <supportedFeatures />
+                <foldername>Admin/Console</foldername>
+                <businessControllerClass>Dnn.Modules.Console.Components.BusinessController</businessControllerClass>
+                <moduleDefinitions>
+                    <moduleDefinition>
+                        <friendlyName>Console2</friendlyName>
+                        <moduleControls>
+                            <moduleControl>
+                                <controlKey/>
+                                <controlSrc>DesktopModules/Admin/Console/ViewConsole.ascx</controlSrc>
+                                <controlTitle>Console</controlTitle>
+                                <controlType>View</controlType>
+                                <iconFile></iconFile>
+                                <helpUrl>http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Console/About the Console Module.htm</helpUrl>
+                                <viewOrder>0</viewOrder>
+                                <supportsPartialRendering>True</supportsPartialRendering>
+                                <supportsPopUps>True</supportsPopUps>
+                            </moduleControl>
+                            <moduleControl>
+                                <controlKey>Settings</controlKey>
+                                <controlSrc>DesktopModules/Admin/Console/Settings.ascx</controlSrc>
+                                <controlTitle>Console Settings</controlTitle>
+                                <controlType>Admin</controlType>
+                                <iconFile></iconFile>
+                                <helpUrl></helpUrl>
+                                <viewOrder>0</viewOrder>
+                                <supportsPartialRendering>True</supportsPartialRendering>
+                                <supportsPopUps>True</supportsPopUps>
+                            </moduleControl>
+                        </moduleControls>
+                    </moduleDefinition>
+                </moduleDefinitions>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(desktopModule.ModuleName, Is.EqualTo("Console"));
+            Assert.That(desktopModule.FolderName, Is.EqualTo("Admin/Console"));
+            Assert.That(desktopModule.BusinessControllerClass, Is.EqualTo("Dnn.Modules.Console.Components.BusinessController"));
+            Assert.That(desktopModule.ModuleDefinitions, Has.Count.EqualTo(1));
+            var definition = desktopModule.ModuleDefinitions.Values.Single();
+            Assert.That(definition.FriendlyName, Is.EqualTo("Console2"));
+            Assert.That(definition.ModuleControls, Has.Count.EqualTo(2));
+            var viewControl = definition.ModuleControls[string.Empty];
+            Assert.That(viewControl.ControlKey, Is.Empty);
+            Assert.That(viewControl.ControlSrc, Is.EqualTo("DesktopModules/Admin/Console/ViewConsole.ascx"));
+            Assert.That(viewControl.ControlTitle, Is.EqualTo("Console"));
+            Assert.That(viewControl.ControlType, Is.EqualTo(SecurityAccessLevel.View));
+            Assert.That(viewControl.IconFile, Is.Empty);
+            Assert.That(viewControl.HelpURL, Is.EqualTo("http://help.dotnetnuke.com/070100/default.htm#Documentation/Building Your Site/Installed Modules/Console/About the Console Module.htm"));
+            Assert.That(viewControl.ViewOrder, Is.Zero);
+            Assert.That(viewControl.SupportsPartialRendering, Is.True);
+            Assert.That(viewControl.SupportsPopUps, Is.True);
+            var settingsControl = definition.ModuleControls["Settings"];
+            Assert.That(settingsControl.ControlKey, Is.EqualTo("Settings"));
+            Assert.That(settingsControl.ControlSrc, Is.EqualTo("DesktopModules/Admin/Console/Settings.ascx"));
+            Assert.That(settingsControl.ControlTitle, Is.EqualTo("Console Settings"));
+            Assert.That(settingsControl.ControlType, Is.EqualTo(SecurityAccessLevel.Admin));
+            Assert.That(settingsControl.IconFile, Is.Empty);
+            Assert.That(settingsControl.HelpURL, Is.Empty);
+            Assert.That(settingsControl.ViewOrder, Is.Zero);
+            Assert.That(settingsControl.SupportsPartialRendering, Is.True);
+            Assert.That(settingsControl.SupportsPopUps, Is.True);
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSelfClosingModuleDefinitions_ReadsRemainingInformationCorrectly()
+    {
+        var desktopModule = ReadXml(
+            """
+            <desktopModule>
+                <moduleName>Console</moduleName>
+                <moduleDefinitions />
+                <foldername>Admin/Console</foldername>
+                <businessControllerClass>Dnn.Modules.Console.Components.BusinessController</businessControllerClass>
+                <supportedFeatures>
+                    <supportedFeature type="Upgradeable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(desktopModule.ModuleName, Is.EqualTo("Console"));
+            Assert.That(desktopModule.FolderName, Is.EqualTo("Admin/Console"));
+            Assert.That(desktopModule.BusinessControllerClass, Is.EqualTo("Dnn.Modules.Console.Components.BusinessController"));
+            Assert.That(desktopModule.ModuleDefinitions, Has.Count.EqualTo(0));
+            Assert.That(desktopModule.IsUpgradeable, Is.True);
+            Assert.That(desktopModule.IsPortable, Is.False);
+            Assert.That(desktopModule.IsSearchable, Is.False);
+            Assert.That(desktopModule.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsUpgradeable));
         }
     }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/DesktopModuleInfoTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/DesktopModuleInfoTests.cs
@@ -1,0 +1,217 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Entities.Modules;
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Xml;
+
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Modules;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class DesktopModuleInfoTests
+{
+    [Test]
+    public void ReadXml_WithUpgradeable_ReadsOneSupportedFeature()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Upgradeable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.True);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsUpgradeable));
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithPortable_ReadsOneSupportedFeature()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Portable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.True);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable));
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSearchable_ReadsOneSupportedFeature()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Searchable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.True);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable));
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSearchableAndPortable_ReadsTwoSupportedFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Searchable" />
+                    <supportedFeature type="Portable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.True);
+            Assert.That(roleGroup.IsSearchable, Is.True);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable + (int)DesktopModuleSupportedFeature.IsPortable));
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSearchableAndUpgradeable_ReadsTwoSupportedFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Searchable" />
+                    <supportedFeature type="Upgradeable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.True);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.True);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsSearchable + (int)DesktopModuleSupportedFeature.IsUpgradeable));
+        }
+    }
+
+    [Test] public void ReadXml_WithPortableAndUpgradeable_ReadsTwoSupportedFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Portable" />
+                    <supportedFeature type="Upgradeable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.True);
+            Assert.That(roleGroup.IsPortable, Is.True);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable + (int)DesktopModuleSupportedFeature.IsUpgradeable));
+        }
+    }
+
+    [Test] public void ReadXml_WithAllThreeFeatures_ReadsThreeSupportedFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                    <supportedFeature type="Portable" />
+                    <supportedFeature type="Upgradeable" />
+                    <supportedFeature type="Searchable" />
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.IsUpgradeable, Is.True);
+            Assert.That(roleGroup.IsPortable, Is.True);
+            Assert.That(roleGroup.IsSearchable, Is.True);
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo((int)DesktopModuleSupportedFeature.IsPortable + (int)DesktopModuleSupportedFeature.IsUpgradeable + (int)DesktopModuleSupportedFeature.IsSearchable));
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithNoSupportedFeatures_DoesNotInitializeFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSelfClosingSupportedFeatures_DoesNotInitializeFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures />
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+        }
+    }
+
+    private static DesktopModuleInfo ReadXml([StringSyntax(StringSyntaxAttribute.Xml)] string xml)
+    {
+        var desktopModule = new DesktopModuleInfo();
+
+        using var textReader = new StringReader(xml);
+        using var xmlReader = XmlReader.Create(textReader);
+        xmlReader.Read();
+        desktopModule.ReadXml(xmlReader);
+
+        return desktopModule;
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/DesktopModuleInfoTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/DesktopModuleInfoTests.cs
@@ -167,6 +167,45 @@ public class DesktopModuleInfoTests
     }
 
     [Test]
+    public void ReadXml_WithEmptySupportedFeatures_DoesNotInitializeFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures></supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithEmptySupportedFeaturesIncludingWhiteSpace_DoesNotInitializeFeatures()
+    {
+        var roleGroup = ReadXml(
+            """
+            <desktopModule>
+                <supportedFeatures>
+                </supportedFeatures>
+            </desktopModule>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.SupportedFeatures, Is.EqualTo(Null.NullInteger));
+            Assert.That(roleGroup.IsUpgradeable, Is.False);
+            Assert.That(roleGroup.IsPortable, Is.False);
+            Assert.That(roleGroup.IsSearchable, Is.False);
+        }
+    }
+
+    [Test]
     public void ReadXml_WithNoSupportedFeatures_DoesNotInitializeFeatures()
     {
         var roleGroup = ReadXml(

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Roles/RoleGroupInfoTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Roles/RoleGroupInfoTests.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Security.Roles;
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Xml;
+
+using DotNetNuke.Security.Roles;
+
+using NUnit.Framework;
+
+[TestFixture]
+public class RoleGroupInfoTests
+{
+    [Test]
+    public void ReadXml_WithRealisticXml_ReadsRoles()
+    {
+        var roleGroup = ReadXml(
+            """
+            <rolegroups>
+              <rolegroup>
+                <rolegroupname>GlobalRoles</rolegroupname>
+                <description>A dummy role group that represents the Global roles</description>
+                <roles>
+                  <role>
+                    <rolename>Administrators</rolename>
+                    <description>Administrators of this Website</description>
+                    <billingfrequency>N</billingfrequency>
+                    <billingperiod>-1</billingperiod>
+                    <servicefee>0</servicefee>
+                    <trialfrequency>N</trialfrequency>
+                    <trialperiod>-1</trialperiod>
+                    <trialfee>0</trialfee>
+                    <ispublic>false</ispublic>
+                    <autoassignment>false</autoassignment>
+                    <rsvpcode />
+                    <iconfile />
+                    <issystemrole>true</issystemrole>
+                    <roletype>adminrole</roletype>
+                    <securitymode>securityrole</securitymode>
+                    <status>approved</status>
+                  </role>
+                  <role>
+                    <rolename>Registered Users</rolename>
+                    <description>Registered Users</description>
+                    <billingfrequency>N</billingfrequency>
+                    <billingperiod>-1</billingperiod>
+                    <servicefee>0</servicefee>
+                    <trialfrequency>N</trialfrequency>
+                    <trialperiod>-1</trialperiod>
+                    <trialfee>0</trialfee>
+                    <ispublic>false</ispublic>
+                    <autoassignment>true</autoassignment>
+                    <rsvpcode />
+                    <iconfile />
+                    <issystemrole>true</issystemrole>
+                    <roletype>registeredrole</roletype>
+                    <securitymode>securityrole</securitymode>
+                    <status>approved</status>
+                  </role>
+                  <role>
+                    <rolename>Subscribers</rolename>
+                    <description>A public role for site subscriptions</description>
+                    <billingfrequency>N</billingfrequency>
+                    <billingperiod>-1</billingperiod>
+                    <servicefee>0</servicefee>
+                    <trialfrequency>N</trialfrequency>
+                    <trialperiod>-1</trialperiod>
+                    <trialfee>0</trialfee>
+                    <ispublic>true</ispublic>
+                    <autoassignment>true</autoassignment>
+                    <rsvpcode />
+                    <iconfile />
+                    <issystemrole>true</issystemrole>
+                    <roletype>subscriberrole</roletype>
+                    <securitymode>securityrole</securitymode>
+                    <status>approved</status>
+                  </role>
+                  <role>
+                    <rolename>Translator (en-US)</rolename>
+                    <description>A role for English (United States) translators</description>
+                    <billingfrequency>N</billingfrequency>
+                    <billingperiod>-1</billingperiod>
+                    <servicefee>0</servicefee>
+                    <trialfrequency>N</trialfrequency>
+                    <trialperiod>-1</trialperiod>
+                    <trialfee>0</trialfee>
+                    <ispublic>false</ispublic>
+                    <autoassignment>false</autoassignment>
+                    <rsvpcode />
+                    <iconfile />
+                    <issystemrole>false</issystemrole>
+                    <roletype>none</roletype>
+                    <securitymode>securityrole</securitymode>
+                    <status>approved</status>
+                  </role>
+                  <role>
+                    <rolename>Unverified Users</rolename>
+                    <description>Unverified Users</description>
+                    <billingfrequency>N</billingfrequency>
+                    <billingperiod>-1</billingperiod>
+                    <servicefee>0</servicefee>
+                    <trialfrequency>N</trialfrequency>
+                    <trialperiod>-1</trialperiod>
+                    <trialfee>0</trialfee>
+                    <ispublic>false</ispublic>
+                    <autoassignment>false</autoassignment>
+                    <rsvpcode />
+                    <iconfile />
+                    <issystemrole>true</issystemrole>
+                    <roletype>unverifiedrole</roletype>
+                    <securitymode>securityrole</securitymode>
+                    <status>approved</status>
+                  </role>
+                </roles>
+              </rolegroup>
+            </rolegroups>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.RoleGroupName, Is.EqualTo("GlobalRoles"));
+            Assert.That(roleGroup.Description, Is.EqualTo("A dummy role group that represents the Global roles"));
+            Assert.That(roleGroup.Roles, Has.Count.EqualTo(5));
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithSelfClosingRoles_ReadsZeroRoles()
+    {
+        var roleGroup = ReadXml(
+            """
+            <rolegroups>
+                <rolegroupname>N</rolegroupname>
+                <description>D</description>
+                <roles />
+            </rolegroups>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.RoleGroupName, Is.EqualTo("N"));
+            Assert.That(roleGroup.Description, Is.EqualTo("D"));
+            Assert.That(roleGroup.Roles, Is.Null);
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithNoRoles_ReadsZeroRoles()
+    {
+        var roleGroup = ReadXml(
+            """
+            <rolegroups>
+                <rolegroupname>N</rolegroupname>
+                <description>D</description>
+            </rolegroups>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.RoleGroupName, Is.EqualTo("N"));
+            Assert.That(roleGroup.Description, Is.EqualTo("D"));
+            Assert.That(roleGroup.Roles, Is.Null);
+        }
+    }
+
+    private static RoleGroupInfo ReadXml([StringSyntax(StringSyntaxAttribute.Xml)] string xml)
+    {
+        var roleGroup = new RoleGroupInfo();
+
+        using var textReader = new StringReader(xml);
+        using var xmlReader = XmlReader.Create(textReader);
+        xmlReader.Read();
+        roleGroup.ReadXml(xmlReader);
+
+        return roleGroup;
+    }
+}

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Roles/RoleGroupInfoTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Security/Roles/RoleGroupInfoTests.cs
@@ -129,6 +129,47 @@ public class RoleGroupInfoTests
     }
 
     [Test]
+    public void ReadXml_WithEmptyRoles_ReadsZeroRoles()
+    {
+        var roleGroup = ReadXml(
+            """
+            <rolegroups>
+                <rolegroupname>N</rolegroupname>
+                <description>D</description>
+                <roles></roles>
+            </rolegroups>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.RoleGroupName, Is.EqualTo("N"));
+            Assert.That(roleGroup.Description, Is.EqualTo("D"));
+            Assert.That(roleGroup.Roles, Is.Null);
+        }
+    }
+
+    [Test]
+    public void ReadXml_WithEmptyRolesWithWhiteSpace_ReadsZeroRoles()
+    {
+        var roleGroup = ReadXml(
+            """
+            <rolegroups>
+                <rolegroupname>N</rolegroupname>
+                <description>D</description>
+                <roles>
+                </roles>
+            </rolegroups>
+            """);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roleGroup.RoleGroupName, Is.EqualTo("N"));
+            Assert.That(roleGroup.Description, Is.EqualTo("D"));
+            Assert.That(roleGroup.Roles, Is.Null);
+        }
+    }
+
+    [Test]
     public void ReadXml_WithSelfClosingRoles_ReadsZeroRoles()
     {
         var roleGroup = ReadXml(

--- a/DNN Platform/Tests/DotNetNuke.Tests.Utilities/StringSyntaxAttribute.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Utilities/StringSyntaxAttribute.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+// from https://github.com/dotnet/runtime/blob/d099f075e45d2aa6007a22b71b45a08758559f80/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+#if !NET7_0_OR_GREATER
+#nullable enable
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies the syntax used in a string.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class StringSyntaxAttribute : Attribute
+    {
+        /// <summary>The syntax identifier for strings containing composite formats for string formatting.</summary>
+        public const string CompositeFormat = nameof(CompositeFormat);
+
+        /// <summary>The syntax identifier for strings containing date format specifiers.</summary>
+        public const string DateOnlyFormat = nameof(DateOnlyFormat);
+
+        /// <summary>The syntax identifier for strings containing date and time format specifiers.</summary>
+        public const string DateTimeFormat = nameof(DateTimeFormat);
+
+        /// <summary>The syntax identifier for strings containing <see cref="Enum"/> format specifiers.</summary>
+        public const string EnumFormat = nameof(EnumFormat);
+
+        /// <summary>The syntax identifier for strings containing <see cref="Guid"/> format specifiers.</summary>
+        public const string GuidFormat = nameof(GuidFormat);
+
+        /// <summary>The syntax identifier for strings containing JavaScript Object Notation (JSON).</summary>
+        public const string Json = nameof(Json);
+
+        /// <summary>The syntax identifier for strings containing numeric format specifiers.</summary>
+        public const string NumericFormat = nameof(NumericFormat);
+
+        /// <summary>The syntax identifier for strings containing regular expressions.</summary>
+        public const string Regex = nameof(Regex);
+
+        /// <summary>The syntax identifier for strings containing time format specifiers.</summary>
+        public const string TimeOnlyFormat = nameof(TimeOnlyFormat);
+
+        /// <summary>The syntax identifier for strings containing <see cref="TimeSpan"/> format specifiers.</summary>
+        public const string TimeSpanFormat = nameof(TimeSpanFormat);
+
+        /// <summary>The syntax identifier for strings containing URIs.</summary>
+        public const string Uri = nameof(Uri);
+
+        /// <summary>The syntax identifier for strings containing XML.</summary>
+        public const string Xml = nameof(Xml);
+
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        public StringSyntaxAttribute(string syntax)
+        {
+            Syntax = syntax;
+            Arguments = Array.Empty<object?>();
+        }
+
+        /// <summary>Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.</summary>
+        /// <param name="syntax">The syntax identifier.</param>
+        /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+        public StringSyntaxAttribute(string syntax, params object?[] arguments)
+        {
+            Syntax = syntax;
+            Arguments = arguments;
+        }
+
+        /// <summary>Gets the identifier of the syntax used.</summary>
+        public string Syntax { get; }
+
+        /// <summary>Optional arguments associated with the specific syntax employed.</summary>
+        public object?[] Arguments { get; }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #7301

## Summary
Adds support for both forms of empty elements in manifest.

As the [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.xml.xmlreader.isemptyelement?view=netframework-4.8.1) states, `System.Xml.XmlReader.IsEmptyElement` supports only self-closing elements:
> gets a value indicating whether the current node is an empty element (for example, `<MyElement/>`).
> 
> Returns
> &nbsp;&nbsp; true if the current node is an element (NodeType equals XmlNodeType.Element) that ends with `/>`; otherwise, false.