### PR TITLE
Add x-default to localized sitemap alternates

### DIFF
--- a/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
+++ b/DNN Platform/Library/Services/Sitemap/CoreSitemapProvider.cs
@@ -144,7 +144,7 @@ namespace DotNetNuke.Services.Sitemap
         /// <param name="localizedTabs">The localized versions of the page.</param>
         /// <param name="ps">The current portal settings.</param>
         /// <param name="now">The date and time used to evaluate page publication windows.</param>
-        /// <returns>The eligible alternate URLs.</returns>
+        /// <returns>The eligible alternate URLs, including the default and x-default URLs when appropriate.</returns>
         internal List<AlternateUrl> GetAlternateUrls(
             TabInfo defaultLanguageTab,
             IEnumerable<TabInfo> localizedTabs,
@@ -177,6 +177,11 @@ namespace DotNetNuke.Services.Sitemap
                 {
                     Url = defaultUrl,
                     Language = defaultLanguageTab.CultureCode,
+                });
+                alternates.Add(new AlternateUrl
+                {
+                    Url = defaultUrl,
+                    Language = "x-default",
                 });
             }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/CoreSitemapProviderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/CoreSitemapProviderTests.cs
@@ -72,7 +72,7 @@ namespace DotNetNuke.Tests.Core.Services.Sitemap
 
             Assert.Multiple(() =>
             {
-                Assert.That(result.Select(alternate => alternate.Language), Is.EqualTo(new[] { "fr-FR", "en-US" }));
+                Assert.That(result.Select(alternate => alternate.Language), Is.EqualTo(new[] { "fr-FR", "en-US", "x-default" }));
                 Assert.That(result, Has.None.Matches<AlternateUrl>(alternate => alternate.Language == "es-ES"));
                 this.globals.Verify(
                     global => global.NavigateURL(
@@ -87,7 +87,7 @@ namespace DotNetNuke.Tests.Core.Services.Sitemap
         }
 
         [Test]
-        public void GetAlternateUrls_UsesCultureSpecificUrls()
+        public void GetAlternateUrls_UsesCultureSpecificUrlsAndAddsXDefault()
         {
             TabInfo defaultTab = CreateTab("en-US");
             TabInfo localizedTab = CreateTab("fr-FR");
@@ -102,11 +102,13 @@ namespace DotNetNuke.Tests.Core.Services.Sitemap
 
             Assert.Multiple(() =>
             {
-                Assert.That(result, Has.Count.EqualTo(2));
+                Assert.That(result, Has.Count.EqualTo(3));
                 Assert.That(result[0].Language, Is.EqualTo("fr-FR"));
                 Assert.That(result[0].Url, Is.EqualTo("https://www.example.fr/page"));
                 Assert.That(result[1].Language, Is.EqualTo("en-US"));
                 Assert.That(result[1].Url, Is.EqualTo("https://www.example.com/page"));
+                Assert.That(result[2].Language, Is.EqualTo("x-default"));
+                Assert.That(result[2].Url, Is.EqualTo("https://www.example.com/page"));
             });
         }
 
@@ -157,6 +159,7 @@ namespace DotNetNuke.Tests.Core.Services.Sitemap
             {
                 Assert.That(result.Select(alternate => alternate.Language), Is.EqualTo(new[] { "fr-FR", "es-ES" }));
                 Assert.That(result, Has.None.Matches<AlternateUrl>(alternate => alternate.Language == "en-US"));
+                Assert.That(result, Has.None.Matches<AlternateUrl>(alternate => alternate.Language == "x-default"));
             });
         }
 

--- a/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/SitemapBuilderTests.cs
+++ b/DNN Platform/Tests/DotNetNuke.Tests.Core/Services/Sitemap/SitemapBuilderTests.cs
@@ -71,6 +71,11 @@ namespace DotNetNuke.Tests.Core.Services.Sitemap
                         Language = "fr-FR",
                         Url = "https://example.fr/fr-fr/page",
                     },
+                    new AlternateUrl
+                    {
+                        Language = "x-default",
+                        Url = "https://example.com/en-us/page",
+                    },
                 },
             };
 
@@ -84,13 +89,16 @@ namespace DotNetNuke.Tests.Core.Services.Sitemap
 
             Assert.Multiple(() =>
             {
-                Assert.That(links, Has.Count.EqualTo(2));
+                Assert.That(links, Has.Count.EqualTo(3));
                 Assert.That(links?[0].Attribute("rel")?.Value, Is.EqualTo("alternate"));
                 Assert.That(links?[0].Attribute("hreflang")?.Value, Is.EqualTo("en-US"));
                 Assert.That(links?[0].Attribute("href")?.Value, Is.EqualTo("https://example.com/en-us/page"));
                 Assert.That(links?[1].Attribute("rel")?.Value, Is.EqualTo("alternate"));
                 Assert.That(links?[1].Attribute("hreflang")?.Value, Is.EqualTo("fr-FR"));
                 Assert.That(links?[1].Attribute("href")?.Value, Is.EqualTo("https://example.fr/fr-fr/page"));
+                Assert.That(links?[2].Attribute("rel")?.Value, Is.EqualTo("alternate"));
+                Assert.That(links?[2].Attribute("hreflang")?.Value, Is.EqualTo("x-default"));
+                Assert.That(links?[2].Attribute("href")?.Value, Is.EqualTo("https://example.com/en-us/page"));
             });
         }
 


### PR DESCRIPTION
## Summary

Closes #7455

Adds `hreflang="x-default"` to valid localized sitemap groups, pointing to DNN's eligible portal-default-language page.

The default page retains its normal language-specific hreflang entry. The additional `x-default` entry is emitted only when:

- at least one eligible localized alternate exists;
- the default-language page passes the normal sitemap eligibility rules.

This uses DNN's existing default-language relationship and `AlternateUrl` serialization path. It does not change language selection, URL generation, portal aliases, sitemap caching, or which pages are included.

## Tests

Focused sitemap tests:

`dotnet test "DNN Platform/Tests/DotNetNuke.Tests.Core/DotNetNuke.Tests.Core.csproj" --no-restore --filter "FullyQualifiedName~Services.Sitemap" --verbosity quiet`

Result: 8 passed, 0 failed, 0 skipped.