### PR TITLE
FIX: default.css > Remove table related resets from reset.scss

### DIFF
--- a/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_reset.scss
+++ b/DNN Platform/Dnn.ClientSide/src/styles/default-css/10.0.0/base/_reset.scss
@@ -4,9 +4,8 @@ a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, strong, sub, sup, tt, var,
 b, u, i, center, dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend, table, caption,
-tbody, tfoot, thead, tr, th, td, article, aside,
-canvas, details, embed, figure, figcaption, footer,
+fieldset, form, label, legend, caption, article, 
+aside, canvas, details, embed, figure, figcaption, footer,
 header, hgroup, menu, nav, output, ruby, section,
 summary, time, mark, audio, video {
   margin: 0;


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

The addition of reset for table, th, td etc, to the reset file in DNN 10, influenced existing themes.
(in some cases borders disappeared, vertical align was suddenly at the bottom as 2 examples)
The safe "fix" is to remove those, which is a "safer solution" than my previous suggestion.
<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #7406

Related to discussion #7372

