### PR TITLE
Reproducible test parameters

### DIFF
--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/BaseSettingsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/BaseSettingsTests.cs
@@ -26,10 +26,10 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
     public abstract class BaseSettingsTests
     {
         public static readonly object[] SettingsCases =
-        {
+        [
             new object[] { "AbcdeF#2@kfdfdfds", 9, 1.45, false, new DateTime(2015, 11, 30, 13, 45, 16), TimeSpan.Zero, TestingEnum.Value1, default(ComplexType), },
-            new object[] { "Bsskk41233[]#%&", -5, -13456.456, true, DateTime.Today.AddDays(-1), new TimeSpan(1, 5, 6, 7), TestingEnum.Value2, new ComplexType(8, -10), },
-        };
+            new object[] { "Bsskk41233[]#%&", -5, -13456.456, true, new DateTime(2026, 7, 8, 9, 10, 11, 12, DateTimeKind.Local), new TimeSpan(1, 5, 6, 7), TestingEnum.Value2, new ComplexType(8, -10), }
+        ];
 
         protected const string SettingNamePrefix = "UnitTestSetting_";
         protected const int ModuleId = 1234;

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/NullableSettingsTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Entities/Modules/Settings/NullableSettingsTests.cs
@@ -25,7 +25,7 @@ namespace DotNetNuke.Tests.Core.Entities.Modules.Settings
         [
             new(null, null, null, null),
             new(string.Empty, -1, new DateTime(2026, 5, 4, 3, 2, 1, DateTimeKind.Utc), TimeSpan.FromMilliseconds(3215648)),
-            new("lorem ipsum", 456, new DateTime(2025, 12, 24, 1, 2, 3, DateTimeKind.Local), DateTime.Today - new DateTime(2025, 12, 24, 1, 2, 3, DateTimeKind.Local))
+            new("lorem ipsum", 456, new DateTime(2025, 12, 24, 1, 2, 3, DateTimeKind.Local), new DateTime(2026, 7, 8, 9, 10, 11, 12, DateTimeKind.Local) - new DateTime(2025, 12, 24, 1, 2, 3, DateTimeKind.Local))
         ];
 
         protected override void SetupServiceProvider(IServiceCollection services)


### PR DESCRIPTION
When using `DateTime.Now` in the test parameters, they show up as removing/adding test cases in each commit.

See, for example, https://github.com/dnnsoftware/Dnn.Platform/pull/7348#issuecomment-4867297590