### PR TITLE
FIX: default.css > double color declaration > _dnn-autocomplete.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/dnn-jquery/_dnn-autocomplete.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/dnn-jquery/_dnn-autocomplete.scss
@@ -22,7 +22,6 @@
             margin: 0px;
             padding: 6px 22px 6px 22px;
             border-top: 1px solid #c9c9c9;
-            color: #666;
             cursor: pointer;
             display: block;
             overflow: hidden;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Minor, no issue created


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Duplicate property in the same rule (dead declaration)
File: ui/dnn-jquery/_dnn-autocomplete.scss:25 and :29 (li rule)
    color: #666;
    ...
    color: #333;
The first color declaration is unreachable dead code.