### PR TITLE
Unable to create social group as non-admin

### DIFF
--- a/DNN Platform/Library/Entities/Users/Social/UserSocial.cs
+++ b/DNN Platform/Library/Entities/Users/Social/UserSocial.cs
@@ -36,13 +36,10 @@ namespace DotNetNuke.Entities.Users.Social
             {
                 var friendsRelationship = RelationshipController.Instance.GetFriendsRelationshipByPortal(this.userInfo.PortalID);
                 var currentUser = UserController.Instance.GetCurrentUserInfo();
-                return this.UserRelationships.SingleOrDefault(ur => (ur.RelationshipId == friendsRelationship.RelationshipId
-                                                                &&
-                                                                ((ur.UserId == this.userInfo.UserID &&
-                                                                 ur.RelatedUserId == currentUser.UserID)
-                                                                 ||
-                                                                 (ur.UserId == currentUser.UserID &&
-                                                                  ur.RelatedUserId == this.userInfo.UserID))));
+                return this.UserRelationships.SingleOrDefault(ur =>
+                    ur.RelationshipId == friendsRelationship.RelationshipId &&
+                    ((ur.UserId == this.userInfo.UserID && ur.RelatedUserId == currentUser.UserID) ||
+                     (ur.UserId == currentUser.UserID && ur.RelatedUserId == this.userInfo.UserID)));
             }
         }
 
@@ -53,10 +50,10 @@ namespace DotNetNuke.Entities.Users.Social
             {
                 var followerRelationship = RelationshipController.Instance.GetFollowersRelationshipByPortal(this.userInfo.PortalID);
                 var currentUser = UserController.Instance.GetCurrentUserInfo();
-                return this.UserRelationships.SingleOrDefault(ur => (ur.RelationshipId == followerRelationship.RelationshipId
-                                                                &&
-                                                                (ur.UserId == this.userInfo.UserID &&
-                                                                 ur.RelatedUserId == currentUser.UserID)));
+                return this.UserRelationships.SingleOrDefault(ur =>
+                    ur.RelationshipId == followerRelationship.RelationshipId &&
+                    ur.UserId == this.userInfo.UserID &&
+                    ur.RelatedUserId == currentUser.UserID);
             }
         }
 
@@ -67,18 +64,16 @@ namespace DotNetNuke.Entities.Users.Social
             {
                 var followerRelationship = RelationshipController.Instance.GetFollowersRelationshipByPortal(this.userInfo.PortalID);
                 var currentUser = UserController.Instance.GetCurrentUserInfo();
-                return this.UserRelationships.SingleOrDefault(ur => (ur.RelationshipId == followerRelationship.RelationshipId
-                                                                &&
-                                                                (ur.UserId == currentUser.UserID &&
-                                                                 ur.RelatedUserId == this.userInfo.UserID)));
+                return this.UserRelationships.SingleOrDefault(ur =>
+                    ur.RelationshipId == followerRelationship.RelationshipId &&
+                    ur.UserId == currentUser.UserID &&
+                    ur.RelatedUserId == this.userInfo.UserID);
             }
         }
 
         /// <summary>Gets a collection of all the relationships the user is a member of.</summary>
-        public IList<UserRelationship> UserRelationships
-        {
-            get { return this.userRelationships ?? (this.userRelationships = RelationshipController.Instance.GetUserRelationships(this.userInfo)); }
-        }
+        public IList<UserRelationship> UserRelationships =>
+            this.userRelationships ??= RelationshipController.Instance.GetUserRelationships(this.userInfo);
 
         /// <summary>Gets list of Relationships for the User.</summary>
         [XmlAttribute]
@@ -86,14 +81,15 @@ namespace DotNetNuke.Entities.Users.Social
         {
             get
             {
-                if (this.relationships == null)
+                if (this.relationships != null)
                 {
-                    this.relationships = RelationshipController.Instance.GetRelationshipsByPortalId(this.userInfo.PortalID);
+                    return this.relationships;
+                }
 
-                    foreach (var r in RelationshipController.Instance.GetRelationshipsByUserId(this.userInfo.UserID))
-                    {
-                        this.relationships.Add(r);
-                    }
+                this.relationships = RelationshipController.Instance.GetRelationshipsByPortalId(this.userInfo.PortalID);
+                foreach (var r in RelationshipController.Instance.GetRelationshipsByUserId(this.userInfo.UserID))
+                {
+                    this.relationships.Add(r);
                 }
 
                 return this.relationships;

--- a/DNN Platform/Library/Entities/Users/UserController.cs
+++ b/DNN Platform/Library/Entities/Users/UserController.cs
@@ -67,6 +67,8 @@ namespace DotNetNuke.Entities.Users
     /// <seealso cref="DotNetNuke.Security.Membership.MembershipProvider"/>
     public partial class UserController : ServiceLocator<IUserController, UserController>, IUserController
     {
+        private const string CurrentUserInfoKey = "UserInfo";
+
         /// <summary>Gets or sets the display name format with support for replacing some tokens.</summary>
         /// <remarks>Valid tokens are: [USERID], [FIRSTNAME], [LASTNAME] and [USERNAME].</remarks>
         public string DisplayFormat { get; set; }
@@ -1845,6 +1847,26 @@ namespace DotNetNuke.Entities.Users
             return GetUserById(portalId, userId);
         }
 
+        /// <summary>
+        /// Updates the user returned by <see cref="IUserController.GetCurrentUserInfo"/>.
+        /// Assumes that <see cref="DataCache.ClearUserCache"/> has already been called.
+        /// </summary>
+        internal static void RefreshCurrentUser()
+        {
+            if (HttpContextSource.Current?.Items[CurrentUserInfoKey] is not UserInfo currentUser)
+            {
+                return;
+            }
+
+            if (Null.IsNull(currentUser.UserID))
+            {
+                return;
+            }
+
+            HttpContextSource.Current.Items[CurrentUserInfoKey] =
+                MembershipProvider.Instance().GetUser(currentUser.PortalID, currentUser.UserID);
+        }
+
         /// <summary>Gets a list of user related portal settings.</summary>
         /// <param name="portalId">The site (portal) id from which to get the settings from.</param>
         /// <param name="settings">The list of settings to filter from.</param>
@@ -2268,7 +2290,7 @@ namespace DotNetNuke.Entities.Users
                 return new UserInfo();
             }
 
-            user = (UserInfo)HttpContext.Current.Items["UserInfo"];
+            user = (UserInfo)HttpContext.Current.Items[CurrentUserInfoKey];
             return user ?? new UserInfo();
         }
 

