### PR TITLE
Apply sitemap eligibility rules to localized alternates

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -54,21 +54,16 @@ namespace DotNetNuke.Services.Sitemap
             {
                 try
                 {
-                    if (!tab.IsDeleted && !tab.DisableLink && tab.TabType == TabType.Normal &&
-                        (Null.IsNull(tab.StartDate) || tab.StartDate < DateTime.Now) &&
-                        (Null.IsNull(tab.EndDate) || tab.EndDate > DateTime.Now) && this.IsTabPublic(tab.TabPermissions))
+                    if (this.IsTabEligibleForSitemap(tab, DateTime.Now))
                     {
-                        if ((this.includeHiddenPages || tab.IsVisible) && tab.HasBeenPublished && tab.AllowIndex)
+                        try
                         {
-                            try
-                            {
-                                pageUrl = this.GetPageUrl(tab, currentLanguage, ps);
-                                urls.Add(pageUrl);
-                            }
-                            catch (Exception exception)
-                            {
-                                Logger.CoreSitemapProviderErrorGettingPageUrl(exception, tab.TabName);
-                            }
+                            pageUrl = this.GetPageUrl(tab, currentLanguage, ps);
+                            urls.Add(pageUrl);
+                        }
+                        catch (Exception exception)
+                        {
+                            Logger.CoreSitemapProviderErrorGettingPageUrl(exception, tab.TabName);
                         }
                     }
                 }
@@ -124,6 +119,68 @@ namespace DotNetNuke.Services.Sitemap
             }
 
             return hasPublicRole;
+        }
+
+        /// <summary>Determines whether a page is eligible to be included in sitemap output.</summary>
+        /// <param name="tab">The page to evaluate.</param>
+        /// <param name="now">The date and time used to evaluate the page publication window.</param>
+        /// <returns><see langword="true"/> when the page is eligible; otherwise, <see langword="false"/>.</returns>
+        internal bool IsTabEligibleForSitemap(TabInfo tab, DateTime now)
+        {
+            return tab != null &&
+                   !tab.IsDeleted &&
+                   !tab.DisableLink &&
+                   tab.TabType == TabType.Normal &&
+                   (Null.IsNull(tab.StartDate) || tab.StartDate < now) &&
+                   (Null.IsNull(tab.EndDate) || tab.EndDate > now) &&
+                   this.IsTabPublic(tab.TabPermissions) &&
+                   (this.includeHiddenPages || tab.IsVisible) &&
+                   tab.HasBeenPublished &&
+                   tab.AllowIndex;
+        }
+
+        /// <summary>Gets the eligible localized URLs for an hreflang group.</summary>
+        /// <param name="defaultLanguageTab">The default-language page.</param>
+        /// <param name="localizedTabs">The localized versions of the page.</param>
+        /// <param name="ps">The current portal settings.</param>
+        /// <param name="now">The date and time used to evaluate page publication windows.</param>
+        /// <returns>The eligible alternate URLs.</returns>
+        internal List<AlternateUrl> GetAlternateUrls(
+            TabInfo defaultLanguageTab,
+            IEnumerable<TabInfo> localizedTabs,
+            PortalSettings ps,
+            DateTime now)
+        {
+            var alternates = new List<AlternateUrl>();
+            List<TabInfo> eligibleLocalizedTabs = localizedTabs.Where(localizedTab => this.IsTabEligibleForSitemap(localizedTab, now)).ToList();
+            bool isDefaultLanguageTabEligible = this.IsTabEligibleForSitemap(defaultLanguageTab, now);
+
+            // A single self-reference is not an alternate-language relationship.
+            if (!isDefaultLanguageTabEligible && eligibleLocalizedTabs.Count < 2)
+            {
+                return alternates;
+            }
+
+            foreach (TabInfo localizedTab in eligibleLocalizedTabs)
+            {
+                alternates.Add(new AlternateUrl
+                {
+                    Url = TestableGlobals.Instance.NavigateURL(localizedTab.TabID, localizedTab.IsSuperTab, ps, string.Empty, localizedTab.CultureCode),
+                    Language = localizedTab.CultureCode,
+                });
+            }
+
+            if (alternates.Count > 0 && isDefaultLanguageTabEligible)
+            {
+                string defaultUrl = TestableGlobals.Instance.NavigateURL(defaultLanguageTab.TabID, defaultLanguageTab.IsSuperTab, ps, string.Empty, defaultLanguageTab.CultureCode);
+                alternates.Add(new AlternateUrl
+                {
+                    Url = defaultUrl,
+                    Language = defaultLanguageTab.CultureCode,
+                });
+            }
+
+            return alternates;
         }
 
         /// <summary>
