### PR TITLE
FIX: default.css > Default css/rgb var not dynamic

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
@@ -53,7 +53,7 @@
             var(--dnn-color-foreground-b, 0),
             0.04);
     }
-    .dnnTableDisplay tr:hover td {
+    tr:hover td {
         background: rgba(
             var(--dnn-color-info-r, 2),
             139,
@@ -68,9 +68,9 @@
 .dnnTableFilter {
     margin-bottom: 18px;
     background: rgba(
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
+        var(--dnn-color-foreground-r, 0),
+        var(--dnn-color-foreground-g, 0),
+        var(--dnn-color-foreground-b, 0),
         0.04);
         .dnnTableDisplay {
             margin-bottom: 0;

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
@@ -56,8 +56,8 @@
     tr:hover td {
         background: rgba(
             var(--dnn-color-info-r, 2),
-            139,
-            255,
+            var(--dnn-color-info-g, 139),
+            var(--dnn-color-info-b, 255),
             0.15);
     }
     tfoot tr:hover td {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Minor issue, not issue created


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

Two of three color channels hardcoded in an otherwise-variable rgba()
File: modules/_tables.scss:56-61 (same rule as 1.3)
    background: rgba(
        var(--dnn-color-info-r, 2),
        139,
        255,
        0.15);
The red channel comes from --dnn-color-info-r, but green/blue are hardcoded
literals (139, 255) instead of --dnn-color-info-g/-b. Even once 1.3 is
fixed, a theme changing --dnn-color-info can only shift one of the three
channels of this hover tint.

Solution: see 1.3 above - use var(--dnn-color-info-g, 139) and
var(--dnn-color-info-b, 255) so all three channels track the theme's
--dnn-color-info the same way -r already does.