--- a/DNN Platform/Library/Entities/Users/UserInfo.cs
+++ b/DNN Platform/Library/Entities/Users/UserInfo.cs
@@ -9,6 +9,7 @@ namespace DotNetNuke.Entities.Users
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
@@ -70,19 +71,15 @@ namespace DotNetNuke.Entities.Users
         {
             get
             {
-                return this.social.GetOrAdd(this.PortalID, i => new UserSocial(this));
+                return this.social.GetOrAdd(this.PortalID, CreateSocial, this);
+
+                static UserSocial CreateSocial(int portalId, UserInfo @this) => new UserSocial(@this);
             }
         }
 
         /// <inheritdoc />
         [Browsable(false)]
-        public CacheLevel Cacheability
-        {
-            get
-            {
-                return CacheLevel.notCacheable;
-            }
-        }
+        public CacheLevel Cacheability => CacheLevel.notCacheable;
 
         /// <summary>Gets or sets the AffiliateId for this user.</summary>
         [Browsable(false)]
@@ -106,8 +103,8 @@ namespace DotNetNuke.Entities.Users
         [MaxLength(50)]
         public string FirstName
         {
-            get { return this.Profile.FirstName; }
-            set { this.Profile.FirstName = value; }
+            get => this.Profile.FirstName;
+            set => this.Profile.FirstName = value;
         }
 
         /// <summary>Gets or sets a value indicating whether the User is deleted.</summary>
@@ -127,8 +124,8 @@ namespace DotNetNuke.Entities.Users
         [MaxLength(50)]
         public string LastName
         {
-            get { return this.Profile.LastName; }
-            set { this.Profile.LastName = value; }
+            get => this.Profile.LastName;
+            set => this.Profile.LastName = value;
         }
 
         /// <summary>Gets or sets the Membership object.</summary>