@@ -187,42 +244,14 @@ namespace DotNetNuke.Services.Sitemap
             // support for alternate pages: https://support.google.com/webmasters/answer/2620865?hl=en
             if (ps.ContentLocalizationEnabled && !objTab.IsNeutralCulture)
             {
-                List<AlternateUrl> alternates = new List<AlternateUrl>();
-                TabInfo currentTab = objTab;
-
-                if (!objTab.IsDefaultLanguage)
+                TabInfo defaultLanguageTab = objTab.IsDefaultLanguage ? objTab : objTab.DefaultLanguageTab;
+                if (defaultLanguageTab != null)
                 {
-                    currentTab = objTab.DefaultLanguageTab;
-                }
-
-                foreach (TabInfo localized in currentTab.LocalizedTabs.Values)
-                {
-                    if ((!localized.IsDeleted && !localized.DisableLink && localized.TabType == TabType.Normal) &&
-                        (Null.IsNull(localized.StartDate) || localized.StartDate < DateTime.Now) &&
-                        (Null.IsNull(localized.EndDate) || localized.EndDate > DateTime.Now) &&
-                        this.IsTabPublic(localized.TabPermissions) &&
-                        (this.includeHiddenPages || localized.IsVisible) && localized.HasBeenPublished)
+                    List<AlternateUrl> alternates = this.GetAlternateUrls(defaultLanguageTab, defaultLanguageTab.LocalizedTabs.Values, ps, DateTime.Now);
+                    if (alternates.Count > 0)
                     {
-                        string alternateUrl = TestableGlobals.Instance.NavigateURL(localized.TabID, localized.IsSuperTab, ps, string.Empty, localized.CultureCode);
-                        alternates.Add(new AlternateUrl()
-                        {
-                            Url = alternateUrl,
-                            Language = localized.CultureCode,
-                        });
+                        pageUrl.AlternateUrls = alternates;
                     }
-                }
-
-                if (alternates.Count > 0)
-                {
-                    // add default language to the list
-                    string alternateUrl = TestableGlobals.Instance.NavigateURL(currentTab.TabID, currentTab.IsSuperTab, ps, string.Empty, currentTab.CultureCode);
-                    alternates.Add(new AlternateUrl()
-                    {
-                        Url = alternateUrl,
-                        Language = currentTab.CultureCode,
-                    });
-
-                    pageUrl.AlternateUrls = alternates;
                 }
             }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/CoreSitemapProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/CoreSitemapProviderTests.cs
