### PR TITLE
FIX: default.css > Invalid rgba() arguments: modules/_tables.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
@@ -68,9 +68,9 @@
 .dnnTableFilter {
     margin-bottom: 18px;
     background: rgba(
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
+        var(--dnn-color-foreground-r, 0),
+        var(--dnn-color-foreground-g, 0),
+        var(--dnn-color-foreground-b, 0),
         0.04);
         .dnnTableDisplay {
             margin-bottom: 0;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
No issue as minor issue


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Invalid rgba() arguments
File: modules/_tables.scss:70-74 (.dnnTableFilter)
    background: rgba(
        var(--dnn-color-foreground, 0),
        var(--dnn-color-foreground, 0),
        var(--dnn-color-foreground, 0),
        0.04);
Elsewhere in the same file (lines 50-54) the correct pattern is used:
separate -r/-g/-b channel variables as the three rgba() numeric arguments.
Here the full color variable (--dnn-color-foreground, which resolves to
something like #444) is used as all three channel arguments instead of
--dnn-color-foreground-r/-g/-b. rgba() expects numbers 0-255 for the first
three arguments, not a color value, so this declaration is invalid and is
dropped by the browser.

Solution:
    background: rgba(
        var(--dnn-color-foreground-r, 0),
        var(--dnn-color-foreground-g, 0),
        var(--dnn-color-foreground-b, 0),
        0.04);