### PR TITLE
FIX: Several strings ignore the selected install-time culture and always render in English in Install Wizard

### DIFF
--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
@@ -490,7 +490,7 @@ Standard Database setup option is unavailable</value>
   <data name="Password.Required" xml:space="preserve">
     <value>Password is required.</value>
   </data>
-<data name="PasswordStrengthFair.Text" xml:space="preserve">
+  <data name="PasswordStrengthFair.Text" xml:space="preserve">
     <value>fair</value>
   </data>
   <data name="PasswordStrengthMinLength.Text" xml:space="preserve">
@@ -513,6 +513,12 @@ Standard Database setup option is unavailable</value>
   </data>
   <data name="PasswordRulesHeadText.Text" xml:space="preserve">
     <value>Password Policy:</value>
+  </data>
+  <data name="ConfirmPasswordUnmatched.Text" xml:space="preserve">
+    <value>Password does not match</value>
+  </data>
+  <data name="ConfirmPasswordMatched.Text" xml:space="preserve">
+    <value>Password Matched</value>
   </data>
   <data name="UserName.Required" xml:space="preserve">
     <value>Username is required.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.resx
@@ -490,6 +490,30 @@ Standard Database setup option is unavailable</value>
   <data name="Password.Required" xml:space="preserve">
     <value>Password is required.</value>
   </data>
+<data name="PasswordStrengthFair.Text" xml:space="preserve">
+    <value>fair</value>
+  </data>
+  <data name="PasswordStrengthMinLength.Text" xml:space="preserve">
+    <value>-character minimum</value>
+  </data>
+  <data name="PasswordStrengthStrong.Text" xml:space="preserve">
+    <value>strong</value>
+  </data>
+  <data name="PasswordStrengthWeak.Text" xml:space="preserve">
+    <value>weak</value>
+  </data>
+  <data name="CriteriaValidationExpression.Text" xml:space="preserve">
+    <value>Validation Expression: {0}</value>
+  </data>
+  <data name="CriteriaAtLeastNSpecialChars.Text" xml:space="preserve">
+    <value>At least {0} non-alphanumeric characters</value>
+  </data>
+  <data name="CriteriaAtLeastNChars.Text" xml:space="preserve">
+    <value>At least {0} characters</value>
+  </data>
+  <data name="PasswordRulesHeadText.Text" xml:space="preserve">
+    <value>Password Policy:</value>
+  </data>
   <data name="UserName.Required" xml:space="preserve">
     <value>Username is required.</value>
   </data>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
@@ -490,6 +490,30 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
   <data name="Password.Required" xml:space="preserve">
     <value>Şifre gereklidir.</value>
   </data>
+  <data name="PasswordStrengthFair.Text" xml:space="preserve">
+    <value>fair</value>
+  </data>
+  <data name="PasswordStrengthMinLength.Text" xml:space="preserve">
+    <value>-character minimum</value>
+  </data>
+  <data name="PasswordStrengthStrong.Text" xml:space="preserve">
+    <value>strong</value>
+  </data>
+  <data name="PasswordStrengthWeak.Text" xml:space="preserve">
+    <value>weak</value>
+  </data>
+  <data name="CriteriaValidationExpression.Text" xml:space="preserve">
+    <value>Validation Expression: {0}</value>
+  </data>
+  <data name="CriteriaAtLeastNSpecialChars.Text" xml:space="preserve">
+    <value>At least {0} non-alphanumeric characters</value>
+  </data>
+  <data name="CriteriaAtLeastNChars.Text" xml:space="preserve">
+    <value>At least {0} characters</value>
+  </data>
+  <data name="PasswordRulesHeadText.Text" xml:space="preserve">
+    <value>Password Policy:</value>
+  </data>
   <data name="UserName.Required" xml:space="preserve">
     <value>Kullanıcı adı zorunludur.</value>
   </data>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
@@ -470,7 +470,7 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
     <value>Parolalar eşleşmiyor.</value>
   </data>
   <data name="Confirm.Required" xml:space="preserve">
-    <value>Onay parolası gereklidir.</value>
+    <value>Parolayı onaylamanız gereklidir.</value>
   </data>
   <data name="DatabaseFilename.Required" xml:space="preserve">
     <value>Veritabanı dosya adı gereklidir.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
