### PR TITLE
FIX: default.css > Headings Duplicate property in the same rule > type.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_type.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_type.scss
@@ -12,7 +12,6 @@ body{
 }
 h1, h2, h3, h4, h5, h6{
     font-family: Arial, Helvetica, sans-serif;
-    font-weight: bold;
     font-weight: inherit;
     line-height: 1.4;
     margin-top: 1rem;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Minor issue > no issue created


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Duplicate property in the same rule (dead declaration)
File: base/_type.scss:15-16 (h1, h2, h3, h4, h5, h6)
    font-weight: bold;
    font-weight: inherit;
Two font-weight declarations back to back in the same rule. The first
(bold) is immediately overwritten by the second (inherit) and has no
effect - dead code.

Solution: remove the dead declaration and keep the one that actually
applies:
    h1, h2, h3, h4, h5, h6 {
        font-family: Arial, Helvetica, sans-serif;
        font-weight: inherit;
        line-height: 1.4;
        margin-top: 1rem;
        margin-bottom: 0.75rem;
    }
