### PR TITLE
Fix Persona bar icon not highlighted when Locked #6697

### DIFF
--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/main.css
@@ -649,7 +649,7 @@ span.dnnFormError:after {
 }
 
 .personabarnav > li#Edit.locked svg .back {
-    fill: var(--dnn-color-tertiary, #0a85c3);
+    fill: var(--dnn-color-pb-menu-locked-icon-background-highlight, #0a85c3);
 }
 
 .personabarnav > li#Edit.locked svg .main {

--- a/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/theme.css
+++ b/Dnn.AdminExperience/Library/Dnn.PersonaBar.UI/admin/personaBar/css/theme.css
@@ -9,6 +9,7 @@ instead of this one.
     --dnn-color-pb-menu-background-hover: var(--dnn-color-tertiary-dark, #0b1c24);
     --dnn-color-pb-menu-icon: var(--dnn-color-tertiary-light,#3c7a9a);
     --dnn-color-pb-menu-icon-background: var(--dnn-color-tertiary-dark, #0b1c24);
+    --dnn-color-pb-menu-locked-icon-background-highlight: var(--dnn-color-primary-dark, #0b1c24);
     --dnn-color-pb-menu-divider: var(--dnn-color-tertiary-light, #1e485e);
     --dnn-color-pb-menu-text-highlight: var(--dnn-color-tertiary-light, #3c7a9a);
     --dnn-pb-menu-brand-background: url('../images/Logo.svg') no-repeat center center;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
This fixes #6697
The issue is that there is no specific CSS var for this state, and thus there would be no way to overrule it specifically for the PB.

<img width="1278" height="672" alt="image" src="https://github.com/user-attachments/assets/d8277b05-1654-43c0-be13-bb4442b872d7" />

I tried setting the tertiary color and the effect was this:

<img width="561" height="726" alt="image" src="https://github.com/user-attachments/assets/fa96eb13-892b-4415-ad89-47a4fbcbd034" />

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

- Added an CSS variable for the PB highlighted icon
- Assigned the primary blue color to it to make it stand out
- 
fixes #6697