@@ -59,8 +59,8 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -491,28 +491,31 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
     <value>Şifre gereklidir.</value>
   </data>
   <data name="PasswordStrengthFair.Text" xml:space="preserve">
-    <value>fair</value>
+    <value>orta</value>
   </data>
   <data name="PasswordStrengthMinLength.Text" xml:space="preserve">
-    <value>-character minimum</value>
+    <value>karakter minimum</value>
   </data>
   <data name="PasswordStrengthStrong.Text" xml:space="preserve">
-    <value>strong</value>
+    <value>güçlü</value>
   </data>
   <data name="PasswordStrengthWeak.Text" xml:space="preserve">
-    <value>weak</value>
+    <value>zayıf</value>
+  </data>
+  <data name="ConfirmPasswordUnmatched.Text" xml:space="preserve">
+    <value>Şifre eşleşmiyor</value>
+  </data>
+  <data name="ConfirmPasswordMatched.Text" xml:space="preserve">
+    <value>Şifre Eşleşti</value>
   </data>
   <data name="CriteriaValidationExpression.Text" xml:space="preserve">
-    <value>Validation Expression: {0}</value>
+    <value>Doğrulama İfadesi: {0}</value>
   </data>
   <data name="CriteriaAtLeastNSpecialChars.Text" xml:space="preserve">
-    <value>At least {0} non-alphanumeric characters</value>
+    <value>En az {0} alfasayısal olmayan karakter</value>
   </data>
   <data name="CriteriaAtLeastNChars.Text" xml:space="preserve">
-    <value>At least {0} characters</value>
-  </data>
-  <data name="PasswordRulesHeadText.Text" xml:space="preserve">
-    <value>Password Policy:</value>
+    <value>En az {0} karakter</value>
   </data>
   <data name="ConfirmPasswordUnmatched.Text" xml:space="preserve">
     <value>Şifre eşleşmiyor</value>
@@ -528,6 +531,14 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
   </data>
   <data name="HostWarning.Text" xml:space="preserve">
     <value>Ana bilgisayar adınız yasaklı karakterler içeriyor (yalnızca a-Z, 0-9, - ve . izin verilir). Kullandığınız ana bilgisayar adını değiştirmelisiniz.</value>
+  </data>
+  <data name="FileAndFolderPermissionCheckFailed.Text" xml:space="preserve">
+    <value>&lt;div class="permission"&gt;&lt;img alt="Web sitesinin kök klasörü için güvenlik ayarlarını gösteren resim, ASPNET veya NT AUTHORITY/NETWORK SERVICE hesapları için Okuma, Yazma ve Değiştirme Kontrolü olarak ayarlanmalıdır." src="..\403-3.gif" align="right" hspace="10"/&gt;
+&lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;Siteniz izin kontrolünü geçemedi.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;
+Windows Gezgini'ni kullanarak web sitenizin klasörlerine gidin ( {0} ). Klasörün üzerine sağ tıklayın ve açılır menüden Paylaşım ve Güvenlik'i seçin. Güvenlik sekmesini seçin. Uygun Kullanıcı Hesabını ekleyin ve İzinleri ayarlayın.
+&lt;br/&gt;&lt;br/&gt;
+&lt;h3&gt;Windows 8 veya daha yeni, Windows Server 2008 R2 veya daha yeni ve IIS7.5 veya daha yeni kullanılıyorsa&lt;/h3&gt;
+&lt;p&gt;IIS AppPool\DefaultAppPool Kullanıcı Hesabının Web Sitesinin sanal kökünde Okuma, Yazma ve Değiştirme Kontrolüne sahip olması gerekir.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Tekrar Kontrol Et&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
   <data name="InstallVersion.Text" xml:space="preserve">
     <value>Yükleme Sürümü Ekleme</value>
@@ -567,13 +578,5 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
   </data>
   <data name="InstallingSslStepSiteNotFound.Text" xml:space="preserve">
     <value>Site {0} bulunamadı, HTTPS ayarlanamadı</value>
