### PR TITLE
Update reset styles in _reset.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_reset.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_reset.scss
@@ -12,7 +12,5 @@ summary, time, mark, audio, video {
   margin: 0;
   padding: 0;
   border: 0;
-  font-size: 100%;
-  font: inherit;
   vertical-align: baseline;
 }


### PR DESCRIPTION
Removed font-size and font properties from the reset styles.
This prevented normal elements like `small`, `em`, `strong` from having their normal behavior.