### PR TITLE
Fix page workflow state when workflow disabled

### DIFF
--- a/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
+++ b/DNN Platform/Modules/HTML/Components/HtmlTextController.cs
@@ -26,6 +26,7 @@ namespace DotNetNuke.Modules.Html
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Internal.SourceGenerators;
     using DotNetNuke.Modules.Html.Components;
@@ -306,9 +307,14 @@ namespace DotNetNuke.Modules.Html
         {
             var tab = TabController.Instance.GetTab(tabId, portalId);
 
-            var workFlowId = tab.StateID == Null.NullInteger
-                ? TabWorkflowSettings.Instance.GetDefaultTabWorkflowId(portalId)
-                : WorkflowStateManager.Instance.GetWorkflowState(tab.StateID).WorkflowID;
+            var isWorkflowEnabled = TabVersionSettings.Instance.IsVersioningEnabled(portalId, tabId)
+                                    && TabWorkflowSettings.Instance.IsWorkflowEnabled(portalId, tabId);
+            var workFlowId = isWorkflowEnabled && tab.StateID != Null.NullInteger
+                ? WorkflowStateManager.Instance.GetWorkflowState(tab.StateID).WorkflowID
+                : isWorkflowEnabled
+                    ? TabWorkflowSettings.Instance.GetDefaultTabWorkflowId(portalId)
+                    : SystemWorkflowManager.Instance.GetDirectPublishWorkflow(portalId)?.WorkflowID
+                        ?? TabWorkflowSettings.Instance.GetDefaultTabWorkflowId(portalId);
 
             var workFlowType = WorkflowManager.Instance.GetWorkflow(workFlowId).WorkflowName;
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
@@ -3,12 +3,34 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Tests.Modules.Html
 {
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Abstractions.Application;
+    using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Entities.Content.Workflow;
+    using DotNetNuke.Entities.Content.Workflow.Entities;
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Modules.Html;
+    using DotNetNuke.Modules.Html.Components;
+
+    using Moq;
     using NUnit.Framework;
 
     [TestFixture]
     public class HtmlTextControllerTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TabController.ClearInstance();
+            TabVersionSettings.ClearInstance();
+            TabWorkflowSettings.ClearInstance();
+            SystemWorkflowManager.ClearInstance();
+            WorkflowManager.ClearInstance();
+        }
+
         [Test]
         public void ManageRelativePaths_DoesNotChangePlainHtml()
         {
@@ -129,6 +151,53 @@ namespace DotNetNuke.Tests.Modules.Html
 <img alt=""another absolute path"" src=""https://dnncommunity.org/DesktopModules/ActiveForums/images/feedicon.gif"" />
 ";
             Assert.That(actual, Is.EqualTo(Expected));
+        }
+
+        [Test]
+        public void GetWorkflow_UsesDirectPublish_WhenTabHasStateButWorkflowIsDisabled()
+        {
+            const int PortalId = 1;
+            const int TabId = 2;
+            const int DirectPublishWorkflowId = 3;
+            var tab = new TabInfo { PortalID = PortalId, TabID = TabId, StateID = 6 };
+            var workflow = new Workflow { WorkflowID = DirectPublishWorkflowId, WorkflowName = "Direct Publish" };
+
+            var tabController = new Mock<ITabController>();
+            tabController.Setup(c => c.GetTab(TabId, PortalId)).Returns(tab);
+            TabController.SetTestableInstance(tabController.Object);
+
+            var tabVersionSettings = new Mock<ITabVersionSettings>();
+            tabVersionSettings.Setup(s => s.IsVersioningEnabled(PortalId, TabId)).Returns(false);
+            TabVersionSettings.SetTestableInstance(tabVersionSettings.Object);
+
+            var systemWorkflowManager = new Mock<ISystemWorkflowManager>();
+            systemWorkflowManager.Setup(m => m.GetDirectPublishWorkflow(PortalId)).Returns(workflow);
+            SystemWorkflowManager.SetTestableInstance(systemWorkflowManager.Object);
+
+            var workflowManager = new Mock<IWorkflowManager>();
+            workflowManager.Setup(m => m.GetWorkflow(DirectPublishWorkflowId)).Returns(workflow);
+            WorkflowManager.SetTestableInstance(workflowManager.Object);
+
+            var result = CreateHtmlTextController().GetWorkflow(1, TabId, PortalId);
+
+            Assert.That(result.Value, Is.EqualTo(DirectPublishWorkflowId));
+        }
+
+        private static HtmlTextController CreateHtmlTextController()
+        {
+            var hostSettings = Mock.Of<IHostSettings>();
+            var portalController = Mock.Of<IPortalController>();
+            return new HtmlTextController(
+                Mock.Of<INavigationManager>(),
+                Mock.Of<IPortalAliasService>(),
+                portalController,
+                Mock.Of<IApplicationStatusInfo>(),
+                hostSettings,
+                new HtmlModuleSettingsRepository(
+                    Mock.Of<IModuleController>(),
+                    hostSettings,
+                    Mock.Of<IHostSettingsService>(),
+                    portalController));
         }
     }
 }

