### PR TITLE
FIX: Remove font-size and line-height value for .Normal

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/modules.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/modules/modules.scss
@@ -12,13 +12,10 @@ td.SubHead{
     margin-bottom: 0;
 }
 
-/* Set text size in modules */
-.Normal,
+/* Color of Disabled and Deleted */
 .NormalDisabled,
 .NormalDeleted {
     color: var(--dnn-color-foreground, #444);
-    font-size: 1rem;
-    line-height: 1.125rem;
     word-wrap: break-word;
 }
 

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -35,13 +35,13 @@
     input[type="email"],
     input[type="search"],
     input[type="password"] {
-        margin-bottom: 1.125rem;
-        padding: 0.5rem;
+        margin-bottom: 1.125em;
+        padding: 0.5em;
         background: var(--dnn-color-background, #fff);
         border: 1px solid var(--dnn-color-foreground-light, #c9c9c9);
         border-radius: var(--dnn-controls-radius, 3px);
         color: var(--dnn-color-foreground, #333);
-        font-size: 0.75rem;
+        font-size: 0.75em;
         width: 45%;
         max-width: 445px;
         + .dnnTertiaryAction{

--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/ui/_forms.scss
@@ -35,13 +35,13 @@
     input[type="email"],
     input[type="search"],
     input[type="password"] {
-        margin-bottom: 1.125em;
-        padding: 0.5em;
+        margin-bottom: 1.125rem;
+        padding: 0.5rem;
         background: var(--dnn-color-background, #fff);
         border: 1px solid var(--dnn-color-foreground-light, #c9c9c9);
         border-radius: var(--dnn-controls-radius, 3px);
         color: var(--dnn-color-foreground, #333);
-        font-size: 0.75em;
+        font-size: 0.75rem;
         width: 45%;
         max-width: 445px;
         + .dnnTertiaryAction{


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->

Here's the why demo: https://youtu.be/MOcLN9YfXTQ

This is what these pages look like with the fix:

Home:

<img width="1920" height="880" alt="image" src="https://github.com/user-attachments/assets/0f622c51-c3ec-4819-8bd8-c31c0faa547b" />


Body 22px:

<img width="1920" height="880" alt="image" src="https://github.com/user-attachments/assets/bd721b94-2cc1-4856-966c-fbb2c224461c" />


fixes #7341
