### PR TITLE
Added dnn.jquery.js script reference to fix broken tooltips

### DIFF
--- a/DNN Platform/Website/Install/InstallWizard.aspx
+++ b/DNN Platform/Website/Install/InstallWizard.aspx
@@ -26,6 +26,7 @@
     <asp:placeholder runat="server" id="ClientResourceIncludes" />
     <form id="form1" runat="server">
         <asp:ScriptManager ID="scManager" runat="server" EnablePageMethods="true"></asp:ScriptManager>
+        <script type="text/javascript" src="../Resources/Shared/scripts/dnn.jquery.js"></script>
         <asp:placeholder id="BodySCRIPTS" runat="server">
         </asp:placeholder>
 


### PR DESCRIPTION
Fixes #7413 with one warning in browser console.
<img width="847" height="668" alt="Install-Wizard-Tooltips-fixed" src="https://github.com/user-attachments/assets/b7c748d9-246a-4cc4-8ebc-0dc47e3dd414" />
<img width="819" height="199" alt="browser_console_warning_install_wizard" src="https://github.com/user-attachments/assets/1a40e967-9461-47a9-8e55-5919af4456df" />



`dnn.jquery.js:2 Do not reference this file directly.
Use JavaScript.RequestRegistration(CommonJs.DnnPlugins) instead.
Or other appropriate CommonJs registration methods as described in https://docs.dnncommunity.org/content/tutorials/client-resources/index.html#javascript-libraries.
This file is unmaintained, may include breaking changes and will be removed in DNN v12.`


<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
