### PR TITLE
Fixed an issue where last item was the target on right-click in resource-manager

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-cardview/dnn-rm-items-cardview.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-cardview/dnn-rm-items-cardview.tsx
@@ -12,15 +12,13 @@ export class DnnRmItemsCardview {
   /** The list of current items. */
   @Prop() currentItems!: GetFolderContentResponse;
 
-  @Element() el: HTMLDnnRmItemsCardviewElement;
+  @Element() el!: HTMLDnnRmItemsCardviewElement;
 
   /** Fires when a folder is double-clicked and emits the folder ID into the event.detail */
-  @Event() dnnRmFolderDoubleClicked: EventEmitter<number>;
+  @Event() dnnRmFolderDoubleClicked!: EventEmitter<number>;
 
   /** Fires when a file is double-clicked and emits the file ID into the event.detail */
-  @Event() dnnRmFileDoubleClicked: EventEmitter<string>;
-
-  private contextMenu: HTMLDnnContextMenuElement;
+  @Event() dnnRmFileDoubleClicked!: EventEmitter<string>;
 
   private handleDoubleClick(item: Item): void {
     if (item.isFolder) {
@@ -28,6 +26,11 @@ export class DnnRmItemsCardview {
     } else {
       this.dnnRmFileDoubleClicked.emit(item.path);
     }
+  }
+
+  private openItemContextMenu(e: MouseEvent): void {
+    const rowMenu = (e.currentTarget as HTMLElement)?.querySelector('dnn-context-menu');
+    rowMenu?.open(e as PointerEvent).catch(console.error);
   }
 
   render() {
@@ -42,7 +45,7 @@ export class DnnRmItemsCardview {
                 onDblClick={() => this.handleDoubleClick(item)}
                 onContextMenu={e => {
                   e.preventDefault();
-                  this.contextMenu.open(e as PointerEvent).catch(console.error);
+                  this.openItemContextMenu(e);
                 }}
               >
                   <div class={selectionUtilities.isItemSelected(item) ? "radio selected" : "radio"}>
@@ -61,7 +64,6 @@ export class DnnRmItemsCardview {
                     {item.itemName}
                   </span>
                   <dnn-context-menu
-                    ref={el => this.contextMenu = el}
                     closeOnClick
                   >
                     {item.isFolder

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-listview/dnn-rm-items-listview.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-items-listview/dnn-rm-items-listview.tsx
@@ -13,15 +13,13 @@ export class DnnRmItemsListview {
   /** The list of current items. */
   @Prop() currentItems!: GetFolderContentResponse;
 
-  @Element() el: HTMLDnnRmItemsListviewElement;
+  @Element() el!: HTMLDnnRmItemsListviewElement;
 
   /** Fires when a folder is double-clicked and emits the folder ID into the event.detail */
-  @Event() dnnRmFolderDoubleClicked: EventEmitter<number>;
+  @Event() dnnRmFolderDoubleClicked!: EventEmitter<number>;
 
   /** Fires when a file is double-clicked and emits the file ID into the event.detail */
-  @Event() dnnRmFileDoubleClicked: EventEmitter<string>;
-
-  private contextMenu: HTMLDnnContextMenuElement;
+  @Event() dnnRmFileDoubleClicked!: EventEmitter<string>;
 
   private getLocalDateString(dateString: string) {
     const date = new Date(dateString);
@@ -29,6 +27,11 @@ export class DnnRmItemsListview {
       <span>{date.toLocaleDateString()}</span>
       <span>{date.toLocaleTimeString()}</span>
     </div>
+  }
+
+  private openItemContextMenu(e: MouseEvent): void {
+    const rowMenu = (e.currentTarget as HTMLElement)?.querySelector('dnn-context-menu');
+    rowMenu?.open(e as PointerEvent).catch(console.error);
   }
 
   private handleRowKeyDown(e: KeyboardEvent, item: Item): void {
@@ -83,7 +86,7 @@ export class DnnRmItemsListview {
                   onClick={() => selectionUtilities.toggleItemSelected(item)}
                   onContextMenu={e => {
                     e.preventDefault();
-                    this.contextMenu.open(e as PointerEvent).catch(console.error);
+                    this.openItemContextMenu(e);
                   }}
                   onDblClick={() => this.handleDoubleClick(item)}
                 >
@@ -101,7 +104,6 @@ export class DnnRmItemsListview {
                   <td>{this.getLocalDateString(item.modifiedOn)}</td>
                   <td class="size">{getFileSize(item.fileSize)}</td>
                   <dnn-context-menu
-                    ref={el => this.contextMenu = el}
                     closeOnClick
                   >
                     {item.isFolder

--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/utilities/filesize-utilities.ts
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/utilities/filesize-utilities.ts
@@ -1,5 +1,5 @@
-export function getFileSize(fileSize: number): string {
-    if (fileSize == undefined || fileSize == undefined){
+export function getFileSize(fileSize?: number): string {
+    if (fileSize == undefined){
         return "";
     }
 


### PR DESCRIPTION
Fixes #7441

A change to simplify context menu handling made it so the target was always reset so the context menu would target the last item instead of the one where the right-click was performed.

This PR resolves that.