### PR TITLE
Fixed an issue leaving an orphan portal when site creation fails

### DIFF
--- a/DNN Platform/Library/Entities/Portals/PortalController.cs
+++ b/DNN Platform/Library/Entities/Portals/PortalController.cs
@@ -1481,6 +1481,10 @@ namespace DotNetNuke.Entities.Portals
                 {
                     this.CreatePortalInternal(portalId, portalName, adminUser, description, keyWords, template, homeDirectory, portalAlias, serverPath, childPath, isChildPortal, ref message);
                 }
+                else
+                {
+                    throw new CreatePortalException(message);
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #7485

## Summary
Creating a site with an existing admin username and a wrong password
inserted a portal row, then skipped alias/template setup, so the site
was returned as success with no alias. Throw CreatePortalException when
admin user creation fails so the existing rollback path deletes the portal.

## Release Note
Fixed an issue where creating a site with an existing admin username and
incorrect password left an incomplete portal with no alias.

## Testing Steps

1. Create admin user (e.g. admin1)
2. Host > Sites > Create Site
3. Uncheck Use current user as site administrator
4. Enter an existing username (admin1) and an incorrect password
5. EXPECTED - get popup with error, portal is not created
6. Enter correct password
7. EXPECTED - portal created with alias
