### PR TITLE
FIX: Ckeditor padding + heading sizes

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss
@@ -11,15 +11,20 @@ h2.dnnFormSectionHead {
     font-size: 2rem;
     line-height: 2.25rem;
     letter-spacing: 0.001875rem;
-    a {
+
+    // The span is coming from forms.scss and is here because not all heading have a link, some only span
+    > a, > span {
         display: block;
-        padding-left: 3px;
-        background: url(../../../../../images/down-icn.png) no-repeat right 50%;
-        text-decoration: none;
+        font-size: 1.125rem;
         color: var(--dnn-color-foreground, #333);
-        font-size: inherit;
+        text-decoration: none;
         letter-spacing: normal;
         font-weight: normal;
+    }
+    a {
+        
+        background: url(../../../../../images/down-icn.png) no-repeat right 50%;
+
         &:hover{
             color: #222;
             background: rgba(

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -245,11 +245,6 @@ div.dnnFormGroup {
     }
 }
 
-/* Pane header */
-.dnnFormSectionHead span {
-    font-size: 18px;
-    color: #222;
-}
 
 /* Tooltips */
 .dnnTooltip {

--- a/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/css/Options.css
+++ b/DNN Platform/Providers/HtmlEditorProviders/DNNConnect.CKE/css/Options.css
@@ -3,9 +3,7 @@ a:hover {color:rgb(204, 0, 0);}
 hr {color: #d9d9d9;background-color: #d9d9d9;height:0;border: 1px solid #d9d9d9;}
 h1 {font-weight: bold;margin: 0;font-size:medium;font-family:Arial, Helvetica, sans-serif; color:#333}
 .ui-tabs .ui-tabs-panel {
-	border: 1px dotted #333; -moz-border-radius: 0.4em; -webkit-border-radius: 0.4em;
-	-ms-border-radius: 0.4em;
-	border-radius: 0.4em; display:block;overflow: auto;height:500px;margin-top:5px;
+	display:block;overflow: auto;height:500px;margin-top:5px; padding: 1em;
 }
 
 .SettingBox {width:100%;padding-left: 5px; margin-right: 15px;float: left; }


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

2 Commits.
A. Very simple add some padding to the CkEditor screen
B. For the heading sizes, ended up being a bit more complex.


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
About the Heading size issue.

I noticed this:

<img width="391" height="581" alt="image" src="https://github.com/user-attachments/assets/82e21202-8056-4c21-81d5-cc8b60e27019" />

A difference in heading sizes.
dnnFormSectionHead can contain a link or a span

The second one contains a span the others a link.

Span size:
 https://github.com/dnnsoftware/Dnn.Platform/blob/1e3b3c80b407867c2bb9d34c82b1714df6231074/DNN%20Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss#L249

Anchor size:
https://github.com/dnnsoftware/Dnn.Platform/blob/1e3b3c80b407867c2bb9d34c82b1714df6231074/DNN%20Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/default.scss#L20

This is why they are different.
If you look at the interface, the heading a really large and IMO the size of the span is actually better than the ones containing a link. In edit users you get this:

Which looks weird IMO

<img width="510" height="373" alt="image" src="https://github.com/user-attachments/assets/6040d5f4-c8a0-4cfd-a4af-ccd9dcd0248c" />

So I moved what was in forms.scss into default.scss (not the best place but at least in one place)
And made them both the same size in rem.

There's a lot more one could changes here, but for now this at least fixes the issue of the header sizes.

FYI,

Manage users after this change:

<img width="467" height="799" alt="image" src="https://github.com/user-attachments/assets/17ec1cb3-3e3a-45a9-81c3-8ff94143a67f" />


Ckeditor manager 

<img width="827" height="612" alt="image" src="https://github.com/user-attachments/assets/e1bedbf3-e143-42f0-9bab-a5bd305eb377" />

fixes #7367 




