### PR TITLE
FIX: default.css > Inconsistent Font Family > forms.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -340,7 +340,7 @@ legend.required:after {
     background: rgba(0,0,0,0.03);
     content: 'Required';
     font-weight: normal;
-    font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
     font-size: 0.6875rem;
     font-style: italic;
     color: var(--dnn-color-foreground-light, #777);


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

##Orphaned/inconsistent font-family
File: ui/_forms.scss:343 (.required label:after, legend.required:after)
    font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
"Trebuchet MS" is not referenced anywhere else in the codebase - every
other font-family declaration uses "Arial, Helvetica, sans-serif". This
one "Required" badge renders in a different typeface than the rest of the
UI regardless of what a theme sets.

Solution: this value was carried over unchanged from the legacy 8.0.0
stylesheet while every other font-family declaration was later normalized
- align it with the rest of the file:
    font-family: Arial, Helvetica, sans-serif;
