### PR TITLE
Add 1/3 and 2/3 (33/66) sizes to responsive dimension utilities #7429

### DIFF
--- a/DNN Platform/Skins/Aperture/src/scss/utilities/_dimension.scss
+++ b/DNN Platform/Skins/Aperture/src/scss/utilities/_dimension.scss
@@ -1,10 +1,12 @@
 @use "../variables/breakpoints";
 
-// Defaine maps for sizes
+// Define maps for sizes
 $sizes: (
     0: 0,
     25: 25%,
+    33: 33.33%,
     50: 50%,
+    66: 66.66%,
     75: 75%,
     100: 100%,
     auto: auto


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
Adds 33: 33.33% and 66: 66.66% entries to the $sizes map used by responsive-dimension, generating aperture-w-*-33, aperture-w-*-66 (and the h/min-w/min-h/max-w/max-h equivalents) for three-column layouts.

Depends on the ordering fix in #7428 — without it, a md-33/md-66 combo could hit the same override bug.

fixes #7429 