-  </data>
-  <data name="FileAndFolderPermissionCheckFailed.Text" xml:space="preserve">
-    <value>&lt;div class="permission"&gt;&lt;img alt="Web sitesinin kök klasörü için güvenlik ayarlarını gösteren resim, ASPNET veya NT AUTHORITY/NETWORK SERVICE hesapları için Okuma, Yazma ve Değiştirme Kontrolü olarak ayarlanmalıdır." src="..\403-3.gif" align="right" hspace="10"/&gt;
-&lt;p&gt;&lt;b&gt;&lt;font color='red'&gt;Siteniz izin kontrolünü geçemedi.&lt;/font&gt;&lt;/b&gt;&lt;/p&gt;
-Windows Gezgini'ni kullanarak web sitenizin klasörlerine gidin ( {0} ). Klasörün üzerine sağ tıklayın ve açılır menüden Paylaşım ve Güvenlik'i seçin. Güvenlik sekmesini seçin. Uygun Kullanıcı Hesabını ekleyin ve İzinleri ayarlayın.
-&lt;br/&gt;&lt;br/&gt;
-&lt;h3&gt;Windows 8 veya daha yeni, Windows Server 2008 R2 veya daha yeni ve IIS7.5 veya daha yeni kullanılıyorsa&lt;/h3&gt;
-&lt;p&gt;IIS AppPool\DefaultAppPool Kullanıcı Hesabının Web Sitesinin sanal kökünde Okuma, Yazma ve Değiştirme Kontrolüne sahip olması gerekir.&lt;/p&gt;&lt;p&gt;&lt;a class="dnnPrimaryAction" href=""&gt;Tekrar Kontrol Et&lt;/a&gt;&lt;/p&gt;&lt;/div&gt;</value>
   </data>
 </root>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
@@ -307,7 +307,7 @@
     <value>Websitesi için kullanmak istediğiniz dil.</value>
   </data>
   <data name="Password.Help" xml:space="preserve">
-    <value>SuperUser hesabının şifresi.</value>
+    <value>Süper Kullanıcı hesabının şifresi.</value>
   </data>
   <data name="UserName.Help" xml:space="preserve">
     <value>Süper Kullanıcı hesabı için kullanıcı adı.</value>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
@@ -517,6 +517,9 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
   <data name="CriteriaAtLeastNChars.Text" xml:space="preserve">
     <value>En az {0} karakter</value>
   </data>
+  <data name="PasswordRulesHeadText.Text" xml:space="preserve">
+    <value>Şifre Politikası:</value>
+  </data>
   <data name="ConfirmPasswordUnmatched.Text" xml:space="preserve">
     <value>Şifre eşleşmiyor</value>
   </data>

--- a/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
+++ b/DNN Platform/Website/Install/App_LocalResources/Installwizard.aspx.tr-TR.resx
@@ -514,6 +514,12 @@ Standart Veritabanı kurulum seçeneği mevcut değil</value>
   <data name="PasswordRulesHeadText.Text" xml:space="preserve">
     <value>Password Policy:</value>
   </data>
+  <data name="ConfirmPasswordUnmatched.Text" xml:space="preserve">
+    <value>Şifre eşleşmiyor</value>
+  </data>
+  <data name="ConfirmPasswordMatched.Text" xml:space="preserve">
+    <value>Şifre Eşleşti</value>
+  </data>
   <data name="UserName.Required" xml:space="preserve">
     <value>Kullanıcı adı zorunludur.</value>
   </data>

