### PR TITLE
Target .NET 10 with Deploy Client

### DIFF
--- a/DotNetNuke.BulkInstall/DotNetNuke.BulkInstall.DeployClient/DotNetNuke.BulkInstall.DeployClient.csproj
+++ b/DotNetNuke.BulkInstall/DotNetNuke.BulkInstall.DeployClient/DotNetNuke.BulkInstall.DeployClient.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary
We should release the deploy client on a framework version that will be supported for a while. No reason to target an older version. Also, `--allow-roll-forward` isn't supported until .NET 9.