--- a/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Modules/Html/HtmlTextControllerTests.cs
@@ -3,9 +3,12 @@
 // See the LICENSE file in the project root for more information
 namespace DotNetNuke.Tests.Modules.Html
 {
+    using System.Collections.Generic;
+
     using DotNetNuke.Abstractions;
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.ComponentModel;
     using DotNetNuke.Entities.Content.Workflow;
     using DotNetNuke.Entities.Content.Workflow.Entities;
     using DotNetNuke.Entities.Modules;
@@ -14,6 +17,8 @@ namespace DotNetNuke.Tests.Modules.Html
     using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Modules.Html;
     using DotNetNuke.Modules.Html.Components;
+    using DotNetNuke.Services.Cache;
+    using DotNetNuke.Tests.Utilities.Fakes;
 
     using Moq;
     using NUnit.Framework;
@@ -21,6 +26,12 @@ namespace DotNetNuke.Tests.Modules.Html
     [TestFixture]
     public class HtmlTextControllerTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            ComponentFactory.RegisterComponentInstance<CachingProvider>(new FakeCachingProvider(new Dictionary<string, object>()));
+        }
+
         [TearDown]
         public void TearDown()
         {

--- a/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
+++ b/Dnn.AdminExperience/Dnn.PersonaBar.Extensions/Components/Pages/PagesControllerImpl.cs
@@ -1377,7 +1377,15 @@ namespace Dnn.PersonaBar.Pages.Components
                 tabWorkflowSettings.SetWorkflowEnabled(tab.PortalID, tab.TabID, pageSettings.WorkflowEnabled.Value);
             }
 
-            ChangeContentWorkflow(tab, pageSettings);
+            if (tabVersionSettings.IsVersioningEnabled(tab.PortalID, tab.TabID)
+                && tabWorkflowSettings.IsWorkflowEnabled(tab.PortalID, tab.TabID))
+            {
+                ChangeContentWorkflow(tab, pageSettings);
+            }
+            else
+            {
+                tab.StateID = Null.NullInteger;
+            }
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Breaking change")]

--- a/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/PagesControllerUnitTests.cs
+++ b/Dnn.AdminExperience/Tests/Dnn.PersonaBar.Pages.Tests/PagesControllerUnitTests.cs
@@ -10,10 +10,14 @@ namespace Dnn.PersonaBar.Pages.Tests
 
     using DotNetNuke.Abstractions.Application;
     using DotNetNuke.Abstractions.Modules;
+    using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Abstractions.Security;
+    using DotNetNuke.Abstractions.Security.Permissions;
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Entities.Tabs.TabVersions;
     using DotNetNuke.Entities.Urls;
     using DotNetNuke.Services.Personalization;
     using DotNetNuke.Tests.Utilities.Fakes;
@@ -89,6 +93,8 @@ namespace Dnn.PersonaBar.Pages.Tests
             DefaultPortalThemeController.ClearInstance();
             CloneModuleExecutionContext.ClearInstance();
             PortalController.ClearInstance();
+            TabVersionSettings.ClearInstance();
+            TabWorkflowSettings.ClearInstance();
         }
 
         [TestCase("http://www.websitename.com/home/", "/home")]
@@ -154,9 +160,29 @@ namespace Dnn.PersonaBar.Pages.Tests
             this.contentVerifierMock.Verify(c => c.IsContentExistsForRequestedPortal(portalId, portalSettings, false));
         }
 
