### PR TITLE
FIX: default.css: 3 small issues

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -214,7 +214,7 @@ div.dnnFormGroup {
         border-color: var(--dnn-color-danger-dark, rgba(255,0,0,0.2));
         color: var(--dnn-color-danger-contrast, black);
         a {
-            color: var(--dnn-color-danger-contrast, black);;
+            color: var(--dnn-color-danger-contrast, black);
         }
     }
     &.dnnFormWarning {

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/jquery-ui/_tabs.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/jquery-ui/_tabs.scss
@@ -15,7 +15,6 @@ ul.dnnAdminTabNav {
         align-items: center;
         a {
             margin-bottom: 0;
-            border-bottom: 0;
             border-radius: var(--dnn-controls-radius, 3px) var(--dnn-controls-radius, 3px) 0px 0px;
             margin-right: 0.25rem;
             padding: 12px 9px 10px 9px;

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/web-controls/_dnn-grid.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/web-controls/_dnn-grid.scss
@@ -19,7 +19,7 @@ tr.dnnGridHeader th{
         padding: 0.375rem;
         border-right: 1px solid var(--dnn-color-foreground-light, #c9c9c9);
         input{
-            margin-bottom: none;
+            margin-bottom: 0;
         }
     }
     &:hover {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Fixed 3 small issues:

## Redundant/conflicting border-bottom declarations
File: ui/jquery-ui/_tabs.scss:18, 23, 24
    border-bottom: 0;                                          (line 18)
    border: 1px solid var(--dnn-color-foreground-light, #c2c2c2); (line 23, shorthand resets border-bottom)
    border-bottom: none;                                       (line 24)
border-bottom is set three times in the same rule. Line 18 is immediately
overwritten by the shorthand on line 23, which is then itself overwritten
on line 24. Lines 18 and 23's border-bottom component have no effect.

Solution: drop the dead line 18 declaration; lines 23-24 already produce
the intended "no border-bottom on the tab link" result:
    a {
        margin-bottom: 0;
        border-radius: var(--dnn-controls-radius, 3px) var(--dnn-controls-radius, 3px) 0px 0px;
        margin-right: 0.25rem;
        padding: 12px 9px 10px 9px;
        text-decoration: none;
        border: 1px solid var(--dnn-color-foreground-light, #c2c2c2);
        border-bottom: none;
        &:hover, &:active{
            color: var(--dnn-color-primary-light, #028bff);
        }
    }
	
##Stray double semicolon
File: ui/_forms.scss:217
    color: var(--dnn-color-danger-contrast, black);;
Harmless but same class of typo as 1.5.

Solution:
    color: var(--dnn-color-danger-contrast, black);
	
##Invalid CSS value
File: ui/web-controls/_dnn-grid.scss:22
    input{
        margin-bottom: none;
    }
"none" is not a valid value for margin-bottom (valid values are lengths,
percentages, or "auto"/initial/inherit/unset - not "none"). Browsers
ignore this declaration entirely. Likely meant to be "margin-bottom: 0;".

Solution:
    input{
        margin-bottom: 0;
    }

