### PR TITLE
FIX: Show expand collapse icons in CKEditor config screen

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
@@ -11,15 +11,20 @@ h2.dnnFormSectionHead {
     font-size: 2rem;
     line-height: 2.25rem;
     letter-spacing: 0.001875rem;
-    a {
+
+    // The span is coming from forms.scss and is here because not all heading have a link, some only span
+    > a, > span {
         display: block;
-        padding-left: 3px;
-        background: url(../../../../../images/down-icn.png) no-repeat right 50%;
-        text-decoration: none;
+        font-size: 1.125rem;
         color: var(--dnn-color-foreground, #333);
-        font-size: inherit;
+        text-decoration: none;
         letter-spacing: normal;
         font-weight: normal;
+    }
+    a {
+        
+        background: url(../../../../../images/down-icn.png) no-repeat right 50%;
+
         &:hover{
             color: #222;
             background: rgba(

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
@@ -11,7 +11,7 @@ h2.dnnFormSectionHead {
     font-size: 2rem;
     line-height: 2.25rem;
     letter-spacing: 0.001875rem;
-    h2.dnnFormSectionHead a {
+    a {
         display: block;
         padding-left: 3px;
         background: url(../../../../../images/down-icn.png) no-repeat right 50%;

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -245,11 +245,6 @@ div.dnnFormGroup {
     }
 }
 
-/* Pane header */
-.dnnFormSectionHead span {
-    font-size: 18px;
-    color: #222;
-}
 
 /* Tooltips */
 .dnnTooltip {


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
There was an accidental double css class wrapping in default.scss, after I removed that the expand collapse icons showed up.

<img width="650" height="651" alt="Clipboard05" src="https://github.com/user-attachments/assets/a8e54af5-cd17-4e3c-a034-ec30d75189f9" />


Result:
<img width="822" height="523" alt="image" src="https://github.com/user-attachments/assets/95ab863e-f95f-43e9-b878-df42622ff80e" />

fixes #7365 



