### PR TITLE
Simplify guard for PR step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           overwrite: true
 
       - name: "Create GitHub Pull Request"
-        if: ${{ success() && !contains('pull_request', github.event_name) && (contains(fromJSON('["develop", "main"]'), github.ref_name) || startsWith('release/', github.ref_name)) }}
+        if: ${{ success() && github.event_name == 'push' && (github.ref_name == 'develop' || startsWith('release/', github.ref_name)) }}
         run: "./build.ps1 --target=CreateGitHubPullRequest --verbosity=$env:CAKE_VERBOSITY"
         env:
           GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}


### PR DESCRIPTION
## Summary
- Avoid using `contains` (see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#contains)
  - There is only one event that can trigger this workflow, `push`, that we would want to create a PR from
- Don't accept `main` branch that this repo doesn't use