@@ -137,13 +134,15 @@ namespace DotNetNuke.Entities.Users
         {
             get
             {
-                if (this.membership == null)
+                if (this.membership != null)
                 {
-                    this.membership = new UserMembership(this);
-                    if ((this.Username != null) && (!string.IsNullOrEmpty(this.Username)))
-                    {
-                        UserController.GetUserMembership(this);
-                    }
+                    return this.membership;
+                }
+
+                this.membership = new UserMembership(this);
+                if ((this.Username != null) && (!string.IsNullOrEmpty(this.Username)))
+                {
+                    UserController.GetUserMembership(this);
                 }
 
                 return this.membership;
@@ -207,24 +206,23 @@ namespace DotNetNuke.Entities.Users
         {
             get
             {
-                return this.roles.GetOrAdd(this.PortalID, i =>
+                return this.roles.GetOrAdd(this.PortalID, CreateRoles, this.Social.Roles);
+
+                static string[] CreateRoles(int portalId, IList<UserRoleInfo> socialRoles)
                 {
-                    var socialRoles = this.Social.Roles;
                     if (socialRoles.Count == 0)
                     {
                         return [];
                     }
-                    else
-                    {
-                        return (from r in this.Social.Roles
-                                      where
-                                          r.Status == RoleStatus.Approved &&
-                                          (r.EffectiveDate < DateTime.Now || Null.IsNull(r.EffectiveDate)) &&
-                                          (r.ExpiryDate > DateTime.Now || Null.IsNull(r.ExpiryDate))
-                                      select r.RoleName)
-                            .ToArray();
-                    }
-                });
+
+                    return (
+                        from r in socialRoles
+                        where r.Status == RoleStatus.Approved &&
+                              (r.EffectiveDate < DateTime.Now || Null.IsNull(r.EffectiveDate)) &&
+                              (r.ExpiryDate > DateTime.Now || Null.IsNull(r.ExpiryDate))
+                        select r.RoleName)
+                        .ToArray();
+                }
             }
 
             set

--- a/DNN Platform/Library/Security/Membership/MembershipProvider.cs
+++ b/DNN Platform/Library/Security/Membership/MembershipProvider.cs
@@ -87,7 +87,7 @@ namespace DotNetNuke.Security.Membership
         public abstract string GetPassword(UserInfo user, string passwordAnswer);
 
         /// <summary>GetUserCountByPortal gets the number of users in the portal.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <returns>The number of users.</returns>
         public abstract int GetUserCountByPortal(int portalId);
 
@@ -124,8 +124,8 @@ namespace DotNetNuke.Security.Membership
         public abstract void UpdateUser(UserInfo user);
 
         /// <summary>UserLogin attempts to log the user in, and returns the User if successful.</summary>
-        /// <param name="portalId">The Id of the Portal the user belongs to.</param>
-        /// <param name="username">The user name of the User attempting to log in.</param>
+        /// <param name="portalId">The ID of the Portal the user belongs to.</param>
+        /// <param name="username">The username of the User attempting to log in.</param>
         /// <param name="password">The password of the User attempting to log in.</param>
         /// <param name="verificationCode">The verification code of the User attempting to log in.</param>
         /// <param name="loginStatus">An enumerated value indicating the login status.</param>
@@ -133,8 +133,8 @@ namespace DotNetNuke.Security.Membership
         public abstract UserInfo UserLogin(int portalId, string username, string password, string verificationCode, ref UserLoginStatus loginStatus);
 
         /// <summary>UserLogin attempts to log the user in, and returns the User if successful.</summary>
-        /// <param name="portalId">The Id of the Portal the user belongs to.</param>
-        /// <param name="username">The user name of the User attempting to log in.</param>
+        /// <param name="portalId">The ID of the Portal the user belongs to.</param>
+        /// <param name="username">The username of the User attempting to log in.</param>
         /// <param name="password">The password of the User attempting to log in (may not be used by all Auth types).</param>
         /// <param name="authType">The type of Authentication Used.</param>
         /// <param name="verificationCode">The verification code of the User attempting to log in.</param>
@@ -144,13 +144,13 @@ namespace DotNetNuke.Security.Membership
 
         // Users Online
 
-        /// <summary>Deletes all UserOnline info from the database that has activity outside of the time window.</summary>
+        /// <summary>Deletes all UserOnline info from the database that has activity outside the time window.</summary>
         /// <param name="timeWindow">Time Window in Minutes.</param>
         [Obsolete("Deprecated in DotNetNuke 8.0.0. Other solutions exist outside of the DNN Platform. Scheduled for removal in v11.0.0.")]
         public abstract void DeleteUsersOnline(int timeWindow);
 
         /// <summary>Gets a collection of Online Users.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <returns>An ArrayList of UserInfo objects.</returns>
         [Obsolete("Deprecated in DotNetNuke 8.0.0. Other solutions exist outside of the DNN Platform. Scheduled for removal in v11.0.0.")]
         public abstract ArrayList GetOnlineUsers(int portalId);
@@ -174,13 +174,13 @@ namespace DotNetNuke.Security.Membership
         // Get Users
 
         /// <summary>GetUserByUserName retrieves a User from the DataStore.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="userId">The id of the user being retrieved from the Data Store.</param>
         /// <returns>The User as a UserInfo object.</returns>
         public abstract UserInfo GetUser(int portalId, int userId);
 
         /// <summary>GetUserByUserName retrieves a User from the DataStore. Supports user caching in memory cache.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="username">The username of the user being retrieved from the Data Store.</param>
         /// <returns>The User as a UserInfo object.</returns>
         public abstract UserInfo GetUserByUserName(int portalId, string username);
@@ -191,7 +191,7 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsers gets all the users of the portal.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
         /// <param name="totalRecords">The total no of records that satisfy the criteria.</param>
@@ -200,7 +200,7 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsersByEmail gets all the users of the portal whose email matches a provided filter expression.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="emailToMatch">The email address to use to find a match.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
@@ -210,7 +210,7 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsersByUserName gets all the users of the portal whose username matches a provided filter expression.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="userNameToMatch">The username to use to find a match.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
@@ -219,7 +219,7 @@ namespace DotNetNuke.Security.Membership
         public abstract ArrayList GetUsersByUserName(int portalId, string userNameToMatch, int pageIndex, int pageSize, ref int totalRecords);
 
         /// <summary>GetUsersByProfileProperty gets all the users of the portal whose profile matches the profile property passed as a parameter.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="propertyName">The name of the property being matched.</param>
         /// <param name="propertyValue">The value of the property being matched.</param>
         /// <param name="pageIndex">The page of records to return.</param>
@@ -235,8 +235,8 @@ namespace DotNetNuke.Security.Membership
         }
 
         /// <summary>GetUserByVanityUrl retrieves a User from the DataStore.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
-        /// <param name="vanityUrl">The vanityUrl of the user being retrieved from the Data Store.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
+        /// <param name="vanityUrl">The vanity URL of the user being retrieved from the Data Store.</param>
         /// <returns>The User as a UserInfo object or <see langword="null"/>.</returns>
         public virtual UserInfo GetUserByVanityUrl(int portalId, string vanityUrl)
         {
@@ -244,7 +244,7 @@ namespace DotNetNuke.Security.Membership
         }
 
         /// <summary>GetUserByPasswordResetToken retrieves a User from the DataStore.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="resetToken">The password reset token.</param>
         /// <returns>The User as a UserInfo object.</returns>
         public virtual UserInfo GetUserByPasswordResetToken(int portalId, string resetToken)
@@ -269,12 +269,12 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsers gets all the users of the portal.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
         /// <param name="totalRecords">The total number of records that satisfy the criteria.</param>
         /// <param name="includeDeleted">Include deleted users.</param>
-        /// <param name="superUsersOnly">Only select super users.</param>
+        /// <param name="superUsersOnly">Only select superusers.</param>
         /// <returns>An ArrayList of UserInfo objects.</returns>
         public virtual ArrayList GetUsers(int portalId, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {
@@ -283,13 +283,13 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsersByEmail gets all the users of the portal whose email matches a provided filter expression.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="emailToMatch">The email address to use to find a match.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
         /// <param name="totalRecords">The total number of records that satisfy the criteria.</param>
         /// <param name="includeDeleted">Include deleted users.</param>
-        /// <param name="superUsersOnly">Only select super users.</param>
+        /// <param name="superUsersOnly">Only select superusers.</param>
         /// <returns>An ArrayList of UserInfo objects.</returns>
         public virtual ArrayList GetUsersByEmail(int portalId, string emailToMatch, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {
@@ -298,13 +298,13 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsersByUserName gets all the users of the portal whose username matches a provided filter expression.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="userNameToMatch">The username to use to find a match.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
         /// <param name="totalRecords">The total number of records that satisfy the criteria.</param>
         /// <param name="includeDeleted">Include deleted users.</param>
-        /// <param name="superUsersOnly">Only select super users.</param>
+        /// <param name="superUsersOnly">Only select superusers.</param>
         /// <returns>An ArrayList of UserInfo objects.</returns>
         public virtual ArrayList GetUsersByUserName(int portalId, string userNameToMatch, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {
@@ -313,13 +313,13 @@ namespace DotNetNuke.Security.Membership
 
         /// <summary>GetUsersByDisplayName gets all the users of the portal whose display name matches a provided filter expression.</summary>
         /// <remarks>If all records are required, (ie no paging) set pageSize = -1.</remarks>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="nameToMatch">The display name to use to find a match.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
         /// <param name="totalRecords">The total number of records that satisfy the criteria.</param>
         /// <param name="includeDeleted">Include deleted users.</param>
-        /// <param name="superUsersOnly">Only select super users.</param>
+        /// <param name="superUsersOnly">Only select superusers.</param>
         /// <returns>An ArrayList of UserInfo objects.</returns>
         public virtual ArrayList GetUsersByDisplayName(int portalId, string nameToMatch, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {
@@ -327,14 +327,14 @@ namespace DotNetNuke.Security.Membership
         }
 
         /// <summary>GetUsersByProfileProperty gets all the users of the portal whose profile matches the profile property passed as a parameter.</summary>
-        /// <param name="portalId">The Id of the Portal.</param>
+        /// <param name="portalId">The ID of the Portal.</param>
         /// <param name="propertyName">The name of the property being matched.</param>
         /// <param name="propertyValue">The value of the property being matched.</param>
         /// <param name="pageIndex">The page of records to return.</param>
         /// <param name="pageSize">The size of the page.</param>
         /// <param name="totalRecords">The total number of records that satisfy the criteria.</param>
         /// <param name="includeDeleted">Include deleted users.</param>
-        /// <param name="superUsersOnly">Only select super users.</param>
+        /// <param name="superUsersOnly">Only select superusers.</param>
         /// <returns>An ArrayList of UserInfo objects.</returns>
         public virtual ArrayList GetUsersByProfileProperty(int portalId, string propertyName, string propertyValue, int pageIndex, int pageSize, ref int totalRecords, bool includeDeleted, bool superUsersOnly)
         {

--- a/DNN Platform/Library/Security/Roles/RoleController.cs
+++ b/DNN Platform/Library/Security/Roles/RoleController.cs
@@ -492,6 +492,7 @@ namespace DotNetNuke.Security.Roles
             // Remove the UserInfo and Roles from the Cache, as they have been modified
             DataCache.ClearUserCache(portalId, user.Username);
             this.ClearRoleCache(portalId);
+            UserController.RefreshCurrentUser();
         }
 
         /// <inheritdoc />

--- a/DNN Platform/Library/Services/FileSystem/FileManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FileManager.cs
@@ -1870,7 +1870,7 @@ namespace DotNetNuke.Services.FileSystem
         }
 
         private void CheckFileAddingRestrictions(IFolderInfo folder, string fileName, bool checkPermissions, bool ignoreWhiteList)
-          {
+        {
             if (checkPermissions && !this.folderPermissionController.CanAddFolder(folder))
             {
                 throw new PermissionsNotMetException(Localization.GetExceptionMessage(

--- a/DNN Platform/Library/Services/FileSystem/FolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/FolderManager.cs
@@ -118,8 +118,9 @@ namespace DotNetNuke.Services.FileSystem
                 if (FolderProvider.Instance(parentFolderMapping.FolderProviderType).SupportsMappedPaths)
                 {
                     folderMapping = parentFolderMapping;
-                    mappedPath = string.IsNullOrEmpty(parentFolder.FolderPath) ? PathUtils.Instance.FormatFolderPath(parentFolder.MappedPath + folderPath)
-                                                                            : PathUtils.Instance.FormatFolderPath(parentFolder.MappedPath + folderPath.Replace(parentFolder.FolderPath, string.Empty));
+                    mappedPath = string.IsNullOrEmpty(parentFolder.FolderPath)
+                        ? PathUtils.Instance.FormatFolderPath(parentFolder.MappedPath + folderPath)
+                        : PathUtils.Instance.FormatFolderPath(parentFolder.MappedPath + folderPath.Replace(parentFolder.FolderPath, string.Empty));
                 }
                 else if (!FolderProvider.Instance(folderMapping.FolderProviderType).SupportsMappedPaths)
                 {
@@ -128,7 +129,7 @@ namespace DotNetNuke.Services.FileSystem
                 else
                 {
                     // Parent foldermapping DOESN'T support mapped path
-                    // abd current foldermapping YES support mapped path
+                    // and current foldermapping YES support mapped path
                     mappedPath = PathUtils.Instance.FormatFolderPath(GetDefaultMappedPath(folderMapping) + mappedPath);
                 }
             }

--- a/DNN Platform/Library/Services/FileSystem/IFolderManager.cs
+++ b/DNN Platform/Library/Services/FileSystem/IFolderManager.cs
@@ -40,7 +40,7 @@ namespace DotNetNuke.Services.FileSystem
 
         /// <summary>
         /// Creates a new folder in the given portal using the provided folder path.
-        /// The same mapping than the parent folder will be used to create this folder. So this method have to be used only to create subfolders.
+        /// The same mapping as the parent folder will be used to create this folder. So this method have to be used only to create subfolders.
         /// </summary>
         /// <param name="portalId">The portal identifier.</param>
         /// <param name="folderPath">The path of the new folder.</param>

--- a/DNN Platform/Modules/Groups/Create.ascx.cs
+++ b/DNN Platform/Modules/Groups/Create.ascx.cs
@@ -28,6 +28,8 @@ using Microsoft.Extensions.DependencyInjection;
 /// <summary>Display the group create view.</summary>
 public partial class Create : GroupsModuleBase
 {
+    private static readonly HashSet<string> DefaultFolderPermissions = new HashSet<string>(["READ", "WRITE", "BROWSE",], StringComparer.OrdinalIgnoreCase);
+
     private readonly INavigationManager navigationManager;
     private readonly IFileManager fileManager;
     private readonly IFolderManager folderManager;
@@ -37,11 +39,12 @@ public partial class Create : GroupsModuleBase
     private readonly IEventLogger eventLogger;
     private readonly DataProvider dataProvider;
     private readonly IHostSettings hostSettings;
+    private readonly IPermissionDefinitionService permissionDefinitionService;
 
     /// <summary>Initializes a new instance of the <see cref="Create"/> class.</summary>
     [Obsolete("Deprecated in DotNetNuke 10.1.1. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
     public Create()
-        : this(null, null, null, null, null, null, null, null)
+        : this(null, null, null, null, null, null, null, null, null)
     {
     }
 
@@ -56,7 +59,7 @@ public partial class Create : GroupsModuleBase
     /// <param name="dataProvider">The data provider.</param>
     [Obsolete("Deprecated in DotNetNuke 10.2.4. Please use overload with IHostSettings. Scheduled removal in v12.0.0.")]
     public Create(INavigationManager navigationManager, IFileManager fileManager, IFolderManager folderManager, IFileContentTypeManager fileContentTypeManager, IRoleController roleController, IApplicationStatusInfo applicationStatusInfo, IEventLogger eventLogger, DataProvider dataProvider)
-        : this(navigationManager, fileManager, folderManager, fileContentTypeManager, roleController, applicationStatusInfo, eventLogger, dataProvider, null)
+        : this(navigationManager, fileManager, folderManager, fileContentTypeManager, roleController, applicationStatusInfo, eventLogger, dataProvider, null, null)
     {
     }
 
@@ -70,7 +73,24 @@ public partial class Create : GroupsModuleBase
     /// <param name="eventLogger">The event logger.</param>
     /// <param name="dataProvider">The data provider.</param>
     /// <param name="hostSettings">The host settings.</param>
+    [Obsolete("Deprecated in DotNetNuke 10.3.3. Please use overload with IHostSettings. Scheduled removal in v12.0.0.")]
     public Create(INavigationManager navigationManager, IFileManager fileManager, IFolderManager folderManager, IFileContentTypeManager fileContentTypeManager, IRoleController roleController, IApplicationStatusInfo applicationStatusInfo, IEventLogger eventLogger, DataProvider dataProvider, IHostSettings hostSettings)
+        : this(navigationManager, fileManager, folderManager, fileContentTypeManager, roleController, applicationStatusInfo, eventLogger, dataProvider, hostSettings, null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="Create"/> class.</summary>
+    /// <param name="navigationManager">The navigation manager.</param>
+    /// <param name="fileManager">The file manager.</param>
+    /// <param name="folderManager">The folder manager.</param>
+    /// <param name="fileContentTypeManager">The file content type manager.</param>
+    /// <param name="roleController">The role controller.</param>
+    /// <param name="applicationStatusInfo">The application status info.</param>
+    /// <param name="eventLogger">The event logger.</param>
+    /// <param name="dataProvider">The data provider.</param>
+    /// <param name="hostSettings">The host settings.</param>
+    /// <param name="permissionDefinitionService">The permission definition service.</param>
+    public Create(INavigationManager navigationManager, IFileManager fileManager, IFolderManager folderManager, IFileContentTypeManager fileContentTypeManager, IRoleController roleController, IApplicationStatusInfo applicationStatusInfo, IEventLogger eventLogger, DataProvider dataProvider, IHostSettings hostSettings, IPermissionDefinitionService permissionDefinitionService)
     {
         this.navigationManager = navigationManager ?? this.DependencyProvider.GetRequiredService<INavigationManager>();
         this.fileManager = fileManager ?? this.DependencyProvider.GetRequiredService<IFileManager>();
@@ -81,6 +101,7 @@ public partial class Create : GroupsModuleBase
         this.eventLogger = eventLogger ?? this.DependencyProvider.GetRequiredService<IEventLogger>();
         this.dataProvider = dataProvider ?? this.DependencyProvider.GetRequiredService<DataProvider>();
         this.hostSettings = hostSettings ?? this.DependencyProvider.GetRequiredService<IHostSettings>();
+        this.permissionDefinitionService = permissionDefinitionService ?? this.DependencyProvider.GetRequiredService<IPermissionDefinitionService>();
     }
 
     /// <inheritdoc />
@@ -188,23 +209,33 @@ public partial class Create : GroupsModuleBase
         roleInfo.Settings.Add("ReviewMembers", this.chkMemberApproved.Checked.ToString());
 
         this.roleController.UpdateRoleSettings(roleInfo, true);
+        this.roleController.AddUserRole(this.PortalId, this.UserId, roleInfo.RoleID, userRoleStatus, true, Null.NullDate, Null.NullDate);
         if (this.inpFile.PostedFile is { ContentLength: > 0 })
         {
-            var groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}") ??
-                              this.folderManager.AddFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
-
-            if (groupFolder != null)
+            var groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
+            if (groupFolder is null)
             {
-                var fileName = Path.GetFileName(this.inpFile.PostedFile.FileName);
-                var fileInfo = this.fileManager.AddFile(groupFolder, fileName, this.inpFile.PostedFile.InputStream, true, true, this.fileContentTypeManager.GetContentType(Path.GetExtension(fileName)));
-                roleInfo.IconFile = $"FileID={fileInfo.FileId}";
-                this.roleController.UpdateRole(roleInfo);
+                groupFolder = this.folderManager.AddFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
+                foreach (var permission in this.permissionDefinitionService.GetDefinitionsByFolder())
+                {
+                    if (DefaultFolderPermissions.Contains(permission.PermissionKey))
+                    {
+                        this.folderManager.SetFolderPermission(groupFolder, permission.PermissionId, roleInfo.RoleID);
+                    }
+                }
+
+                // reload groupFolder so that it has the new permissions in the AddFile call below
+                groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
             }
+
+            var fileName = Path.GetFileName(this.inpFile.PostedFile.FileName);
+            var fileInfo = this.fileManager.AddFile(groupFolder, fileName, this.inpFile.PostedFile.InputStream, true, true, this.fileContentTypeManager.GetContentType(Path.GetExtension(fileName)));
+            roleInfo.IconFile = $"FileID={fileInfo.FileId}";
+            this.roleController.UpdateRole(roleInfo);
         }
 
         var notifications = new Notifications(this.hostSettings);
 
-        this.roleController.AddUserRole(this.PortalId, this.UserId, roleInfo.RoleID, userRoleStatus, true, Null.NullDate, Null.NullDate);
         if (roleInfo.Status == RoleStatus.Pending)
         {
             // Send notification to Group Moderators to approve/reject group.

--- a/DNN Platform/Modules/Groups/Create.ascx.cs
+++ b/DNN Platform/Modules/Groups/Create.ascx.cs
@@ -102,7 +102,8 @@ public partial class Create : GroupsModuleBase
 
     private void Cancel_Click(object sender, EventArgs e)
     {
-        this.Response.Redirect(this.ModuleContext.NavigateUrl(this.TabId, string.Empty, false, null));
+        var groupListingUrl = this.navigationManager.NavigateURL(this.TabId);
+        this.Response.Redirect(groupListingUrl);
     }
 
     private void Create_Click(object sender, EventArgs e)
@@ -215,6 +216,7 @@ public partial class Create : GroupsModuleBase
             GroupUtilities.CreateJournalEntry(roleInfo, this.UserInfo);
         }
 
-        this.Response.Redirect(this.ModuleContext.NavigateUrl(this.TabId, string.Empty, false, null));
+        var groupListingUrl = this.navigationManager.NavigateURL(this.TabId);
+        this.Response.Redirect(groupListingUrl);
     }
 }

--- a/DNN Platform/Modules/Groups/Create.ascx.cs
+++ b/DNN Platform/Modules/Groups/Create.ascx.cs
@@ -28,8 +28,6 @@ using Microsoft.Extensions.DependencyInjection;
 /// <summary>Display the group create view.</summary>
 public partial class Create : GroupsModuleBase
 {
-    private static readonly HashSet<string> DefaultFolderPermissions = new HashSet<string>(["READ", "WRITE", "BROWSE",], StringComparer.OrdinalIgnoreCase);
-
     private readonly INavigationManager navigationManager;
     private readonly IFileManager fileManager;
     private readonly IFolderManager folderManager;
@@ -39,7 +37,6 @@ public partial class Create : GroupsModuleBase
     private readonly IEventLogger eventLogger;
     private readonly DataProvider dataProvider;
     private readonly IHostSettings hostSettings;
-    private readonly IPermissionDefinitionService permissionDefinitionService;
 
     /// <summary>Initializes a new instance of the <see cref="Create"/> class.</summary>
     [Obsolete("Deprecated in DotNetNuke 10.1.1. Please use overload with INavigationManager. Scheduled removal in v12.0.0.")]
@@ -59,7 +56,7 @@ public partial class Create : GroupsModuleBase
     /// <param name="dataProvider">The data provider.</param>
     [Obsolete("Deprecated in DotNetNuke 10.2.4. Please use overload with IHostSettings. Scheduled removal in v12.0.0.")]
     public Create(INavigationManager navigationManager, IFileManager fileManager, IFolderManager folderManager, IFileContentTypeManager fileContentTypeManager, IRoleController roleController, IApplicationStatusInfo applicationStatusInfo, IEventLogger eventLogger, DataProvider dataProvider)
-        : this(navigationManager, fileManager, folderManager, fileContentTypeManager, roleController, applicationStatusInfo, eventLogger, dataProvider, null, null)
+        : this(navigationManager, fileManager, folderManager, fileContentTypeManager, roleController, applicationStatusInfo, eventLogger, dataProvider, null)
     {
     }
 
@@ -73,24 +70,7 @@ public partial class Create : GroupsModuleBase
     /// <param name="eventLogger">The event logger.</param>
     /// <param name="dataProvider">The data provider.</param>
     /// <param name="hostSettings">The host settings.</param>
-    [Obsolete("Deprecated in DotNetNuke 10.3.3. Please use overload with IHostSettings. Scheduled removal in v12.0.0.")]
     public Create(INavigationManager navigationManager, IFileManager fileManager, IFolderManager folderManager, IFileContentTypeManager fileContentTypeManager, IRoleController roleController, IApplicationStatusInfo applicationStatusInfo, IEventLogger eventLogger, DataProvider dataProvider, IHostSettings hostSettings)
-        : this(navigationManager, fileManager, folderManager, fileContentTypeManager, roleController, applicationStatusInfo, eventLogger, dataProvider, hostSettings, null)
-    {
-    }
-
-    /// <summary>Initializes a new instance of the <see cref="Create"/> class.</summary>
-    /// <param name="navigationManager">The navigation manager.</param>
-    /// <param name="fileManager">The file manager.</param>
-    /// <param name="folderManager">The folder manager.</param>
-    /// <param name="fileContentTypeManager">The file content type manager.</param>
-    /// <param name="roleController">The role controller.</param>
-    /// <param name="applicationStatusInfo">The application status info.</param>
-    /// <param name="eventLogger">The event logger.</param>
-    /// <param name="dataProvider">The data provider.</param>
-    /// <param name="hostSettings">The host settings.</param>
-    /// <param name="permissionDefinitionService">The permission definition service.</param>
-    public Create(INavigationManager navigationManager, IFileManager fileManager, IFolderManager folderManager, IFileContentTypeManager fileContentTypeManager, IRoleController roleController, IApplicationStatusInfo applicationStatusInfo, IEventLogger eventLogger, DataProvider dataProvider, IHostSettings hostSettings, IPermissionDefinitionService permissionDefinitionService)
     {
         this.navigationManager = navigationManager ?? this.DependencyProvider.GetRequiredService<INavigationManager>();
         this.fileManager = fileManager ?? this.DependencyProvider.GetRequiredService<IFileManager>();
@@ -101,7 +81,6 @@ public partial class Create : GroupsModuleBase
         this.eventLogger = eventLogger ?? this.DependencyProvider.GetRequiredService<IEventLogger>();
         this.dataProvider = dataProvider ?? this.DependencyProvider.GetRequiredService<DataProvider>();
         this.hostSettings = hostSettings ?? this.DependencyProvider.GetRequiredService<IHostSettings>();
-        this.permissionDefinitionService = permissionDefinitionService ?? this.DependencyProvider.GetRequiredService<IPermissionDefinitionService>();
     }
 
     /// <inheritdoc />
@@ -209,33 +188,19 @@ public partial class Create : GroupsModuleBase
         roleInfo.Settings.Add("ReviewMembers", this.chkMemberApproved.Checked.ToString());
 
         this.roleController.UpdateRoleSettings(roleInfo, true);
-        this.roleController.AddUserRole(this.PortalId, this.UserId, roleInfo.RoleID, userRoleStatus, true, Null.NullDate, Null.NullDate);
         if (this.inpFile.PostedFile is { ContentLength: > 0 })
         {
-            var groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
-            if (groupFolder is null)
-            {
-                groupFolder = this.folderManager.AddFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
-                foreach (var permission in this.permissionDefinitionService.GetDefinitionsByFolder())
-                {
-                    if (DefaultFolderPermissions.Contains(permission.PermissionKey))
-                    {
-                        this.folderManager.SetFolderPermission(groupFolder, permission.PermissionId, roleInfo.RoleID);
-                    }
-                }
-
-                // reload groupFolder so that it has the new permissions in the AddFile call below
-                groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
-            }
-
+            var groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}") ??
+                              this.folderManager.AddFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
             var fileName = Path.GetFileName(this.inpFile.PostedFile.FileName);
-            var fileInfo = this.fileManager.AddFile(groupFolder, fileName, this.inpFile.PostedFile.InputStream, true, true, this.fileContentTypeManager.GetContentType(Path.GetExtension(fileName)));
+            var fileInfo = this.fileManager.AddFile(groupFolder, fileName, this.inpFile.PostedFile.InputStream, true, false, this.fileContentTypeManager.GetContentType(Path.GetExtension(fileName)));
             roleInfo.IconFile = $"FileID={fileInfo.FileId}";
             this.roleController.UpdateRole(roleInfo);
         }
 
         var notifications = new Notifications(this.hostSettings);
 
+        this.roleController.AddUserRole(this.PortalId, this.UserId, roleInfo.RoleID, userRoleStatus, true, Null.NullDate, Null.NullDate);
         if (roleInfo.Status == RoleStatus.Pending)
         {
             // Send notification to Group Moderators to approve/reject group.

--- a/DNN Platform/Modules/Groups/GroupEdit.ascx.cs
+++ b/DNN Platform/Modules/Groups/GroupEdit.ascx.cs
@@ -68,18 +68,11 @@ public partial class GroupEdit : GroupsModuleBase
     /// <param name="e">The event args.</param>
     protected void Page_Load(object sender, EventArgs e)
     {
-        JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.DnnPlugins);
-
-        this.imgGroup.Src = this.Page.ResolveUrl("~/DesktopModules/SocialGroups/Images/") + "sample-group-profile.jpg";
-        if (this.Page.IsPostBack || this.GroupId <= 0)
-        {
-            return;
-        }
-
         var roleInfo = this.roleController.GetRoleById(this.PortalId, this.GroupId);
-        if (roleInfo == null)
+        if (this.GroupId > 0 && roleInfo == null)
         {
-            this.Response.Redirect(this.ModuleContext.NavigateUrl(this.TabId, string.Empty, false));
+            var groupListingUrl = this.navigationManager.NavigateURL(this.TabId);
+            this.Response.Redirect(groupListingUrl);
             return;
         }
 
@@ -87,9 +80,17 @@ public partial class GroupEdit : GroupsModuleBase
         {
             if (roleInfo.CreatedByUserID != this.UserInfo.UserID)
             {
-                this.Response.Redirect(
-                    this.ModuleContext.NavigateUrl(this.TabId, string.Empty, false, $"groupid={this.GroupId}"));
+                var viewGroupUrl = this.navigationManager.NavigateURL(this.TabId, string.Empty, $"groupid={this.GroupId}");
+                this.Response.Redirect(viewGroupUrl);
             }
+        }
+
+        JavaScript.RequestRegistration(this.appStatus, this.eventLogger, this.PortalSettings, CommonJs.DnnPlugins);
+
+        this.imgGroup.Src = this.Page.ResolveUrl("~/DesktopModules/SocialGroups/Images/sample-group-profile.jpg");
+        if (this.Page.IsPostBack || this.GroupId <= 0)
+        {
+            return;
         }
 
         this.txtGroupName.Visible = !roleInfo.IsSystemRole;
@@ -118,7 +119,8 @@ public partial class GroupEdit : GroupsModuleBase
 
     private void Cancel_Click(object sender, EventArgs e)
     {
-        this.Response.Redirect(this.ModuleContext.NavigateUrl(this.TabId, string.Empty, false, $"groupid={this.GroupId}"));
+        var viewGroupUrl = this.navigationManager.NavigateURL(this.TabId, string.Empty, $"groupid={this.GroupId}");
+        this.Response.Redirect(viewGroupUrl);
     }
 
     private void Save_Click(object sender, EventArgs e)
@@ -161,14 +163,7 @@ public partial class GroupEdit : GroupsModuleBase
             roleInfo.Description = this.txtDescription.Text;
             roleInfo.IsPublic = this.rdAccessTypePublic.Checked;
 
-            if (roleInfo.Settings.ContainsKey("ReviewMembers"))
-            {
-                roleInfo.Settings["ReviewMembers"] = this.chkMemberApproved.Checked.ToString();
-            }
-            else
-            {
-                roleInfo.Settings.Add("ReviewMembers", this.chkMemberApproved.Checked.ToString());
-            }
+            roleInfo.Settings["ReviewMembers"] = this.chkMemberApproved.Checked.ToString();
 
             this.roleController.UpdateRoleSettings(roleInfo, true);
             this.roleController.UpdateRole(roleInfo);
@@ -178,19 +173,17 @@ public partial class GroupEdit : GroupsModuleBase
                 var groupFolder = this.folderManager.GetFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}") ??
                                   this.folderManager.AddFolder(this.PortalSettings.PortalId, $"Groups/{roleInfo.RoleID}");
 
-                if (groupFolder != null)
-                {
-                    var fileName = Path.GetFileName(this.inpFile.PostedFile.FileName);
-                    var fileInfo = this.fileManager.AddFile(groupFolder, fileName, this.inpFile.PostedFile.InputStream, true, true, this.fileContentTypeManager.GetContentType(Path.GetExtension(fileName)));
-                    roleInfo.IconFile = $"FileID={fileInfo.FileId}";
-                    this.roleController.UpdateRole(roleInfo);
-                }
+                var fileName = Path.GetFileName(this.inpFile.PostedFile.FileName);
+                var fileInfo = this.fileManager.AddFile(groupFolder, fileName, this.inpFile.PostedFile.InputStream, true, true, this.fileContentTypeManager.GetContentType(Path.GetExtension(fileName)));
+                roleInfo.IconFile = $"FileID={fileInfo.FileId}";
+                this.roleController.UpdateRole(roleInfo);
             }
 
             // Clear Roles Cache
             DataCache.RemoveCache("GetRoles");
         }
 
-        this.Response.Redirect(this.navigationManager.NavigateURL(this.TabId, string.Empty, $"groupid={this.GroupId}"));
+        var viewGroupUrl = this.navigationManager.NavigateURL(this.TabId, string.Empty, $"groupid={this.GroupId}");
+        this.Response.Redirect(viewGroupUrl);
     }
 }


### PR DESCRIPTION
## Summary
When creating a social group and supplying an image, the creation fails (partially succeeds in a non-recoverable way) because uploading the group image runs into a permissions failure. The solution ended up being to not check the permissions, because having the ability to create the group already confirms the ability to upload to that group's folder (but the actual permission grant to that folder has to happen later in some scenarios).