--- a/DNN Platform/Website/Install/InstallWizard.aspx
+++ b/DNN Platform/Website/Install/InstallWizard.aspx
@@ -505,7 +505,8 @@
             this.install = function () {
                 $.startProgressbar();
                 //Call PageMethod which triggers long running operation
-                PageMethods.RunInstall(function () {
+                PageMethods.RunInstall($("#PageLocale")[0].value, function () {
+
                 }, function (err) {
                     if (err._statusCode === 500 && !err._stackTrace) { //the error thrown by azure proxy, then need ignore.
                         return;
@@ -825,7 +826,7 @@
 
             var installationLogStartLine = 0;
             var getInstallationLog = function () {
-                PageMethods.GetInstallationLog(installationLogStartLine, function (result) {
+                PageMethods.GetInstallationLog(installationLogStartLine, $("#PageLocale")[0].value, function (result) {
                     if (result) {
                         if (installationLogStartLine === 0)
                             $('#installation-log').html(result);

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -227,18 +227,20 @@ namespace DotNetNuke.Services.Install
         }
 
         /// <summary>Runs the installer.</summary>
+        /// <param name="cultureCode">The culture selected by the user in the wizard UI (from the PageLocale field), used as the source of truth for localization since the static culture field does not survive an AppDomain restart.</param>
         [WebMethod]
-        public static void RunInstall()
+        public static void RunInstall(string cultureCode)
         {
             installerRunning = false;
-            LaunchAutoInstall(Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>());
+            LaunchAutoInstall(Globals.GetCurrentServiceProvider().GetRequiredService<IApplicationStatusInfo>(), cultureCode);
         }
 
         /// <summary>Gets the installation log.</summary>
         /// <param name="startRow">At which line to start obtaining log lines.</param>
+        /// <param name="cultureCode">The culture selected by the user in the wizard UI (from the PageLocale field), used as the source of truth for localization since the static culture field does not survive an AppDomain restart.</param>
         /// <returns>Log string from the provided line number forward.</returns>
         [WebMethod]
-        public static object GetInstallationLog(int startRow)
+        public static object GetInstallationLog(int startRow, string cultureCode)
         {
             const int maxLines = 500;
             var logFile = InstallController.Instance.InstallerLogName;
@@ -655,7 +657,7 @@ namespace DotNetNuke.Services.Install
                 try
                 {
                     installerRunning = true;
-                    LaunchAutoInstall(this.appStatus);
+                    LaunchAutoInstall(this.appStatus, culture);
                 }
                 catch (Exception)
                 {
@@ -667,7 +669,7 @@ namespace DotNetNuke.Services.Install
             {
                 if (installerRunning)
                 {
-                    LaunchAutoInstall(this.appStatus);
+                    LaunchAutoInstall(this.appStatus, culture);
                 }
                 else
                 {
@@ -735,7 +737,7 @@ namespace DotNetNuke.Services.Install
             }
         }
 
-        private static void LaunchAutoInstall(IApplicationStatusInfo appStatus)
+        private static void LaunchAutoInstall(IApplicationStatusInfo appStatus, string cultureCode = null)
         {
             if (appStatus.Status == UpgradeStatus.None)
             {
@@ -749,9 +751,12 @@ namespace DotNetNuke.Services.Install
             // Set Script timeout to MAX value
             HttpContext.Current.Server.ScriptTimeout = int.MaxValue;
 
-            if (culture != null)
+            // Prefer the culture passed in explicitly (e.g. from the client's PageLocale field) over the
+            // static culture field, which does not survive an AppDomain restart triggered mid-install.
+            var effectiveCulture = !string.IsNullOrEmpty(cultureCode) ? cultureCode : culture;
+            if (effectiveCulture != null)
             {
-                Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
+                Thread.CurrentThread.CurrentUICulture = new CultureInfo(effectiveCulture);
             }
 
             Install(appStatus);

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -580,6 +580,20 @@ namespace DotNetNuke.Services.Install
             this.txtPassword.CssClass = "password-strength";
 
             var options = new DnnPaswordStrengthOptions();
+
+            // The Install Wizard cannot assume App_GlobalResources/WebControls.resx
+            // (which DnnPaswordStrengthOptions reads by default) has been translated
+            // for the selected culture at install time. Override with this page's
+            // own local resource file, consistent with every other string on this page.
+            options.MinLengthText = this.LocalizeString("PasswordStrengthMinLength");
+            options.WeakText = this.LocalizeString("PasswordStrengthWeak");
+            options.FairText = this.LocalizeString("PasswordStrengthFair");
+            options.StrongText = this.LocalizeString("PasswordStrengthStrong");
+            options.CriteriaAtLeastNCharsText = this.LocalizeString("CriteriaAtLeastNChars");
+            options.CriteriaAtLeastNSpecialCharsText = this.LocalizeString("CriteriaAtLeastNSpecialChars");
+            options.CriteriaValidationExpressionText = this.LocalizeString("CriteriaValidationExpression");
+            options.PasswordRulesHeadText = this.LocalizeString("PasswordRulesHeadText");
+
             var optionsAsJsonString = Json.Serialize(options);
             var script = string.Format(
                 "dnn.initializePasswordStrength('.{0}', {1});{2}",

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -278,7 +278,10 @@ namespace DotNetNuke.Services.Install
 
                 if (!errorLogged)
                 {
-                    return Localization.GetString("NoErrorsLogged", "~/Install/App_LocalResources/InstallWizard.aspx.resx");
+                    return Localization.GetString(
+                        "NoErrorsLogged",
+                        "~/Install/App_LocalResources/InstallWizard.aspx.resx",
+                        !string.IsNullOrEmpty(cultureCode) ? cultureCode : culture);
                 }
 
                 return sb.ToString();

--- a/DNN Platform/Website/Install/InstallWizard.aspx.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.cs
@@ -611,6 +611,8 @@ namespace DotNetNuke.Services.Install
                 ContainerSelector = ".dnnFormPassword",
                 UnmatchedCssClass = "unmatched",
                 MatchedCssClass = "matched",
+                ConfirmPasswordUnmatchedText = this.LocalizeString("ConfirmPasswordUnmatched"),
+                ConfirmPasswordMatchedText = this.LocalizeString("ConfirmPasswordMatched"),
             };
 
             var confirmOptionsAsJsonString = Json.Serialize(confirmPasswordOptions);

--- a/DNN Platform/Website/Install/InstallWizard.aspx.designer.cs
+++ b/DNN Platform/Website/Install/InstallWizard.aspx.designer.cs
@@ -141,6 +141,15 @@ namespace DotNetNuke.Services.Install
         protected global::System.Web.UI.WebControls.LinkButton lang_nl_NL;
 
         /// <summary>
+        /// lang_tr_TR control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.LinkButton lang_tr_TR;
+
+        /// <summary>
         /// lblDotNetNukeInstalltion control.
         /// </summary>
         /// <remarks>
@@ -777,7 +786,7 @@ namespace DotNetNuke.Services.Install
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputHidden __dnnVariable;
+        protected global::System.Web.UI.HtmlControls.HtmlInputHidden @__dnnVariable;
 
         /// <summary>
         /// PageLocale control.


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

Fixes #7424
<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Fixes the Install Wizard's password-strength meter always rendering in English, regardless of the selected install-time culture, even when `InstallWizard.aspx.<culture>.resx` is fully translated.


## Root cause
`DnnPaswordStrengthOptions`'s constructor hardcodes its text source to `App_GlobalResources/WebControls.resx` via `Utilities.GetLocalizedString`. The Install Wizard runs before the rest of the application (including global resource translations for every culture) is guaranteed to be in place, so this dependency silently breaks localization for this one widget on this one page — every other string on `InstallWizard.aspx` already correctly reads from the page's own local resource file. In addition, culture field in `DNN Platform/Website/Install/InstallWizard.aspx.cs`  doesn't survive an AppDomain restart during install, so localization would silently fall back to default.


## Changes
- `InstallWizard.aspx.cs`: after constructing `DnnPaswordStrengthOptions`, override its `MinLengthText`, `WeakText`, `FairText`, `StrongText`, `CriteriaAtLeastNCharsText`, `CriteriaAtLeastNSpecialCharsText`, `CriteriaValidationExpressionText`, and `PasswordRulesHeadText` fields using the page's existing `LocalizeString()` helper, before serialization.
- `InstallWizard.aspx.resx` (base) and all shipped `InstallWizard.aspx.<culture>.resx` files: added the corresponding resource keys, values copied/translated from `App_GlobalResources/WebControls.resx`.
- No Errors Logged message localization
- Password match validation messages
- `cultureCode` implementation
- Turkish translations added/improved

## Testing performed
- [ ] Fresh install using default culture has no problems in the Install Wizard
- [ ] Fresh install, culture = tr-TR: strength meter, confirm-password indicator, and "no errors logged" message all fully localized; numeric substitution in strength-meter rules correct
- [ ] Manual visual check, mismatched-password check, and empty-log check
   
## Notes for reviewers
- Other shipped culture resx files have **not** been updated in this PR and will fall back to whatever default missing-key behavior is until follow-up translations land — flagging so maintainers can decide whether to gate this PR on all cultures being updated together or ship incrementally.