### PR TITLE
FIX: default.css > Conflicting duplicate rule padding blocks for the same selectors > forms.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -173,7 +173,7 @@ div.dnnFormGroup {
 .dnnTertiaryAction,
 .dnnLogin .LoginTabGroup span {
     display: inline-block;
-    padding: 0.5625rem;
+    padding: 0.375rem;
     margin-bottom: 0.5625rem;
     cursor: pointer;
     min-width: 4.6875rem;
@@ -186,14 +186,7 @@ div.dnnFormGroup {
     text-decoration: none;
     text-align: center;
 }
-.dnnFormItem button, .dnnFormItem input[type="button"],
-.dnnFormItem input[type="reset"],
-.dnnFormItem input[type="submit"],
-.dnnPrimaryAction,
-.dnnSecondaryAction,
-.dnnTertiaryAction {
-    padding: 0.375rem;
-}
+
 
 .dnnFormMessage{
     display: block;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Minor issue, no issue created


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

Conflicting duplicate rule blocks for the same selectors
File: ui/_forms.scss:169-177 and 189-195
First block (line 177):
    padding: 0.5625rem;
Second block, four lines later, targeting an overlapping selector list
(.dnnFormItem button, input[type=button/reset/submit], .dnnPrimaryAction,
.dnnSecondaryAction, .dnnTertiaryAction) (line 195):
    padding: 0.375rem;
The second declaration silently wins for the shared selectors. Having two
separate rule blocks assign different values to the same property on
overlapping selectors makes it unclear which value is "the" intended
padding.

Solution: the end result (buttons/actions at 0.375rem,
