### PR TITLE
Avoids TypeLoadException in PreparePackaging redirect generation

### DIFF
--- a/Build/Tasks/PreparePackaging.cs
+++ b/Build/Tasks/PreparePackaging.cs
@@ -4,11 +4,15 @@
 namespace DotNetNuke.Build.Tasks
 {
     using System;
+    using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
+    using System.Reflection;
     using System.Xml.Linq;
 
     using Cake.Common.Diagnostics;
     using Cake.Common.IO;
+    using Cake.Core.IO;
     using Cake.Frosting;
     using Cake.Json;
     using Dnn.CakeUtils;
@@ -60,14 +64,52 @@ namespace DotNetNuke.Build.Tasks
 
             context.PackagingPatterns = context.DeserializeJsonFromFile<PackagingPatterns>("./Build/Tasks/packaging.json");
             var files = context.GetFilesByPatterns(context.WebsiteDir, BinFolderInclude, context.PackagingPatterns.InstallExclude);
-            var parsedAssemblies = files.ParseAssemblies();
-            parsedAssemblies.RemoveAll(a => a.PublicKeyToken is null);
-            var redirects = parsedAssemblies.ConvertAll(a => a.AssemblyBindingRedirect());
+            var redirects = BuildBindingRedirects(files);
             assemblyBinding.Add(redirects.ToArray<object>());
 
             // save XML document to target file
             var targetFile = context.WebsiteDir + context.File("web.config");
             doc.Save(targetFile);
+        }
+
+        private static List<XElement> BuildBindingRedirects(IEnumerable<FilePath> files)
+        {
+            XNamespace asm = "urn:schemas-microsoft-com:asm.v1";
+            var redirects = new List<XElement>();
+
+            foreach (var file in files)
+            {
+                AssemblyName assemblyName;
+                try
+                {
+                    assemblyName = AssemblyName.GetAssemblyName(file.FullPath);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                var tokenBytes = assemblyName.GetPublicKeyToken();
+                if (tokenBytes == null || tokenBytes.Length == 0 || string.IsNullOrEmpty(assemblyName.Name) || assemblyName.Version == null)
+                {
+                    continue;
+                }
+
+                var token = string.Concat(tokenBytes.Select(static b => b.ToString("x2", CultureInfo.InvariantCulture)));
+                redirects.Add(
+                    new XElement(
+                        asm + "dependentAssembly",
+                        new XElement(
+                            asm + "assemblyIdentity",
+                            new XAttribute("name", assemblyName.Name),
+                            new XAttribute("publicKeyToken", token)),
+                        new XElement(
+                            asm + "bindingRedirect",
+                            new XAttribute("oldVersion", "0.0.0.0-32767.32767.32767.32767"),
+                            new XAttribute("newVersion", assemblyName.Version.ToString()))));
+            }
+
+            return redirects;
         }
     }
 }

--- a/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.03.03.SqlDataProvider
+++ b/DNN Platform/Website/Providers/DataProviders/SqlDataProvider/10.03.03.SqlDataProvider
@@ -1,0 +1,9 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/


### PR DESCRIPTION
Replace Dnn.CakeUtils ParseAssemblies usage in Build/Tasks/PreparePackaging.cs with metadata-only assembly inspection using AssemblyName.GetAssemblyName.

This prevents net10 packaging failures caused by reflection over legacy framework attributes (e.g., System.Web.UI.WebResourceAttribute) when parsing ClientDependency.Core and similar assemblies.

Closes #7338 