+        [Test]
+        public void UpdateTabWorkflowFromPageSettings_ClearsState_WhenWorkflowPostedButPortalWorkflowDisabled()
+        {
+            var tab = new TabInfo { PortalID = 1, TabID = 2, StateID = 6 };
+            var pageSettings = new PageSettings { EnabledVersioning = true, WorkflowEnabled = true, WorkflowId = 9 };
+            var tabVersionSettings = new Mock<ITabVersionSettings>();
+            var tabWorkflowSettings = new Mock<ITabWorkflowSettings>();
+            tabVersionSettings.Setup(s => s.IsVersioningEnabled(tab.PortalID)).Returns(false);
+            tabWorkflowSettings.Setup(s => s.IsWorkflowEnabled(tab.PortalID)).Returns(false);
+            TabVersionSettings.SetTestableInstance(tabVersionSettings.Object);
+            TabWorkflowSettings.SetTestableInstance(tabWorkflowSettings.Object);
+
+            this.InitializePageController();
+            ((TestablePagesControllerImpl)this.pagesController).UpdateTabWorkflowFromPageSettingsForTest(tab, pageSettings);
+
+            Assert.That(tab.StateID, Is.EqualTo(Null.NullInteger));
+            tabVersionSettings.Verify(s => s.SetEnabledVersioningForTab(It.IsAny<int>(), It.IsAny<bool>()), Times.Never);
+            tabWorkflowSettings.Verify(s => s.SetWorkflowEnabled(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>()), Times.Never);
+        }
+
         private void InitializePageController()
         {
-            this.pagesController = new PagesControllerImpl(
+            this.pagesController = new TestablePagesControllerImpl(
                 this.businessControllerProviderMock.Object,
                 this.tabControllerMock.Object,
                 this.moduleControllerMock.Object,
@@ -169,6 +195,47 @@ namespace Dnn.PersonaBar.Pages.Tests
                 this.contentVerifierMock.Object,
                 this.portalControllerMock.Object,
                 this.personalizationControllerMock.Object);
+        }
+
+        private sealed class TestablePagesControllerImpl : PagesControllerImpl
+        {
+            public TestablePagesControllerImpl(
+                IBusinessControllerProvider businessControllerProvider,
+                ITabController tabController,
+                IModuleController moduleController,
+                IPageUrlsController pageUrlsController,
+                ITemplateController templateController,
+                IDefaultPortalThemeController defaultPortalThemeController,
+                ICloneModuleExecutionContext cloneModuleExecutionContext,
+                IUrlRewriterUtilsWrapper urlRewriterUtilsWrapper,
+                IFriendlyUrlWrapper friendlyUrlWrapper,
+                IContentVerifier contentVerifier,
+                IPortalController portalController,
+                PersonalizationController personalizationController)
+                : base(
+                    businessControllerProvider,
+                    tabController,
+                    moduleController,
+                    pageUrlsController,
+                    templateController,
+                    defaultPortalThemeController,
+                    cloneModuleExecutionContext,
+                    urlRewriterUtilsWrapper,
+                    friendlyUrlWrapper,
+                    contentVerifier,
+                    portalController,
+                    personalizationController,
+                    Mock.Of<IPermissionDefinitionService>(),
+                    Mock.Of<IPortalAliasService>(),
+                    Mock.Of<IHostSettings>(),
+                    Mock.Of<IHostSettingsService>())
+            {
+            }
+
+            public void UpdateTabWorkflowFromPageSettingsForTest(TabInfo tab, PageSettings pageSettings)
+            {
+                this.UpdateTabWorkflowFromPageSettings(tab, pageSettings);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #7305

## Summary

This PR prevents page-level workflow settings from being applied when workflow/versioning is disabled at the site level.

Root cause: the Pages settings UI could submit workflow/versioning values even when those features were disabled globally. The saved tab settings then poisoned the page workflow state, so newly added Text/HTML modules could be created as draft content and remain hidden in view mode.

The fix keeps page workflow/versioning disabled unless the portal-level feature is enabled, so Text/HTML content is published normally on sites where workflow is not active.

Verified locally with:
- clean DNN 10.3.2 install
- site workflow/versioning disabled
- page workflow/versioning toggled in page settings
- newly added Text/HTML modules remain visible in view mode