### PR TITLE
FIX: default.css > Accidental dnnTableDisplay nesting > tables.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
@@ -53,7 +53,7 @@
             var(--dnn-color-foreground-b, 0),
             0.04);
     }
-    .dnnTableDisplay tr:hover td {
+    tr:hover td {
         background: rgba(
             var(--dnn-color-info-r, 2),
             139,
@@ -68,9 +68,9 @@
 .dnnTableFilter {
     margin-bottom: 18px;
     background: rgba(
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
+        var(--dnn-color-foreground-r, 0),
+        var(--dnn-color-foreground-g, 0),
+        var(--dnn-color-foreground-b, 0),
         0.04);
         .dnnTableDisplay {
             margin-bottom: 0;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
No issue as minor typo


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Broken selector caused by accidental nesting
File: modules/_tables.scss:56 (inside .dnnTableDisplay { ... })
    .dnnTableDisplay tr:hover td { ... }
This rule is nested inside the .dnnTableDisplay block, so SCSS compiles it
to ".dnnTableDisplay .dnnTableDisplay tr:hover td" - a selector that
requires a .dnnTableDisplay element nested inside another .dnnTableDisplay
element. That never occurs in the real markup, so the row hover background
this rule defines never applies.