### PR TITLE
FIX: Default.css > Typo in custom property name > ui/_forms.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -589,7 +589,7 @@ a.pinHelp:hover {
     background-position: -150px 0px;
 }
 .dnnCheckbox-focus {
-    outline: 2px solid var(--dnn-color-forground, black);
+    outline: 2px solid var(--dnn-color-foreground, black);
     outline-offset: 2px;
 }
 .dnnBoxLabel{ display: inline-block;}


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
As this is a typo, I did not create an issue for it.


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

File: ui/_forms.scss:592
    outline: 2px solid var(--dnn-color-forground, black);
Should reference --dnn-color-foreground (missing "e"). Because the name
doesn't match the variable a theme actually sets, this rule always falls
back to the literal "black" - a theme's foreground color can never reach
this focus outline.