@@ -1,0 +1,244 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace DotNetNuke.Tests.Core.Services.Sitemap
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using DotNetNuke.Abstractions.Portals;
+    using DotNetNuke.Common.Internal;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Tabs;
+    using DotNetNuke.Entities.Urls;
+    using DotNetNuke.Security.Permissions;
+    using DotNetNuke.Services.Sitemap;
+
+    using Moq;
+    using NUnit.Framework;
+
+    using NewBrowserTypes = DotNetNuke.Abstractions.Urls.BrowserTypes;
+
+    [TestFixture]
+    public class CoreSitemapProviderTests
+    {
+        private Mock<IGlobals> globals;
+        private PortalSettings portalSettings;
+        private TestCoreSitemapProvider provider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.globals = new Mock<IGlobals>();
+            this.portalSettings = new PortalSettings();
+            this.provider = new TestCoreSitemapProvider();
+            TestableGlobals.SetTestableInstance(this.globals.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TestableGlobals.ClearInstance();
+        }
+
+        [Test]
+        public void IsTabEligibleForSitemap_WhenAllowIndexIsFalse_ReturnsFalse()
+        {
+            TabInfo tab = CreateTab("fr-FR", allowIndex: false);
+
+            bool result = this.provider.IsTabEligibleForSitemap(tab, DateTime.UtcNow);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void GetAlternateUrls_ExcludesLocalizedPagesThatDisallowIndexing()
+        {
+            TabInfo defaultTab = CreateTab("en-US");
+            TabInfo indexableTab = CreateTab("fr-FR");
+            TabInfo noIndexTab = CreateTab("es-ES", allowIndex: false);
+            this.SetupUrl("en-US", "https://example.com/page");
+            this.SetupUrl("fr-FR", "https://example.fr/page");
+
+            List<AlternateUrl> result = this.provider.GetAlternateUrls(
+                defaultTab,
+                new[] { indexableTab, noIndexTab },
+                this.portalSettings,
+                DateTime.UtcNow);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Select(alternate => alternate.Language), Is.EqualTo(new[] { "fr-FR", "en-US" }));
+                Assert.That(result, Has.None.Matches<AlternateUrl>(alternate => alternate.Language == "es-ES"));
+                this.globals.Verify(
+                    global => global.NavigateURL(
+                        It.IsAny<int>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<PortalSettings>(),
+                        It.IsAny<string>(),
+                        "es-ES",
+                        It.IsAny<string[]>()),
+                    Times.Never);
+            });
+        }
+
+        [Test]
+        public void GetAlternateUrls_UsesCultureSpecificUrls()
+        {
+            TabInfo defaultTab = CreateTab("en-US");
+            TabInfo localizedTab = CreateTab("fr-FR");
+            this.SetupUrl("en-US", "https://www.example.com/page");
+            this.SetupUrl("fr-FR", "https://www.example.fr/page");
+
+            List<AlternateUrl> result = this.provider.GetAlternateUrls(
+                defaultTab,
+                new[] { localizedTab },
+                this.portalSettings,
+                DateTime.UtcNow);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Has.Count.EqualTo(2));
+                Assert.That(result[0].Language, Is.EqualTo("fr-FR"));
+                Assert.That(result[0].Url, Is.EqualTo("https://www.example.fr/page"));
+                Assert.That(result[1].Language, Is.EqualTo("en-US"));
+                Assert.That(result[1].Url, Is.EqualTo("https://www.example.com/page"));
+            });
+        }
+
+        [Test]
+        public void GetAlternateUrls_WhenDefaultPageDisallowsIndexingAndOnlyOneLocalizedPageIsEligible_ReturnsNoAlternates()
+        {
+            TabInfo defaultTab = CreateTab("en-US", allowIndex: false);
+            TabInfo localizedTab = CreateTab("fr-FR");
+            this.SetupUrl("fr-FR", "https://www.example.fr/page");
+
+            List<AlternateUrl> result = this.provider.GetAlternateUrls(
+                defaultTab,
+                new[] { localizedTab },
+                this.portalSettings,
+                DateTime.UtcNow);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Empty);
+                this.globals.Verify(
+                    global => global.NavigateURL(
+                        It.IsAny<int>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<PortalSettings>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string[]>()),
+                    Times.Never);
+            });
+        }
+
+        [Test]
+        public void GetAlternateUrls_WhenDefaultPageDisallowsIndexingAndTwoLocalizedPagesAreEligible_ReturnsLocalizedAlternates()
+        {
+            TabInfo defaultTab = CreateTab("en-US", allowIndex: false);
+            TabInfo frenchTab = CreateTab("fr-FR");
+            TabInfo spanishTab = CreateTab("es-ES");
+            this.SetupUrl("fr-FR", "https://www.example.fr/page");
+            this.SetupUrl("es-ES", "https://www.example.es/page");
+
+            List<AlternateUrl> result = this.provider.GetAlternateUrls(
+                defaultTab,
+                new[] { frenchTab, spanishTab },
+                this.portalSettings,
+                DateTime.UtcNow);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Select(alternate => alternate.Language), Is.EqualTo(new[] { "fr-FR", "es-ES" }));
+                Assert.That(result, Has.None.Matches<AlternateUrl>(alternate => alternate.Language == "en-US"));
+            });
+        }
+
+        [Test]
+        public void GetAliasByPortalIdAndSettings_WithCultureSpecificAlias_SelectsMatchingDomain()
+        {
+            PortalAliasInfo defaultAlias = CreatePortalAlias("www.example.com", "en-US", isPrimary: true);
+            PortalAliasInfo frenchAlias = CreatePortalAlias("www.example.fr", "fr-FR", isPrimary: true);
+            var urlAction = new UrlAction("http", string.Empty, string.Empty)
+            {
+                HttpAlias = "www.example.com",
+                PortalId = 0,
+            };
+
+            PortalAliasInfo result = new[] { defaultAlias, frenchAlias }.GetAliasByPortalIdAndSettings(
+                0,
+                urlAction,
+                "fr-FR",
+                NewBrowserTypes.Normal);
+
+            Assert.That(((IPortalAliasInfo)result).HttpAlias, Is.EqualTo("www.example.fr"));
+        }
+
+        private static TabInfo CreateTab(string cultureCode, bool allowIndex = true)
+        {
+            var tab = new TabInfo
+            {
+                CultureCode = cultureCode,
+                IsVisible = true,
+                HasBeenPublished = true,
+                Url = string.Empty,
+            };
+            var settings = new Hashtable
+            {
+                ["AllowIndex"] = allowIndex.ToString(),
+            };
+
+            SetPrivateField(tab, "settings", settings);
+            SetPrivateField(tab, "permissions", new TabPermissionCollection());
+            return tab;
+        }
+
+        private static void SetPrivateField(TabInfo tab, string fieldName, object value)
+        {
+            FieldInfo field = typeof(TabInfo).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            field.SetValue(tab, value);
+        }
+
+        private static PortalAliasInfo CreatePortalAlias(string httpAlias, string cultureCode, bool isPrimary)
+        {
+            var alias = new PortalAliasInfo
+            {
+                CultureCode = cultureCode,
+                IsPrimary = isPrimary,
+            };
+            var aliasInfo = (IPortalAliasInfo)alias;
+            aliasInfo.HttpAlias = httpAlias;
+            aliasInfo.PortalId = 0;
+            aliasInfo.BrowserType = NewBrowserTypes.Normal;
+            return alias;
+        }
+
+        private void SetupUrl(string cultureCode, string url)
+        {
+            this.globals
+                .Setup(global => global.NavigateURL(
+                    It.IsAny<int>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<PortalSettings>(),
+                    string.Empty,
+                    cultureCode,
+                    It.IsAny<string[]>()))
+                .Returns(url);
+        }
+
+        private class TestCoreSitemapProvider : CoreSitemapProvider
+        {
+            public override bool IsTabPublic(TabPermissionCollection objTabPermissions)
+            {
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7449

Applies the same sitemap eligibility rules to localized and default-language
alternates that DNN already applies to primary sitemap entries.

This prevents pages that are deleted, disabled, unpublished, outside their
publication window, non-public, excluded by sitemap visibility settings, or
configured with `AllowIndex=false` from appearing inside hreflang groups.

The change also:

- avoids emitting a self-only alternate group when fewer than two eligible
  language versions remain;
- preserves DNN's existing culture-specific URL and portal-alias selection path;
- adds focused regression coverage without changing portal-alias production logic.

`x-default` is intentionally excluded and preserved for a separate enhancement
proposal.

## Tests

Focused sitemap tests:

`dotnet test "DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj" --no-restore --filter "FullyQualifiedName~Services.Sitemap" --verbosity quiet`

Result: 8 passed, 0 failed, 0 skipped.