### PR TITLE
Improved css reset for deafault.css

### DIFF
--- a/DNN Platform/Dnn.ClientSide/build.ts
+++ b/DNN Platform/Dnn.ClientSide/build.ts
@@ -57,6 +57,7 @@ async function buildScss(input: string, output: string): Promise<void> {
         {
           sourceMap: true,
           sourceMapIncludeSources: true,
+          importers: [new sass.NodePackageImporter()],
         }
     );
 

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_reset.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_reset.scss
@@ -1,18 +1,1 @@
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center, dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend, table, caption,
-tbody, tfoot, thead, tr, th, td, article, aside,
-canvas, details, embed, figure, figcaption, footer,
-header, hgroup, menu, nav, output, ruby, section,
-summary, time, mark, audio, video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
+@use "pkg:modern-normalize";


### PR DESCRIPTION
"modern-normalize" was already in the dev-dependencies for the clientside project but was unused. Instead a manual css reset was in place which was too strong and made the default `em` `<i>` `<strong>` `<b>` have wrong defaults that made them useless.

I believe this was temporary and the intention was to use modern-normalize in the first place and it was gorgotten.

This PR fixes that. The above elements now look fine and I went over the default theme and the DNN UI parts and it appers to not have affected them.

Closes #7352
