### PR TITLE
Restore hreflang alternate links in localized sitemaps

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/SitemapBuilder.cs
+++ b/DNN Platform/Library/Services/Sitemap/SitemapBuilder.cs
@@ -243,17 +243,18 @@ namespace DotNetNuke.Services.Sitemap
             writer.WriteElementString("changefreq", sitemapUrl.ChangeFrequency.ToString().ToLowerInvariant());
             writer.WriteElementString("priority", sitemapUrl.Priority.ToString("F01", CultureInfo.InvariantCulture));
 
-            ////if (sitemapUrl.AlternateUrls != null)
-            ////{
-            ////   foreach (AlternateUrl alternate in sitemapUrl.AlternateUrls)
-            ////   {
-            ////       writer.WriteStartElement("link", "http://www.w3.org/1999/xhtml");
-            ////       writer.WriteAttributeString("rel", "alternate");
-            ////       writer.WriteAttributeString("hreflang", alternate.Language);
-            ////       writer.WriteAttributeString("href", alternate.Url);
-            ////       writer.WriteEndElement();
-            ////   }
-            ////}
+            if (sitemapUrl.AlternateUrls != null)
+            {
+                foreach (AlternateUrl alternate in sitemapUrl.AlternateUrls)
+                {
+                    writer.WriteStartElement("link", "http://www.w3.org/1999/xhtml");
+                    writer.WriteAttributeString("rel", "alternate");
+                    writer.WriteAttributeString("hreflang", alternate.Language);
+                    writer.WriteAttributeString("href", alternate.Url);
+                    writer.WriteEndElement();
+                }
+            }
+
             writer.WriteEndElement();
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/SitemapBuilderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/SitemapBuilderTests.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Services.Sitemap
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Xml.Linq;
+
+    using DotNetNuke.Services.Sitemap;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SitemapBuilderTests
+    {
+        private const string SitemapNamespace = "http://www.sitemaps.org/schemas/sitemap/0.9";
+        private const string XhtmlNamespace = "http://www.w3.org/1999/xhtml";
+
+        [Test]
+        public void WriteSitemap_WithoutAlternateUrls_WritesStandardFields()
+        {
+            var sitemapUrl = new SitemapUrl
+            {
+                Url = "https://example.com/en-us/page",
+                LastModified = new DateTime(2026, 8, 4),
+                ChangeFrequency = SitemapChangeFrequency.Daily,
+                Priority = 0.5F,
+            };
+
+            var document = WriteSitemap(sitemapUrl);
+            XNamespace sitemap = SitemapNamespace;
+            XNamespace xhtml = XhtmlNamespace;
+            var url = document.Root?.Element(sitemap + "url");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(document.Root?.GetNamespaceOfPrefix("xhtml"), Is.EqualTo(xhtml));
+                Assert.That(url, Is.Not.Null);
+                Assert.That(url?.Element(sitemap + "loc")?.Value, Is.EqualTo("https://example.com/en-us/page"));
+                Assert.That(url?.Element(sitemap + "lastmod")?.Value, Is.EqualTo("2026-08-04"));
+                Assert.That(url?.Element(sitemap + "changefreq")?.Value, Is.EqualTo("daily"));
+                Assert.That(url?.Element(sitemap + "priority")?.Value, Is.EqualTo("0.5"));
+                Assert.That(url?.Elements(xhtml + "link"), Is.Empty);
+            });
+        }
+
+        [Test]
+        public void WriteSitemap_WithAlternateUrls_WritesHreflangLinks()
+        {
+            var sitemapUrl = new SitemapUrl
+            {
+                Url = "https://example.com/en-us/page",
+                LastModified = new DateTime(2026, 8, 4),
+                ChangeFrequency = SitemapChangeFrequency.Daily,
+                Priority = 0.5F,
+                AlternateUrls = new List<AlternateUrl>
+                {
+                    new AlternateUrl
+                    {
+                        Language = "en-US",
+                        Url = "https://example.com/en-us/page",
+                    },
+                    new AlternateUrl
+                    {
+                        Language = "fr-FR",
+                        Url = "https://example.fr/fr-fr/page",
+                    },
+                },
+            };
+
+            var document = WriteSitemap(sitemapUrl);
+            XNamespace sitemap = SitemapNamespace;
+            XNamespace xhtml = XhtmlNamespace;
+            var links = document.Root?
+                .Element(sitemap + "url")?
+                .Elements(xhtml + "link")
+                .ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(links, Has.Count.EqualTo(2));
+                Assert.That(links?[0].Attribute("rel")?.Value, Is.EqualTo("alternate"));
+                Assert.That(links?[0].Attribute("hreflang")?.Value, Is.EqualTo("en-US"));
+                Assert.That(links?[0].Attribute("href")?.Value, Is.EqualTo("https://example.com/en-us/page"));
+                Assert.That(links?[1].Attribute("rel")?.Value, Is.EqualTo("alternate"));
+                Assert.That(links?[1].Attribute("hreflang")?.Value, Is.EqualTo("fr-FR"));
+                Assert.That(links?[1].Attribute("href")?.Value, Is.EqualTo("https://example.fr/fr-fr/page"));
+            });
+        }
+
+        private static XDocument WriteSitemap(SitemapUrl sitemapUrl)
+        {
+            var builder = (SitemapBuilder)FormatterServices.GetUninitializedObject(typeof(SitemapBuilder));
+            var writeSitemap = typeof(SitemapBuilder).GetMethod("WriteSitemap", BindingFlags.Instance | BindingFlags.NonPublic);
+            using var output = new StringWriter(CultureInfo.InvariantCulture);
+
+            Assert.That(writeSitemap, Is.Not.Null);
+            writeSitemap.Invoke(builder, new object[] { false, output, 0, new List<SitemapUrl> { sitemapUrl } });
+
+            return XDocument.Parse(output.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Restores hreflang alternate links in XML sitemaps for sites using
Content Localization.

DNN already builds the localized alternate URL collection in
`CoreSitemapProvider` and assigns it to `SitemapUrl.AlternateUrls`.

`SitemapBuilder` already declares the XHTML namespace, but the existing
code that serializes `AlternateUrls` as `xhtml:link` elements was
commented out. This PR restores that serialization.

DNN-21481 originally introduced hreflang sitemap serialization.
DNN-4122 later disabled it in the same change that introduced
culture-specific sitemap output. Restoring the serialization exposes
the relationships between localized versions without adding localized
pages back as `loc` entries in the same sitemap.

Google supports hreflang annotations in XML sitemaps and allows
alternate URLs to exist on different domains:

https://developers.google.com/search/docs/specialty/international/localized-versions

## Scope

This PR does not change how DNN determines localized page URLs. It only
serializes the existing `AlternateUrls` collection.

## Tests

Added focused tests that verify:

- Standard sitemap fields remain unchanged without alternates.
- The XHTML namespace is declared.
- One `xhtml:link` is emitted per alternate URL.
- Each link contains the expected `rel`, `hreflang`, and `href`.
- Cross-domain alternate URLs are serialized.

Focused test result: 2 passed, 0 failed.

## Notes

Existing cached sitemap files may need to expire or be regenerated
before the restored links become visible.

Fixes #7446