### PR TITLE
FIX: default.css > h2.dnn form section head a > default.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
@@ -17,7 +17,7 @@ h2.dnnFormSectionHead {
         background: url(../../../../../images/down-icn.png) no-repeat right 50%;
         text-decoration: none;
         color: var(--dnn-color-foreground, #333);
-        font-size: 7.375rem;;
+        font-size: inherit;
         letter-spacing: normal;
         font-weight: normal;
         &:hover{

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
@@ -53,7 +53,7 @@
             var(--dnn-color-foreground-b, 0),
             0.04);
     }
-    .dnnTableDisplay tr:hover td {
+    tr:hover td {
         background: rgba(
             var(--dnn-color-info-r, 2),
             139,
@@ -68,9 +68,9 @@
 .dnnTableFilter {
     margin-bottom: 18px;
     background: rgba(
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
-        var(--dnn-color-foreground, 0),
+        var(--dnn-color-foreground-r, 0),
+        var(--dnn-color-foreground-g, 0),
+        var(--dnn-color-foreground-b, 0),
         0.04);
         .dnnTableDisplay {
             margin-bottom: 0;

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/_tables.scss
@@ -56,8 +56,8 @@
     tr:hover td {
         background: rgba(
             var(--dnn-color-info-r, 2),
-            139,
-            255,
+            var(--dnn-color-info-g, 139),
+            var(--dnn-color-info-b, 255),
             0.15);
     }
     tfoot tr:hover td {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Oversized font-size + stray double semicolon
File: default.scss: 20
font-size: 7.375rem;

Sets the font-size of the section-head toggle link (h2.dnnFormSectionHead a)
to ~118px, which is inconsistent with every other heading/link size in the
file (all in the 0.75rem-2.375rem range). Also has a stray second
semicolon. Looks like a copy/paste or unit error.


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Reset font size to inherit
